### PR TITLE
Disable Whisper GPU execution on macOS

### DIFF
--- a/src/kai/transcribe.py
+++ b/src/kai/transcribe.py
@@ -17,6 +17,7 @@ from raw audio bytes to transcript string.
 
 import asyncio
 import logging
+import sys
 import tempfile
 from pathlib import Path
 
@@ -78,17 +79,28 @@ async def transcribe_voice(audio_data: bytes, model_path: Path) -> str:
             label="ffmpeg",
         )
 
-        # Step 2: Transcribe WAV → text via whisper-cli
+        # Step 2: Transcribe WAV → text via whisper-cli. The Metal path in
+        # current whisper.cpp builds is not reliable from Kai's macOS
+        # LaunchDaemon context: it can hang until the outer timeout, while the
+        # same input completes promptly on CPU. Keep GPU selection unchanged
+        # on other platforms.
+        whisper_command = ["whisper-cli"]
+        if sys.platform == "darwin":
+            whisper_command.append("--no-gpu")
+        whisper_command.extend(
+            [
+                "--model",
+                str(model_path),
+                "--file",
+                str(wav_path),
+                "--no-prints",
+                "--no-timestamps",
+                "--language",
+                "en",
+            ]
+        )
         stdout = await _run(
-            "whisper-cli",
-            "--model",
-            str(model_path),
-            "--file",
-            str(wav_path),
-            "--no-prints",
-            "--no-timestamps",
-            "--language",
-            "en",
+            *whisper_command,
             label="whisper-cli",
         )
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -159,7 +159,7 @@ class TestTranscribeVoice:
 
     @pytest.mark.asyncio
     async def test_whisper_args(self, tmp_path):
-        """Verifies whisper-cli is called with model path and --no-timestamps."""
+        """Verifies the common whisper-cli model and output arguments."""
         model = tmp_path / "model.bin"
         model.touch()
 
@@ -178,3 +178,41 @@ class TestTranscribeVoice:
         assert "--model" in whisper_args
         assert str(model) in whisper_args
         assert "--no-timestamps" in whisper_args
+
+    @pytest.mark.asyncio
+    async def test_whisper_disables_gpu_on_macos(self, tmp_path):
+        """macOS service transcription avoids the unreliable Metal path."""
+        model = tmp_path / "model.bin"
+        model.touch()
+        captured_args = []
+
+        async def _mock_exec(*args, **kwargs):
+            captured_args.append(args)
+            return _make_proc(stdout=b"text", returncode=0)
+
+        with (
+            patch("kai.transcribe.sys.platform", "darwin"),
+            patch("asyncio.create_subprocess_exec", side_effect=_mock_exec),
+        ):
+            await transcribe_voice(b"audio", model)
+
+        assert "--no-gpu" in captured_args[1]
+
+    @pytest.mark.asyncio
+    async def test_whisper_leaves_gpu_selection_unchanged_elsewhere(self, tmp_path):
+        """Non-macOS installations retain whisper.cpp's platform default."""
+        model = tmp_path / "model.bin"
+        model.touch()
+        captured_args = []
+
+        async def _mock_exec(*args, **kwargs):
+            captured_args.append(args)
+            return _make_proc(stdout=b"text", returncode=0)
+
+        with (
+            patch("kai.transcribe.sys.platform", "linux"),
+            patch("asyncio.create_subprocess_exec", side_effect=_mock_exec),
+        ):
+            await transcribe_voice(b"audio", model)
+
+        assert "--no-gpu" not in captured_args[1]


### PR DESCRIPTION
## Summary

- add `--no-gpu` to Kai's `whisper-cli` invocation on macOS only
- retain whisper.cpp's default GPU selection on Linux and other platforms
- pin both platform branches with focused command-construction tests

## Diagnosis

The post-#845 voice smoke test used a six-second Telegram voice message but failed with:

```text
Transcription failed: whisper-cli timed out after 30 seconds
```

This failure occurs before the new Workshop voice-shadow path. The deployed service also predated #845, so the failure was independently reproducible against the existing transcription implementation.

On the installed macOS host with whisper.cpp 1.9.1:

- the default Metal/GPU command terminated abnormally during a direct shell reproduction and hangs in the LaunchDaemon path until Kai's timeout;
- the otherwise identical command with `--no-gpu` completed successfully in 1.11 seconds.

The input was six seconds long, so increasing the 30-second timeout would mask the backend problem rather than address it.

## Scope

This PR changes only command construction in `transcribe_voice()`:

- Darwin: `whisper-cli --no-gpu ...`
- every other platform: `whisper-cli ...`

It does not change voice configuration, model selection, the timeout, authentication, transcription error handling, Telegram replies, prompts, history, or Workshop authority.

## Validation

- direct six-second host benchmark with `--no-gpu`: 1.11 seconds, exit 0
- `make check`
- `make typecheck`
- `python -m pytest tests/test_transcribe.py tests/test_bot.py -q` — 377 passed
- `python -m pytest tests/ -q` — 5199 passed, 1 skipped

## Post-merge verification

No `make config` is required. One `make install` will deploy both merged #845 and this fix. Then:

1. Send a short Telegram voice message.
2. Confirm the transcript echo and normal agent response.
3. Run `make install-status` and confirm Workshop message parity remains clean.
4. Repeat once after a service restart or subsequent install to provide restart evidence.
