### PR TITLE
Keep protected user provisioning install-owned

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -55,8 +55,7 @@ from kai.backend import (
     assemble_turn_context,
     build_foreign_workspace_reminder,
     build_session_context,
-    ensure_user_memory,
-    ensure_user_preferences,
+    ensure_user_context_files,
     sanitize_agent_environment,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
@@ -1208,18 +1207,17 @@ class AcpBackend(AgentBackend):
         # session_context, semantic memory, workspace reminder stacked
         # above).
         #
-        # The ensure_user_memory / ensure_user_preferences calls below
-        # run exactly once per session because _fresh_session flips to
-        # False unconditionally. A transient OSError inside either
-        # helper is logged as a warning but not retried on subsequent
-        # messages of the same session. Failure modes are persistent
-        # (permissions, missing parent dir), not transient, so the
-        # one-shot behavior is acceptable.
+        # Development/single-user lazy bootstrap runs once per session.
+        # Protected installs skip service-side file mutation here because
+        # make install has already provisioned the user-owned files.
         session_ctx = ""
         if self._fresh_session:
             self._fresh_session = False
-            ensure_user_memory(chat_id, DATA_DIR)
-            ensure_user_preferences(chat_id, DATA_DIR)
+            ensure_user_context_files(
+                chat_id,
+                DATA_DIR,
+                defer_user_file_reads=self.defer_user_file_reads,
+            )
             session_ctx = build_session_context(
                 workspace=self.workspace,
                 home_workspace=self.home_workspace,

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -750,17 +750,38 @@ def ensure_user_preferences(chat_id: int | None, data_dir: Path) -> None:
         )
 
 
+def ensure_user_context_files(
+    chat_id: int | None,
+    data_dir: Path,
+    *,
+    defer_user_file_reads: bool = False,
+) -> None:
+    """Prepare writable memory/preferences files for an agent session.
+
+    ``defer_user_file_reads`` identifies the protected-install handoff: the
+    outer service must neither read nor mutate the target OS user's private
+    files. Those files are provisioned with the correct ownership by
+    ``make install`` and are consumed later by the user-owned backend process.
+
+    Development and single-user runs retain the historical lazy bootstrap.
+    """
+    if defer_user_file_reads:
+        return
+    ensure_user_memory(chat_id, data_dir)
+    ensure_user_preferences(chat_id, data_dir)
+
+
 def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     """
     Lazily create the per-user home workspace directory.
 
     Returns the path that should be used as the user's home workspace
     when users.yaml does not set an explicit home_workspace override.
-    Idempotent and cheap: a stat and a possible mkdir. Called on every
-    session init (and on `/workspace home`) so that any user without a
-    pre-created `home/<chat_id>/` - single-user dev, test runs, or a
-    user added to users.yaml after install - still lands in a valid
-    directory on their first message.
+    Idempotent and cheap: a stat and a possible mkdir. Used by development
+    and single-user session initialization so a user without a pre-created
+    `home/<chat_id>/` still lands in a valid directory on first message.
+    Protected installs do not call this helper at runtime; their per-user
+    directories are provisioned by ``make install`` under the target owner.
 
     This is the companion to ensure_user_memory() above. Same scope
     caveats apply (copied verbatim because the multi-user ownership
@@ -915,12 +936,11 @@ def resolve_home_workspace(
     Resolution order:
     1. `user.home_workspace` from users.yaml when set (admin override,
        returned as-is with no second-guessing).
-    2. `<data_dir>/home/<chat_id>/`, auto-created via ensure_user_home()
-       for interactive users. For notification-only chat_ids (a chat
-       that received a routed notification but has no users.yaml
-       entry of its own) the path is returned without bootstrapping,
-       so the bot does not silently provision an empty home directory
-       for a chat that will never have an interactive session.
+    2. `<data_dir>/home/<chat_id>/`. Development and single-user runs lazily
+       create it via ensure_user_home(). Protected installs require it to have
+       been provisioned by ``make install``. For notification-only chat_ids (a
+       chat that received a routed notification but has no users.yaml entry of
+       its own) the path is returned without bootstrapping.
 
     All call sites (pool.py session init / get_workspace fallback,
     bot.py `/workspace home` handler and workspace listings) MUST go
@@ -971,9 +991,21 @@ def resolve_home_workspace(
     if _is_notification_only_chat_id(chat_id, config):
         return data_dir / "home" / str(chat_id)
 
-    # Interactive user: use the per-user Kai-managed directory under
-    # data_dir. ensure_user_home is idempotent so calling it on every
-    # resolution is cheap.
+    # A protected install has a separate service identity and backend OS
+    # identity. Runtime must not lazily create this directory as the service
+    # user: doing so produces the wrong owner and defeats the private 0700
+    # boundary. The installer is the authoritative provisioning step.
+    if chat_id is not None and getattr(config, "protected_install", False) is True:
+        path = data_dir / "home" / str(chat_id)
+        if not path.is_dir():
+            raise RuntimeError(
+                f"Protected user home is not provisioned for chat_id {chat_id}: "
+                f"{path}. Run `make install` to provision configured users."
+            )
+        return path
+
+    # Development / single-user path: use the per-user Kai-managed directory
+    # under data_dir. ensure_user_home supplies the historical lazy bootstrap.
     return ensure_user_home(chat_id, data_dir)
 
 

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -37,8 +37,7 @@ from kai.backend import (
     assemble_turn_context,
     build_foreign_workspace_reminder,
     build_session_context,
-    ensure_user_memory,
-    ensure_user_preferences,
+    ensure_user_context_files,
     sanitize_agent_environment,
 )
 from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
@@ -747,21 +746,17 @@ class ClaudeCodeBackend(AgentBackend):
         # the lifecycle into it would couple the helper to per-
         # backend internals it has no other reason to know about.
         #
-        # The single-call MEMORY.md/PREFERENCES.md bootstrap retry
-        # caveat from before extraction still applies: the seed runs
-        # exactly once per session because `_fresh_session` flips to
-        # False unconditionally; a transient OSError inside
-        # `ensure_user_memory` / `ensure_user_preferences` is logged
-        # as a warning but not retried on subsequent messages of the
-        # same session. Failure modes here are persistent
-        # (permissions, missing parent dir), not transient, so the
-        # one-shot behavior is acceptable; documenting it so future
-        # readers do not assume self-healing.
+        # Development/single-user lazy bootstrap runs once per session.
+        # Protected installs skip service-side file mutation here because
+        # make install has already provisioned the user-owned files.
         session_ctx = ""
         if self._fresh_session:
             self._fresh_session = False
-            ensure_user_memory(chat_id, DATA_DIR)
-            ensure_user_preferences(chat_id, DATA_DIR)
+            ensure_user_context_files(
+                chat_id,
+                DATA_DIR,
+                defer_user_file_reads=self.defer_user_file_reads,
+            )
             session_ctx = build_session_context(
                 workspace=self.workspace,
                 home_workspace=self.home_workspace,

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -62,8 +62,7 @@ from kai.backend import (
     assemble_turn_context,
     build_foreign_workspace_reminder,
     build_session_context,
-    ensure_user_memory,
-    ensure_user_preferences,
+    ensure_user_context_files,
     sanitize_agent_environment,
 )
 from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
@@ -809,8 +808,11 @@ class CodexBackend(AgentBackend):
         session_ctx = ""
         if self._fresh_session:
             self._fresh_session = False
-            ensure_user_memory(chat_id, DATA_DIR)
-            ensure_user_preferences(chat_id, DATA_DIR)
+            ensure_user_context_files(
+                chat_id,
+                DATA_DIR,
+                defer_user_file_reads=self.defer_user_file_reads,
+            )
             session_ctx = build_session_context(
                 workspace=self.workspace,
                 home_workspace=self.home_workspace,

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -20,8 +20,7 @@ from kai.backend import (
     assemble_turn_context,
     build_foreign_workspace_reminder,
     build_session_context,
-    ensure_user_memory,
-    ensure_user_preferences,
+    ensure_user_context_files,
     sanitize_agent_environment,
 )
 from kai.backend_registry import resolve_backend_command
@@ -345,8 +344,11 @@ class PiBackend(AgentBackend):
         session_context = ""
         if self._fresh_session:
             self._fresh_session = False
-            ensure_user_memory(chat_id, DATA_DIR)
-            ensure_user_preferences(chat_id, DATA_DIR)
+            ensure_user_context_files(
+                chat_id,
+                DATA_DIR,
+                defer_user_file_reads=self.defer_user_file_reads,
+            )
             session_context = build_session_context(
                 workspace=self.workspace,
                 home_workspace=self.home_workspace,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -13,6 +13,8 @@ import stat
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from kai.agent_failure import AgentFailureKind
 from kai.backend import (
     AgentResponse,
@@ -20,6 +22,7 @@ from kai.backend import (
     StreamEvent,
     build_foreign_workspace_reminder,
     build_session_context,
+    ensure_user_context_files,
     ensure_user_home,
     ensure_user_memory,
     ensure_user_preferences,
@@ -936,6 +939,36 @@ class TestEnsureUserHome:
         assert not (result / ".claude" / "CLAUDE.md").exists()
 
 
+class TestEnsureUserContextFiles:
+    """Protected installs never touch user-owned context files in the daemon."""
+
+    def test_protected_handoff_skips_all_lazy_bootstrap(self, tmp_path):
+        with (
+            patch("kai.backend.ensure_user_memory") as ensure_memory,
+            patch("kai.backend.ensure_user_preferences") as ensure_preferences,
+        ):
+            ensure_user_context_files(
+                42,
+                tmp_path,
+                defer_user_file_reads=True,
+            )
+
+        ensure_memory.assert_not_called()
+        ensure_preferences.assert_not_called()
+        assert not (tmp_path / "memory").exists()
+        assert not (tmp_path / "preferences").exists()
+
+    def test_development_path_retains_lazy_bootstrap(self, tmp_path):
+        with (
+            patch("kai.backend.ensure_user_memory") as ensure_memory,
+            patch("kai.backend.ensure_user_preferences") as ensure_preferences,
+        ):
+            ensure_user_context_files(42, tmp_path)
+
+        ensure_memory.assert_called_once_with(42, tmp_path)
+        ensure_preferences.assert_called_once_with(42, tmp_path)
+
+
 class TestResolveHomeWorkspace:
     """
     Tests for the public resolver used by pool.py and bot.py.
@@ -945,7 +978,12 @@ class TestResolveHomeWorkspace:
     answer cannot drift between session init and `/workspace home`.
     """
 
-    def _config(self, user_configs: dict | None = None) -> Config:
+    def _config(
+        self,
+        user_configs: dict | None = None,
+        *,
+        protected_install: bool = False,
+    ) -> Config:
         """Build a minimal Config with optional user_configs dict.
 
         Post-#565 tranche A `Config.user_configs` is a non-optional
@@ -956,6 +994,7 @@ class TestResolveHomeWorkspace:
             telegram_bot_token="test",
             allowed_user_ids={1},
             user_configs=user_configs if user_configs is not None else {},
+            protected_install=protected_install,
         )
 
     def test_prefers_users_yaml(self, tmp_path):
