### PR TITLE
fix: isolate per-user history and uploads

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -3984,6 +3984,7 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         direction="user",
         chat_id=chat_id,
         text=caption,
+        reader_user=reader_user,
         media={
             "type": "photo",
             "workshop_message_shadowed": workshop_inbound_message_id is not None,
@@ -4245,6 +4246,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         direction="user",
         chat_id=chat_id,
         text=history_text,
+        reader_user=reader_user,
         media={
             "type": "document",
             "filename": file_name,
@@ -4294,6 +4296,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         return
 
     chat_id = _chat_id(update)
+    reader_user = _upload_reader_user(context, chat_id)
     pool = _get_pool(context)
     config: Config = context.bot_data["config"]
 
@@ -4332,12 +4335,24 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     try:
         transcript = await transcribe_voice(audio_data, config.whisper_model_path)
     except TranscriptionError as e:
-        log_message(direction="user", chat_id=chat_id, text=voice_placeholder, media=voice_media)
+        log_message(
+            direction="user",
+            chat_id=chat_id,
+            text=voice_placeholder,
+            media=voice_media,
+            reader_user=reader_user,
+        )
         await update.message.reply_text(f"Transcription failed: {e}")
         return
 
     if not transcript:
-        log_message(direction="user", chat_id=chat_id, text=voice_placeholder, media=voice_media)
+        log_message(
+            direction="user",
+            chat_id=chat_id,
+            text=voice_placeholder,
+            media=voice_media,
+            reader_user=reader_user,
+        )
         await update.message.reply_text("Couldn't make out any speech in that voice message.")
         return
 
@@ -4349,7 +4364,13 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     # output behaviour change in the provenance work: previous behaviour
     # wrote only the duration placeholder, which silently lost the user's
     # actual words and made source view useless for voice-derived rows.
-    user_log = log_message(direction="user", chat_id=chat_id, text=transcript, media=voice_media)
+    user_log = log_message(
+        direction="user",
+        chat_id=chat_id,
+        text=transcript,
+        media=voice_media,
+        reader_user=reader_user,
+    )
 
     prompt = f"[Voice message transcription]: {transcript}"
     model = pool.get_model(chat_id)
@@ -4532,10 +4553,11 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
     chat_id = _chat_id(update)
     prompt = update.message.text
+    reader_user = _upload_reader_user(context, chat_id)
     # Capture the user LogEntry so _handle_response can thread it to
     # the provenance writer. None on JSONL write failure; the extraction
     # path then skips provenance stamping for this exchange.
-    user_log = log_message(direction="user", chat_id=chat_id, text=prompt)
+    user_log = log_message(direction="user", chat_id=chat_id, text=prompt, reader_user=reader_user)
     workshop_inbound_message_id: MessageId | None = None
     recorder = context.bot_data.get("workshop_inbound_recorder")
     if recorder is not None:
@@ -4630,6 +4652,7 @@ async def _handle_response(
     assert update.message is not None
     # Check voice mode before starting
     config: Config = context.bot_data["config"]
+    reader_user = _upload_reader_user(context, chat_id)
     voice_mode = "off"
     if config.tts_enabled:
         voice_mode = await sessions.get_setting(f"voice_mode:{chat_id}") or "off"
@@ -4725,9 +4748,19 @@ async def _handle_response(
     # may try to address it instead of the current message.
     if final_response is None:
         if stopped_by_user:
-            log_message(direction="assistant", chat_id=chat_id, text="[stopped by user]")
+            log_message(
+                direction="assistant",
+                chat_id=chat_id,
+                text="[stopped by user]",
+                reader_user=reader_user,
+            )
         else:
-            log_message(direction="assistant", chat_id=chat_id, text="[no response]")
+            log_message(
+                direction="assistant",
+                chat_id=chat_id,
+                text="[no response]",
+                reader_user=reader_user,
+            )
             await update.message.reply_text("Error: No response from agent")
         return
 
@@ -4740,7 +4773,12 @@ async def _handle_response(
         # surface even on a regression.
         error_text = render_agent_failure(final_response.failure_kind, final_response.error, config, chat_id)
         visible_error = error_text.removeprefix("Error: ")
-        log_message(direction="assistant", chat_id=chat_id, text=f"[error: {visible_error}]")
+        log_message(
+            direction="assistant",
+            chat_id=chat_id,
+            text=f"[error: {visible_error}]",
+            reader_user=reader_user,
+        )
         # Send the error notice as a NEW message (not an edit of the
         # live streamed message), so any tool-use, partial reasoning,
         # and intermediate output the user was watching stays visible.
@@ -4764,7 +4802,12 @@ async def _handle_response(
     # the exact JSONL ts/date/sha256 the line landed with. None means
     # the append failed (logged by log_message itself); the extraction
     # path then skips provenance stamping for this exchange.
-    assistant_log = log_message(direction="assistant", chat_id=chat_id, text=final_text)
+    assistant_log = log_message(
+        direction="assistant",
+        chat_id=chat_id,
+        text=final_text,
+        reader_user=reader_user,
+    )
 
     workshop_outbound_message_id: MessageId | None = None
     outbound_recorder = context.bot_data.get("workshop_outbound_recorder")

--- a/src/kai/cron.py
+++ b/src/kai/cron.py
@@ -48,6 +48,15 @@ _CONDITION_NOT_MET_PREFIX = (
 )
 
 
+def _history_reader_user(context: ContextTypes.DEFAULT_TYPE, chat_id: int) -> str | None:
+    """Resolve the OS user allowed to search one scheduled chat's history."""
+    config = context.bot_data.get("config")
+    if config is None:
+        return None
+    user_config = config.get_user_config(chat_id)
+    return user_config.os_user if user_config and user_config.os_user else None
+
+
 async def _send_chunked(bot: ExtBot, chat_id: int, text: str) -> None:
     """
     Send a potentially long message as multiple Telegram-safe chunks.
@@ -259,6 +268,7 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
     prompt = data["prompt"]
     auto_remove = data["auto_remove"]
     job_id = data["job_id"]
+    reader_user = _history_reader_user(context, chat_id)
 
     log.info("Job %d '%s' fired (type=%s)", job_id, data["name"], job_type)
 
@@ -267,7 +277,12 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
         # Strip stray backslash escapes (e.g. \! from bash double-quoting in curl)
         prompt = prompt.replace("\\!", "!").replace("\\.", ".").replace("\\?", "?")
         try:
-            log_message(direction="assistant", chat_id=chat_id, text=f"[Reminder: {data['name']}] {prompt}")
+            log_message(
+                direction="assistant",
+                chat_id=chat_id,
+                text=f"[Reminder: {data['name']}] {prompt}",
+                reader_user=reader_user,
+            )
             await context.bot.send_message(chat_id=chat_id, text=prompt)
         except Forbidden:
             log.warning("Job %d: chat %d is gone, deactivating", job_id, chat_id)
@@ -336,7 +351,7 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
             clean_text = f"{after_marker}\n{rest}".strip() if after_marker else rest
             msg = f"[Job: {data['name']}]\n{clean_text}" if clean_text else f"[Job: {data['name']}] Condition met."
             try:
-                log_message(direction="assistant", chat_id=chat_id, text=msg)
+                log_message(direction="assistant", chat_id=chat_id, text=msg, reader_user=reader_user)
                 await _send_chunked(context.bot, chat_id, msg)
             except Forbidden:
                 log.warning("Job %d: chat %d is gone, deactivating", job_id, chat_id)
@@ -361,7 +376,7 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
                     f"[Job: {data['name']}]\n{clean_text}" if clean_text else f"[Job: {data['name']}] Still checking..."
                 )
                 try:
-                    log_message(direction="assistant", chat_id=chat_id, text=msg)
+                    log_message(direction="assistant", chat_id=chat_id, text=msg, reader_user=reader_user)
                     await _send_chunked(context.bot, chat_id, msg)
                 except Forbidden:
                     log.warning("Job %d: chat %d is gone, deactivating", job_id, chat_id)
@@ -382,7 +397,7 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
             # Non-conditional or non-auto-remove: always deliver the response
             msg = f"[Job: {data['name']}]\n{response_text}"
             try:
-                log_message(direction="assistant", chat_id=chat_id, text=msg)
+                log_message(direction="assistant", chat_id=chat_id, text=msg, reader_user=reader_user)
                 await _send_chunked(context.bot, chat_id, msg)
             except Forbidden:
                 log.warning("Job %d: chat %d is gone, deactivating", job_id, chat_id)

--- a/src/kai/history.py
+++ b/src/kai/history.py
@@ -23,12 +23,14 @@ summary of the last few messages for ambient recall at session start.
 import hashlib
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Literal
 
 from kai.config import DATA_DIR
+from kai.named_access import grant_named_read_access
 
 log = logging.getLogger(__name__)
 
@@ -107,6 +109,7 @@ def log_message(
     chat_id: int,
     text: str,
     media: dict | None = None,
+    reader_user: str | None = None,
 ) -> LogEntry | None:
     """
     Append a single message record to today's JSONL chat log.
@@ -129,6 +132,8 @@ def log_message(
         chat_id: Telegram chat ID the message belongs to.
         text: The message text content.
         media: Optional metadata dict for non-text messages (photos, voice, documents).
+        reader_user: Optional mapped OS user allowed to search this user's
+            otherwise service-private history.
     """
     # Per-user subdirectory: DATA_DIR/history/<chat_id>/YYYY-MM-DD.jsonl
     # Separates users on disk so grep/jq searches are naturally scoped
@@ -157,9 +162,47 @@ def log_message(
     # caller, defeating the safety property the LogEntry | None
     # contract is meant to provide.
     try:
-        user_dir.mkdir(parents=True, exist_ok=True)
-        with open(filepath, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        if _LOG_DIR.is_symlink():
+            raise OSError(f"refusing symlinked history root: {_LOG_DIR}")
+        if _LOG_DIR.exists() and not _LOG_DIR.is_dir():
+            raise OSError(f"refusing non-directory history root: {_LOG_DIR}")
+        _LOG_DIR.mkdir(parents=True, exist_ok=True, mode=0o711)
+        os.chmod(_LOG_DIR, 0o711)
+
+        if user_dir.is_symlink():
+            raise OSError(f"refusing symlinked user history directory: {user_dir}")
+        if user_dir.exists() and not user_dir.is_dir():
+            raise OSError(f"refusing non-directory user history path: {user_dir}")
+        new_user_dir = not user_dir.exists()
+        user_dir.mkdir(mode=0o700, exist_ok=True)
+        # On Linux, chmod after setfacl rewrites the ACL mask and can silently
+        # revoke the mapped reader. The installer owns reconciliation for
+        # existing trees; runtime sets the base mode only at creation time.
+        if new_user_dir or not reader_user:
+            os.chmod(user_dir, 0o700)
+        if new_user_dir and reader_user:
+            grant_named_read_access(user_dir, reader_user, directory=True)
+
+        if filepath.is_symlink():
+            raise OSError(f"refusing symlinked history file: {filepath}")
+        if filepath.exists() and not filepath.is_file():
+            raise OSError(f"refusing non-regular history file: {filepath}")
+        new_file = not filepath.exists()
+        flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(filepath, flags, 0o600)
+        try:
+            if new_file or not reader_user:
+                os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "a", encoding="utf-8") as f:
+                fd = -1
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        finally:
+            if fd >= 0:
+                os.close(fd)
+        if new_file and reader_user:
+            grant_named_read_access(filepath, reader_user, directory=False)
     except OSError:
         log.exception("Failed to write chat log")
         # Returning None (not a populated LogEntry) is the contract

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -62,6 +62,7 @@ from kai.config import (
     models_for_backend,
     validate_model_for_backend,
 )
+from kai.named_access import replace_named_read_access
 from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
 from kai.workshop.diagnostics import workshop_bootstrap_status, workshop_message_parity_status
@@ -3593,8 +3594,9 @@ def _secure_upload_directories(
     svc_uid: int,
     svc_gid: int,
     dry_run: bool,
+    reader_users: dict[str, str] | None = None,
 ) -> None:
-    """Reconcile service-owned upload directories without touching uploads.
+    """Reconcile service-owned upload directories and historical uploads.
 
     Kai writes Telegram uploads before handing their exact paths to an agent
     OS user.  The service therefore owns the shared upload root and each
@@ -3603,10 +3605,11 @@ def _secure_upload_directories(
     per-user directory owned by that agent user, which prevents Kai from
     enforcing the traversal-only directory mode at upload time.
 
-    Validate every managed path before changing any of them, then repair only
-    directory ownership and mode.  Historical files and unknown directories
-    are deliberately left untouched.
+    Validate every managed tree before changing any of it. Historical files
+    become service-owned and private, with a named read ACL for only the
+    configured agent OS user. Unknown directories remain untouched.
     """
+    reader_users = reader_users or {}
     files_root = data_path / "files"
     if files_root.is_symlink():
         raise RuntimeError(f"Refusing unsafe upload path: {files_root}")
@@ -3616,6 +3619,7 @@ def _secure_upload_directories(
         raise RuntimeError(f"Refusing unsafe upload path: {files_root}")
 
     managed_paths = [files_root]
+    managed_trees: dict[str, tuple[list[Path], list[Path]]] = {}
     for name in sorted(known_user_dir_names):
         user_dir = files_root / name
         if user_dir.is_symlink():
@@ -3625,6 +3629,7 @@ def _secure_upload_directories(
         if not user_dir.is_dir():
             raise RuntimeError(f"Refusing unsafe upload path: {user_dir}")
         managed_paths.append(user_dir)
+        managed_trees[name] = _validate_regular_tree(user_dir, label="upload")
 
     repairs: list[Path] = []
     for path in managed_paths:
@@ -3639,12 +3644,117 @@ def _secure_upload_directories(
     if dry_run:
         for path in repairs:
             print(f"[DRY RUN] Would secure upload directory: {path} ({svc_uid}:{svc_gid}, mode 0711)")
+        for name, (directories, files) in managed_trees.items():
+            print(
+                f"[DRY RUN] Would secure {len(files)} upload file(s) and "
+                f"{len(directories)} nested directory entry/entries under {files_root / name}"
+            )
         return
 
     for path in repairs:
         _set_ownership(path, svc_uid, svc_gid, recursive=False)
         os.chmod(path, _PRIVATE_USER_ROOT_MODE)
         print(f"  Secured upload directory {path} ({svc_uid}:{svc_gid}, mode 0711)")
+
+    replace_named_read_access(files_root, None, directory=True)
+    for name, (directories, files) in managed_trees.items():
+        reader_user = reader_users.get(name)
+        user_dir = files_root / name
+        replace_named_read_access(user_dir, None, directory=True)
+        for directory in directories:
+            os.chown(directory, svc_uid, svc_gid)
+            os.chmod(directory, _PRIVATE_USER_DIR_MODE)
+            replace_named_read_access(directory, reader_user, directory=True)
+        for path in files:
+            os.chown(path, svc_uid, svc_gid)
+            os.chmod(path, _PRIVATE_USER_FILE_MODE)
+            replace_named_read_access(path, reader_user, directory=False)
+        if files or directories:
+            print(f"  Secured historical uploads under {user_dir}")
+
+
+def _validate_regular_tree(root: Path, *, label: str) -> tuple[list[Path], list[Path]]:
+    """Return nested directories/files after rejecting every unsafe entry."""
+    directories: list[Path] = []
+    files: list[Path] = []
+    pending = [root]
+    while pending:
+        current = pending.pop()
+        for entry in current.iterdir():
+            if entry.is_symlink():
+                raise RuntimeError(f"Refusing unsafe {label} path: {entry}")
+            if entry.is_dir():
+                directories.append(entry)
+                pending.append(entry)
+            elif entry.is_file():
+                files.append(entry)
+            else:
+                raise RuntimeError(f"Refusing unsafe {label} path: {entry}")
+    return sorted(directories), sorted(files)
+
+
+def _secure_history_directories(
+    data_path: Path,
+    reader_users: dict[str, str],
+    svc_uid: int,
+    svc_gid: int,
+    dry_run: bool,
+) -> None:
+    """Make transcripts private while preserving mapped-agent search access."""
+    history_root = data_path / "history"
+    if history_root.is_symlink():
+        raise RuntimeError(f"Refusing unsafe history path: {history_root}")
+    if not history_root.exists():
+        return
+    if not history_root.is_dir():
+        raise RuntimeError(f"Refusing unsafe history path: {history_root}")
+
+    user_trees: dict[Path, tuple[list[Path], list[Path]]] = {}
+    root_files: list[Path] = []
+    for entry in history_root.iterdir():
+        if entry.is_symlink():
+            raise RuntimeError(f"Refusing unsafe history path: {entry}")
+        if entry.is_dir():
+            user_trees[entry] = _validate_regular_tree(entry, label="history")
+        elif entry.is_file():
+            root_files.append(entry)
+        else:
+            raise RuntimeError(f"Refusing unsafe history path: {entry}")
+
+    if dry_run:
+        print(f"[DRY RUN] Would secure history root: {history_root} ({svc_uid}:{svc_gid}, mode 0711)")
+        for user_dir, (directories, files) in sorted(user_trees.items()):
+            reader = reader_users.get(user_dir.name)
+            access = f"readable by {reader}" if reader else "service-private"
+            print(
+                f"[DRY RUN] Would secure history tree: {user_dir} "
+                f"({len(files)} file(s), {len(directories)} nested directory entry/entries, {access})"
+            )
+        if root_files:
+            print(f"[DRY RUN] Would secure {len(root_files)} legacy flat history file(s)")
+        return
+
+    os.chown(history_root, svc_uid, svc_gid)
+    os.chmod(history_root, _PRIVATE_USER_ROOT_MODE)
+    replace_named_read_access(history_root, None, directory=True)
+    for path in root_files:
+        os.chown(path, svc_uid, svc_gid)
+        os.chmod(path, _PRIVATE_USER_FILE_MODE)
+        replace_named_read_access(path, None, directory=False)
+    for user_dir, (directories, files) in user_trees.items():
+        reader = reader_users.get(user_dir.name)
+        os.chown(user_dir, svc_uid, svc_gid)
+        os.chmod(user_dir, _PRIVATE_USER_DIR_MODE)
+        replace_named_read_access(user_dir, reader, directory=True)
+        for directory in directories:
+            os.chown(directory, svc_uid, svc_gid)
+            os.chmod(directory, _PRIVATE_USER_DIR_MODE)
+            replace_named_read_access(directory, reader, directory=True)
+        for path in files:
+            os.chown(path, svc_uid, svc_gid)
+            os.chmod(path, _PRIVATE_USER_FILE_MODE)
+            replace_named_read_access(path, reader, directory=False)
+    print(f"  Secured conversation history under {history_root}")
 
 
 def _managed_identity_state(user_home: Path) -> tuple[Path, Path, str | None, str | None]:
@@ -3834,6 +3944,7 @@ def _apply_migrate(
     # the misconfiguration after disk mutation would leave operators
     # diagnosing a half-applied state.
     per_user_ids: dict[str, tuple[int, int]] = {}
+    reader_users: dict[str, str] = {}
     for chat_id, os_user in memory_owners:
         if os_user is None:
             continue
@@ -3847,18 +3958,8 @@ def _apply_migrate(
                 f"users.yaml entry, then re-run sudo make install."
             ) from exc
         per_user_ids[str(chat_id)] = (pwd_entry.pw_uid, pwd_entry.pw_gid)
+        reader_users[str(chat_id)] = os_user
     known_user_dir_names = {str(chat_id) for chat_id, _os_user in memory_owners if chat_id is not None}
-
-    # Upload directories are service-owned even when memory/preferences/home
-    # belong to the agent OS user.  The service creates private files and
-    # grants the configured agent exact-file read access during handoff.
-    _secure_upload_directories(
-        data_path,
-        known_user_dir_names,
-        svc_uid,
-        svc_gid,
-        dry_run,
-    )
 
     # Resolve the primary operator's chat_id (first yaml entry). When
     # users.yaml is absent or empty (first-ever install, single-user
@@ -3967,6 +4068,28 @@ def _apply_migrate(
             print(f"[DRY RUN] Would migrate {copied} uploaded file(s) to {files_dst}")
         elif not copied and not dry_run:
             print("  Uploaded files already migrated or no files to copy")
+
+    # Reconcile after the legacy upload copy so newly migrated files cannot
+    # retain their source ownership/mode. Upload directories stay
+    # service-owned; only the configured agent OS user receives exact-file
+    # read access. History uses the same ownership boundary but grants the
+    # mapped user directory traversal/listing so grep/jq transcript search
+    # continues to work.
+    _secure_upload_directories(
+        data_path,
+        known_user_dir_names,
+        svc_uid,
+        svc_gid,
+        dry_run,
+        reader_users=reader_users,
+    )
+    _secure_history_directories(
+        data_path,
+        reader_users,
+        svc_uid,
+        svc_gid,
+        dry_run,
+    )
 
     # -- Memory directory ownership --
     # Two ownership tiers in a single tree:
@@ -4854,7 +4977,7 @@ def _apply_directories(
         (data_path, svc_uid, svc_gid, 0o755),  # user-owned data dir
         (data_path / "logs", svc_uid, svc_gid, 0o755),
         (data_path / "files", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
-        (data_path / "history", svc_uid, svc_gid, 0o755),
+        (data_path / "history", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         (data_path / "memory", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         # Per-user preferences root (#400). Top-level dir is service-
         # owned so the bot can lazily create new preferences/<chat_id>/

--- a/src/kai/named_access.py
+++ b/src/kai/named_access.py
@@ -1,0 +1,72 @@
+"""Platform-specific named read access for service-owned private files."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(command: list[str], *, action: str) -> None:
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"exit status {result.returncode}"
+        raise OSError(f"{action}: {detail}")
+
+
+def _grant_command(path: Path, reader_user: str, *, directory: bool) -> list[str]:
+    if sys.platform == "darwin":
+        permissions = (
+            "list,search,readattr,readextattr,readsecurity" if directory else "read,readattr,readextattr,readsecurity"
+        )
+        return [
+            "/bin/chmod",
+            "+a",
+            f"user:{reader_user} allow {permissions}",
+            str(path),
+        ]
+    if sys.platform.startswith("linux"):
+        setfacl = shutil.which("setfacl")
+        if setfacl is None:
+            raise OSError("setfacl is required for isolated named-file access on Linux")
+        permissions = "r-x" if directory else "r--"
+        return [setfacl, "-m", f"u:{reader_user}:{permissions}", str(path)]
+    raise OSError(f"isolated named-file access is unsupported on {sys.platform}")
+
+
+def grant_named_read_access(path: Path, reader_user: str, *, directory: bool) -> None:
+    """Grant one OS user read/traversal access to an otherwise private path."""
+    _run(
+        _grant_command(path, reader_user, directory=directory),
+        action=f"could not grant access to {reader_user} for {path}",
+    )
+
+
+def replace_named_read_access(
+    path: Path,
+    reader_user: str | None,
+    *,
+    directory: bool,
+) -> None:
+    """Replace Kai-managed extended ACLs with at most one named reader.
+
+    Protected history and upload paths are Kai-owned, so the installer owns
+    their complete extended-ACL contract. Clearing first prevents an old
+    ``os_user`` from retaining access after an operator changes users.yaml.
+    """
+    if sys.platform == "darwin":
+        clear_command = ["/bin/chmod", "-N", str(path)]
+    elif sys.platform.startswith("linux"):
+        setfacl = shutil.which("setfacl")
+        if setfacl is None:
+            raise OSError("setfacl is required for isolated named-file access on Linux")
+        # Directories can carry default ACLs that silently grant access to
+        # future children. Remove both access (-b) and default (-k) entries.
+        clear_command = [setfacl, "-b", "-k", str(path)] if directory else [setfacl, "-b", str(path)]
+    else:
+        raise OSError(f"isolated named-file access is unsupported on {sys.platform}")
+
+    _run(clear_command, action=f"could not clear stale access for {path}")
+    if reader_user:
+        grant_named_read_access(path, reader_user, directory=directory)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2882,7 +2882,12 @@ class TestHandlePhoto:
 
         mock_file = MagicMock()
         mock_file.download_as_bytearray = AsyncMock(return_value=bytearray(b"image-data"))
-        ctx = _make_context(config=_make_config(allowed_user_ids={1}))
+        ctx = _make_context(
+            config=_make_config(
+                allowed_user_ids={1},
+                user_configs={1: UserConfig(telegram_id=1, name="Daniel", os_user="daniel")},
+            )
+        )
         ctx.bot.get_file = AsyncMock(return_value=mock_file)
         inbound = AsyncMock()
         inbound_id = MessageId("msg_00000000000000000000000000000001")
@@ -2932,6 +2937,7 @@ class TestHandlePhoto:
             direction="user",
             chat_id=1,
             text=body,
+            reader_user="daniel",
             media={"type": "photo", "workshop_message_shadowed": True},
         )
         assert response.await_args.kwargs["workshop_inbound_message_id"] == inbound_id
@@ -3173,6 +3179,7 @@ class TestHandleDocument:
             direction="user",
             chat_id=1,
             text=expected_body,
+            reader_user=None,
             media={
                 "type": "document",
                 "filename": file_name,

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -386,12 +386,17 @@ class TestJobCallbackReminder:
     @pytest.mark.asyncio()
     async def test_logs_message_to_history(self, mock_context):
         """Reminder delivery is recorded in message history."""
+        user_config = MagicMock(os_user="daniel")
+        config = MagicMock()
+        config.get_user_config.return_value = user_config
+        mock_context.bot_data["config"] = config
         with patch("kai.cron.log_message") as mock_log:
             await _job_callback(mock_context)
         mock_log.assert_called_once()
         call_kwargs = mock_log.call_args.kwargs
         assert call_kwargs["direction"] == "assistant"
         assert call_kwargs["chat_id"] == 12345
+        assert call_kwargs["reader_user"] == "daniel"
 
     @pytest.mark.asyncio()
     async def test_forbidden_deactivates_and_removes(self, mock_context):

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -421,7 +421,7 @@ class TestErrorMessageLifecycle:
 
         captured_log: list[str] = []
 
-        def _capture_log(*, direction, chat_id, text):
+        def _capture_log(*, direction, chat_id, text, reader_user=None):
             captured_log.append(text)
 
         with (
@@ -459,7 +459,7 @@ class TestErrorMessageLifecycle:
 
         captured_log: list[str] = []
 
-        def _capture_log(*, direction, chat_id, text):
+        def _capture_log(*, direction, chat_id, text, reader_user=None):
             captured_log.append(text)
 
         with (

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,7 +1,9 @@
 """Tests for history.py message logging and retrieval."""
 
 import json
+import stat
 from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -74,6 +76,69 @@ class TestLogMessage:
         assert not (_log_dir / f"{today}.jsonl").exists()
         # File is in the per-user subdirectory
         assert (_log_dir / "1" / f"{today}.jsonl").exists()
+
+    def test_creates_private_history_tree(self, _log_dir):
+        log_message(direction="user", chat_id=1, text="private")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+
+        assert stat.S_IMODE(_log_dir.stat().st_mode) == 0o711
+        assert stat.S_IMODE((_log_dir / "1").stat().st_mode) == 0o700
+        assert stat.S_IMODE((_log_dir / "1" / f"{today}.jsonl").stat().st_mode) == 0o600
+
+    def test_grants_mapped_reader_on_new_directory_and_file(self, _log_dir, monkeypatch):
+        grant = MagicMock()
+        monkeypatch.setattr(history, "grant_named_read_access", grant)
+
+        result = log_message(
+            direction="user",
+            chat_id=1,
+            text="private",
+            reader_user="daniel",
+        )
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+
+        assert result is not None
+        assert grant.call_args_list == [
+            call(_log_dir / "1", "daniel", directory=True),
+            call(_log_dir / "1" / f"{today}.jsonl", "daniel", directory=False),
+        ]
+
+    def test_existing_file_does_not_accumulate_duplicate_acl(self, _log_dir, monkeypatch):
+        grant = MagicMock()
+        monkeypatch.setattr(history, "grant_named_read_access", grant)
+
+        log_message(direction="user", chat_id=1, text="first", reader_user="daniel")
+        grant.reset_mock()
+        log_message(direction="user", chat_id=1, text="second", reader_user="daniel")
+
+        grant.assert_not_called()
+
+    def test_acl_failure_keeps_file_private_and_returns_none(self, _log_dir, monkeypatch):
+        def fail_for_file(_path, _reader, *, directory):
+            if not directory:
+                raise OSError("acl failed")
+
+        monkeypatch.setattr(history, "grant_named_read_access", fail_for_file)
+
+        result = log_message(direction="user", chat_id=1, text="private", reader_user="daniel")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        path = _log_dir / "1" / f"{today}.jsonl"
+
+        assert result is None
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    def test_refuses_symlinked_daily_file(self, _log_dir):
+        user_dir = _log_dir / "1"
+        user_dir.mkdir()
+        target = _log_dir / "target"
+        target.write_text("unchanged")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        (user_dir / f"{today}.jsonl").symlink_to(target)
+
+        result = log_message(direction="user", chat_id=1, text="attack")
+
+        assert result is None
+        assert target.read_text() == "unchanged"
 
 
 # ── get_recent_history ───────────────────────────────────────────────
@@ -603,16 +668,7 @@ class TestLogEntryContract:
     def test_oserror_returns_none(self, monkeypatch, _log_dir):
         """An OSError during the JSONL append yields None, not a
         populated entry that would point at a never-written line."""
-        import builtins
-
-        original = builtins.open
-
-        def boom(path, mode="r", *args, **kwargs):
-            if "a" in mode:
-                raise OSError("disk full")
-            return original(path, mode, *args, **kwargs)
-
-        monkeypatch.setattr(builtins, "open", boom)
+        monkeypatch.setattr(history.os, "open", MagicMock(side_effect=OSError("disk full")))
         entry = log_message(direction="user", chat_id=1, text="lost")
         assert entry is None
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -57,6 +57,7 @@ from kai.install import (
     _retire_install_home_claude,
     _retire_install_home_dir,
     _secure_codex_turn_image_staging,
+    _secure_history_directories,
     _secure_upload_directories,
     _set_ownership,
     _src_checksum,
@@ -99,6 +100,7 @@ def _isolate_installed_backend_discovery(monkeypatch, tmp_path):
             "pi": "/test/bin/pi",
         },
     )
+    monkeypatch.setattr("kai.install.replace_named_read_access", MagicMock())
 
 
 # ── Validation helpers ───────────────────────────────────────────────
@@ -5064,7 +5066,7 @@ class TestSecureCodexTurnImageStaging:
 
 
 class TestSecureUploadDirectories:
-    def test_repairs_managed_directories_without_touching_existing_files(self, tmp_path, monkeypatch, capsys):
+    def test_repairs_managed_directories_and_secures_existing_files(self, tmp_path, monkeypatch, capsys):
         files_root = tmp_path / "data" / "files"
         user_dir = files_root / "12345"
         user_dir.mkdir(parents=True)
@@ -5090,12 +5092,12 @@ class TestSecureUploadDirectories:
         assert chowned == [
             (files_root, 9876, 9877),
             (user_dir, 9876, 9877),
+            (historical, 9876, 9877),
         ]
         assert stat.S_IMODE(files_root.stat().st_mode) == 0o711
         assert stat.S_IMODE(user_dir.stat().st_mode) == 0o711
         assert historical.read_bytes() == b"keep"
-        assert stat.S_IMODE(historical.stat().st_mode) == 0o644
-        assert historical not in {path for path, _uid, _gid in chowned}
+        assert stat.S_IMODE(historical.stat().st_mode) == 0o600
         assert "Secured upload directory" in capsys.readouterr().out
 
     def test_dry_run_reports_repairs_without_mutating(self, tmp_path, monkeypatch, capsys):
@@ -5121,6 +5123,48 @@ class TestSecureUploadDirectories:
         output = capsys.readouterr().out
         assert f"[DRY RUN] Would secure upload directory: {files_root}" in output
         assert f"[DRY RUN] Would secure upload directory: {user_dir}" in output
+
+    def test_replaces_file_acl_with_only_configured_reader(self, tmp_path, monkeypatch):
+        user_dir = tmp_path / "data" / "files" / "12345"
+        user_dir.mkdir(parents=True)
+        historical = user_dir / "photo.jpg"
+        historical.write_bytes(b"keep")
+        monkeypatch.setattr("kai.install.os.chown", MagicMock())
+        replace = MagicMock()
+        monkeypatch.setattr("kai.install.replace_named_read_access", replace)
+
+        _secure_upload_directories(
+            tmp_path / "data",
+            {"12345"},
+            svc_uid=9876,
+            svc_gid=9877,
+            dry_run=False,
+            reader_users={"12345": "daniel"},
+        )
+
+        replace.assert_any_call(historical, "daniel", directory=False)
+
+    def test_refuses_file_symlink_before_any_repair(self, tmp_path, monkeypatch):
+        user_dir = tmp_path / "data" / "files" / "12345"
+        user_dir.mkdir(parents=True)
+        target = tmp_path / "attacker-controlled"
+        target.write_text("unchanged")
+        (user_dir / "photo.jpg").symlink_to(target)
+        chown = MagicMock()
+        monkeypatch.setattr("kai.install.os.chown", chown)
+
+        with pytest.raises(RuntimeError, match="Refusing unsafe upload path"):
+            _secure_upload_directories(
+                tmp_path / "data",
+                {"12345"},
+                svc_uid=9876,
+                svc_gid=9877,
+                dry_run=False,
+                reader_users={"12345": "daniel"},
+            )
+
+        assert target.read_text() == "unchanged"
+        chown.assert_not_called()
 
     def test_refuses_managed_symlink_before_any_repair(self, tmp_path, monkeypatch):
         files_root = tmp_path / "data" / "files"
@@ -5167,6 +5211,97 @@ class TestSecureUploadDirectories:
 
         assert chowned == []
         assert stat.S_IMODE(unknown.stat().st_mode) == 0o775
+
+
+class TestSecureHistoryDirectories:
+    def test_secures_configured_and_unknown_history(self, tmp_path, monkeypatch):
+        history_root = tmp_path / "data" / "history"
+        configured = history_root / "12345"
+        unknown = history_root / "-100999"
+        configured.mkdir(parents=True)
+        unknown.mkdir()
+        configured_file = configured / "2026-08-11.jsonl"
+        unknown_file = unknown / "2026-08-11.jsonl"
+        legacy_file = history_root / "2025-01-01.jsonl"
+        for path in (configured_file, unknown_file, legacy_file):
+            path.write_text("{}\n")
+            path.chmod(0o644)
+        history_root.chmod(0o755)
+        configured.chmod(0o755)
+        unknown.chmod(0o755)
+        monkeypatch.setattr("kai.install.os.chown", MagicMock())
+        replace = MagicMock()
+        monkeypatch.setattr("kai.install.replace_named_read_access", replace)
+
+        _secure_history_directories(
+            tmp_path / "data",
+            {"12345": "daniel"},
+            svc_uid=9876,
+            svc_gid=9877,
+            dry_run=False,
+        )
+
+        assert stat.S_IMODE(history_root.stat().st_mode) == 0o711
+        assert stat.S_IMODE(configured.stat().st_mode) == 0o700
+        assert stat.S_IMODE(unknown.stat().st_mode) == 0o700
+        assert stat.S_IMODE(configured_file.stat().st_mode) == 0o600
+        assert stat.S_IMODE(unknown_file.stat().st_mode) == 0o600
+        assert stat.S_IMODE(legacy_file.stat().st_mode) == 0o600
+        replace.assert_any_call(configured, "daniel", directory=True)
+        replace.assert_any_call(configured_file, "daniel", directory=False)
+        replace.assert_any_call(unknown, None, directory=True)
+        replace.assert_any_call(unknown_file, None, directory=False)
+        replace.assert_any_call(legacy_file, None, directory=False)
+
+    def test_dry_run_reports_without_mutation(self, tmp_path, monkeypatch, capsys):
+        user_dir = tmp_path / "data" / "history" / "12345"
+        user_dir.mkdir(parents=True)
+        history_root = user_dir.parent
+        transcript = user_dir / "2026-08-11.jsonl"
+        transcript.write_text("{}\n")
+        history_root.chmod(0o755)
+        user_dir.chmod(0o755)
+        transcript.chmod(0o644)
+        chown = MagicMock()
+        replace = MagicMock()
+        monkeypatch.setattr("kai.install.os.chown", chown)
+        monkeypatch.setattr("kai.install.replace_named_read_access", replace)
+
+        _secure_history_directories(
+            tmp_path / "data",
+            {"12345": "daniel"},
+            svc_uid=9876,
+            svc_gid=9877,
+            dry_run=True,
+        )
+
+        assert stat.S_IMODE(history_root.stat().st_mode) == 0o755
+        assert stat.S_IMODE(user_dir.stat().st_mode) == 0o755
+        assert stat.S_IMODE(transcript.stat().st_mode) == 0o644
+        chown.assert_not_called()
+        replace.assert_not_called()
+        assert "[DRY RUN] Would secure history tree" in capsys.readouterr().out
+
+    def test_refuses_symlink_before_any_mutation(self, tmp_path, monkeypatch):
+        user_dir = tmp_path / "data" / "history" / "12345"
+        user_dir.mkdir(parents=True)
+        target = tmp_path / "attacker-controlled"
+        target.write_text("unchanged")
+        (user_dir / "2026-08-11.jsonl").symlink_to(target)
+        chown = MagicMock()
+        monkeypatch.setattr("kai.install.os.chown", chown)
+
+        with pytest.raises(RuntimeError, match="Refusing unsafe history path"):
+            _secure_history_directories(
+                tmp_path / "data",
+                {"12345": "daniel"},
+                svc_uid=9876,
+                svc_gid=9877,
+                dry_run=False,
+            )
+
+        assert target.read_text() == "unchanged"
+        chown.assert_not_called()
 
 
 class TestApplyMigrate:

--- a/tests/test_named_access.py
+++ b/tests/test_named_access.py
@@ -1,0 +1,113 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from kai import named_access
+
+
+def _completed() -> MagicMock:
+    result = MagicMock()
+    result.returncode = 0
+    result.stderr = ""
+    return result
+
+
+def test_macos_grants_directory_traversal_and_listing(monkeypatch, tmp_path):
+    run = MagicMock(return_value=_completed())
+    monkeypatch.setattr(named_access.sys, "platform", "darwin")
+    monkeypatch.setattr(named_access.subprocess, "run", run)
+
+    path = tmp_path / "history"
+    named_access.grant_named_read_access(path, "daniel", directory=True)
+
+    run.assert_called_once_with(
+        [
+            "/bin/chmod",
+            "+a",
+            "user:daniel allow list,search,readattr,readextattr,readsecurity",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_macos_replacement_clears_stale_acl_before_grant(monkeypatch, tmp_path):
+    run = MagicMock(return_value=_completed())
+    monkeypatch.setattr(named_access.sys, "platform", "darwin")
+    monkeypatch.setattr(named_access.subprocess, "run", run)
+    path = tmp_path / "messages.jsonl"
+
+    named_access.replace_named_read_access(path, "daniel", directory=False)
+
+    assert [call.args[0] for call in run.call_args_list] == [
+        ["/bin/chmod", "-N", str(path)],
+        [
+            "/bin/chmod",
+            "+a",
+            "user:daniel allow read,readattr,readextattr,readsecurity",
+            str(path),
+        ],
+    ]
+
+
+def test_linux_replacement_uses_setfacl(monkeypatch, tmp_path):
+    run = MagicMock(return_value=_completed())
+    monkeypatch.setattr(named_access.sys, "platform", "linux")
+    monkeypatch.setattr(named_access.shutil, "which", lambda _name: "/usr/bin/setfacl")
+    monkeypatch.setattr(named_access.subprocess, "run", run)
+    path = tmp_path / "messages.jsonl"
+
+    named_access.replace_named_read_access(path, "alice", directory=False)
+
+    assert [call.args[0] for call in run.call_args_list] == [
+        ["/usr/bin/setfacl", "-b", str(path)],
+        ["/usr/bin/setfacl", "-m", "u:alice:r--", str(path)],
+    ]
+
+
+def test_linux_directory_replacement_removes_default_acl(monkeypatch, tmp_path):
+    run = MagicMock(return_value=_completed())
+    monkeypatch.setattr(named_access.sys, "platform", "linux")
+    monkeypatch.setattr(named_access.shutil, "which", lambda _name: "/usr/bin/setfacl")
+    monkeypatch.setattr(named_access.subprocess, "run", run)
+    path = tmp_path / "history"
+
+    named_access.replace_named_read_access(path, "alice", directory=True)
+
+    assert [call.args[0] for call in run.call_args_list] == [
+        ["/usr/bin/setfacl", "-b", "-k", str(path)],
+        ["/usr/bin/setfacl", "-m", "u:alice:r-x", str(path)],
+    ]
+
+
+def test_replacement_without_reader_only_clears_acl(monkeypatch, tmp_path):
+    run = MagicMock(return_value=_completed())
+    monkeypatch.setattr(named_access.sys, "platform", "darwin")
+    monkeypatch.setattr(named_access.subprocess, "run", run)
+    path = tmp_path / "group-history"
+
+    named_access.replace_named_read_access(path, None, directory=True)
+
+    run.assert_called_once()
+    assert run.call_args.args[0] == ["/bin/chmod", "-N", str(path)]
+
+
+def test_missing_linux_setfacl_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.setattr(named_access.sys, "platform", "linux")
+    monkeypatch.setattr(named_access.shutil, "which", lambda _name: None)
+
+    with pytest.raises(OSError, match="setfacl is required"):
+        named_access.replace_named_read_access(tmp_path / "history", "alice", directory=True)
+
+
+def test_acl_command_failure_is_reported(monkeypatch, tmp_path):
+    result = _completed()
+    result.returncode = 1
+    result.stderr = "permission denied"
+    monkeypatch.setattr(named_access.sys, "platform", "darwin")
+    monkeypatch.setattr(named_access.subprocess, "run", MagicMock(return_value=result))
+
+    with pytest.raises(OSError, match="permission denied"):
+        named_access.grant_named_read_access(tmp_path / "history", "alice", directory=True)


### PR DESCRIPTION
## Summary

- make per-user conversation history service-owned and private instead of locally world-readable
- preserve direct backend transcript search through a named read/list ACL for only the OS user mapped to that Telegram principal
- migrate historical files in configured per-user upload directories from legacy `0644` ownership to service-owned private files with exact-user read access
- reject symlink and non-regular entries before installer mutation, and use no-follow append opens for runtime history writes
- reconcile ACLs by replacement so changing `os_user` revokes stale access on the next install

## Security boundary

Before this change, deployed history directories were `0755` and JSONL transcripts were `0644`. Any sibling local account could list and read conversation history. Older uploaded files could also remain `0644`; traversal-only parent directories reduced discovery but did not make a known file path private.

After this change:

- `/var/lib/kai/history` is service-owned `0711`
- configured per-user history directories are service-owned `0700`
- transcript files are service-owned `0600`
- only the configured `os_user` receives directory list/search and file read access through a named ACL
- unknown/group history directories and legacy flat transcript files remain service-private with no agent ACL
- configured per-user upload directories remain `0711`, while their historical files become service-owned `0600` with exact-file read ACLs for only the mapped `os_user`
- unknown upload directories remain untouched

macOS uses native `chmod` ACLs. Linux uses `setfacl` and fails closed when that tool is unavailable. Installer reconciliation clears old access and default ACLs before applying the current mapping.

## Runtime behavior

Every Telegram and scheduled-job history write now carries the mapped OS user into the history layer. New history roots, user directories, and daily files are created with private modes. Daily JSONL files are opened append-only with `O_NOFOLLOW` where supported, and symlink/non-regular targets are rejected.

The mapped backend user retains the existing ability to search its own JSONL transcripts with `grep` or `jq`. The Kai service retains ownership and append access. Single-user/service-user operation remains supported when no separate reader is required.

## Install and migration behavior

`make install` validates each managed history/upload tree before changing any entry, then:

1. completes any legacy upload copy
2. repairs configured upload ownership, modes, and ACLs
3. repairs all history ownership, modes, and ACLs

`DRY_RUN=1` reports the intended repairs without calling `chown`, `chmod`, or ACL commands. Unsafe symlinks abort before any managed tree mutation.

## Verification

- `make check`
- `python -m pytest -q tests/`
- result: `5192 passed, 1 skipped`

Focused coverage includes macOS/Linux ACL commands, stale/default ACL removal, missing-`setfacl` failure, runtime private creation, ACL failure handling, no-follow symlink rejection, mapped-user propagation from Telegram and cron, existing-data migration, unknown history isolation, unknown upload preservation, and dry-run non-mutation.
