### PR TITLE
Add explicit Workshop channel authorization

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -261,6 +261,7 @@ The first code milestone should be **canonical conversation shadowing**. It esta
 - `external_identities`
 - `workshop_memberships`
 - `channels`
+- `channel_memberships`
 - `channel_bindings`
 - `agents`
 - `channel_agents`
@@ -277,6 +278,7 @@ Identifiers should be opaque, globally unique strings. Telegram numeric identifi
 - `principal.created`
 - `external_identity.bound`
 - `channel.created`
+- `channel.member_added`
 - `transport.channel_bound`
 - `agent.created`
 - `channel.agent_attached`
@@ -494,10 +496,10 @@ The review distinguishes implemented structural evidence from live operational e
 
 1. **Deploy and observe:** install the merged shadow sequence, create fresh plain-text exchanges, run `make install-status` before and after a service restart, and retain only counts/state as evidence. A single clean sample is a smoke test, not sustained parity.
 2. **Canonical timeline query contract, unused by production:** implemented as a transport-independent, paginated channel timeline reader with stable cursors and mandatory principal/channel authorization. It accepts no Telegram IDs and replaces no JSONL reads.
-3. **Canonical channel authorization policy:** model who may read each channel. Workshop membership alone must not imply access to every direct channel; the current shared default workshop makes that unsafe. Bind the timeline authorization protocol to this policy before exposing a read surface.
+3. **Canonical channel authorization policy:** implemented with explicit, replayable channel memberships. Workshop membership alone does not imply access to every direct channel; the current shared default workshop makes that unsafe. The concrete timeline authorizer requires both an explicit channel membership and membership in the channel's workshop.
 4. **Authenticated read-only diagnostic surface:** expose snapshot and replay semantics to a minimal local Workshop diagnostic client. It must reuse principal authorization, reveal no cross-channel data, and accept no commands.
 5. **Media and artifact shadow:** introduce canonical artifact metadata and provenance for successful photo, document, and voice ingress while preserving current files, prompts, and Telegram behavior.
 6. **Durable delivery outbox:** define `delivery.requested`, attempts, idempotent claims, retry/failure policy, and crash recovery before any direct Telegram send is replaced.
 7. **Repeat the authority review:** require sustained installed parity, media coverage, read-client restart/reconnect evidence, and live delivery recovery before approving a cutover PR.
 
-The next code PR is item 3: a test-first canonical channel authorization policy. The timeline reader deliberately has no permissive default and remains production-unused until that policy exists. This advances the Phase 1 read model without creating dual-read behavior or weakening the hold decision.
+The next code PR is item 4: an authenticated, read-only local diagnostic surface backed by the canonical timeline query and channel policy. It must accept no commands and remains separate from production Telegram and JSONL authority. This advances the Phase 1 read model without creating dual-read behavior or weakening the hold decision.