@@ -991,6 +1030,35 @@ class TestResolveHomeWorkspace:
         result = resolve_home_workspace(42, config, data_dir=tmp_path)
         assert result == tmp_path / "home" / "42"
         assert result.is_dir()
+
+    def test_protected_install_uses_preprovisioned_home_without_mutation(self, tmp_path):
+        config = self._config(
+            user_configs={42: UserConfig(telegram_id=42, name="real-user", os_user="alice")},
+            protected_install=True,
+        )
+        home = tmp_path / "home" / "42"
+        home.mkdir(parents=True)
+
+        with patch("kai.backend.ensure_user_home") as ensure_home:
+            result = resolve_home_workspace(42, config, data_dir=tmp_path)
+
+        assert result == home
+        ensure_home.assert_not_called()
+
+    def test_protected_install_requires_install_provisioning(self, tmp_path):
+        config = self._config(
+            user_configs={42: UserConfig(telegram_id=42, name="real-user", os_user="alice")},
+            protected_install=True,
+        )
+
+        with (
+            patch("kai.backend.ensure_user_home") as ensure_home,
+            pytest.raises(RuntimeError, match=r"Run `make install`"),
+        ):
+            resolve_home_workspace(42, config, data_dir=tmp_path)
+
+        ensure_home.assert_not_called()
+        assert not (tmp_path / "home" / "42").exists()
 
     def test_anon_when_chat_id_none(self, tmp_path):
         """

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -206,8 +206,7 @@ class TestPiStartup:
 class TestPiTurns:
     @pytest.fixture(autouse=True)
     def no_context_io(self, monkeypatch):
-        monkeypatch.setattr("kai.pi.ensure_user_memory", lambda *a, **kw: None)
-        monkeypatch.setattr("kai.pi.ensure_user_preferences", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.pi.ensure_user_context_files", lambda *a, **kw: None)
         monkeypatch.setattr("kai.pi.build_session_context", lambda **kw: "")
         monkeypatch.setattr("kai.pi.build_foreign_workspace_reminder", lambda *a, **kw: None)
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -476,7 +476,7 @@ class TestPerUserBackendRouting:
             assert isinstance(instance, expected_type)
             assert instance.max_session_hours == 6.5
 
-    def test_protected_install_defers_user_file_reads_for_all_backends(self):
+    def test_protected_install_defers_user_file_reads_for_all_backends(self, tmp_path):
         """Protected installs stop backend context from reading user files in the daemon."""
         from kai.claude import ClaudeCodeBackend
         from kai.codex import CodexBackend
@@ -496,6 +496,8 @@ class TestPerUserBackendRouting:
                 model="anthropic/claude-sonnet-4-6",
             ),
         }
+        for chat_id in users:
+            (tmp_path / "home" / str(chat_id)).mkdir(parents=True)
         config = _make_config(protected_install=True, user_configs=users)
         pool = SubprocessPool(config=config, services_info=[])
         for chat_id, expected_type in [


### PR DESCRIPTION
## Summary\n\n- stop the outer Kai service from lazily creating or modifying per-user home, memory, and preference files in protected installs\n- require make install to have provisioned each configured interactive user home, with an actionable error if it has not\n- preserve the existing lazy bootstrap behavior for development and single-user runs\n- apply the protected handoff consistently across Claude, Codex, Goose, OpenCode, and Pi\n\n## Why\n\nProtected per-user directories are owned by each backend OS user and mode 0700. The service process should not probe or mutate their contents. The old lazy bootstrap produced repeated permission warnings and could create a newly configured user directory under the wrong owner before the next install.\n\n## Verification\n\n- make check\n- 558 shared backend and pool tests\n- full suite: 5095 passed, 1 skipped\n\n## Follow-up\n\nBackend-native identity instruction files are intentionally a separate bounded change: Claude will use CLAUDE.md; Codex, Goose, OpenCode, and Pi will use AGENTS.md.