### PR TITLE
Repair stale upload directory ownership

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3587,6 +3587,66 @@ def _secure_codex_turn_image_staging(data_path: Path, dry_run: bool) -> None:
         print(f"  Secured Codex image staging root {staging_root} (mode 0711)")
 
 
+def _secure_upload_directories(
+    data_path: Path,
+    known_user_dir_names: set[str],
+    svc_uid: int,
+    svc_gid: int,
+    dry_run: bool,
+) -> None:
+    """Reconcile service-owned upload directories without touching uploads.
+
+    Kai writes Telegram uploads before handing their exact paths to an agent
+    OS user.  The service therefore owns the shared upload root and each
+    configured user's directory; the agent receives read access to individual
+    files through the upload handoff ACL.  Older installs may instead have a
+    per-user directory owned by that agent user, which prevents Kai from
+    enforcing the traversal-only directory mode at upload time.
+
+    Validate every managed path before changing any of them, then repair only
+    directory ownership and mode.  Historical files and unknown directories
+    are deliberately left untouched.
+    """
+    files_root = data_path / "files"
+    if files_root.is_symlink():
+        raise RuntimeError(f"Refusing unsafe upload path: {files_root}")
+    if not files_root.exists():
+        return
+    if not files_root.is_dir():
+        raise RuntimeError(f"Refusing unsafe upload path: {files_root}")
+
+    managed_paths = [files_root]
+    for name in sorted(known_user_dir_names):
+        user_dir = files_root / name
+        if user_dir.is_symlink():
+            raise RuntimeError(f"Refusing unsafe upload path: {user_dir}")
+        if not user_dir.exists():
+            continue
+        if not user_dir.is_dir():
+            raise RuntimeError(f"Refusing unsafe upload path: {user_dir}")
+        managed_paths.append(user_dir)
+
+    repairs: list[Path] = []
+    for path in managed_paths:
+        current = path.stat()
+        if (
+            current.st_uid != svc_uid
+            or current.st_gid != svc_gid
+            or stat.S_IMODE(current.st_mode) != _PRIVATE_USER_ROOT_MODE
+        ):
+            repairs.append(path)
+
+    if dry_run:
+        for path in repairs:
+            print(f"[DRY RUN] Would secure upload directory: {path} ({svc_uid}:{svc_gid}, mode 0711)")
+        return
+
+    for path in repairs:
+        _set_ownership(path, svc_uid, svc_gid, recursive=False)
+        os.chmod(path, _PRIVATE_USER_ROOT_MODE)
+        print(f"  Secured upload directory {path} ({svc_uid}:{svc_gid}, mode 0711)")
+
+
 def _managed_identity_state(user_home: Path) -> tuple[Path, Path, str | None, str | None]:
     """Inspect and validate one managed user's canonical/compatibility files.
 
@@ -3788,6 +3848,17 @@ def _apply_migrate(
             ) from exc
         per_user_ids[str(chat_id)] = (pwd_entry.pw_uid, pwd_entry.pw_gid)
     known_user_dir_names = {str(chat_id) for chat_id, _os_user in memory_owners if chat_id is not None}
+
+    # Upload directories are service-owned even when memory/preferences/home
+    # belong to the agent OS user.  The service creates private files and
+    # grants the configured agent exact-file read access during handoff.
+    _secure_upload_directories(
+        data_path,
+        known_user_dir_names,
+        svc_uid,
+        svc_gid,
+        dry_run,
+    )
 
     # Resolve the primary operator's chat_id (first yaml entry). When
     # users.yaml is absent or empty (first-ever install, single-user

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -57,6 +57,7 @@ from kai.install import (
     _retire_install_home_claude,
     _retire_install_home_dir,
     _secure_codex_turn_image_staging,
+    _secure_upload_directories,
     _set_ownership,
     _src_checksum,
     _start_service,
@@ -5060,6 +5061,112 @@ class TestSecureCodexTurnImageStaging:
 
         with pytest.raises(RuntimeError, match="Refusing unsafe Codex image staging path"):
             _secure_codex_turn_image_staging(data_path, dry_run=False)
+
+
+class TestSecureUploadDirectories:
+    def test_repairs_managed_directories_without_touching_existing_files(self, tmp_path, monkeypatch, capsys):
+        files_root = tmp_path / "data" / "files"
+        user_dir = files_root / "12345"
+        user_dir.mkdir(parents=True)
+        files_root.chmod(0o755)
+        user_dir.chmod(0o775)
+        historical = user_dir / "photo.jpg"
+        historical.write_bytes(b"keep")
+        historical.chmod(0o644)
+        chowned: list[tuple[Path, int, int]] = []
+        monkeypatch.setattr(
+            "kai.install.os.chown",
+            lambda path, uid, gid: chowned.append((Path(path), uid, gid)),
+        )
+
+        _secure_upload_directories(
+            tmp_path / "data",
+            {"12345"},
+            svc_uid=9876,
+            svc_gid=9877,
+            dry_run=False,
+        )
+
+        assert chowned == [
+            (files_root, 9876, 9877),
+            (user_dir, 9876, 9877),
+        ]
+        assert stat.S_IMODE(files_root.stat().st_mode) == 0o711
+        assert stat.S_IMODE(user_dir.stat().st_mode) == 0o711
+        assert historical.read_bytes() == b"keep"
+        assert stat.S_IMODE(historical.stat().st_mode) == 0o644
+        assert historical not in {path for path, _uid, _gid in chowned}
+        assert "Secured upload directory" in capsys.readouterr().out
+
+    def test_dry_run_reports_repairs_without_mutating(self, tmp_path, monkeypatch, capsys):
+        user_dir = tmp_path / "data" / "files" / "12345"
+        user_dir.mkdir(parents=True)
+        files_root = user_dir.parent
+        files_root.chmod(0o755)
+        user_dir.chmod(0o775)
+        chown = MagicMock()
+        monkeypatch.setattr("kai.install.os.chown", chown)
+
+        _secure_upload_directories(
+            tmp_path / "data",
+            {"12345"},
+            svc_uid=9876,
+            svc_gid=9877,
+            dry_run=True,
+        )
+
+        assert stat.S_IMODE(files_root.stat().st_mode) == 0o755
+        assert stat.S_IMODE(user_dir.stat().st_mode) == 0o775
+        chown.assert_not_called()
+        output = capsys.readouterr().out
+        assert f"[DRY RUN] Would secure upload directory: {files_root}" in output
+        assert f"[DRY RUN] Would secure upload directory: {user_dir}" in output
+
+    def test_refuses_managed_symlink_before_any_repair(self, tmp_path, monkeypatch):
+        files_root = tmp_path / "data" / "files"
+        files_root.mkdir(parents=True)
+        files_root.chmod(0o755)
+        target = tmp_path / "attacker-controlled"
+        target.mkdir()
+        (files_root / "12345").symlink_to(target, target_is_directory=True)
+        chown = MagicMock()
+        monkeypatch.setattr("kai.install.os.chown", chown)
+
+        with pytest.raises(RuntimeError, match="Refusing unsafe upload path"):
+            _secure_upload_directories(
+                tmp_path / "data",
+                {"12345"},
+                svc_uid=9876,
+                svc_gid=9877,
+                dry_run=False,
+            )
+
+        assert stat.S_IMODE(files_root.stat().st_mode) == 0o755
+        chown.assert_not_called()
+
+    def test_leaves_unknown_directories_untouched(self, tmp_path, monkeypatch):
+        files_root = tmp_path / "data" / "files"
+        unknown = files_root / "not-configured"
+        unknown.mkdir(parents=True)
+        files_root.chmod(0o711)
+        unknown.chmod(0o775)
+        chowned: list[Path] = []
+        monkeypatch.setattr(
+            "kai.install.os.chown",
+            lambda path, _uid, _gid: chowned.append(Path(path)),
+        )
+        current = files_root.stat()
+
+        _secure_upload_directories(
+            tmp_path / "data",
+            set(),
+            svc_uid=current.st_uid,
+            svc_gid=current.st_gid,
+            dry_run=False,
+        )
+
+        assert chowned == []
+        assert stat.S_IMODE(unknown.stat().st_mode) == 0o775
 
 
 class TestApplyMigrate:


### PR DESCRIPTION
## Summary

- reconcile the shared upload root and configured Telegram users' upload directories to service ownership and mode `0711` during installation
- validate all managed upload paths before mutation and reject symlinked or non-directory paths
- preserve historical upload file ownership, content, and modes, and leave unknown directories untouched
- provide an exact dry-run preview of directory repairs

## Root cause

The live installation had `/var/lib/kai/files/2114582497` owned by `daniel`, while Kai runs as the `kai` service user. The upload handler correctly tries to enforce mode `0711`, but only the directory owner can change its mode, so `chmod` failed with `EPERM` before the new Workshop artifact shadow ran.

## Verification

- `make check`
- `.venv/bin/python -m pytest tests/test_install.py -q` — 549 passed
- `.venv/bin/python -m pytest -q` — 5168 passed, 1 skipped

## Deployment validation

After merge:

1. Run `make DRY_RUN=1 install`; it should preview securing `/var/lib/kai/files/2114582497` as the Kai service UID/GID with mode `0711`.
2. Run `make install`.
3. Upload a photo through Telegram and confirm Kai can inspect it without an upload-save error.

Closes #840
