### PR TITLE
Add authorized canonical Workshop timeline query

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -478,7 +478,7 @@ The review distinguishes implemented structural evidence from live operational e
 | Event-to-projection and canonical-to-JSONL parity diagnostics | `make install-status` replays relevant event facts, detects projection and two-way eligible-history divergence, and exposes counts without content or identities | Pass in automated tests |
 | Installed-system parity across fresh messages and a service restart | The diagnostic has not yet accumulated reviewed, sustained clean observations from the deployed installation | Not yet proven |
 | Media ingress and artifact provenance | Photo, document, and voice paths are deliberately excluded from the current text shadow; canonical artifact metadata does not yet exist | Missing |
-| Canonical timeline query and client synchronization | No supported timeline query, snapshot cursor, resumable event stream, or read-only Workshop client exists | Missing |
+| Canonical timeline query and client synchronization | A production-unused canonical query now defines authorized channel reads and snapshot-stable pagination; concrete channel policy, a resumable event stream, and a read-only Workshop client do not yet exist | Partial |
 | Durable outbound delivery | Current delivery events observe direct Telegram attempts after the fact; there is no `delivery.requested` outbox, lease, retry policy, or crash recovery | Missing |
 | Legacy transcript consumers | Context assembly, memory provenance, evaluation, and operator history tools still read JSONL directly | Not migrated |
 
@@ -493,10 +493,11 @@ The review distinguishes implemented structural evidence from live operational e
 ### 18.2 Next bounded sequence
 
 1. **Deploy and observe:** install the merged shadow sequence, create fresh plain-text exchanges, run `make install-status` before and after a service restart, and retain only counts/state as evidence. A single clean sample is a smoke test, not sustained parity.
-2. **Canonical timeline query contract, unused by production:** add a transport-independent, paginated channel timeline reader with stable cursors and principal/channel authorization inputs. It must not accept Telegram IDs and must not replace JSONL reads.
-3. **Authenticated read-only diagnostic surface:** expose snapshot and replay semantics to a minimal local Workshop diagnostic client. It must reuse principal authorization, reveal no cross-channel data, and accept no commands.
-4. **Media and artifact shadow:** introduce canonical artifact metadata and provenance for successful photo, document, and voice ingress while preserving current files, prompts, and Telegram behavior.
-5. **Durable delivery outbox:** define `delivery.requested`, attempts, idempotent claims, retry/failure policy, and crash recovery before any direct Telegram send is replaced.
-6. **Repeat the authority review:** require sustained installed parity, media coverage, read-client restart/reconnect evidence, and live delivery recovery before approving a cutover PR.
+2. **Canonical timeline query contract, unused by production:** implemented as a transport-independent, paginated channel timeline reader with stable cursors and mandatory principal/channel authorization. It accepts no Telegram IDs and replaces no JSONL reads.
+3. **Canonical channel authorization policy:** model who may read each channel. Workshop membership alone must not imply access to every direct channel; the current shared default workshop makes that unsafe. Bind the timeline authorization protocol to this policy before exposing a read surface.
+4. **Authenticated read-only diagnostic surface:** expose snapshot and replay semantics to a minimal local Workshop diagnostic client. It must reuse principal authorization, reveal no cross-channel data, and accept no commands.
+5. **Media and artifact shadow:** introduce canonical artifact metadata and provenance for successful photo, document, and voice ingress while preserving current files, prompts, and Telegram behavior.
+6. **Durable delivery outbox:** define `delivery.requested`, attempts, idempotent claims, retry/failure policy, and crash recovery before any direct Telegram send is replaced.
+7. **Repeat the authority review:** require sustained installed parity, media coverage, read-client restart/reconnect evidence, and live delivery recovery before approving a cutover PR.
 
-The next code PR is item 2: a test-first, production-unused canonical timeline query. It advances the Phase 1 read model without creating dual-read behavior or weakening the hold decision.
+The next code PR is item 3: a test-first canonical channel authorization policy. The timeline reader deliberately has no permissive default and remains production-unused until that policy exists. This advances the Phase 1 read model without creating dual-read behavior or weakening the hold decision.

