### PR TITLE
Canonicalize managed identity across backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ make install-status
 
 Protected mode requires every Telegram user to have a unique `os_user` that differs from the Kai service account; this keeps persistent agents from inheriting the daemon's protected-config capabilities. Single-user mode runs the agent as the operator account.
 
+Kai-managed per-user identity has one editable source: `<DATA_DIR>/home/<chat_id>/AGENTS.md`. Codex, Goose, OpenCode, and Pi consume that file directly. Claude Code receives a generated `.claude/CLAUDE.md` adapter containing only `@../AGENTS.md`. On upgrade, `make install` migrates existing customized Claude identity content into `AGENTS.md`; if both files contain different customizations, installation stops without choosing or overwriting either one. Instruction files owned by individual project repositories remain independent.
+
 Protected Linux installations that use Codex image input also require `setfacl` (normally provided by the distribution's `acl` package). Kai uses a read-only named ACL so an image can remain private to the service and its intended `os_user`; if ACL support is unavailable, that image is dropped with a user-visible notice instead of being made world-readable.
 
 For full installation details, see [Getting Started](https://github.com/dcellison/kai/wiki/Getting-Started), [Multi-User Setup](https://github.com/dcellison/kai/wiki/Multi-User-Setup), and [System Architecture](https://github.com/dcellison/kai/wiki/System-Architecture).

--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -737,7 +737,7 @@ class AcpBackend(AgentBackend):
         self._next_id: int = 1
         self._lock = asyncio.Lock()  # Serializes all message sends
         # True until the first send() finishes; first-message context
-        # (CLAUDE.md / PREFERENCES.md / session_context) is injected
+        # (AGENTS.md / PREFERENCES.md / session_context) is injected
         # exactly once per session.
         self._fresh_session: bool = True
         self._stderr_task: asyncio.Task | None = None
@@ -1225,6 +1225,7 @@ class AcpBackend(AgentBackend):
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
                 data_dir=DATA_DIR,
+                backend_name=self.backend_name,
                 memory_enabled=self.memory_enabled,
                 defer_user_file_reads=self.defer_user_file_reads,
             )

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -17,6 +17,7 @@ prompt assembly that is identical across all backends.
 import logging
 import os
 import shutil
+import tempfile
 import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
@@ -31,6 +32,7 @@ from kai.config import (
     Config,
     WorkspaceConfig,
     canonicalize_model_for_backend,
+    get_user_backend_and_provider,
     validate_model_for_backend,
 )
 from kai.history import get_recent_history
@@ -40,6 +42,7 @@ log = logging.getLogger(__name__)
 _PRIVATE_USER_ROOT_MODE = 0o711
 _PRIVATE_USER_DIR_MODE = 0o700
 _PRIVATE_USER_FILE_MODE = 0o600
+_CLAUDE_IDENTITY_ADAPTER = "@../AGENTS.md\n"
 
 
 def _chmod_private_user_root(path: Path) -> None:
@@ -358,6 +361,7 @@ def build_session_context(
     workspace_config: WorkspaceConfig | None,
     chat_id: int | None,
     data_dir: Path,
+    backend_name: str | None = None,
     memory_enabled: bool = False,
     defer_user_file_reads: bool = False,
 ) -> str:
@@ -377,6 +381,9 @@ def build_session_context(
         workspace_config: Per-workspace config (for system_prompt).
         chat_id: Telegram chat ID for history scoping and API routing.
         data_dir: Root data directory (memory, history, files live here).
+        backend_name: Canonical backend identifier used to validate explicit
+            identity routing. Required whenever the active workspace differs
+            from the home workspace.
         memory_enabled: Operator-intent flag (Config.memory_enabled).
             Drives the memory subsystem marker emission and gates
             MEMORY.md injection. Reflects intent, not runtime success;
@@ -397,7 +404,16 @@ def build_session_context(
     # and read_text()) and permission errors, matching the pattern
     # in get_workspace_system_prompt().
     if workspace != home_workspace:
-        identity_path = home_workspace / ".claude" / "CLAUDE.md"
+        if backend_name is None:
+            raise ValueError("backend_name is required for foreign-workspace identity routing")
+        if backend_name not in VALID_BACKENDS:
+            raise ValueError(f"Unknown backend for identity routing: {backend_name!r}")
+        # AGENTS.md is the canonical content source for every backend. Claude's
+        # native home-workspace surface is a thin import adapter, but injecting
+        # that literal adapter text into a foreign-workspace prompt would not
+        # cause Claude's file loader to expand it. Read (or ask the isolated
+        # subprocess to read) the canonical source directly here.
+        identity_path = home_workspace / "AGENTS.md"
         if defer_user_file_reads:
             parts.append(
                 "[Your core identity and instructions are stored at "
@@ -418,7 +434,7 @@ def build_session_context(
     # startup, the marker still says "enabled" so write attempts
     # surface the failure as 503s rather than silently re-routing to
     # MEMORY.md. Always emit (per-deployment, not per-user) so the
-    # routing rule in CLAUDE.md / PREFERENCES.md can branch on a
+    # routing rule in AGENTS.md / PREFERENCES.md can branch on a
     # uniformly-present signal.
     mode = "enabled" if memory_enabled else "disabled"
     parts.append(f"[Memory subsystem: {mode}]")
@@ -771,7 +787,76 @@ def ensure_user_context_files(
     ensure_user_preferences(chat_id, data_dir)
 
 
-def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
+def _write_private_text_atomic(path: Path, content: str) -> None:
+    """Atomically replace a private user file without a partial-write window."""
+    path.parent.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        os.chmod(temp_path, _PRIVATE_USER_FILE_MODE)
+        temp_path.replace(path)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _ensure_development_identity_files(home: Path, backend_name: str) -> None:
+    """Seed the canonical identity and the selected backend's adapter.
+
+    Protected installations use the stricter installer migration instead.
+    This helper preserves the historical lazy bootstrap for development and
+    single-user runs while retaining the same one-source identity contract.
+    """
+    if backend_name not in VALID_BACKENDS:
+        raise ValueError(f"Unknown backend for identity provisioning: {backend_name!r}")
+
+    agents_dst = home / "AGENTS.md"
+    claude_dir = home / ".claude"
+    claude_dst = claude_dir / "CLAUDE.md"
+    template = PROJECT_ROOT / "templates" / "AGENTS.md"
+
+    if claude_dir.is_symlink():
+        raise RuntimeError(f"Refusing symlinked Kai identity directory: {claude_dir}")
+    if claude_dir.exists() and not claude_dir.is_dir():
+        raise RuntimeError(f"Kai Claude identity path is not a directory: {claude_dir}")
+    if agents_dst.is_symlink() or claude_dst.is_symlink():
+        raise RuntimeError(f"Refusing symlinked Kai identity surface under {home}")
+    if agents_dst.exists() and not agents_dst.is_file():
+        raise RuntimeError(f"Kai identity path is not a regular file: {agents_dst}")
+    if claude_dst.exists() and not claude_dst.is_file():
+        raise RuntimeError(f"Kai Claude adapter path is not a regular file: {claude_dst}")
+
+    claude_content = claude_dst.read_text() if claude_dst.is_file() else None
+    if not agents_dst.exists():
+        if claude_content is not None:
+            if claude_content == _CLAUDE_IDENTITY_ADAPTER:
+                raise RuntimeError(f"Claude identity adapter exists but canonical identity is missing: {agents_dst}")
+            _write_private_text_atomic(agents_dst, claude_content)
+        elif template.is_file():
+            shutil.copy2(template, agents_dst)
+            _chmod_private_user_file(agents_dst)
+        else:
+            _write_private_text_atomic(agents_dst, "# Identity\n")
+
+    agents_content = agents_dst.read_text()
+    if claude_content not in (None, _CLAUDE_IDENTITY_ADAPTER, agents_content):
+        raise RuntimeError(
+            f"Conflicting customized identity files: {agents_dst} and {claude_dst}. Reconcile them before continuing."
+        )
+    if backend_name == "claude":
+        claude_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
+        _chmod_private_user_dir(claude_dir)
+        if claude_content != _CLAUDE_IDENTITY_ADAPTER:
+            _write_private_text_atomic(claude_dst, _CLAUDE_IDENTITY_ADAPTER)
+    elif claude_content in (_CLAUDE_IDENTITY_ADAPTER, agents_content):
+        claude_dst.unlink(missing_ok=True)
+
+    _chmod_private_user_file(agents_dst)
+
+
+def ensure_user_home(chat_id: int | None, data_dir: Path, *, backend_name: str) -> Path:
     """
     Lazily create the per-user home workspace directory.
 
@@ -814,17 +899,10 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     os_user entries added after install still require a reinstall so
     install.py can apply the correct ownership.
 
-    Like ensure_user_memory and ensure_user_preferences, this seeds
-    `<home>/.claude/CLAUDE.md` from `templates/.claude/CLAUDE.md` when
-    the file is absent. Without that seed, a user added to users.yaml
-    AFTER install (or any dev / single-user path without an install
-    pass) gets an empty home workspace and the bot's identity-injection
-    path in `build_session_context` silently fails on the missing file -
-    the gap PR #449 inadvertently exposed and #450 reverted. The
-    install-time eager pass in `install.py:_apply_migrate` covers
-    users present in users.yaml at install time so their CLAUDE.md
-    lands with the right per-user ownership; this lazy fallback
-    bootstraps anyone else on their first message.
+    The lazy path also seeds the canonical `AGENTS.md`. Claude receives a
+    `.claude/CLAUDE.md` adapter importing that file; other backends use
+    `AGENTS.md` directly. Existing customized CLAUDE.md content is migrated
+    into AGENTS.md before the adapter is written.
     """
     # chat_id of None means we have no real Telegram session to key on
     # (test runs, health checks, smoke runs without users.yaml). Use a
@@ -864,34 +942,13 @@ def ensure_user_home(chat_id: int | None, data_dir: Path) -> Path:
     except PermissionError:
         pass
 
-    # Lazy bootstrap of `<home>/.claude/CLAUDE.md`. Parallel to
-    # ensure_user_memory and ensure_user_preferences: stat, possible
-    # mkdir, possible copy2. The OSError swallow matches the sibling
-    # bootstraps - a permissions issue here must not prevent the bot
-    # from answering a message. The read path in
-    # build_session_context already handles missing files gracefully,
-    # so a failed seed degrades to the silent-no-identity behavior we
-    # had before #447 rather than crashing the session.
+    # Lazy identity bootstrap. Protected installs never reach this path;
+    # install.py owns their migration and per-user ownership reconciliation.
     try:
-        claude_dir = path / ".claude"
-        claude_dst = claude_dir / "CLAUDE.md"
-        if not claude_dst.exists():
-            claude_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
-            _chmod_private_user_dir(claude_dir)
-            template = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
-            if template.is_file():
-                shutil.copy2(template, claude_dst)
-            else:
-                # No template on this host (incomplete install tree).
-                # Match ensure_user_memory's `# Memory\n` /
-                # ensure_user_preferences' `# Preferences\n` last-resort
-                # placeholder so the inner agent has a writable file.
-                claude_dst.write_text("# Identity\n")
-        _chmod_private_user_dir(claude_dir)
-        _chmod_private_user_file(claude_dst)
+        _ensure_development_identity_files(path, backend_name)
     except OSError:
         log.warning(
-            "ensure_user_home: could not seed CLAUDE.md at %s",
+            "ensure_user_home: could not seed backend identity at %s",
             path,
             exc_info=True,
         )
@@ -1005,8 +1062,10 @@ def resolve_home_workspace(
         return path
 
     # Development / single-user path: use the per-user Kai-managed directory
-    # under data_dir. ensure_user_home supplies the historical lazy bootstrap.
-    return ensure_user_home(chat_id, data_dir)
+    # under data_dir. The effective backend selects the native identity surface
+    # without assigning priority to any backend.
+    backend_name, _provider = get_user_backend_and_provider(user, config)
+    return ensure_user_home(chat_id, data_dir, backend_name=backend_name)
 
 
 def build_foreign_workspace_reminder(workspace: Path, home_workspace: Path) -> str | None:
@@ -1076,7 +1135,7 @@ def extract_text_query(prompt: str | list) -> str:
     The memory retrieval query MUST come from the raw user message, not
     from the prompt after session context, memory recall, or reminder
     blocks have been prepended. On a fresh session the prepended
-    CLAUDE.md, MEMORY.md, history, and API docs reach ~10-20KB; if any
+    AGENTS.md, MEMORY.md, history, and API docs reach ~10-20KB; if any
     of that ends up in the embedding query, the first message's memory
     retrieval is essentially random and the user-visible behavior is
     "Kai never remembers anything on the first turn of a new session."
@@ -1115,7 +1174,7 @@ async def assemble_turn_context(
     Backend-neutral assembly of the per-turn prompt around a single
     user message. Captures the original user text as the memory
     search query BEFORE any context is prepended (so the embedding
-    vector is not polluted by injected CLAUDE.md / history / API docs
+    vector is not polluted by injected AGENTS.md / history / API docs
     on fresh sessions), then layers prefixes in an order whose
     inverse is the final reading order:
 
@@ -1172,7 +1231,7 @@ async def assemble_turn_context(
     # permanent prompt-shape fixture for interactive backends.
     prompt = prepend_to_prompt(prompt, USER_MESSAGE_MARKER)
 
-    # First-session context (CLAUDE.md + PREFERENCES.md + recent
+    # First-session context (AGENTS.md + PREFERENCES.md + recent
     # history + API context) is built by the caller because the
     # fresh-session lifecycle is backend-owned. Empty string is the
     # normal non-fresh-session value.

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -764,6 +764,7 @@ class ClaudeCodeBackend(AgentBackend):
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
                 data_dir=DATA_DIR,
+                backend_name=self.backend_name,
                 memory_enabled=self.memory_enabled,
                 defer_user_file_reads=self.defer_user_file_reads,
             )

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -820,6 +820,7 @@ class CodexBackend(AgentBackend):
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
                 data_dir=DATA_DIR,
+                backend_name=self.backend_name,
                 memory_enabled=self.memory_enabled,
                 defer_user_file_reads=self.defer_user_file_reads,
             )

--- a/src/kai/eval/behavioral.py
+++ b/src/kai/eval/behavioral.py
@@ -701,10 +701,10 @@ async def _run_subprocess(
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-        # Neutral cwd: no CLAUDE.md discovery at subprocess startup.
+        # Neutral cwd: no AGENTS.md / CLAUDE.md discovery at startup.
         # Without this, claude --print would walk up from the harness's
         # cwd and pick up the operator's per-user
-        # home_workspace/.claude/CLAUDE.md (Kai's bot identity: voice
+        # home_workspace identity files (Kai's bot identity: voice
         # rules, persona, scheduling API docs). The judge's evaluations
         # would then be filtered through Kai's persona, and the generator
         # would receive bot-voice priming; both confounds the spec

--- a/src/kai/eval/modeswitch.py
+++ b/src/kai/eval/modeswitch.py
@@ -459,6 +459,7 @@ async def _run_verify() -> int:
                 workspace_config=None,
                 chat_id=_FIXTURE_CHAT_ID,
                 data_dir=tmp_root,
+                backend_name="codex",
                 memory_enabled=False,
             )
 
@@ -542,6 +543,7 @@ async def _run_verify() -> int:
                 workspace_config=None,
                 chat_id=_FIXTURE_CHAT_ID,
                 data_dir=tmp_root,
+                backend_name="codex",
                 memory_enabled=True,
             )
 

--- a/src/kai/goose.py
+++ b/src/kai/goose.py
@@ -16,6 +16,7 @@ The Goose ACP protocol:
     Finish:   JSON-RPC result with matching id + stopReason
 """
 
+import json
 import logging
 import os
 
@@ -152,6 +153,10 @@ class GooseBackend(AcpBackend):
             base_env["GOOSE_MODEL"] = mapped
         if self.provider:
             base_env["GOOSE_PROVIDER"] = goose_provider_id(self.provider)
+        # Kai provisions one canonical backend-neutral instruction file.
+        # Restrict Goose's context discovery to that surface so it cannot
+        # consume a stale Claude compatibility file after a backend switch.
+        base_env["CONTEXT_FILE_NAMES"] = json.dumps(["AGENTS.md"])
         return base_env
 
     def preserved_env_vars(self) -> tuple[str, ...]:
@@ -179,6 +184,7 @@ class GooseBackend(AcpBackend):
         return (
             "GOOSE_MODEL",
             "GOOSE_PROVIDER",
+            "CONTEXT_FILE_NAMES",
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
             "GOOGLE_API_KEY",

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -88,6 +88,11 @@ _DEFAULT_SERVICE_USER = "kai"
 # Current install.conf schema version
 _CONF_VERSION = 1
 
+# Claude discovers instructions through CLAUDE.md, while Kai's canonical
+# managed identity is backend-neutral AGENTS.md. Keep the compatibility file
+# deliberately content-free so there is only one editable source of truth.
+_CLAUDE_IDENTITY_ADAPTER = "@../AGENTS.md\n"
+
 # Plist label for the launchd service
 _LAUNCHD_LABEL = "com.syrinx.kai"
 
@@ -2916,6 +2921,53 @@ def _collect_user_memory_owners(users_yaml_path: str | Path) -> list[tuple[int, 
     return result
 
 
+def _collect_user_effective_backends(
+    users_yaml_path: str | Path,
+    default_backend: str | None,
+) -> dict[int, str | None]:
+    """Return each valid chat ID's explicit or inherited backend.
+
+    ``None`` is accepted only for direct migration-helper callers that do not
+    have the apply command's resolved default. Production apply always passes
+    a validated default backend. Unknown explicit values fail the install
+    rather than provisioning the wrong backend-native identity surface.
+    """
+    path = Path(users_yaml_path)
+    if default_backend is not None:
+        default_backend = default_backend.strip().lower()
+        if default_backend not in VALID_BACKENDS:
+            raise ValueError(f"Invalid default backend {default_backend!r} for identity provisioning")
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {}
+    if not text.strip():
+        return {}
+    data = yaml.safe_load(text)
+    if not isinstance(data, dict) or not isinstance(data.get("users"), list):
+        return {}
+
+    result: dict[int, str | None] = {}
+    for entry in data["users"]:
+        if not isinstance(entry, dict):
+            continue
+        telegram_id = entry.get("telegram_id")
+        if not isinstance(telegram_id, int) or telegram_id in result:
+            continue
+        raw_backend = _entry_backend(entry)
+        if isinstance(raw_backend, str) and raw_backend.strip():
+            backend = raw_backend.strip().lower()
+            if backend not in VALID_BACKENDS:
+                raise ValueError(
+                    f"users.yaml entry chat_id={telegram_id} names unknown backend {backend!r}. Source: {path}."
+                )
+        else:
+            backend = default_backend
+        result[telegram_id] = backend
+    return result
+
+
 def _collect_user_home_overrides(users_yaml_path: str | Path) -> dict[int, Path]:
     """
     Read users.yaml and return a chat_id -> home_workspace override mapping.
@@ -3535,6 +3587,60 @@ def _secure_codex_turn_image_staging(data_path: Path, dry_run: bool) -> None:
         print(f"  Secured Codex image staging root {staging_root} (mode 0711)")
 
 
+def _managed_identity_state(user_home: Path) -> tuple[Path, Path, str | None, str | None]:
+    """Inspect and validate one managed user's canonical/compatibility files.
+
+    The installer runs as root over a directory owned by an agent OS user, so
+    it must never follow an instruction-file symlink. Two different regular
+    files are also ambiguous: silently choosing either would discard operator
+    customization. Validation happens before any identity write.
+    """
+    claude_dir = user_home / ".claude"
+    if user_home.is_symlink() or claude_dir.is_symlink():
+        raise RuntimeError(f"Refusing symlinked managed identity directory under {user_home}")
+    if user_home.exists() and not user_home.is_dir():
+        raise RuntimeError(f"Refusing non-directory managed user home: {user_home}")
+    if claude_dir.exists() and not claude_dir.is_dir():
+        raise RuntimeError(f"Refusing non-directory Claude identity path: {claude_dir}")
+    agents_path = user_home / "AGENTS.md"
+    claude_path = claude_dir / "CLAUDE.md"
+    for label, path in (("canonical identity", agents_path), ("Claude adapter", claude_path)):
+        if path.is_symlink():
+            raise RuntimeError(f"Refusing symlinked {label} path: {path}")
+        if path.exists() and not path.is_file():
+            raise RuntimeError(f"Refusing non-regular {label} path: {path}")
+
+    agents_content = agents_path.read_text() if agents_path.is_file() else None
+    claude_content = claude_path.read_text() if claude_path.is_file() else None
+    if agents_content is None and claude_content == _CLAUDE_IDENTITY_ADAPTER:
+        raise RuntimeError(f"Claude identity adapter exists but canonical identity is missing: {agents_path}")
+    if (
+        agents_content is not None
+        and claude_content is not None
+        and claude_content not in (_CLAUDE_IDENTITY_ADAPTER, agents_content)
+    ):
+        raise RuntimeError(
+            f"Conflicting customized identity files: {agents_path} and {claude_path}. "
+            "Reconcile their content before re-running `make install`; neither file was changed."
+        )
+    return agents_path, claude_path, agents_content, claude_content
+
+
+def _write_managed_identity_atomic(path: Path, content: str) -> None:
+    """Atomically write a private managed identity file in its directory."""
+    path.parent.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        os.chmod(temporary, _PRIVATE_USER_FILE_MODE)
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
 def _apply_migrate(
     data_path: Path,
     install_path: Path,
@@ -3542,6 +3648,7 @@ def _apply_migrate(
     svc_gid: int,
     dry_run: bool,
     users_yaml_path: Path | None = None,
+    default_backend: str | None = None,
 ) -> None:
     """
     Migrate runtime data from the development directory to the data directory.
@@ -3560,6 +3667,10 @@ def _apply_migrate(
         users_yaml_path: Path to the installed users.yaml. None means
             the module-level USERS_YAML (the post-_apply_secrets
             location); tests redirect it by patching that attribute.
+        default_backend: Validated installation default used by users without
+            a per-user backend. Production apply always supplies it. ``None``
+            is retained for focused helper tests and means the installer must
+            preserve, rather than infer, any backend-specific adapter.
     """
     # None resolves to the module-level USERS_YAML at call time rather
     # than in the signature: a def-time default would bake the
@@ -3956,6 +4067,10 @@ def _apply_migrate(
         # resolve_home_workspace returns it verbatim at runtime. Case
         # 1: no override - provision the per-user default slot.
         user_dir = override if override is not None else home_root / str(chat_id)
+        if user_dir.is_symlink():
+            raise RuntimeError(f"Refusing symlinked managed user home: {user_dir}")
+        if user_dir.exists() and not user_dir.is_dir():
+            raise RuntimeError(f"Refusing non-directory managed user home: {user_dir}")
         user_dir_exists = user_dir.exists()
         if dry_run:
             if str(chat_id) in per_user_ids:
@@ -3979,159 +4094,122 @@ def _apply_migrate(
         if not user_dir_exists:
             print(f"  Created {user_dir}")
 
-    # -- CLAUDE.md per-user pre-creation --
-    # Mirror the MEMORY.md / PREFERENCES.md per-user pattern above. For
-    # every users.yaml entry we pre-create
-    # <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md from the template, so
-    # `backend.build_session_context`'s identity-injection path and
-    # the inner Claude's native CLAUDE.md discovery in the home
-    # workspace both have a real file to read. Without this seed, a
-    # new user's home workspace is an empty directory and the bot
-    # runs with no baseline identity for that chat_id - the gap that
-    # PR #449 inadvertently exposed and #450 reverted.
-    #
-    # Lazy bootstrap at runtime (backend.ensure_user_home) is the
-    # fallback for chat_ids added between installs; this eager pass
-    # is for users present in users.yaml at install time so they get
-    # the right ownership (chowned to their os_user via the
-    # _set_ownership call) instead of service-owned-via-mkdir.
-    home_template = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
-    # Cache the template existence check once; the path is fixed for
-    # the duration of the loop and is_file() would otherwise stat the
-    # same inode N times for N users.
+    # -- Canonical per-user identity and backend-native adapters --
+    # AGENTS.md is the sole editable Kai-managed identity source. Claude's
+    # native CLAUDE.md surface imports it; every other backend consumes
+    # AGENTS.md directly. Existing customized CLAUDE.md content is migrated
+    # losslessly before compatibility files are changed.
+    home_template = PROJECT_ROOT / "templates" / "AGENTS.md"
     home_template_exists = home_template.is_file()
+    effective_backends = _collect_user_effective_backends(users_yaml_path, default_backend)
 
+    # Validate every managed identity surface before changing any of them.
+    # This prevents a conflict for a later user from leaving earlier users
+    # partially migrated.
+    managed_identities: list[tuple[int, str | None, Path, Path, str | None, str | None]] = []
     for chat_id, _os_user in memory_owners:
         if chat_id is None:
             continue
         override = home_overrides.get(chat_id)
-        # Case 3: override outside DATA_DIR is operator-managed; the
-        # home-creation loop above skipped it for the same reason and
-        # we follow suit here. Touching it from the installer would
-        # write under a path the operator owns.
         if override is not None and not override.is_relative_to(data_path_resolved):
             continue
         user_home = override if override is not None else home_root / str(chat_id)
-        claude_dir = user_home / ".claude"
-        claude_dst = claude_dir / "CLAUDE.md"
+        agents_path, claude_path, agents_content, claude_content = _managed_identity_state(user_home)
+        managed_identities.append(
+            (
+                chat_id,
+                effective_backends.get(chat_id, default_backend),
+                agents_path,
+                claude_path,
+                agents_content,
+                claude_content,
+            )
+        )
 
+    for chat_id, backend_name, agents_path, claude_path, agents_content, claude_content in managed_identities:
         if dry_run:
-            if not claude_dst.exists():
-                if home_template_exists:
-                    print(f"[DRY RUN] Would seed {claude_dst} from {home_template}")
+            if agents_content is None:
+                if claude_content is not None:
+                    print(f"[DRY RUN] Would migrate {claude_path} -> {agents_path} (preserving customized content)")
+                elif home_template_exists:
+                    print(f"[DRY RUN] Would seed {agents_path} from {home_template}")
                 else:
-                    print(f"[DRY RUN] Would seed {claude_dst} with placeholder (template missing)")
-            else:
-                # Migration preview for an existing per-user copy. The
-                # seed branch above only fires when claude_dst is
-                # missing; the migration preview fires when claude_dst
-                # exists and the sentinel header may or may not be in
-                # place. Inspecting claude_dst here, before the
-                # `continue` below, ensures the dry-run preview reaches
-                # parity with what the live branch will do; without
-                # this branch, the dry-run output would silently omit
-                # the migration step the live install would execute.
-                #
-                # The helper's three-state return is the structural
-                # distinction that lets the preview print accurate text
-                # per case. Truthy/falsy alone would conflate sentinel-
-                # present (False) with the failure paths (None), producing
-                # a misleading "already present" line when the helper had
-                # actually warned about a different problem.
-                if home_template_exists:
-                    migration_result = _migrate_recalled_memory_section(claude_dst, home_template, dry_run=True)
-                    if migration_result is True:
-                        print(f"[DRY RUN] Would append Reading Recalled Memory section to {claude_dst}")
-                    elif migration_result is False:
-                        # Sentinel present; surface the no-op explicitly so
-                        # the operator sees the migration was considered.
-                        print(
-                            f"[DRY RUN] {claude_dst}: Reading Recalled Memory "
-                            f"section already present, no migration needed"
-                        )
-                    # else: migration_result is None; the helper already
-                    # printed its own WARNING for the specific failure path.
-                    # No additional preview line needed.
-                else:
-                    # Template missing entirely; the helper is never called
-                    # because of the short-circuit above, so no warning has
-                    # been printed in this iteration. Surface the gap so the
-                    # dry-run preview is honest about what the install can
-                    # and cannot do for this user.
-                    print(f"[DRY RUN] {claude_dst}: cannot evaluate migration (template missing at {home_template})")
+                    print(f"[DRY RUN] Would seed {agents_path} with placeholder (template missing)")
+
+            migration_source: Path | None = None
+            if agents_content is not None:
+                migration_source = agents_path
+            elif claude_content is not None:
+                migration_source = claude_path
+            if migration_source is not None and home_template_exists:
+                migration_result = _migrate_recalled_memory_section(
+                    migration_source,
+                    home_template,
+                    dry_run=True,
+                )
+                if migration_result is True:
+                    print(f"[DRY RUN] Would append Reading Recalled Memory section to {agents_path}")
+                elif migration_result is False:
+                    print(
+                        f"[DRY RUN] {agents_path}: Reading Recalled Memory section already present, no migration needed"
+                    )
+            elif migration_source is not None and not home_template_exists:
+                print(f"[DRY RUN] {agents_path}: cannot evaluate migration (template missing at {home_template})")
+
+            if backend_name == "claude":
+                if claude_content != _CLAUDE_IDENTITY_ADAPTER:
+                    print(f"[DRY RUN] Would write Claude identity adapter: {claude_path}")
+            elif backend_name is not None and claude_content is not None:
+                print(f"[DRY RUN] Would remove retired Claude identity copy: {claude_path}")
+            elif backend_name is None and claude_content is not None:
+                print(f"[DRY RUN] Would keep legacy identity copy synchronized: {claude_path}")
             continue
 
-        # Idempotent: never overwrite an operator-customized destination.
-        # `not exists()` is the same guard ensure_user_memory and
-        # ensure_user_preferences use; matches the seed-step contract.
-        claude_dir.mkdir(parents=True, exist_ok=True)
-        # mkdir's mode= is masked by umask; force the private mode
-        # explicitly. The user-owned home slot is now 0700, so no
-        # sibling user needs traversal through this subdir.
-        os.chmod(claude_dir, _PRIVATE_USER_DIR_MODE)
-        if not claude_dst.exists():
-            # Wrap the actual file write in try/except so an OSError
-            # (broken symlink at claude_dst, mounted FS, permissions)
-            # surfaces with a clear operator-readable line BEFORE the
-            # traceback aborts the install. Matches the rmtree wrap
-            # in `_retire_install_home_claude`; install-time policy
-            # is to abort loudly on a real error, not log-and-continue
-            # (that swallow is `backend.ensure_user_home`'s contract
-            # for the runtime path where session-init cannot crash).
-            try:
-                if home_template_exists:
-                    shutil.copy2(home_template, claude_dst)
-                    print(f"  Seeded {claude_dst} from CLAUDE.md template")
+        try:
+            if agents_content is None:
+                if claude_content is not None:
+                    _write_managed_identity_atomic(agents_path, claude_content)
+                    print(f"  Migrated identity {claude_path} -> {agents_path}")
+                elif home_template_exists:
+                    _write_managed_identity_atomic(agents_path, home_template.read_text())
+                    print(f"  Seeded {agents_path} from AGENTS.md template")
                 else:
-                    # Last-resort placeholder so the inner Claude has
-                    # something to read. Mirrors MEMORY.md / PREFERENCES.md
-                    # missing-template precedent above.
-                    claude_dst.write_text("# Identity\n")
-                    print(f"  WARNING: {home_template} not found; wrote placeholder to {claude_dst}")
-            except OSError as exc:
-                print(f"  ERROR: could not seed {claude_dst}: {exc}")
-                raise
+                    _write_managed_identity_atomic(agents_path, "# Identity\n")
+                    print(f"  WARNING: {home_template} not found; wrote placeholder to {agents_path}")
 
-        # Append the Reading Recalled Memory section to pre-existing
-        # per-user CLAUDE.md copies that predate the section. Lands
-        # AFTER the seed step (so a fresh-seeded file from the current
-        # template carries the section already, and the helper's
-        # sentinel check is a clean no-op) and BEFORE the
-        # `_set_ownership` chown step below (so the migration's
-        # atomic `Path.replace`, which produces a new inode owned by
-        # the install runner, gets reconciled back to the per-user
-        # `os_user` in the same iteration; the chown comment block
-        # below names the #347 regression shape this prevents).
-        if home_template_exists and _migrate_recalled_memory_section(claude_dst, home_template, dry_run=False) is True:
-            print(f"  Appended Reading Recalled Memory section to {claude_dst}")
+            if (
+                home_template_exists
+                and _migrate_recalled_memory_section(agents_path, home_template, dry_run=False) is True
+            ):
+                print(f"  Appended Reading Recalled Memory section to {agents_path}")
 
-        # Recursive chown over the .claude/ subdir so both the
-        # directory and the freshly-seeded CLAUDE.md land on the
-        # per-user os_user. The home-creation loop above only chowns
-        # user_dir non-recursively, so without this pass the .claude/
-        # tree would inherit service-user ownership from mkdir and
-        # the inner subprocess (sudo -H -u <os_user>) could read but
-        # not write CLAUDE.md - the same #347 regression the per-user
-        # memory pattern fixed.
-        #
-        # The chown runs UNCONDITIONALLY on every install, even when
-        # the seed step skipped because CLAUDE.md already existed.
-        # Functionally mirrors the MEMORY.md / PREFERENCES.md
-        # ownership reconciliation: idempotent per-install reset
-        # corrects os_user drift. (Structurally those blocks use a
-        # separate iterdir-based pass over the whole tree; this block
-        # inlines the chown into the per-user seed loop because the
-        # tree we care about is one .claude/ subdir per chat_id,
-        # which iterdir would walk anyway.) Without the unconditional
-        # reset, a chat_id whose os_user changed in users.yaml between
-        # installs would keep its old ownership and the new subprocess
-        # could not write the identity file.
-        if str(chat_id) in per_user_ids:
-            uid, gid = per_user_ids[str(chat_id)]
-            _set_ownership(claude_dir, uid, gid, recursive=True)
-        else:
-            _set_ownership(claude_dir, svc_uid, svc_gid, recursive=True)
-        _set_private_user_tree_modes(claude_dir)
+            if backend_name == "claude":
+                claude_path.parent.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
+                os.chmod(claude_path.parent, _PRIVATE_USER_DIR_MODE)
+                if not claude_path.is_file() or claude_path.read_text() != _CLAUDE_IDENTITY_ADAPTER:
+                    _write_managed_identity_atomic(claude_path, _CLAUDE_IDENTITY_ADAPTER)
+                    print(f"  Wrote Claude identity adapter {claude_path}")
+            elif backend_name is not None:
+                if claude_path.is_file():
+                    claude_path.unlink()
+                    print(f"  Removed retired Claude identity copy {claude_path}")
+            elif claude_path.is_file():
+                # Compatibility for direct helper callers that lack a resolved
+                # backend. Do not infer one; keep the old file synchronized so
+                # a repeated migration remains unambiguous.
+                canonical_content = agents_path.read_text()
+                if claude_path.read_text() != canonical_content:
+                    _write_managed_identity_atomic(claude_path, canonical_content)
+
+            os.chmod(agents_path, _PRIVATE_USER_FILE_MODE)
+            uid, gid = per_user_ids.get(str(chat_id), (svc_uid, svc_gid))
+            _set_ownership(agents_path, uid, gid, recursive=False)
+            if claude_path.parent.is_dir():
+                _set_ownership(claude_path.parent, uid, gid, recursive=True)
+                _set_private_user_tree_modes(claude_path.parent)
+        except OSError as exc:
+            print(f"  ERROR: could not provision managed identity for chat_id={chat_id}: {exc}")
+            raise
 
     # -- Per-os-user temp directories (#454) --
     # The inner Claude binary writes a content-hashed settings cache
@@ -4548,7 +4626,14 @@ def _cmd_apply() -> None:
         )
 
         # -- Step 9: Migrate runtime data --
-        _apply_migrate(data_path, install_path, svc_uid, svc_gid, dry_run)
+        _apply_migrate(
+            data_path,
+            install_path,
+            svc_uid,
+            svc_gid,
+            dry_run,
+            default_backend=agent_backend,
+        )
 
         # -- Step 10: Generate service definition --
         webhook_port = int(env.get("WEBHOOK_PORT", "8080"))
@@ -4896,9 +4981,9 @@ def _migrate_identity_to_claude_md(
 
 
 # Sentinel header used by `_migrate_recalled_memory_section` to detect
-# whether a per-user CLAUDE.md already carries the Reading Recalled
+# whether a per-user AGENTS.md already carries the Reading Recalled
 # Memory section. Module-level constant so the migration helper, the
-# dry-run preview branch in the per-user CLAUDE.md seed loop, and the
+# dry-run preview branch in the per-user identity provisioning loop, and the
 # sibling install tests all read the same literal. A drift in this
 # string would let the migration re-append on every install (sentinel
 # always missing) and silently double-write the section.
@@ -4906,24 +4991,24 @@ _RECALLED_MEMORY_SECTION_HEADER = "## Reading Recalled Memory"
 
 
 def _migrate_recalled_memory_section(
-    claude_dst: Path,
+    identity_dst: Path,
     template_path: Path,
     *,
     dry_run: bool,
 ) -> bool | None:
     """
     Idempotently append the Reading Recalled Memory section from the
-    tracked CLAUDE.md template to an existing per-user CLAUDE.md copy.
+    tracked AGENTS.md template to an existing per-user AGENTS.md copy.
 
     Three return states so the dry-run preview can distinguish the
     legitimate no-op from any failure path:
 
     - True: the section would be (or was) appended. Sentinel absent in
-      claude_dst, template present and well-formed.
-    - False: the section is already present in claude_dst (sentinel
+      identity_dst, template present and well-formed.
+    - False: the section is already present in identity_dst (sentinel
       header matched line-strip-equal). Nothing to do; not an error.
-    - None: helper could not proceed. Failure paths include claude_dst
-      not a regular file, claude_dst unreadable, template_path
+    - None: helper could not proceed. Failure paths include identity_dst
+      not a regular file, identity_dst unreadable, template_path
       unreadable, and template missing the section header. Each path
       prints its own operator-facing warning before returning None, so
       the caller does not need to surface additional output.
@@ -4949,7 +5034,7 @@ def _migrate_recalled_memory_section(
     Atomic via Path.replace on a temp file in the same directory. The
     rename closes the partial-write window where a crash or signal
     mid-write could leave the per-user copy half-populated. The temp
-    file lives in claude_dst's parent so the rename stays within one
+    file lives in identity_dst's parent so the rename stays within one
     filesystem; `Path.replace` delegates to `os.replace`, which calls
     `rename(2)` and surfaces `EXDEV` as `OSError` for cross-filesystem
     targets. No silent fallback to copy+unlink (that is `shutil.move`'s
@@ -4960,7 +5045,7 @@ def _migrate_recalled_memory_section(
     rename(2); the post-rename file inherits the temp file's ownership
     (the install runner, typically root via `sudo make install`), not
     the per-user `os_user` the inner Claude subprocess writes as. The
-    per-user CLAUDE.md seed loop calls this helper BEFORE the
+    per-user AGENTS.md provisioning loop calls this helper BEFORE the
     `_set_ownership` chown step, so the appended file's ownership is
     reconciled in the same iteration; the comment block at the chown
     site documents the #347 regression shape this prevents.
@@ -4973,11 +5058,11 @@ def _migrate_recalled_memory_section(
     of pre-migration per-user copies is empirically zero.
 
     Args:
-        claude_dst: The per-user CLAUDE.md to append to. Path returned
+        identity_dst: The per-user AGENTS.md to append to. Path returned
             by the per-user seed loop's resolution of
-            `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md`.
+            `<DATA_DIR>/home/<chat_id>/AGENTS.md`.
         template_path: The tracked template
-            (`templates/.claude/CLAUDE.md`). Section text is extracted
+            (`templates/AGENTS.md`). Section text is extracted
             from here on every call so a future revision to the
             section's wording in the template propagates to the next
             install's migration run.
@@ -4988,12 +5073,12 @@ def _migrate_recalled_memory_section(
     """
     # Skip if the per-user copy does not exist. The seed step earlier
     # in the loop just wrote a fresh copy from the current template if
-    # claude_dst was missing, so by the time live execution reaches
-    # this helper, claude_dst should exist; the explicit check guards
+    # identity_dst was missing, so by the time live execution reaches
+    # this helper, identity_dst should exist; the explicit check guards
     # the dry-run branch (where the seed is a preview-only print) and
     # the operator-managed-override branch (where the seed is skipped
     # entirely).
-    if not claude_dst.is_file():
+    if not identity_dst.is_file():
         return None
 
     # Read the per-user copy and check for the sentinel header on a
@@ -5003,13 +5088,13 @@ def _migrate_recalled_memory_section(
     # is the precise check that matches what the migration's own
     # append produces.
     try:
-        existing = claude_dst.read_text()
+        existing = identity_dst.read_text()
     except OSError as exc:
         # Broken symlink, permissions, mount issue. Match the
         # ensure_user_home swallow pattern: surface to operator log,
         # continue the install rather than abort. The next install
         # retries; the lazy seed path will also retry on first message.
-        print(f"  WARNING: could not read {claude_dst} for migration: {exc}")
+        print(f"  WARNING: could not read {identity_dst} for migration: {exc}")
         return None
 
     for line in existing.splitlines():
@@ -5039,11 +5124,11 @@ def _migrate_recalled_memory_section(
         # not in the template; warn so the operator notices and either
         # restores the template or removes this helper from the install
         # flow. Mirrors the placeholder-warning shape the per-user
-        # CLAUDE.md seed loop uses ("WARNING: <template> not found").
+        # AGENTS.md provisioning loop uses ("WARNING: <template> not found").
         print(
             f"  WARNING: {template_path} is missing the "
             f"{_RECALLED_MEMORY_SECTION_HEADER!r} section; "
-            f"cannot migrate {claude_dst}"
+            f"cannot migrate {identity_dst}"
         )
         return None
 
@@ -5083,17 +5168,17 @@ def _migrate_recalled_memory_section(
     # leaves a recoverable artifact at a known path rather than a random
     # mkstemp name. The try/except cleans up the temp file when
     # write_text fails partway, so a partial-write does not leave debris
-    # in the .claude/ directory.
-    temp_path = claude_dst.parent / (claude_dst.name + ".tmp")
+    # in the identity file's directory.
+    temp_path = identity_dst.parent / (identity_dst.name + ".tmp")
     try:
         temp_path.write_text(new_content)
-        temp_path.replace(claude_dst)
+        temp_path.replace(identity_dst)
     except OSError as exc:
         # Clean up the partial temp file before propagating so a retry
         # is not blocked by a stale .tmp file. unlink(missing_ok=True)
         # handles the case where write_text never created the file.
         temp_path.unlink(missing_ok=True)
-        print(f"  ERROR: could not migrate {claude_dst}: {exc}")
+        print(f"  ERROR: could not migrate {identity_dst}: {exc}")
         raise
 
     return True
@@ -5106,12 +5191,12 @@ def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:
 
     Both paths predate the per-user `home_workspace` migration in #353.
     Since #353 every session resolves identity from the per-user
-    `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md`; nothing in the
+    `<DATA_DIR>/home/<chat_id>/AGENTS.md`; nothing in the
     runtime reads either of the paths this helper deletes. Issue #447
     retires the install-tree scaffolding entirely. The per-user
-    `CLAUDE.md` is seeded by `_apply_migrate`'s home block (eager,
+    `AGENTS.md` is seeded by `_apply_migrate`'s home block (eager,
     install-time) and `backend.ensure_user_home` (lazy, first-message
-    fallback) from the still-tracked `templates/.claude/CLAUDE.md`.
+    fallback) from the tracked `templates/AGENTS.md`.
 
     Behavior is idempotent: pre-checks (`is_dir()` for the subtree,
     `is_symlink() or is_file()` for IDENTITY.md) make a missing path
@@ -5316,7 +5401,7 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     # Config templates (e.g. goose-config.yaml) referenced by later
     # install steps like _apply_goose_config(). Root-owned since
     # these are static templates, not runtime data. Per-user runtime
-    # CLAUDE.md is seeded by `_apply_migrate`'s home block (eager)
+    # AGENTS.md is seeded by `_apply_migrate`'s home block (eager)
     # and `backend.ensure_user_home` (lazy, first-message fallback);
     # neither touches the install tree.
     config_src = PROJECT_ROOT / "templates" / "config"

--- a/src/kai/opencode.py
+++ b/src/kai/opencode.py
@@ -292,6 +292,10 @@ class OpenCodeBackend(AcpBackend):
         which is the right behavior for an unconfigured-on-purpose
         adapter (e.g. operator running tests).
         """
+        # OpenCode otherwise falls back to Claude instruction files when an
+        # AGENTS.md is absent. Kai's identity contract is explicit: OpenCode
+        # receives AGENTS.md only.
+        base_env["OPENCODE_DISABLE_CLAUDE_CODE_PROMPT"] = "1"
         if self.model:
             base_env["OPENCODE_CONFIG_CONTENT"] = json.dumps({"model": self.model})
         return base_env
@@ -322,6 +326,7 @@ class OpenCodeBackend(AcpBackend):
         """
         return (
             "OPENCODE_CONFIG_CONTENT",
+            "OPENCODE_DISABLE_CLAUDE_CODE_PROMPT",
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
             "GOOGLE_API_KEY",

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -356,6 +356,7 @@ class PiBackend(AgentBackend):
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
                 data_dir=DATA_DIR,
+                backend_name=self.backend_name,
                 memory_enabled=self.memory_enabled,
                 defer_user_file_reads=self.defer_user_file_reads,
             )

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## About This File
 
-This file is the bootstrap template for inner Claude's identity. The installer copies it to `<DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md` for every user in `users.yaml` at install time; `backend.ensure_user_home` lazily seeds it for users added later on first message. Edit your per-user copy (the destination) to add operator-personal content; the tracked template ships universal content only. Once you have customized your per-user copy, you can delete this "About This File" section there.
+This file is the bootstrap template for Kai's backend-neutral identity. The installer copies it to `<DATA_DIR>/home/<chat_id>/AGENTS.md` for every user in `users.yaml` at install time; `backend.ensure_user_home` lazily seeds it for users added later in development mode. Claude receives a thin `.claude/CLAUDE.md` import adapter; all managed identity content remains here. Edit the per-user `AGENTS.md` to add operator-personal content; the tracked template ships universal content only. Once customized, you can delete this "About This File" section from the per-user copy.
 
 ## Who You Are
 
@@ -10,8 +10,8 @@ You're Kai, a personal AI assistant accessed via Telegram. You run locally on th
 
 ## Hard Rules
 
-- NEVER modify the Kai source repository from inner Claude. Read, review, and report only. Source edits go through the operator or another Claude session.
-- NEVER use `EnterPlanMode`. Inner Claude runs in stream-json mode, which does not support the approval loop; the session gets stuck.
+- NEVER modify the Kai source repository from the conversational agent. Read, review, and report only. Source edits go through the operator or a separate development session.
+- NEVER enter an interactive planning or approval mode that requires a UI callback. Kai's backend sessions do not provide that callback and will get stuck.
 - ONLY do what the operator explicitly asks. Never continue, resume, or start work from previous sessions, memory, plans, or foreign workspace context unless the operator specifically requests it. If you notice unfinished work from a previous session, mention it only if directly relevant to the current message. A request to "remember X" means save it to memory and nothing else.
 
 ## Public-Facing Content Rules
@@ -50,7 +50,7 @@ The artifact itself (the spec, the PR, the issue) is durable on its own; status 
 
 ### Rules go to PREFERENCES.md, but only on explicit instruction
 
-The `[Your personal preferences (file: ...):]` block injects PREFERENCES.md, the curated always-on rule layer. It is NOT a target for proactive saves. Treat it like CLAUDE.md: read every turn, edited deliberately, never silently appended.
+The `[Your personal preferences (file: ...):]` block injects PREFERENCES.md, the curated always-on rule layer. It is NOT a target for proactive saves. Treat it like this AGENTS.md identity file: read every turn, edited deliberately, never silently appended.
 
 Write to PREFERENCES.md ONLY when the operator explicitly instructs ("save this as a preference," "add this to PREFERENCES," "make this always-on"). Even on explicit instruction, surface the proposed wording and confirm before persisting. Each entry pays a token cost on every turn, so growth must be deliberate.
 
@@ -104,31 +104,31 @@ curl -s -X POST http://localhost:8080/api/schedule \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
   -d '{"chat_id": <chat_id>, "name": "Laundry", "prompt": "Time to do the laundry!", "schedule_type": "once", "schedule_data": {"run_at": "2026-02-08T19:00:00+00:00"}}'
 
-# Claude job (you process the prompt each time it fires)
+# Agent job (you process the prompt each time it fires)
 curl -s -X POST http://localhost:8080/api/schedule \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "name": "Weather", "prompt": "What is the weather today?", "job_type": "claude", "schedule_type": "daily", "schedule_data": {"times": ["08:00"]}}'
+  -d '{"chat_id": <chat_id>, "name": "Weather", "prompt": "What is the weather today?", "job_type": "agent", "schedule_type": "daily", "schedule_data": {"times": ["08:00"]}}'
 
 # Auto-remove job (deactivates when condition is met, with progress updates)
 curl -s -X POST http://localhost:8080/api/schedule \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "name": "Package tracker", "prompt": "Has my package arrived? Give a brief status update.", "job_type": "claude", "auto_remove": true, "notify_on_check": true, "schedule_type": "interval", "schedule_data": {"seconds": 3600}}'
+  -d '{"chat_id": <chat_id>, "name": "Package tracker", "prompt": "Has my package arrived? Give a brief status update.", "job_type": "agent", "auto_remove": true, "notify_on_check": true, "schedule_type": "interval", "schedule_data": {"seconds": 3600}}'
 ```
 
 For auto-remove jobs, start your response with `CONDITION_MET: <message>` when the condition is satisfied, or `CONDITION_NOT_MET` to silently continue. If `notify_on_check` is enabled, use `CONDITION_NOT_MET: <status message>` to send progress updates while continuing to monitor.
 
 ### API fields:
 - `name` - job name (required)
-- `prompt` - message text or Claude prompt (required)
+- `prompt` - message text or agent prompt (required)
 - `schedule_type` - `once`, `daily`, or `interval` (required)
 - `schedule_data` - schedule details (required):
   - `once`: `{"run_at": "ISO-datetime"}` (UTC)
   - `daily`: `{"times": ["HH:MM", ...]}` (UTC)
   - `interval`: `{"seconds": N}`
-- `job_type` - `reminder` (default) or `claude`
-- `auto_remove` - deactivate when condition met (claude jobs only)
+- `job_type` - `reminder` (default) or `agent`
+- `auto_remove` - deactivate when condition met (agent jobs only)
 - `notify_on_check` - send CONDITION_NOT_MET messages to user (auto_remove only, default false)
 - `chat_id` - integer; required for correct routing in multi-user setups
 

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -14,7 +14,7 @@
 #   5. Restart Kai.
 #
 # Kai injects authentication from the server-side env at call time — API keys never
-# enter Claude's context. See <DATA_DIR>/home/<chat_id>/.claude/CLAUDE.md for usage docs.
+# enter the selected agent's context. See <DATA_DIR>/home/<chat_id>/AGENTS.md for usage docs.
 #
 # Auth types:
 #   bearer  — Authorization: Bearer $KEY

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -68,11 +68,10 @@ class TestBuildSessionContext:
         assert "core identity and instructions" not in result
 
     def test_foreign_workspace_injects_identity(self, tmp_path):
-        """Identity injected from home CLAUDE.md when in foreign workspace."""
+        """Canonical AGENTS.md identity is injected in a foreign workspace."""
         home = tmp_path / "home"
         home.mkdir()
-        (home / ".claude").mkdir()
-        (home / ".claude" / "CLAUDE.md").write_text("Be helpful.")
+        (home / "AGENTS.md").write_text("Be helpful.")
 
         foreign = tmp_path / "foreign"
         foreign.mkdir()
@@ -88,6 +87,7 @@ class TestBuildSessionContext:
                 workspace_config=None,
                 chat_id=None,
                 data_dir=data_dir,
+                backend_name="claude",
             )
 
         assert result is not None
@@ -98,8 +98,7 @@ class TestBuildSessionContext:
         """Protected mode avoids daemon-side reads of user-owned files."""
         home = tmp_path / "home" / "12345"
         home.mkdir(parents=True)
-        (home / ".claude").mkdir()
-        (home / ".claude" / "CLAUDE.md").write_text("PRIVATE IDENTITY")
+        (home / "AGENTS.md").write_text("PRIVATE IDENTITY")
 
         foreign = tmp_path / "foreign"
         foreign.mkdir()
@@ -119,15 +118,42 @@ class TestBuildSessionContext:
                 workspace_config=None,
                 chat_id=12345,
                 data_dir=data_dir,
+                backend_name="codex",
                 defer_user_file_reads=True,
             )
 
         assert "PRIVATE IDENTITY" not in result
         assert "PRIVATE PREFS" not in result
         assert "PRIVATE MEMORY" not in result
-        assert str(home / ".claude" / "CLAUDE.md") in result
+        assert str(home / "AGENTS.md") in result
         assert str(pref_dir / "PREFERENCES.md") in result
         assert str(memory_dir / "MEMORY.md") in result
+
+    @pytest.mark.parametrize("backend_name", ["claude", "codex", "goose", "opencode", "pi"])
+    def test_foreign_workspace_uses_canonical_identity_for_every_backend(self, tmp_path, backend_name):
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "AGENTS.md").write_text("CANONICAL IDENTITY")
+        (home / ".claude").mkdir()
+        (home / ".claude" / "CLAUDE.md").write_text("@../AGENTS.md\n")
+        foreign = tmp_path / "foreign"
+        foreign.mkdir()
+        data_dir = tmp_path / "data"
+        (data_dir / "memory").mkdir(parents=True)
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=foreign,
+                home_workspace=home,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+                backend_name=backend_name,
+            )
+
+        assert "CANONICAL IDENTITY" in result
+        assert "@../AGENTS.md" not in result
 
     def test_memory_exists(self, tmp_path):
         """Memory content included when file exists and is non-empty."""
@@ -745,7 +771,7 @@ class TestEnsureUserHome:
 
     def test_creates_directory(self, tmp_path):
         """First call materializes home/<chat_id>/ under data_dir."""
-        result = ensure_user_home(12345, tmp_path)
+        result = ensure_user_home(12345, tmp_path, backend_name="codex")
         assert result == tmp_path / "home" / "12345"
         assert result.is_dir()
 
@@ -755,12 +781,12 @@ class TestEnsureUserHome:
         the directory after first creation; clobbering it would lose
         user-authored files (cloned repos, notes, etc.).
         """
-        first = ensure_user_home(12345, tmp_path)
+        first = ensure_user_home(12345, tmp_path, backend_name="codex")
         # Drop a sentinel so we can verify the second call leaves it alone.
         sentinel = first / "userfile.txt"
         sentinel.write_text("user content")
 
-        second = ensure_user_home(12345, tmp_path)
+        second = ensure_user_home(12345, tmp_path, backend_name="codex")
         assert second == first
         assert sentinel.read_text() == "user content"
 
@@ -770,7 +796,7 @@ class TestEnsureUserHome:
         admin-less startup paths (tests, health checks). Returning None
         would force defensive None-checks at every call site.
         """
-        result = ensure_user_home(None, tmp_path)
+        result = ensure_user_home(None, tmp_path, backend_name="codex")
         assert result == tmp_path / "home" / "anon"
         assert result.is_dir()
 
@@ -791,7 +817,7 @@ class TestEnsureUserHome:
         (tmp_path / "home").mkdir()
         prev_umask = _os.umask(0o777)
         try:
-            result = ensure_user_home(99, tmp_path)
+            result = ensure_user_home(99, tmp_path, backend_name="codex")
         finally:
             _os.umask(prev_umask)
 
@@ -799,70 +825,68 @@ class TestEnsureUserHome:
         assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
         assert stat.S_IMODE((tmp_path / "home").stat().st_mode) == 0o711
 
-    def test_seeds_claude_md_from_template(self, tmp_path):
-        """
-        Lazy bootstrap: ensure_user_home seeds <home>/.claude/CLAUDE.md
-        from templates/.claude/CLAUDE.md when absent. Without this seed,
-        a user added to users.yaml AFTER install (or any dev path
-        without an install pass) gets an empty home workspace and the
-        bot's identity-injection path silently fails on the missing
-        file. Parallel to ensure_user_memory's MEMORY.md seed.
-        """
-        # Build a fake source tree under tmp_path so we can patch
-        # PROJECT_ROOT to it. The real PROJECT_ROOT has a template, but
-        # using the real path would make this test order-dependent on
-        # whether the template currently exists in the working tree.
+    def test_claude_seeds_canonical_identity_and_adapter(self, tmp_path):
         fake_root = tmp_path / "src_root"
-        template_dir = fake_root / "templates" / ".claude"
-        template_dir.mkdir(parents=True)
-        template = template_dir / "CLAUDE.md"
-        template.write_text("# Kai template\n")
+        (fake_root / "templates").mkdir(parents=True)
+        (fake_root / "templates" / "AGENTS.md").write_text("# Kai template\n")
 
-        data_dir = tmp_path / "data"
         with patch("kai.backend.PROJECT_ROOT", fake_root):
-            home = ensure_user_home(99, data_dir)
+            home = ensure_user_home(99, tmp_path / "data", backend_name="claude")
 
+        agents_dst = home / "AGENTS.md"
         claude_dst = home / ".claude" / "CLAUDE.md"
-        assert claude_dst.is_file(), f"Expected lazy seed at {claude_dst}"
-        assert claude_dst.read_text() == "# Kai template\n"
-        assert stat.S_IMODE((home / ".claude").stat().st_mode) == 0o700
+        assert agents_dst.read_text() == "# Kai template\n"
+        assert claude_dst.read_text() == "@../AGENTS.md\n"
+        assert stat.S_IMODE(agents_dst.stat().st_mode) == 0o600
         assert stat.S_IMODE(claude_dst.stat().st_mode) == 0o600
 
-    def test_seed_is_idempotent(self, tmp_path):
-        """An existing per-user CLAUDE.md is never overwritten on later calls."""
+    @pytest.mark.parametrize("backend_name", ["codex", "goose", "opencode", "pi"])
+    def test_non_claude_backend_seeds_only_agents_md(self, tmp_path, backend_name):
         fake_root = tmp_path / "src_root"
-        template_dir = fake_root / "templates" / ".claude"
-        template_dir.mkdir(parents=True)
-        (template_dir / "CLAUDE.md").write_text("# UPSTREAM\n")
+        (fake_root / "templates").mkdir(parents=True)
+        (fake_root / "templates" / "AGENTS.md").write_text("# Kai template\n")
 
-        data_dir = tmp_path / "data"
         with patch("kai.backend.PROJECT_ROOT", fake_root):
-            home = ensure_user_home(99, data_dir)
+            home = ensure_user_home(99, tmp_path / "data", backend_name=backend_name)
 
-        # Operator customizes after first seed.
-        claude_dst = home / ".claude" / "CLAUDE.md"
-        claude_dst.write_text("# OPERATOR CUSTOMIZED\n")
+        assert (home / "AGENTS.md").read_text() == "# Kai template\n"
+        assert not (home / ".claude" / "CLAUDE.md").exists()
 
-        # Second call must leave the customized content alone.
+    def test_existing_claude_identity_migrates_without_content_loss(self, tmp_path):
+        fake_root = tmp_path / "src_root"
+        (fake_root / "templates").mkdir(parents=True)
+        (fake_root / "templates" / "AGENTS.md").write_text("# UPSTREAM\n")
+        home = tmp_path / "data" / "home" / "99"
+        (home / ".claude").mkdir(parents=True)
+        (home / ".claude" / "CLAUDE.md").write_text("# OPERATOR CUSTOMIZED\n")
+
         with patch("kai.backend.PROJECT_ROOT", fake_root):
-            ensure_user_home(99, data_dir)
+            ensure_user_home(99, tmp_path / "data", backend_name="claude")
 
-        assert claude_dst.read_text() == "# OPERATOR CUSTOMIZED\n"
+        assert (home / "AGENTS.md").read_text() == "# OPERATOR CUSTOMIZED\n"
+        assert (home / ".claude" / "CLAUDE.md").read_text() == "@../AGENTS.md\n"
+
+    def test_conflicting_customized_identity_files_fail_closed(self, tmp_path):
+        home = tmp_path / "data" / "home" / "99"
+        (home / ".claude").mkdir(parents=True)
+        (home / "AGENTS.md").write_text("# canonical\n")
+        (home / ".claude" / "CLAUDE.md").write_text("# different\n")
+
+        with pytest.raises(RuntimeError, match="Conflicting customized identity files"):
+            ensure_user_home(99, tmp_path / "data", backend_name="claude")
+
+        assert (home / "AGENTS.md").read_text() == "# canonical\n"
+        assert (home / ".claude" / "CLAUDE.md").read_text() == "# different\n"
 
     def test_seed_writes_placeholder_when_template_missing(self, tmp_path):
-        """Missing template: last-resort placeholder so the file is writable."""
         fake_root = tmp_path / "src_root"
-        # Intentionally do not create templates/.claude/CLAUDE.md.
-        (fake_root / "templates" / ".claude").mkdir(parents=True)
+        (fake_root / "templates").mkdir(parents=True)
 
-        data_dir = tmp_path / "data"
         with patch("kai.backend.PROJECT_ROOT", fake_root):
-            home = ensure_user_home(99, data_dir)
+            home = ensure_user_home(99, tmp_path / "data", backend_name="codex")
 
-        claude_dst = home / ".claude" / "CLAUDE.md"
-        assert claude_dst.is_file()
-        # Placeholder mirrors the MEMORY.md / PREFERENCES.md precedent.
-        assert claude_dst.read_text() == "# Identity\n"
+        assert (home / "AGENTS.md").read_text() == "# Identity\n"
+        assert not (home / ".claude" / "CLAUDE.md").exists()
 
     def test_chmod_eperm_does_not_crash(self, tmp_path):
         """
@@ -890,9 +914,9 @@ class TestEnsureUserHome:
         def chmod_eperm(path, mode, **kwargs):
             # Match the production failure shape: EPERM only on the
             # per-user dir we are trying to harden; let any other chmod
-            # call (e.g. inside the .claude/ seed branch via shutil.copy2)
-            # fall through to the real implementation. The **kwargs catch
-            # is needed because shutil.copy2 passes follow_symlinks=True.
+            # call inside identity provisioning to fall through to the real
+            # implementation. Keep **kwargs for compatibility with callers
+            # that pass follow_symlinks.
             if str(path) == str(target):
                 raise PermissionError(1, "Operation not permitted", str(path))
             real_chmod(path, mode, **kwargs)
@@ -900,7 +924,7 @@ class TestEnsureUserHome:
         with patch("kai.backend.os.chmod", side_effect=chmod_eperm):
             # Must not raise. The caller depends on this returning the
             # path so the session context build can proceed.
-            result = ensure_user_home(12345, tmp_path)
+            result = ensure_user_home(12345, tmp_path, backend_name="codex")
 
         assert result == target
 
@@ -914,14 +938,14 @@ class TestEnsureUserHome:
         # Build the source tree before patching so the setup mkdirs do
         # not hit the patched failure.
         fake_root = tmp_path / "src_root"
-        (fake_root / "templates" / ".claude").mkdir(parents=True)
-        (fake_root / "templates" / ".claude" / "CLAUDE.md").write_text("# Kai\n")
+        (fake_root / "templates").mkdir(parents=True)
+        (fake_root / "templates" / "AGENTS.md").write_text("# Kai\n")
 
         def boom(*_args, **_kwargs) -> None:
             raise OSError("simulated permission denied")
 
         data_dir = tmp_path / "data"
-        # Patch the seed step's copy2 to raise. The outer path.mkdir
+        # Patch the seed step's template copy to raise. The outer path.mkdir
         # for data_dir/home/<chat_id>/ runs cleanly (the function-
         # under-test handles its own dir creation before reaching the
         # seed branch); only the seed copy fails. Must not raise: the
@@ -931,12 +955,12 @@ class TestEnsureUserHome:
             patch("kai.backend.PROJECT_ROOT", fake_root),
             patch("kai.backend.shutil.copy2", side_effect=boom),
         ):
-            result = ensure_user_home(99, data_dir)
+            result = ensure_user_home(99, data_dir, backend_name="codex")
 
         assert result == data_dir / "home" / "99"
         # The seed file should NOT have been written; the OSError
         # handler should have logged and continued silently.
-        assert not (result / ".claude" / "CLAUDE.md").exists()
+        assert not (result / "AGENTS.md").exists()
 
 
 class TestEnsureUserContextFiles:
@@ -993,6 +1017,7 @@ class TestResolveHomeWorkspace:
         return Config(
             telegram_bot_token="test",
             allowed_user_ids={1},
+            default_backend="codex",
             user_configs=user_configs if user_configs is not None else {},
             protected_install=protected_install,
         )

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1660,9 +1660,8 @@ class TestContextInjection:
     def home_workspace(self, tmp_path, monkeypatch):
         """Create a home workspace with identity file and DATA_DIR memory."""
         home = tmp_path / "home"
-        claude_dir = home / ".claude"
-        claude_dir.mkdir(parents=True)
-        (claude_dir / "CLAUDE.md").write_text("You are Kai.")
+        home.mkdir(parents=True)
+        (home / "AGENTS.md").write_text("You are Kai.")
 
         # Personal memory now lives under DATA_DIR, not the workspace
         data_dir = tmp_path / "data"
@@ -1975,7 +1974,7 @@ class TestContextInjection:
     async def test_memory_query_captured_before_session_context_pollution(self, home_workspace, foreign_workspace):
         """Pin the read-path invariant for the integration: when Claude
         is on a fresh session (so build_session_context fires and the
-        prompt grows to include CLAUDE.md, recent history, API docs,
+        prompt grows to include AGENTS.md, recent history, API docs,
         etc.), format_context must still receive the RAW user text as
         the embedding query, not the post-prepend prompt. Pre-fix
         shape was protected inside claude._send_locked by capturing

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -381,6 +381,16 @@ class TestHandshake:
         assert call_kwargs["env"]["GOOSE_MODEL"] == "claude-opus-4-8"
 
     @pytest.mark.asyncio
+    async def test_native_context_discovery_is_agents_only(self):
+        g = _make_goose()
+        proc = _make_mock_proc(_handshake_lines())
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)) as mock_exec:
+            await g._ensure_started()
+
+        assert json.loads(mock_exec.call_args[1]["env"]["CONTEXT_FILE_NAMES"]) == ["AGENTS.md"]
+
+    @pytest.mark.asyncio
     async def test_model_passthrough_for_non_anthropic(self):
         """Non-Anthropic providers pass model value through unchanged."""
         g = _make_goose(model="sonnet", provider="openai")
@@ -1271,6 +1281,7 @@ class TestPreservedEnvVars:
         assert g.preserved_env_vars() == (
             "GOOSE_MODEL",
             "GOOSE_PROVIDER",
+            "CONTEXT_FILE_NAMES",
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
             "GOOGLE_API_KEY",
@@ -1305,7 +1316,7 @@ class TestPreservedEnvVars:
         argv = list(captured["argv"])
         assert argv[:4] == ["sudo", "-H", "-u", "goose-user"]
         assert argv[4] == (
-            "--preserve-env=GOOSE_MODEL,GOOSE_PROVIDER,ANTHROPIC_API_KEY,"
+            "--preserve-env=GOOSE_MODEL,GOOSE_PROVIDER,CONTEXT_FILE_NAMES,ANTHROPIC_API_KEY,"
             "OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY,"
             "ANTHROPIC_HOST,OPENAI_HOST,OPENAI_BASE_PATH,OLLAMA_HOST,"
             "KAI_WEBHOOK_SECRET,TMPDIR"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7079,55 +7079,53 @@ class TestRetireInstallHomeDir:
 # ── Per-user CLAUDE.md seed (in _apply_migrate's home block) ─────────
 
 
-class TestApplyMigrateClaudeMdSeed:
-    """
-    _apply_migrate's home block seeds <DATA_DIR>/home/<chat_id>/.claude/
-    CLAUDE.md from templates/.claude/CLAUDE.md for every users.yaml
-    entry. Without this seed, a new user's home workspace is an empty
-    directory and the bot has no baseline identity to read. The pattern
-    mirrors the MEMORY.md / PREFERENCES.md seed blocks above this one
-    in the same function. Lazy bootstrap (backend.ensure_user_home) is
-    the fallback for chat_ids added between installs and is covered by
-    its own test module.
-    """
+class TestApplyMigrateManagedIdentity:
+    """Install-time canonical identity migration and backend adapters."""
 
     def _write_users_yaml(self, path: Path, entries: list[dict]) -> None:
         path.write_text(yaml.safe_dump({"users": entries}))
 
-    def _stub_pwd_getpwnam(self):
-        # Map any os_user to a fixed uid/gid pair. _apply_migrate
-        # validates os_user existence up front via pwd.getpwnam; in
-        # tests we redirect to a stub so we do not need real OS
-        # accounts on the test host. The chown calls inside the
-        # function are themselves stubbed out via patch("os.chown")
-        # in each test, so the uid/gid values here are placeholders.
+    def _source(self, tmp_path: Path, *, identity: str | None = "# Kai template\n") -> Path:
+        src = tmp_path / "source"
+        templates = src / "templates"
+        claude_templates = templates / ".claude"
+        claude_templates.mkdir(parents=True)
+        if identity is not None:
+            (templates / "AGENTS.md").write_text(identity)
+        (claude_templates / "MEMORY.md").write_text("# Memory\n")
+        (claude_templates / "PREFERENCES.md").write_text("# Preferences\n")
+        return src
+
+    @staticmethod
+    def _pwd():
         class _Pw:
             pw_uid = 1234
             pw_gid = 1234
 
         return _Pw()
 
-    def test_fresh_install_seeds_per_user_claude_md(self, tmp_path):
-        """A users.yaml entry produces a populated CLAUDE.md at the per-user path."""
-        src = tmp_path / "source"
-        ws_claude = src / "templates" / ".claude"
-        ws_claude.mkdir(parents=True)
-        (ws_claude / "CLAUDE.md").write_text("# Kai template\n")
-        # The seed loop is shared with MEMORY.md / PREFERENCES.md; supply
-        # those templates too so the rest of _apply_migrate does not
-        # diverge into placeholder branches.
-        (ws_claude / "MEMORY.md").write_text("# Memory\n")
-        (ws_claude / "PREFERENCES.md").write_text("# Preferences\n")
+    def _apply(
+        self,
+        tmp_path: Path,
+        *,
+        backend: str,
+        entry_backend: str | None = None,
+        dry_run: bool = False,
+        source_identity: str | None = "# Kai template\n",
+    ) -> tuple[Path, Path, Path]:
+        src = self._source(tmp_path, identity=source_identity)
         users_yaml = tmp_path / "users.yaml"
-        self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
-
+        entry = {"telegram_id": 12345, "os_user": "alice"}
+        if entry_backend is not None:
+            entry["backend"] = entry_backend
+        self._write_users_yaml(users_yaml, [entry])
         data_path = tmp_path / "data"
         install_path = tmp_path / "install"
-        install_path.mkdir()
+        install_path.mkdir(exist_ok=True)
 
         with (
             patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
+            patch("kai.install.pwd.getpwnam", return_value=self._pwd()),
             patch("kai.install._set_ownership"),
             patch("os.chown"),
         ):
@@ -7136,123 +7134,138 @@ class TestApplyMigrateClaudeMdSeed:
                 install_path,
                 svc_uid=0,
                 svc_gid=0,
-                dry_run=False,
-                users_yaml_path=Path(users_yaml),
+                dry_run=dry_run,
+                users_yaml_path=users_yaml,
+                default_backend=backend,
+            )
+        return data_path / "home" / "12345", users_yaml, src
+
+    def test_fresh_claude_user_gets_agents_and_thin_adapter(self, tmp_path):
+        home, _users, _src = self._apply(tmp_path, backend="claude")
+        assert (home / "AGENTS.md").read_text() == "# Kai template\n"
+        assert (home / ".claude" / "CLAUDE.md").read_text() == "@../AGENTS.md\n"
+        assert stat.S_IMODE((home / "AGENTS.md").stat().st_mode) == 0o600
+        assert stat.S_IMODE((home / ".claude" / "CLAUDE.md").stat().st_mode) == 0o600
+
+    @pytest.mark.parametrize("backend", ["codex", "goose", "opencode", "pi"])
+    def test_fresh_non_claude_user_gets_only_agents(self, tmp_path, backend):
+        home, _users, _src = self._apply(tmp_path, backend=backend)
+        assert (home / "AGENTS.md").read_text() == "# Kai template\n"
+        assert not (home / ".claude" / "CLAUDE.md").exists()
+
+    def test_explicit_user_backend_overrides_install_default(self, tmp_path):
+        home, _users, _src = self._apply(
+            tmp_path,
+            backend="codex",
+            entry_backend="claude",
+        )
+        assert (home / ".claude" / "CLAUDE.md").read_text() == "@../AGENTS.md\n"
+
+    def test_unknown_user_backend_does_not_fall_back(self, tmp_path):
+        with pytest.raises(ValueError, match="unknown backend"):
+            self._apply(
+                tmp_path,
+                backend="codex",
+                entry_backend="not-a-backend",
             )
 
-        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
-        assert claude_dst.is_file(), f"Expected seed at {claude_dst}"
-        assert claude_dst.read_text() == "# Kai template\n"
+        assert not (tmp_path / "data" / "home" / "12345" / "AGENTS.md").exists()
 
-    def test_existing_per_user_claude_md_survives_reinstall(self, tmp_path):
-        """Idempotent: an operator-customized destination is never overwritten."""
-        src = tmp_path / "source"
-        ws_claude = src / "templates" / ".claude"
-        ws_claude.mkdir(parents=True)
-        (ws_claude / "CLAUDE.md").write_text("# Kai template\n")
-        (ws_claude / "MEMORY.md").write_text("# Memory\n")
-        (ws_claude / "PREFERENCES.md").write_text("# Preferences\n")
-        users_yaml = tmp_path / "users.yaml"
-        self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
+    def test_existing_claude_content_migrates_before_adapter(self, tmp_path):
+        home = tmp_path / "data" / "home" / "12345"
+        (home / ".claude").mkdir(parents=True)
+        old_content = "# OPERATOR CUSTOMIZED\nKeep this exact text.\n"
+        (home / ".claude" / "CLAUDE.md").write_text(old_content)
 
-        data_path = tmp_path / "data"
-        claude_dir = data_path / "home" / "12345" / ".claude"
-        claude_dir.mkdir(parents=True)
-        claude_dst = claude_dir / "CLAUDE.md"
-        claude_dst.write_text("# OPERATOR CUSTOMIZED\n")
+        migrated_home, _users, _src = self._apply(
+            tmp_path,
+            backend="claude",
+            source_identity="# Template without migration section\n",
+        )
 
-        install_path = tmp_path / "install"
-        install_path.mkdir()
+        assert migrated_home == home
+        assert (home / "AGENTS.md").read_text() == old_content
+        assert (home / ".claude" / "CLAUDE.md").read_text() == "@../AGENTS.md\n"
 
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
-            patch("kai.install._set_ownership"),
-            patch("os.chown"),
-        ):
-            _apply_migrate(
-                data_path,
-                install_path,
-                svc_uid=0,
-                svc_gid=0,
-                dry_run=False,
-                users_yaml_path=Path(users_yaml),
-            )
+    def test_non_claude_migration_removes_retired_copy(self, tmp_path):
+        home = tmp_path / "data" / "home" / "12345"
+        (home / ".claude").mkdir(parents=True)
+        old_content = "# OPERATOR CUSTOMIZED\n"
+        (home / ".claude" / "CLAUDE.md").write_text(old_content)
 
-        # Customized content survives.
-        assert claude_dst.read_text() == "# OPERATOR CUSTOMIZED\n"
+        self._apply(
+            tmp_path,
+            backend="pi",
+            source_identity="# Template without migration section\n",
+        )
 
-    def test_missing_template_writes_placeholder(self, tmp_path):
-        """Missing template: last-resort placeholder so the file is writable."""
-        src = tmp_path / "source"
-        ws_claude = src / "templates" / ".claude"
-        ws_claude.mkdir(parents=True)
-        # CLAUDE.md template intentionally absent; MEMORY.md / PREFERENCES.md
-        # present so the rest of _apply_migrate runs normally.
-        (ws_claude / "MEMORY.md").write_text("# Memory\n")
-        (ws_claude / "PREFERENCES.md").write_text("# Preferences\n")
-        users_yaml = tmp_path / "users.yaml"
-        self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
+        assert (home / "AGENTS.md").read_text() == old_content
+        assert not (home / ".claude" / "CLAUDE.md").exists()
 
-        data_path = tmp_path / "data"
-        install_path = tmp_path / "install"
-        install_path.mkdir()
+    def test_conflicting_customized_files_abort_without_changes(self, tmp_path):
+        home = tmp_path / "data" / "home" / "12345"
+        (home / ".claude").mkdir(parents=True)
+        (home / "AGENTS.md").write_text("# canonical\n")
+        (home / ".claude" / "CLAUDE.md").write_text("# different\n")
 
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
-            patch("kai.install._set_ownership"),
-            patch("os.chown"),
-        ):
-            _apply_migrate(
-                data_path,
-                install_path,
-                svc_uid=0,
-                svc_gid=0,
-                dry_run=False,
-                users_yaml_path=Path(users_yaml),
-            )
+        with pytest.raises(RuntimeError, match="Conflicting customized identity files"):
+            self._apply(tmp_path, backend="claude")
 
-        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
-        assert claude_dst.is_file()
-        assert claude_dst.read_text() == "# Identity\n"
+        assert (home / "AGENTS.md").read_text() == "# canonical\n"
+        assert (home / ".claude" / "CLAUDE.md").read_text() == "# different\n"
 
-    def test_dry_run_predicts_seed(self, tmp_path, capsys):
-        """Dry-run names the source and destination for the seed it would write."""
-        src = tmp_path / "source"
-        ws_claude = src / "templates" / ".claude"
-        ws_claude.mkdir(parents=True)
-        (ws_claude / "CLAUDE.md").write_text("# Kai template\n")
-        (ws_claude / "MEMORY.md").write_text("# Memory\n")
-        (ws_claude / "PREFERENCES.md").write_text("# Preferences\n")
-        users_yaml = tmp_path / "users.yaml"
-        self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
+    def test_symlinked_identity_surface_is_refused(self, tmp_path):
+        home = tmp_path / "data" / "home" / "12345"
+        home.mkdir(parents=True)
+        target = tmp_path / "outside"
+        target.write_text("outside\n")
+        (home / "AGENTS.md").symlink_to(target)
 
-        data_path = tmp_path / "data"
-        install_path = tmp_path / "install"
-        install_path.mkdir()
+        with pytest.raises(RuntimeError, match="Refusing symlinked canonical identity"):
+            self._apply(tmp_path, backend="codex")
 
-        with (
-            patch("kai.install.PROJECT_ROOT", src),
-            patch("kai.install.pwd.getpwnam", return_value=self._stub_pwd_getpwnam()),
-        ):
-            _apply_migrate(
-                data_path,
-                install_path,
-                svc_uid=0,
-                svc_gid=0,
-                dry_run=True,
-                users_yaml_path=Path(users_yaml),
-            )
+        assert target.read_text() == "outside\n"
+
+    def test_symlinked_claude_directory_is_refused(self, tmp_path):
+        home = tmp_path / "data" / "home" / "12345"
+        home.mkdir(parents=True)
+        outside = tmp_path / "outside-claude"
+        outside.mkdir()
+        (home / ".claude").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(RuntimeError, match="symlinked managed identity directory"):
+            self._apply(tmp_path, backend="claude")
+
+        assert list(outside.iterdir()) == []
+
+    def test_dry_run_reports_migration_and_changes_nothing(self, tmp_path, capsys):
+        home = tmp_path / "data" / "home" / "12345"
+        (home / ".claude").mkdir(parents=True)
+        old_content = "# customized\n"
+        claude_path = home / ".claude" / "CLAUDE.md"
+        claude_path.write_text(old_content)
+
+        self._apply(
+            tmp_path,
+            backend="claude",
+            dry_run=True,
+            source_identity="# Template without migration section\n",
+        )
 
         output = capsys.readouterr().out
-        expected_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
-        # Dry-run preview names the per-user destination path. The
-        # template source path is in the same line; pin one substring
-        # so a path-format change does not flake the test.
-        assert f"Would seed {expected_dst}" in output
-        # Dry run never touches disk.
-        assert not expected_dst.exists()
+        assert f"Would migrate {claude_path} -> {home / 'AGENTS.md'}" in output
+        assert f"Would write Claude identity adapter: {claude_path}" in output
+        assert not (home / "AGENTS.md").exists()
+        assert claude_path.read_text() == old_content
+
+    def test_missing_template_writes_agents_placeholder(self, tmp_path):
+        home, _users, _src = self._apply(
+            tmp_path,
+            backend="codex",
+            source_identity=None,
+        )
+        assert (home / "AGENTS.md").read_text() == "# Identity\n"
+        assert not (home / ".claude" / "CLAUDE.md").exists()
 
 
 # ── _migrate_identity_to_claude_md ───────────────────────────────────

--- a/tests/test_install_recalled_memory_migration.py
+++ b/tests/test_install_recalled_memory_migration.py
@@ -1,13 +1,13 @@
 """Tests for the Reading Recalled Memory migration helper.
 
 Covers `kai.install._migrate_recalled_memory_section` and its wiring into
-the per-user CLAUDE.md seed loop in `_apply_migrate`.
+the per-user AGENTS.md provisioning loop in `_apply_migrate`.
 
 The helper appends the `## Reading Recalled Memory` section from the
-tracked CLAUDE.md template to pre-existing per-user copies that predate
+tracked AGENTS.md template to pre-existing per-user copies that predate
 the section. Without it, operators already on prior installs would
 never pick up the new section (the seed step in `_apply_migrate`'s
-per-user CLAUDE.md block guards with `if not claude_dst.exists()`, so
+per-user AGENTS.md block guards with `if not identity_dst.exists()`, so
 a stale per-user copy survives reinstall untouched), and the rule
 would only apply to users added after the section landed in the template.
 
@@ -209,7 +209,7 @@ class TestMigrateRecalledMemorySection:
         # Per-user copy is byte-for-byte unchanged.
         assert per_user.read_text() == _STALE_PER_USER_COPY
         # Warning surfaces to operator stdout per the placeholder-warning
-        # shape the per-user CLAUDE.md seed loop uses when the template
+        # shape the per-user AGENTS.md provisioning loop uses when the template
         # is missing.
         warning = capsys.readouterr().out
         assert "WARNING" in warning
@@ -218,7 +218,7 @@ class TestMigrateRecalledMemorySection:
     # ── Case 5: per-user copy is a broken symlink ──
 
     def test_skip_with_warning_on_broken_symlink(self, tmp_path, capsys):
-        """Broken symlink at claude_dst: skip with warning, no exception escapes.
+        """Broken symlink at identity_dst: skip with warning, no exception escapes.
 
         Returns None (failure path) so the dry-run preview can suppress the
         "already present" line that would otherwise mislead the operator.
@@ -291,7 +291,7 @@ class TestApplyMigrateRecalledMemoryIntegration:
     """Spec §6.3: three integration cases covering the dry-run wiring.
 
     Drives the migration through `_apply_migrate` so the dry-run preview
-    branch (the `if dry_run:` branch in the per-user CLAUDE.md seed
+    branch (the `if dry_run:` branch in the per-user AGENTS.md provisioning
     loop) and the live branch (after `copy2`, before `_set_ownership`)
     are exercised together. The patches mirror the sibling
     TestApplyMigrateClaudeMdSeed in test_install.py so we do not need
@@ -311,12 +311,12 @@ class TestApplyMigrateRecalledMemoryIntegration:
 
         return _Pw()
 
-    def _build_install_layout(self, tmp_path, template_content, claude_dst_content=None):
+    def _build_install_layout(self, tmp_path, template_content, agents_dst_content=None):
         """Set up an install layout with a populated template and optional pre-existing per-user copy."""
         src = tmp_path / "source"
         ws_claude = src / "templates" / ".claude"
         ws_claude.mkdir(parents=True)
-        (ws_claude / "CLAUDE.md").write_text(template_content)
+        (src / "templates" / "AGENTS.md").write_text(template_content)
         # MEMORY.md and PREFERENCES.md templates are referenced by the
         # sibling seed blocks in _apply_migrate; provide them so the
         # function does not divert into a placeholder branch that
@@ -328,10 +328,10 @@ class TestApplyMigrateRecalledMemoryIntegration:
         self._write_users_yaml(users_yaml, [{"telegram_id": 12345, "os_user": "alice"}])
 
         data_path = tmp_path / "data"
-        if claude_dst_content is not None:
-            claude_dir = data_path / "home" / "12345" / ".claude"
-            claude_dir.mkdir(parents=True)
-            (claude_dir / "CLAUDE.md").write_text(claude_dst_content)
+        if agents_dst_content is not None:
+            user_home = data_path / "home" / "12345"
+            user_home.mkdir(parents=True)
+            (user_home / "AGENTS.md").write_text(agents_dst_content)
 
         install_path = tmp_path / "install"
         install_path.mkdir()
@@ -345,7 +345,7 @@ class TestApplyMigrateRecalledMemoryIntegration:
         src, data_path, install_path, users_yaml = self._build_install_layout(
             tmp_path,
             template_content=_TEMPLATE_WITH_SECTION,
-            claude_dst_content=_STALE_PER_USER_COPY,
+            agents_dst_content=_STALE_PER_USER_COPY,
         )
 
         with (
@@ -363,14 +363,14 @@ class TestApplyMigrateRecalledMemoryIntegration:
                 users_yaml_path=Path(users_yaml),
             )
 
-        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
+        agents_dst = data_path / "home" / "12345" / "AGENTS.md"
         # File contents unchanged (dry-run).
-        assert claude_dst.read_text() == _STALE_PER_USER_COPY
+        assert agents_dst.read_text() == _STALE_PER_USER_COPY
         # The dry-run preview surfaces in stdout so an operator running
         # `make install --dry-run` sees the planned migration.
         output = capsys.readouterr().out
         assert "[DRY RUN] Would append Reading Recalled Memory section" in output
-        assert str(claude_dst) in output
+        assert str(agents_dst) in output
 
     # ── Case B: current + dry-run ──
 
@@ -381,7 +381,7 @@ class TestApplyMigrateRecalledMemoryIntegration:
             template_content=_TEMPLATE_WITH_SECTION,
             # Per-user copy carries the section already (e.g. seeded
             # from a current template or migrated in a prior install).
-            claude_dst_content=_TEMPLATE_WITH_SECTION,
+            agents_dst_content=_TEMPLATE_WITH_SECTION,
         )
 
         with (
@@ -399,20 +399,20 @@ class TestApplyMigrateRecalledMemoryIntegration:
                 users_yaml_path=Path(users_yaml),
             )
 
-        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
-        assert claude_dst.read_text() == _TEMPLATE_WITH_SECTION
+        agents_dst = data_path / "home" / "12345" / "AGENTS.md"
+        assert agents_dst.read_text() == _TEMPLATE_WITH_SECTION
         output = capsys.readouterr().out
         assert "Reading Recalled Memory section already present" in output
 
     # ── Case D: dry-run when the tracked template is missing entirely ──
 
-    def test_dry_run_surfaces_template_missing_when_claude_dst_exists(self, tmp_path, capsys):
-        """claude_dst exists + template absent + dry-run: surface the gap.
+    def test_dry_run_surfaces_template_missing_when_agents_dst_exists(self, tmp_path, capsys):
+        """agents_dst exists + template absent + dry-run: surface the gap.
 
         Without an explicit preview line for this case the dry-run output
         would silently omit the migration step the operator might assume
-        would run. The seed branch above only fires when claude_dst is
-        missing, so under the (claude_dst exists, template missing)
+        would run. The seed branch above only fires when agents_dst is
+        missing, so under the (agents_dst exists, template missing)
         combination the operator would otherwise see no relevant output.
         """
         src, data_path, install_path, users_yaml = self._build_install_layout(
@@ -421,12 +421,12 @@ class TestApplyMigrateRecalledMemoryIntegration:
             # template; passing None here is not how the helper is set
             # up. We rebuild the layout manually to omit the template.
             template_content=_TEMPLATE_WITH_SECTION,
-            claude_dst_content=_STALE_PER_USER_COPY,
+            agents_dst_content=_STALE_PER_USER_COPY,
         )
-        # Remove the CLAUDE.md template so home_template_exists is False
+        # Remove the AGENTS.md template so home_template_exists is False
         # at the seed-loop's check. MEMORY.md and PREFERENCES.md templates
         # remain so the sibling seed blocks do not emit unrelated noise.
-        (src / "templates" / ".claude" / "CLAUDE.md").unlink()
+        (src / "templates" / "AGENTS.md").unlink()
 
         with (
             patch("kai.install.PROJECT_ROOT", src),
@@ -443,9 +443,9 @@ class TestApplyMigrateRecalledMemoryIntegration:
                 users_yaml_path=Path(users_yaml),
             )
 
-        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
+        agents_dst = data_path / "home" / "12345" / "AGENTS.md"
         # File unchanged in dry-run mode.
-        assert claude_dst.read_text() == _STALE_PER_USER_COPY
+        assert agents_dst.read_text() == _STALE_PER_USER_COPY
         # The dry-run preview names the failure explicitly so the operator
         # knows the migration was considered and could not proceed.
         output = capsys.readouterr().out
@@ -466,7 +466,7 @@ class TestApplyMigrateRecalledMemoryIntegration:
         src, data_path, install_path, users_yaml = self._build_install_layout(
             tmp_path,
             template_content=_TEMPLATE_WITH_SECTION,
-            claude_dst_content=_STALE_PER_USER_COPY,
+            agents_dst_content=_STALE_PER_USER_COPY,
         )
 
         with (
@@ -484,19 +484,19 @@ class TestApplyMigrateRecalledMemoryIntegration:
                 users_yaml_path=Path(users_yaml),
             )
 
-        claude_dst = data_path / "home" / "12345" / ".claude" / "CLAUDE.md"
-        content = claude_dst.read_text()
+        agents_dst = data_path / "home" / "12345" / "AGENTS.md"
+        content = agents_dst.read_text()
         # The section landed.
         assert _RECALLED_MEMORY_SECTION_HEADER in content
         # The operator's prior content survived.
         assert "OPERATOR LOCAL EDIT" in content
-        # _set_ownership was called for the per-user .claude/ subdir
+        # _set_ownership was called for the per-user AGENTS.md
         # AFTER the migration ran (the migration is sync, so any
         # _set_ownership call we see was issued after the migration's
         # Path.replace returned). At least one recursive call against
-        # the claude_dir is the contract; the seed loop calls
+        # the canonical identity is the contract; the provisioning loop calls
         # _set_ownership unconditionally per-iteration.
         called_paths = [call.args[0] for call in set_ownership_mock.call_args_list]
-        assert any("12345" in str(p) and ".claude" in str(p) for p in called_paths), (
-            f"_set_ownership was not called against the per-user .claude/ dir: {called_paths}"
+        assert agents_dst in called_paths, (
+            f"_set_ownership was not called against the per-user AGENTS.md: {called_paths}"
         )

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -190,6 +190,10 @@ class TestBuildEnv:
         assert env["BAZ"] == "qux"
         assert "OPENCODE_CONFIG_CONTENT" in env
 
+    def test_claude_prompt_fallback_is_disabled(self):
+        env = _make_opencode().build_env({})
+        assert env["OPENCODE_DISABLE_CLAUDE_CODE_PROMPT"] == "1"
+
 
 # ── build_initialize_params ─────────────────────────────────────────
 
@@ -841,6 +845,7 @@ class TestPreservedEnvVars:
         b = _make_opencode()
         assert b.preserved_env_vars() == (
             "OPENCODE_CONFIG_CONTENT",
+            "OPENCODE_DISABLE_CLAUDE_CODE_PROMPT",
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
             "GOOGLE_API_KEY",
@@ -871,7 +876,7 @@ class TestPreservedEnvVars:
         argv = list(captured["argv"])
         assert argv[:4] == ["sudo", "-H", "-u", "oc-user"]
         assert argv[4] == (
-            "--preserve-env=OPENCODE_CONFIG_CONTENT,ANTHROPIC_API_KEY,"
+            "--preserve-env=OPENCODE_CONFIG_CONTENT,OPENCODE_DISABLE_CLAUDE_CODE_PROMPT,ANTHROPIC_API_KEY,"
             "OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY,"
             "KAI_WEBHOOK_SECRET,TMPDIR"
         )

--- a/tests/test_template_agents_md.py
+++ b/tests/test_template_agents_md.py
@@ -1,6 +1,6 @@
-"""Tests for the tracked inner-agent CLAUDE.md template.
+"""Tests for the tracked backend-neutral AGENTS.md template.
 
-The template at templates/.claude/CLAUDE.md is the source for every per-user
+The template at templates/AGENTS.md is the source for every per-user
 inner-agent identity file. It ships to new users via the install-time seed
 step and is the upstream of the _migrate_recalled_memory_section helper.
 Regressions to the structure or wording of pinned sections would propagate
@@ -22,7 +22,7 @@ from kai.config import PROJECT_ROOT
 # Path to the tracked template. Resolved through PROJECT_ROOT so the test
 # follows whatever install/dev anchoring config.py has bound rather than
 # hardcoding a relative path that breaks under either layout.
-_TEMPLATE = PROJECT_ROOT / "templates" / ".claude" / "CLAUDE.md"
+_TEMPLATE = PROJECT_ROOT / "templates" / "AGENTS.md"
 
 # The section header serves as the migration helper's sentinel. Pinning
 # it here means a rename in the template fails this test before it


### PR DESCRIPTION
## Summary

- Make per-user `AGENTS.md` the single editable source for Kai-managed identity.
- Give Claude-backed users a generated `.claude/CLAUDE.md` adapter containing only `@../AGENTS.md`.
- Keep Codex, Goose, OpenCode, and Pi on the canonical `AGENTS.md` surface.
- Inject canonical `AGENTS.md` content directly when a session works outside its home workspace.
- Constrain Goose context discovery to `AGENTS.md` and disable OpenCode's Claude prompt fallback.
- Leave repository-owned instruction files and external home-workspace overrides untouched.

## Upgrade and safety behavior

- Migrate an existing customized `CLAUDE.md` into `AGENTS.md` before changing the compatibility file.
- Resolve each user's effective backend from its explicit `users.yaml` entry or the validated installation default.
- Write the Claude adapter only for Claude users and remove the retired managed Claude copy for other backends.
- Stop without changing either identity file if `AGENTS.md` and `CLAUDE.md` contain different customizations.
- Refuse symlinked or non-regular managed user homes, `.claude` directories, and instruction paths.
- Use private atomic writes and reconcile mode and ownership on every install.
- Preserve the zero-mutation dry-run contract while reporting the planned migration and adapter action.

## Documentation

- Move the tracked identity template from `templates/.claude/CLAUDE.md` to `templates/AGENTS.md`.
- Make template language backend-neutral and update scheduled-agent examples to the canonical `agent` job type.
- Document that operators edit `AGENTS.md`, not the generated Claude adapter.

## Verification

- `make check`
- `make typecheck`
- Full pytest suite: 5,117 passed, 1 skipped.
- Focused migration coverage for all five backends, per-user override precedence, content preservation, conflict refusal, symlink refusal, ownership modes, and dry-run behavior.

Fixes #827