--- a/src/kai/workshop/__init__.py
+++ b/src/kai/workshop/__init__.py
@@ -6,11 +6,13 @@ Telegram routing, histories, and responses remain authoritative until replay
 and parity evidence supports an explicit cutover.
 """
 
+from kai.workshop.authorization import CanonicalChannelAuthorizer
 from kai.workshop.domain import (
     AgentId,
     ChannelAgentId,
     ChannelBindingId,
     ChannelId,
+    ChannelMembershipId,
     DeliveryId,
     EventEnvelope,
     EventId,
@@ -42,9 +44,11 @@ from kai.workshop.timeline import (
 __all__ = [
     "AgentId",
     "AppendResult",
+    "CanonicalChannelAuthorizer",
     "ChannelAgentId",
     "ChannelBindingId",
     "ChannelId",
+    "ChannelMembershipId",
     "ChannelTimelineAuthorizer",
     "DeliveryId",
     "EventEnvelope",

--- a/src/kai/workshop/authorization.py
+++ b/src/kai/workshop/authorization.py
@@ -1,0 +1,27 @@
+"""Canonical principal authorization policies for Kai Workshop."""
+
+from __future__ import annotations
+
+from kai.workshop.domain import ChannelId, PrincipalId
+from kai.workshop.store import WorkshopEventStore
+
+
+class CanonicalChannelAuthorizer:
+    """Authorize reads through explicit channel and workshop memberships."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def can_read_channel(self, principal_id: PrincipalId, channel_id: ChannelId) -> bool:
+        """Return true only for an explicit, workshop-aligned channel member."""
+        if not isinstance(principal_id, PrincipalId) or not isinstance(channel_id, ChannelId):
+            return False
+        async with self._store.connection.execute(
+            "SELECT 1 FROM channel_memberships cm "
+            "JOIN channels c ON c.id = cm.channel_id "
+            "JOIN workshop_memberships wm ON wm.principal_id = cm.principal_id "
+            "AND wm.workshop_id = c.workshop_id "
+            "WHERE cm.principal_id = ? AND cm.channel_id = ? LIMIT 1",
+            (principal_id, channel_id),
+        ) as cursor:
+            return await cursor.fetchone() is not None

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -14,6 +14,7 @@ from kai.workshop.domain import (
     ChannelAgentId,
     ChannelBindingId,
     ChannelId,
+    ChannelMembershipId,
     EventEnvelope,
     ExternalIdentityId,
     OpaqueId,
@@ -185,6 +186,14 @@ async def bootstrap_default_workshop(
         external_identity_id = ExternalIdentityId.derived(workshop_id, f"external-identity:{token}")
         membership_id = WorkshopMembershipId.derived(workshop_id, f"membership:human:{token}")
         channel_id = ChannelId.derived(workshop_id, f"direct-channel:{channel_token}")
+        human_channel_membership_id = ChannelMembershipId.derived(
+            workshop_id,
+            f"channel-membership:{channel_token}:human:{token}",
+        )
+        agent_channel_membership_id = ChannelMembershipId.derived(
+            workshop_id,
+            f"channel-membership:{channel_token}:agent:kai",
+        )
         binding_id = ChannelBindingId.derived(workshop_id, f"channel-binding:{channel_token}")
         channel_agent_id = ChannelAgentId.derived(workshop_id, f"channel-agent:{channel_token}:kai")
         await ensure(
@@ -218,6 +227,28 @@ async def bootstrap_default_workshop(
             aggregate_type="channel",
             aggregate_id=channel_id,
             payload={"kind": "direct", "name": "Direct"},
+        )
+        await ensure(
+            idempotency_key=_idempotency_key("channel-membership-human", channel_token),
+            event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+            aggregate_type="channel_membership",
+            aggregate_id=human_channel_membership_id,
+            payload={
+                "channel_id": channel_id,
+                "principal_id": principal_id,
+                "role": "owner",
+            },
+        )
+        await ensure(
+            idempotency_key=_idempotency_key("channel-membership-agent", channel_token),
+            event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+            aggregate_type="channel_membership",
+            aggregate_id=agent_channel_membership_id,
+            payload={
+                "channel_id": channel_id,
+                "principal_id": agent_principal_id,
+                "role": "participant",
+            },
         )
         await ensure(
             idempotency_key=_idempotency_key("channel-binding", channel_token),

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -24,16 +24,20 @@ from kai.workshop.domain import (
 _REQUIRED_TABLES = {
     "workshops",
     "principals",
+    "workshop_memberships",
     "agents",
     "channel_bindings",
+    "channel_memberships",
     "projection_checkpoints",
 }
 
 _PARITY_TABLES = {
+    "channel_memberships",
     "event_log",
     "messages",
     "principals",
     "channel_bindings",
+    "workshop_memberships",
 }
 _TELEGRAM_SUBJECT_PATTERN = re.compile(r"^-?[0-9]+$")
 _SYNTHETIC_ASSISTANT_PATTERN = re.compile(
@@ -62,7 +66,9 @@ class _ReplayMessage:
 @dataclass(frozen=True, slots=True)
 class _ReplayState:
     principal_kinds: dict[str, str]
+    workshop_memberships: dict[str, tuple[str, str, str]]
     channel_bindings: dict[str, tuple[str, str, str]]
+    channel_memberships: dict[str, tuple[str, str, str]]
     messages: tuple[_ReplayMessage, ...]
 
 
@@ -104,6 +110,7 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
                 "SELECT COUNT(*) FROM channel_bindings WHERE transport = ?",
                 ("telegram",),
             )
+            channel_membership_count = _scalar(connection, "SELECT COUNT(*) FROM channel_memberships")
             projection_count = _scalar(
                 connection,
                 "SELECT COUNT(*) FROM projection_checkpoints WHERE name = ?",
@@ -114,9 +121,10 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
     except (OSError, sqlite3.Error) as exc:
         return f"Workshop bootstrap: NOT VERIFIED ({type(exc).__name__})"
 
-    expected_state_present = expected_humans is None or (
-        human_count >= expected_humans and telegram_binding_count >= expected_humans
-    )
+    expected_memberships = 2 * (human_count if expected_humans is None else expected_humans)
+    expected_state_present = (
+        expected_humans is None or (human_count >= expected_humans and telegram_binding_count >= expected_humans)
+    ) and channel_membership_count >= expected_memberships
     initialized = workshop_count >= 1 and agent_count >= 1 and projection_count == 1 and expected_state_present
     state = "initialized" if initialized else "pending"
     expectation = (
@@ -124,7 +132,8 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
     )
     return (
         f"Workshop bootstrap: {state}; workshops={workshop_count}, humans={human_count}, "
-        f"Telegram bindings={telegram_binding_count}, agents={agent_count}; {expectation}"
+        f"Telegram bindings={telegram_binding_count}, channel memberships={channel_membership_count}, "
+        f"agents={agent_count}; {expectation}"
     )
 
 
@@ -168,7 +177,9 @@ def _insert_replayed_fact(facts: dict[str, Any], fact_id: str, value: Any) -> No
 
 def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
     principal_kinds: dict[str, str] = {}
+    workshop_memberships: dict[str, tuple[str, str, str]] = {}
     channel_bindings: dict[str, tuple[str, str, str]] = {}
+    channel_memberships: dict[str, tuple[str, str, str]] = {}
     replayed: list[_ReplayMessage] = []
     for row in connection.execute("SELECT * FROM event_log ORDER BY position"):
         envelope = _event_from_row(row)
@@ -178,6 +189,8 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
             envelope.event_type
             in {
                 WorkshopEventType.PRINCIPAL_CREATED,
+                WorkshopEventType.WORKSHOP_MEMBER_ADDED,
+                WorkshopEventType.CHANNEL_MEMBER_ADDED,
                 WorkshopEventType.TRANSPORT_CHANNEL_BOUND,
                 WorkshopEventType.MESSAGE_CREATED,
             }
@@ -191,6 +204,17 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
                 _required_payload_text(payload, "kind"),
             )
             continue
+        if envelope.event_type == WorkshopEventType.WORKSHOP_MEMBER_ADDED:
+            _insert_replayed_fact(
+                workshop_memberships,
+                aggregate_id,
+                (
+                    str(envelope.workshop_id),
+                    _required_payload_text(payload, "principal_id"),
+                    _required_payload_text(payload, "role"),
+                ),
+            )
+            continue
         if envelope.event_type == WorkshopEventType.TRANSPORT_CHANNEL_BOUND:
             _insert_replayed_fact(
                 channel_bindings,
@@ -199,6 +223,17 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
                     _required_payload_text(payload, "channel_id"),
                     _required_payload_text(payload, "transport"),
                     _required_payload_text(payload, "external_channel_id"),
+                ),
+            )
+            continue
+        if envelope.event_type == WorkshopEventType.CHANNEL_MEMBER_ADDED:
+            _insert_replayed_fact(
+                channel_memberships,
+                aggregate_id,
+                (
+                    _required_payload_text(payload, "channel_id"),
+                    _required_payload_text(payload, "principal_id"),
+                    _required_payload_text(payload, "role"),
                 ),
             )
             continue
@@ -230,7 +265,9 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
         )
     return _ReplayState(
         principal_kinds=principal_kinds,
+        workshop_memberships=workshop_memberships,
         channel_bindings=channel_bindings,
+        channel_memberships=channel_memberships,
         messages=tuple(replayed),
     )
 
@@ -277,10 +314,20 @@ def _projection_mismatches(connection: sqlite3.Connection, replayed: _ReplayStat
             "SELECT id, channel_id, transport, external_channel_id FROM channel_bindings"
         ).fetchall()
     }
+    actual_workshop_memberships = {
+        str(row[0]): (str(row[1]), str(row[2]), str(row[3]))
+        for row in connection.execute("SELECT id, workshop_id, principal_id, role FROM workshop_memberships").fetchall()
+    }
+    actual_channel_memberships = {
+        str(row[0]): (str(row[1]), str(row[2]), str(row[3]))
+        for row in connection.execute("SELECT id, channel_id, principal_id, role FROM channel_memberships").fetchall()
+    }
     mismatches = (
         _mapping_mismatches(expected, actual)
         + _mapping_mismatches(replayed.principal_kinds, actual_principal_kinds)
+        + _mapping_mismatches(replayed.workshop_memberships, actual_workshop_memberships)
         + _mapping_mismatches(replayed.channel_bindings, actual_bindings)
+        + _mapping_mismatches(replayed.channel_memberships, actual_channel_memberships)
     )
     return len(actual), mismatches
 

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -26,6 +26,7 @@ class WorkshopEventType(StrEnum):
     PRINCIPAL_CREATED = "principal.created"
     EXTERNAL_IDENTITY_BOUND = "external_identity.bound"
     CHANNEL_CREATED = "channel.created"
+    CHANNEL_MEMBER_ADDED = "channel.member_added"
     TRANSPORT_CHANNEL_BOUND = "transport.channel_bound"
     AGENT_CREATED = "agent.created"
     CHANNEL_AGENT_ATTACHED = "channel.agent_attached"
@@ -81,6 +82,10 @@ class ChannelId(OpaqueId):
     prefix = "chn"
 
 
+class ChannelMembershipId(OpaqueId):
+    prefix = "chm"
+
+
 class ChannelBindingId(OpaqueId):
     prefix = "cbd"
 
@@ -113,6 +118,7 @@ _ID_TYPES: dict[str, type[OpaqueId]] = {
         ExternalIdentityId,
         WorkshopMembershipId,
         ChannelId,
+        ChannelMembershipId,
         ChannelBindingId,
         AgentId,
         ChannelAgentId,

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -21,7 +21,7 @@ class CanonicalConversationProjection:
     """Rebuild the initial Workshop collaboration records from events."""
 
     name = "canonical_conversations"
-    version = 2
+    version = 3
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         for table in (
@@ -29,6 +29,7 @@ class CanonicalConversationProjection:
             "messages",
             "channel_agents",
             "channel_bindings",
+            "channel_memberships",
             "channels",
             "agents",
             "workshop_memberships",
@@ -93,6 +94,21 @@ class CanonicalConversationProjection:
                     envelope.workshop_id,
                     _required_text(payload, "kind"),
                     name,
+                    occurred_at,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.CHANNEL_MEMBER_ADDED:
+            role = _required_text(payload, "role")
+            if role not in {"owner", "participant"}:
+                raise ValueError("Workshop channel member role must be 'owner' or 'participant'")
+            await connection.execute(
+                "INSERT INTO channel_memberships "
+                "(id, channel_id, principal_id, role, created_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    _required_text(payload, "channel_id"),
+                    _required_text(payload, "principal_id"),
+                    role,
                     occurred_at,
                 ),
             )

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 2
+WORKSHOP_SCHEMA_VERSION = 3
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,7 +156,25 @@ _DELIVERY_SCHEMA = SchemaMigration(
     ),
 )
 
-_MIGRATIONS = (_INITIAL_SCHEMA, _DELIVERY_SCHEMA)
+_CHANNEL_MEMBERSHIP_SCHEMA = SchemaMigration(
+    version=3,
+    name="explicit_channel_memberships",
+    statements=(
+        """
+        CREATE TABLE channel_memberships (
+            id TEXT PRIMARY KEY,
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
+            role TEXT NOT NULL CHECK (role IN ('owner', 'participant')),
+            created_at TEXT NOT NULL,
+            UNIQUE (channel_id, principal_id)
+        )
+        """,
+        "CREATE INDEX channel_memberships_principal_channel_idx ON channel_memberships (principal_id, channel_id)",
+    ),
+)
+
+_MIGRATIONS = (_INITIAL_SCHEMA, _DELIVERY_SCHEMA, _CHANNEL_MEMBERSHIP_SCHEMA)
 
 
 async def migrate_workshop_schema(

--- a/tests/test_workshop_authorization.py
+++ b/tests/test_workshop_authorization.py
@@ -1,0 +1,164 @@
+"""Contracts for canonical, explicit Workshop channel authorization."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.authorization import CanonicalChannelAuthorizer
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.domain import ChannelId, ChannelMembershipId, PrincipalId, WorkshopId
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import WorkshopEventStore
+from kai.workshop.timeline import TimelineAccessDeniedError, read_channel_timeline
+
+_NOW = datetime(2026, 8, 11, 13, 0, tzinfo=UTC)
+
+
+async def _open_store(
+    path: Path,
+) -> tuple[WorkshopEventStore, PrincipalId, ChannelId, PrincipalId, ChannelId, PrincipalId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman("Admin", "admin", "telegram", "101", "101"),
+            BootstrapHuman("Member", "member", "telegram", "202", "202"),
+        ),
+    )
+    async with store.connection.execute(
+        "SELECT e.external_subject, e.principal_id, b.channel_id "
+        "FROM external_identities e JOIN channel_bindings b "
+        "ON b.transport = e.provider AND b.external_channel_id = e.external_subject "
+        "ORDER BY e.external_subject"
+    ) as cursor:
+        rows = list(await cursor.fetchall())
+    async with store.connection.execute("SELECT id FROM principals WHERE kind = 'agent'") as cursor:
+        agent_row = await cursor.fetchone()
+    assert len(rows) == 2
+    assert agent_row is not None
+    return (
+        store,
+        PrincipalId(str(rows[0][1])),
+        ChannelId(str(rows[0][2])),
+        PrincipalId(str(rows[1][1])),
+        ChannelId(str(rows[1][2])),
+        PrincipalId(str(agent_row[0])),
+    )
+
+
+class TestCanonicalChannelAuthorizer:
+    async def test_human_can_read_own_direct_channel_only(self, tmp_path: Path):
+        store, admin_id, admin_channel, member_id, member_channel, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            authorizer = CanonicalChannelAuthorizer(store)
+
+            assert await authorizer.can_read_channel(admin_id, admin_channel) is True
+            assert await authorizer.can_read_channel(member_id, member_channel) is True
+            assert await authorizer.can_read_channel(admin_id, member_channel) is False
+            assert await authorizer.can_read_channel(member_id, admin_channel) is False
+        finally:
+            await store.close()
+
+    async def test_workshop_admin_role_does_not_grant_cross_channel_access(self, tmp_path: Path):
+        store, admin_id, _, _, member_channel, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            async with store.connection.execute(
+                "SELECT role FROM workshop_memberships WHERE principal_id = ?",
+                (admin_id,),
+            ) as cursor:
+                role = await cursor.fetchone()
+            assert role is not None and role[0] == "admin"
+
+            assert await CanonicalChannelAuthorizer(store).can_read_channel(admin_id, member_channel) is False
+        finally:
+            await store.close()
+
+    async def test_attached_agent_can_read_each_channel_it_participates_in(self, tmp_path: Path):
+        store, _, first_channel, _, second_channel, agent_id = await _open_store(tmp_path / "kai.db")
+        try:
+            authorizer = CanonicalChannelAuthorizer(store)
+
+            assert await authorizer.can_read_channel(agent_id, first_channel) is True
+            assert await authorizer.can_read_channel(agent_id, second_channel) is True
+        finally:
+            await store.close()
+
+    async def test_unknown_principal_or_channel_fails_closed(self, tmp_path: Path):
+        store, admin_id, admin_channel, _, _, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            authorizer = CanonicalChannelAuthorizer(store)
+
+            assert await authorizer.can_read_channel(PrincipalId.new(), admin_channel) is False
+            assert await authorizer.can_read_channel(admin_id, ChannelId.new()) is False
+        finally:
+            await store.close()
+
+    async def test_cross_workshop_membership_record_does_not_grant_access(self, tmp_path: Path):
+        store, admin_id, _, _, _, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            other_workshop = WorkshopId.new()
+            other_channel = ChannelId.new()
+            await store.connection.execute(
+                "INSERT INTO workshops (id, name, created_at) VALUES (?, ?, ?)",
+                (other_workshop, "Other", _NOW.isoformat()),
+            )
+            await store.connection.execute(
+                "INSERT INTO channels (id, workshop_id, kind, name, created_at) VALUES (?, ?, ?, ?, ?)",
+                (other_channel, other_workshop, "direct", "Other", _NOW.isoformat()),
+            )
+            await store.connection.execute(
+                "INSERT INTO channel_memberships (id, channel_id, principal_id, role, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (ChannelMembershipId.new(), other_channel, admin_id, "owner", _NOW.isoformat()),
+            )
+            await store.connection.commit()
+
+            assert await CanonicalChannelAuthorizer(store).can_read_channel(admin_id, other_channel) is False
+        finally:
+            await store.close()
+
+    async def test_projection_rebuild_restores_explicit_memberships(self, tmp_path: Path):
+        store, admin_id, admin_channel, member_id, member_channel, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            await store.connection.execute("DELETE FROM channel_memberships")
+            await store.connection.commit()
+
+            await store.rebuild_projection(CanonicalConversationProjection())
+            authorizer = CanonicalChannelAuthorizer(store)
+
+            assert await authorizer.can_read_channel(admin_id, admin_channel) is True
+            assert await authorizer.can_read_channel(member_id, member_channel) is True
+            assert await authorizer.can_read_channel(admin_id, member_channel) is False
+        finally:
+            await store.close()
+
+    async def test_timeline_uses_concrete_channel_policy(self, tmp_path: Path):
+        store, admin_id, admin_channel, member_id, _, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            await record_inbound_message(
+                store,
+                InboundMessage("telegram", "9001", "42", "101", "101", "Private", _NOW),
+            )
+            authorizer = CanonicalChannelAuthorizer(store)
+
+            own_page = await read_channel_timeline(
+                store,
+                principal_id=admin_id,
+                channel_id=admin_channel,
+                authorizer=authorizer,
+            )
+            assert [message.body for message in own_page.messages] == ["Private"]
+
+            with pytest.raises(TimelineAccessDeniedError):
+                await read_channel_timeline(
+                    store,
+                    principal_id=member_id,
+                    channel_id=admin_channel,
+                    authorizer=authorizer,
+                )
+        finally:
+            await store.close()

--- a/tests/test_workshop_bootstrap.py
+++ b/tests/test_workshop_bootstrap.py
@@ -66,7 +66,7 @@ class TestDefaultWorkshopBootstrap:
             [_human(202, "Second"), _human(101, "Admin", role="admin")],
         )
 
-        assert result.created_events == 16
+        assert result.created_events == 20
         assert result.existing_events == 0
         assert result.human_count == 2
         assert result.channel_count == 2
@@ -90,6 +90,11 @@ class TestDefaultWorkshopBootstrap:
             bindings = await cursor.fetchall()
         async with connection.execute("SELECT COUNT(*) FROM channel_agents") as cursor:
             channel_agent_count = (await cursor.fetchone())[0]
+        async with connection.execute(
+            "SELECT p.kind, cm.role, COUNT(*) FROM channel_memberships cm "
+            "JOIN principals p ON p.id = cm.principal_id GROUP BY p.kind, cm.role ORDER BY p.kind"
+        ) as cursor:
+            channel_memberships = [tuple(row) for row in await cursor.fetchall()]
 
         assert len(workshops) == 1
         assert workshops[0][1] == "Kai Workshop"
@@ -104,6 +109,7 @@ class TestDefaultWorkshopBootstrap:
         assert all(row[1] == "direct" for row in channels)
         assert [(row[0], row[1]) for row in bindings] == [("telegram", "101"), ("telegram", "202")]
         assert channel_agent_count == 2
+        assert channel_memberships == [("agent", "participant", 2), ("human", "owner", 2)]
 
     async def test_human_principal_and_conversation_have_distinct_ids(self, store):
         await bootstrap_default_workshop(store, [_human(101, "Admin", role="admin")])
@@ -128,9 +134,9 @@ class TestDefaultWorkshopBootstrap:
         second = await bootstrap_default_workshop(store, [_human(101, "Admin", role="admin")])
         second_events = await store.read_events()
 
-        assert first.created_events == 10
+        assert first.created_events == 12
         assert second.created_events == 0
-        assert second.existing_events == 10
+        assert second.existing_events == 12
         assert second.workshop_id == first.workshop_id
         assert second.agent_id == first.agent_id
         assert second_events == first_events
@@ -167,11 +173,30 @@ class TestDefaultWorkshopBootstrap:
             [_human(101, "Admin", role="admin"), _human(202, "Second")],
         )
 
-        assert result.created_events == 6
-        assert result.existing_events == 10
+        assert result.created_events == 8
+        assert result.existing_events == 12
         assert result.human_count == 2
         assert result.channel_count == 2
-        assert len(await store.read_events()) == 16
+        assert len(await store.read_events()) == 20
+
+    async def test_existing_bootstrap_receives_missing_channel_memberships(self, store):
+        await bootstrap_default_workshop(
+            store,
+            [_human(101, "Admin", role="admin"), _human(202, "Second")],
+        )
+        await store.connection.execute("DELETE FROM channel_memberships")
+        await store.connection.execute("DELETE FROM event_log WHERE event_type = 'channel.member_added'")
+        await store.connection.commit()
+
+        result = await bootstrap_default_workshop(
+            store,
+            [_human(101, "Admin", role="admin"), _human(202, "Second")],
+        )
+
+        assert result.created_events == 4
+        assert result.existing_events == 16
+        async with store.connection.execute("SELECT COUNT(*) FROM channel_memberships") as cursor:
+            assert (await cursor.fetchone())[0] == 4
 
     async def test_duplicate_external_identity_or_channel_is_rejected(self, store):
         with pytest.raises(ValueError, match="Duplicate bootstrap external identity"):
@@ -239,7 +264,8 @@ class TestWorkshopBootstrapStatus:
         status = workshop_bootstrap_status(db_path, expected_humans=1)
 
         assert status == (
-            "Workshop bootstrap: initialized; workshops=1, humans=1, Telegram bindings=1, agents=1; expected humans=1"
+            "Workshop bootstrap: initialized; workshops=1, humans=1, Telegram bindings=1, "
+            "channel memberships=2, agents=1; expected humans=1"
         )
         assert "Secret Name" not in status
         assert "101" not in status

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -13,6 +13,7 @@ import pytest
 from kai.workshop.domain import (
     AgentId,
     ChannelId,
+    ChannelMembershipId,
     DeliveryId,
     EventEnvelope,
     EventId,
@@ -62,6 +63,7 @@ class TestWorkshopIdentifiers:
             (WorkshopId, "prn_00000000000000000000000000000001"),
             (PrincipalId, "principal-1"),
             (ChannelId, "chn_not-hex"),
+            (ChannelMembershipId, "cag_00000000000000000000000000000001"),
             (AgentId, ""),
             (MessageId, "msg_0000000000000000000000000000000"),
             (DeliveryId, "msg_00000000000000000000000000000001"),
@@ -81,6 +83,7 @@ class TestEventEnvelope:
             "principal.created",
             "external_identity.bound",
             "channel.created",
+            "channel.member_added",
             "transport.channel_bound",
             "agent.created",
             "channel.agent_attached",
@@ -145,6 +148,7 @@ class TestWorkshopSchema:
             "external_identities",
             "workshop_memberships",
             "channels",
+            "channel_memberships",
             "channel_bindings",
             "agents",
             "channel_agents",
@@ -155,7 +159,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 2
+        assert await workshop_store.schema_version() == 3
 
     async def test_schema_migration_is_idempotent(self, tmp_path: Path):
         path = tmp_path / "workshop.db"
@@ -163,7 +167,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 2
+        assert await second.schema_version() == 3
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -184,12 +188,37 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 2
-            assert "deliveries" in await upgraded.schema_tables()
+            assert await upgraded.schema_version() == 3
+            assert {"deliveries", "channel_memberships"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT version FROM workshop_schema_migrations ORDER BY version"
             ) as cursor:
-                assert [row[0] for row in await cursor.fetchall()] == [1, 2]
+                assert [row[0] for row in await cursor.fetchall()] == [1, 2, 3]
+        finally:
+            await upgraded.close()
+
+    async def test_version_two_database_upgrades_without_replacing_existing_records(self, tmp_path: Path, monkeypatch):
+        from kai.workshop import schema
+
+        path = tmp_path / "workshop.db"
+        with monkeypatch.context() as migration_context:
+            migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 2)
+            migration_context.setattr(schema, "_MIGRATIONS", (schema._INITIAL_SCHEMA, schema._DELIVERY_SCHEMA))
+            version_two = await WorkshopEventStore.open(path)
+            workshop_id = WorkshopId.new()
+            await version_two.connection.execute(
+                "INSERT INTO workshops (id, name, created_at) VALUES (?, ?, ?)",
+                (workshop_id, "Existing", "2026-08-11T12:00:00Z"),
+            )
+            await version_two.connection.commit()
+            await version_two.close()
+
+        upgraded = await WorkshopEventStore.open(path)
+        try:
+            assert await upgraded.schema_version() == 3
+            assert "channel_memberships" in await upgraded.schema_tables()
+            async with upgraded.connection.execute("SELECT name FROM workshops WHERE id = ?", (workshop_id,)) as cursor:
+                assert (await cursor.fetchone())[0] == "Existing"
         finally:
             await upgraded.close()
 

--- a/tests/test_workshop_parity.py
+++ b/tests/test_workshop_parity.py
@@ -167,6 +167,48 @@ class TestWorkshopMessageParityStatus:
         assert "101" not in status
         assert "202" not in status
 
+    async def test_channel_authorization_projection_drift_is_reported(self, tmp_path: Path):
+        db_path = tmp_path / "kai.db"
+        history_root = tmp_path / "history"
+        await _build_conversation(db_path)
+        _write_history(
+            history_root,
+            [_record("user", "Secret question", seconds=0), _record("assistant", "Secret answer", seconds=2)],
+        )
+        store = await WorkshopEventStore.open(db_path)
+        try:
+            await store.connection.execute("DELETE FROM channel_memberships WHERE role = 'owner'")
+            await store.connection.commit()
+        finally:
+            await store.close()
+
+        status = workshop_message_parity_status(db_path, history_root)
+
+        assert "parity: diverged" in status
+        assert "replay mismatches=1" in status
+        assert "Secret" not in status
+
+    async def test_workshop_membership_projection_drift_is_reported(self, tmp_path: Path):
+        db_path = tmp_path / "kai.db"
+        history_root = tmp_path / "history"
+        await _build_conversation(db_path)
+        _write_history(
+            history_root,
+            [_record("user", "Secret question", seconds=0), _record("assistant", "Secret answer", seconds=2)],
+        )
+        store = await WorkshopEventStore.open(db_path)
+        try:
+            await store.connection.execute("DELETE FROM workshop_memberships WHERE role = 'admin'")
+            await store.connection.commit()
+        finally:
+            await store.close()
+
+        status = workshop_message_parity_status(db_path, history_root)
+
+        assert "parity: diverged" in status
+        assert "replay mismatches=1" in status
+        assert "Secret" not in status
+
     async def test_missing_jsonl_record_is_reported(self, tmp_path: Path):
         db_path = tmp_path / "kai.db"
         history_root = tmp_path / "history"


### PR DESCRIPTION
## Summary

- add explicit, event-sourced channel memberships with typed opaque identifiers
- add additive Workshop schema migration v3 and projection version 3
- deterministically bootstrap each direct-channel human as owner and the attached Kai agent as participant
- add a concrete channel authorizer for the canonical timeline reader
- extend non-secret parity diagnostics to detect channel and workshop membership projection drift

## Authorization model

Read access requires both:

1. an explicit principal membership in the requested channel
2. membership by that principal in the same Workshop that owns the channel

Workshop roles do not imply channel access. In particular, an admin in the default Workshop cannot read another human direct channel without an explicit membership. Unknown principals, unknown channels, and malformed cross-Workshop membership rows fail closed.

## Existing-install migration

- schema migration is additive and preserves existing records
- service bootstrap appends only missing channel membership events
- a two-human v2 installation gains four deterministic events: one human and one agent membership per direct channel
- projection replay reconstructs the same grants after restart

## Compatibility and authority

- the timeline reader remains unused by production
- no HTTP or diagnostic read endpoint is exposed
- Telegram routing and responses are unchanged
- JSONL remains transcript authority
- direct Telegram delivery remains delivery authority
- backend configuration and execution are unchanged

## Verification

- 5066 passed, 1 skipped
- 115 focused Workshop tests passed
- Ruff lint and format checks passed
- Pyright passed with zero errors
- module-size check passed