--- a/src/kai/workshop/__init__.py
+++ b/src/kai/workshop/__init__.py
@@ -30,6 +30,14 @@ from kai.workshop.store import (
     StoredEvent,
     WorkshopEventStore,
 )
+from kai.workshop.timeline import (
+    ChannelTimelineAuthorizer,
+    TimelineAccessDeniedError,
+    TimelineCursorError,
+    TimelineMessage,
+    TimelinePage,
+    read_channel_timeline,
+)
 
 __all__ = [
     "AgentId",
@@ -37,6 +45,7 @@ __all__ = [
     "ChannelAgentId",
     "ChannelBindingId",
     "ChannelId",
+    "ChannelTimelineAuthorizer",
     "DeliveryId",
     "EventEnvelope",
     "EventId",
@@ -48,8 +57,13 @@ __all__ = [
     "Projection",
     "ProjectionCheckpoint",
     "StoredEvent",
+    "TimelineAccessDeniedError",
+    "TimelineCursorError",
+    "TimelineMessage",
+    "TimelinePage",
     "WorkshopEventStore",
     "WorkshopEventType",
     "WorkshopId",
     "WorkshopMembershipId",
+    "read_channel_timeline",
 ]

--- a/src/kai/workshop/timeline.py
+++ b/src/kai/workshop/timeline.py
@@ -1,0 +1,214 @@
+"""Authorized, transport-independent reads of canonical Workshop timelines."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+from kai.workshop.domain import ChannelId, MessageId, PrincipalId
+from kai.workshop.store import WorkshopEventStore
+
+_CURSOR_PREFIX = "v1."
+_MAX_CURSOR_LENGTH = 512
+_MAX_PAGE_SIZE = 100
+_MAX_SQLITE_INTEGER = 2**63 - 1
+
+
+class TimelineAccessDeniedError(PermissionError):
+    """The principal may not read the requested channel timeline."""
+
+
+class TimelineCursorError(ValueError):
+    """A timeline pagination cursor is invalid for the requested channel."""
+
+
+class ChannelTimelineAuthorizer(Protocol):
+    """Authorize a principal against one specific canonical channel."""
+
+    async def can_read_channel(self, principal_id: PrincipalId, channel_id: ChannelId) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class TimelineMessage:
+    """One canonical message suitable for a transport-neutral timeline."""
+
+    message_id: MessageId
+    channel_id: ChannelId
+    author_principal_id: PrincipalId
+    author_kind: str
+    author_display_name: str
+    reply_to_message_id: MessageId | None
+    body: str
+    event_position: int
+    created_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class TimelinePage:
+    """A stable page from a bounded snapshot of one channel timeline."""
+
+    messages: tuple[TimelineMessage, ...]
+    next_cursor: str | None
+    through_position: int
+
+
+@dataclass(frozen=True, slots=True)
+class _CursorState:
+    channel_id: ChannelId
+    after_position: int
+    through_position: int
+
+
+def _encode_cursor(state: _CursorState) -> str:
+    payload = json.dumps(
+        {
+            "after_position": state.after_position,
+            "channel_id": state.channel_id,
+            "through_position": state.through_position,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    encoded = base64.urlsafe_b64encode(payload).rstrip(b"=").decode("ascii")
+    return f"{_CURSOR_PREFIX}{encoded}"
+
+
+def _decode_cursor(cursor: str) -> _CursorState:
+    if not isinstance(cursor, str) or not cursor.startswith(_CURSOR_PREFIX) or len(cursor) > _MAX_CURSOR_LENGTH:
+        raise TimelineCursorError("Invalid timeline cursor")
+    encoded = cursor.removeprefix(_CURSOR_PREFIX)
+    if not encoded:
+        raise TimelineCursorError("Invalid timeline cursor")
+    padding = "=" * (-len(encoded) % 4)
+    try:
+        raw = base64.b64decode(encoded + padding, altchars=b"-_", validate=True)
+        payload = json.loads(raw.decode("utf-8"))
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise TimelineCursorError("Invalid timeline cursor") from exc
+    if not isinstance(payload, dict) or set(payload) != {
+        "after_position",
+        "channel_id",
+        "through_position",
+    }:
+        raise TimelineCursorError("Invalid timeline cursor")
+    after_position = payload["after_position"]
+    through_position = payload["through_position"]
+    if (
+        not isinstance(after_position, int)
+        or isinstance(after_position, bool)
+        or not isinstance(through_position, int)
+        or isinstance(through_position, bool)
+        or after_position < 0
+        or through_position < after_position
+        or through_position > _MAX_SQLITE_INTEGER
+    ):
+        raise TimelineCursorError("Invalid timeline cursor")
+    try:
+        channel_id = ChannelId(payload["channel_id"])
+    except (TypeError, ValueError) as exc:
+        raise TimelineCursorError("Invalid timeline cursor") from exc
+    return _CursorState(channel_id, after_position, through_position)
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _validate_request(principal_id: PrincipalId, channel_id: ChannelId, limit: int) -> None:
+    if not isinstance(principal_id, PrincipalId):
+        raise ValueError("principal_id must be a PrincipalId")
+    if not isinstance(channel_id, ChannelId):
+        raise ValueError("channel_id must be a ChannelId")
+    if not isinstance(limit, int) or isinstance(limit, bool) or not 1 <= limit <= _MAX_PAGE_SIZE:
+        raise ValueError(f"limit must be an integer from 1 through {_MAX_PAGE_SIZE}")
+
+
+async def _authorize(
+    authorizer: ChannelTimelineAuthorizer,
+    principal_id: PrincipalId,
+    channel_id: ChannelId,
+) -> None:
+    allowed = await authorizer.can_read_channel(principal_id, channel_id)
+    if allowed is not True:
+        raise TimelineAccessDeniedError("Timeline access denied")
+
+
+async def _channel_exists(store: WorkshopEventStore, channel_id: ChannelId) -> bool:
+    async with store.connection.execute("SELECT 1 FROM channels WHERE id = ?", (channel_id,)) as cursor:
+        return await cursor.fetchone() is not None
+
+
+async def _latest_message_position(store: WorkshopEventStore, channel_id: ChannelId) -> int:
+    async with store.connection.execute(
+        "SELECT COALESCE(MAX(created_event_position), 0) FROM messages WHERE channel_id = ?",
+        (channel_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        raise RuntimeError("Timeline boundary query returned no row")
+    return int(row[0])
+
+
+async def read_channel_timeline(
+    store: WorkshopEventStore,
+    *,
+    principal_id: PrincipalId,
+    channel_id: ChannelId,
+    authorizer: ChannelTimelineAuthorizer,
+    cursor: str | None = None,
+    limit: int = 50,
+) -> TimelinePage:
+    """Read an authorized, stable snapshot page from one canonical channel."""
+    _validate_request(principal_id, channel_id, limit)
+    await _authorize(authorizer, principal_id, channel_id)
+
+    if not await _channel_exists(store, channel_id):
+        raise TimelineAccessDeniedError("Timeline access denied")
+
+    if cursor is None:
+        state = _CursorState(channel_id, 0, await _latest_message_position(store, channel_id))
+    else:
+        state = _decode_cursor(cursor)
+        if state.channel_id != channel_id:
+            raise TimelineCursorError("Timeline cursor belongs to another channel")
+
+    async with store.connection.execute(
+        "SELECT m.id, m.channel_id, m.author_principal_id, p.kind, p.display_name, "
+        "m.reply_to_message_id, m.body, m.created_event_position, m.created_at "
+        "FROM messages m JOIN principals p ON p.id = m.author_principal_id "
+        "WHERE m.channel_id = ? AND m.created_event_position > ? "
+        "AND m.created_event_position <= ? ORDER BY m.created_event_position ASC LIMIT ?",
+        (channel_id, state.after_position, state.through_position, limit + 1),
+    ) as query_cursor:
+        rows = list(await query_cursor.fetchall())
+
+    has_more = len(rows) > limit
+    page_rows = rows[:limit]
+    messages = tuple(
+        TimelineMessage(
+            message_id=MessageId(str(row[0])),
+            channel_id=ChannelId(str(row[1])),
+            author_principal_id=PrincipalId(str(row[2])),
+            author_kind=str(row[3]),
+            author_display_name=str(row[4]),
+            reply_to_message_id=MessageId(str(row[5])) if row[5] is not None else None,
+            body=str(row[6]),
+            event_position=int(row[7]),
+            created_at=_parse_timestamp(str(row[8])),
+        )
+        for row in page_rows
+    )
+    next_cursor = None
+    if has_more:
+        next_cursor = _encode_cursor(
+            _CursorState(
+                channel_id=channel_id,
+                after_position=messages[-1].event_position,
+                through_position=state.through_position,
+            )
+        )
+    return TimelinePage(messages, next_cursor, state.through_position)

--- a/tests/test_workshop_timeline.py
+++ b/tests/test_workshop_timeline.py
@@ -1,0 +1,290 @@
+"""Contracts for the production-unused canonical Workshop timeline reader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.domain import ChannelId, MessageId, PrincipalId
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.outbound import OutboundMessage, record_outbound_message
+from kai.workshop.store import WorkshopEventStore
+from kai.workshop.timeline import (
+    TimelineAccessDeniedError,
+    TimelineCursorError,
+    read_channel_timeline,
+)
+
+_NOW = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+
+
+@dataclass
+class _Authorizer:
+    allowed: set[tuple[PrincipalId, ChannelId]]
+    calls: list[tuple[PrincipalId, ChannelId]] = field(default_factory=list)
+
+    async def can_read_channel(self, principal_id: PrincipalId, channel_id: ChannelId) -> bool:
+        self.calls.append((principal_id, channel_id))
+        return (principal_id, channel_id) in self.allowed
+
+
+async def _identity_for(
+    store: WorkshopEventStore,
+    external_subject: str,
+) -> tuple[PrincipalId, ChannelId]:
+    async with store.connection.execute(
+        "SELECT e.principal_id, b.channel_id FROM external_identities e "
+        "JOIN channel_bindings b ON b.transport = e.provider "
+        "AND b.external_channel_id = e.external_subject "
+        "WHERE e.provider = 'telegram' AND e.external_subject = ?",
+        (external_subject,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return PrincipalId(str(row[0])), ChannelId(str(row[1]))
+
+
+async def _open_store(path: Path) -> tuple[WorkshopEventStore, PrincipalId, ChannelId, PrincipalId, ChannelId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman("User One", "admin", "telegram", "101", "101"),
+            BootstrapHuman("User Two", "member", "telegram", "202", "202"),
+        ),
+    )
+    first_principal, first_channel = await _identity_for(store, "101")
+    second_principal, second_channel = await _identity_for(store, "202")
+    return store, first_principal, first_channel, second_principal, second_channel
+
+
+async def _record_user_message(
+    store: WorkshopEventStore,
+    *,
+    ordinal: int,
+    body: str,
+) -> None:
+    await record_inbound_message(
+        store,
+        InboundMessage(
+            "telegram",
+            str(9000 + ordinal),
+            str(40 + ordinal),
+            "101",
+            "101",
+            body,
+            _NOW + timedelta(seconds=ordinal),
+        ),
+    )
+
+
+class TestCanonicalTimelineQuery:
+    async def test_authorized_reader_returns_canonical_messages_in_event_order(self, tmp_path: Path):
+        store, principal_id, channel_id, _, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            inbound = await record_inbound_message(
+                store,
+                InboundMessage("telegram", "9001", "42", "101", "101", "Question", _NOW),
+            )
+            await record_outbound_message(
+                store,
+                OutboundMessage(
+                    MessageId(str(inbound.event.envelope.aggregate_id)),
+                    "Answer",
+                    _NOW + timedelta(seconds=1),
+                ),
+            )
+            authorizer = _Authorizer({(principal_id, channel_id)})
+
+            page = await read_channel_timeline(
+                store,
+                principal_id=principal_id,
+                channel_id=channel_id,
+                authorizer=authorizer,
+            )
+
+            assert [message.body for message in page.messages] == ["Question", "Answer"]
+            assert [message.author_kind for message in page.messages] == ["human", "agent"]
+            assert [message.author_display_name for message in page.messages] == ["User One", "Kai"]
+            assert page.messages[1].reply_to_message_id == page.messages[0].message_id
+            assert all(message.channel_id == channel_id for message in page.messages)
+            assert [message.event_position for message in page.messages] == sorted(
+                message.event_position for message in page.messages
+            )
+            assert page.through_position == page.messages[-1].event_position
+            assert page.next_cursor is None
+            assert authorizer.calls == [(principal_id, channel_id)]
+        finally:
+            await store.close()
+
+    async def test_denied_reader_receives_no_timeline(self, tmp_path: Path):
+        store, principal_id, channel_id, _, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            await _record_user_message(store, ordinal=1, body="Private content")
+            authorizer = _Authorizer(set())
+
+            with pytest.raises(TimelineAccessDeniedError):
+                await read_channel_timeline(
+                    store,
+                    principal_id=principal_id,
+                    channel_id=channel_id,
+                    authorizer=authorizer,
+                )
+
+            assert authorizer.calls == [(principal_id, channel_id)]
+        finally:
+            await store.close()
+
+    async def test_denial_happens_before_any_storage_lookup(self, tmp_path: Path):
+        store, principal_id, channel_id, _, _ = await _open_store(tmp_path / "kai.db")
+        await store.close()
+        authorizer = _Authorizer(set())
+
+        with pytest.raises(TimelineAccessDeniedError):
+            await read_channel_timeline(
+                store,
+                principal_id=principal_id,
+                channel_id=channel_id,
+                authorizer=authorizer,
+            )
+
+        assert authorizer.calls == [(principal_id, channel_id)]
+
+    async def test_authorized_but_unknown_channel_fails_closed(self, tmp_path: Path):
+        store, principal_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+        unknown_channel = ChannelId.new()
+        try:
+            authorizer = _Authorizer({(principal_id, unknown_channel)})
+
+            with pytest.raises(TimelineAccessDeniedError):
+                await read_channel_timeline(
+                    store,
+                    principal_id=principal_id,
+                    channel_id=unknown_channel,
+                    authorizer=authorizer,
+                )
+        finally:
+            await store.close()
+
+    async def test_snapshot_cursor_excludes_messages_added_between_pages(self, tmp_path: Path):
+        store, principal_id, channel_id, _, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            for ordinal in range(1, 4):
+                await _record_user_message(store, ordinal=ordinal, body=f"Message {ordinal}")
+            authorizer = _Authorizer({(principal_id, channel_id)})
+
+            first = await read_channel_timeline(
+                store,
+                principal_id=principal_id,
+                channel_id=channel_id,
+                authorizer=authorizer,
+                limit=2,
+            )
+            assert [message.body for message in first.messages] == ["Message 1", "Message 2"]
+            assert first.next_cursor is not None
+            first_cursor = first.next_cursor
+
+            repeated = await read_channel_timeline(
+                store,
+                principal_id=principal_id,
+                channel_id=channel_id,
+                authorizer=authorizer,
+                limit=2,
+            )
+            assert repeated.next_cursor == first_cursor
+
+            await _record_user_message(store, ordinal=4, body="Message 4")
+            second = await read_channel_timeline(
+                store,
+                principal_id=principal_id,
+                channel_id=channel_id,
+                authorizer=authorizer,
+                cursor=first_cursor,
+                limit=2,
+            )
+
+            assert [message.body for message in second.messages] == ["Message 3"]
+            assert second.through_position == first.through_position
+            assert second.next_cursor is None
+
+            fresh = await read_channel_timeline(
+                store,
+                principal_id=principal_id,
+                channel_id=channel_id,
+                authorizer=authorizer,
+                limit=10,
+            )
+            assert [message.body for message in fresh.messages] == [
+                "Message 1",
+                "Message 2",
+                "Message 3",
+                "Message 4",
+            ]
+            assert fresh.through_position > first.through_position
+        finally:
+            await store.close()
+
+    async def test_cursor_is_bound_to_its_channel(self, tmp_path: Path):
+        store, principal_id, channel_id, second_principal, second_channel = await _open_store(tmp_path / "kai.db")
+        try:
+            for ordinal in range(1, 3):
+                await _record_user_message(store, ordinal=ordinal, body=f"Message {ordinal}")
+            authorizer = _Authorizer(
+                {
+                    (principal_id, channel_id),
+                    (second_principal, second_channel),
+                }
+            )
+            first = await read_channel_timeline(
+                store,
+                principal_id=principal_id,
+                channel_id=channel_id,
+                authorizer=authorizer,
+                limit=1,
+            )
+            assert first.next_cursor is not None
+
+            with pytest.raises(TimelineCursorError):
+                await read_channel_timeline(
+                    store,
+                    principal_id=second_principal,
+                    channel_id=second_channel,
+                    authorizer=authorizer,
+                    cursor=first.next_cursor,
+                )
+        finally:
+            await store.close()
+
+    @pytest.mark.parametrize("cursor", ["", "not-a-cursor", "v2.invalid", "v1.***"])
+    async def test_malformed_cursor_fails_closed(self, tmp_path: Path, cursor: str):
+        store, principal_id, channel_id, _, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            with pytest.raises(TimelineCursorError):
+                await read_channel_timeline(
+                    store,
+                    principal_id=principal_id,
+                    channel_id=channel_id,
+                    authorizer=_Authorizer({(principal_id, channel_id)}),
+                    cursor=cursor,
+                )
+        finally:
+            await store.close()
+
+    @pytest.mark.parametrize("limit", [0, -1, 101, True])
+    async def test_limit_is_bounded(self, tmp_path: Path, limit: int):
+        store, principal_id, channel_id, _, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            with pytest.raises(ValueError, match="limit"):
+                await read_channel_timeline(
+                    store,
+                    principal_id=principal_id,
+                    channel_id=channel_id,
+                    authorizer=_Authorizer({(principal_id, channel_id)}),
+                    limit=limit,
+                )
+        finally:
+            await store.close()


### PR DESCRIPTION
## Summary

- add a production-unused, transport-independent reader for canonical channel timelines
- require an explicit principal/channel authorizer before any channel or message lookup
- return opaque typed IDs, author metadata, reply relationships, and event ordering
- add bounded snapshot pagination with deterministic, versioned cursors tied to one channel
- document that a concrete per-channel authorization policy is required before any read surface is exposed

## Security properties

- the API accepts canonical PrincipalId and ChannelId values, never Telegram identifiers
- denied requests reach no storage lookup
- unknown channels fail with the same access-denied result
- cursors cannot be reused across channels and malformed or out-of-range input fails closed
- no permissive authorization default exists

## Compatibility and authority

- no production caller is added
- Telegram routing, JSONL transcript reads, and direct delivery remain authoritative
- no schema or installation change is included
- the authority-review hold remains in place

## Verification

- 5054 passed, 1 skipped
- 92 focused Workshop tests passed
- ruff lint and format checks passed
- pyright passed with zero errors
- module-size check passed