### PR TITLE
Fix macOS Whisper scheduling under launchd

### DIFF
--- a/src/kai/transcribe.py
+++ b/src/kai/transcribe.py
@@ -23,6 +23,9 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
+_MACOS_TASKPOLICY = "/usr/sbin/taskpolicy"
+_TASKPOLICY_TIMEOUT_SECONDS = 5
+
 
 class TranscriptionError(Exception):
     """
@@ -140,6 +143,9 @@ async def _run(*cmd: str, label: str) -> str:
             f"{label} not found. Install with: brew install {'whisper-cpp' if 'whisper' in label else label}"
         ) from None
 
+    if label == "whisper-cli" and sys.platform == "darwin":
+        await _remove_macos_background_policy(proc.pid)
+
     try:
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
     except TimeoutError:
@@ -152,3 +158,35 @@ async def _run(*cmd: str, label: str) -> str:
         raise TranscriptionError(f"{label} failed (exit {proc.returncode}): {err}")
 
     return stdout.decode()
+
+
+async def _remove_macos_background_policy(pid: int) -> None:
+    """Remove launchd's inherited background scheduling from Whisper only."""
+    try:
+        policy_proc = await asyncio.create_subprocess_exec(
+            _MACOS_TASKPOLICY,
+            "-B",
+            "-p",
+            str(pid),
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        log.warning("Could not adjust Whisper scheduling: %s is missing", _MACOS_TASKPOLICY)
+        return
+
+    try:
+        _, stderr = await asyncio.wait_for(policy_proc.communicate(), timeout=_TASKPOLICY_TIMEOUT_SECONDS)
+    except TimeoutError:
+        policy_proc.kill()
+        await policy_proc.wait()
+        log.warning("Could not adjust Whisper scheduling: taskpolicy timed out")
+        return
+
+    if policy_proc.returncode != 0:
+        detail = stderr.decode(errors="replace").strip()[:200]
+        log.warning(
+            "Could not adjust Whisper scheduling: taskpolicy exited %d%s",
+            policy_proc.returncode,
+            f": {detail}" if detail else "",
+        )

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -6,6 +6,7 @@ timeout, stderr truncation) and the transcribe_voice() pipeline (model
 validation, full pipeline with mocked subprocesses).
 """
 
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,11 +16,12 @@ from kai.transcribe import TranscriptionError, _run, transcribe_voice
 # ── Test helpers ─────────────────────────────────────────────────────
 
 
-def _make_proc(stdout=b"", stderr=b"", returncode=0):
+def _make_proc(stdout=b"", stderr=b"", returncode=0, pid=1234):
     """Create a mock subprocess with controllable communicate() output."""
     proc = MagicMock()
     proc.communicate = AsyncMock(return_value=(stdout, stderr))
     proc.returncode = returncode
+    proc.pid = pid
     proc.kill = MagicMock()
     proc.wait = AsyncMock()
     return proc
@@ -98,6 +100,56 @@ class TestRun:
         snippet = msg.split(": ", 1)[1] if ": " in msg else msg
         assert len(snippet) <= 200
 
+    @pytest.mark.asyncio
+    async def test_macos_whisper_is_removed_from_background_scheduling(self):
+        """Whisper alone escapes the LaunchDaemon's inherited background policy."""
+        whisper_proc = _make_proc(stdout=b"hello\n", pid=4321)
+        policy_proc = _make_proc()
+
+        with (
+            patch("kai.transcribe.sys.platform", "darwin"),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                side_effect=[whisper_proc, policy_proc],
+            ) as exec_mock,
+        ):
+            result = await _run("whisper-cli", "--no-gpu", label="whisper-cli")
+
+        assert result == "hello\n"
+        assert exec_mock.await_args_list[1].args == (
+            "/usr/sbin/taskpolicy",
+            "-B",
+            "-p",
+            "4321",
+        )
+
+    @pytest.mark.asyncio
+    async def test_macos_non_whisper_process_keeps_background_scheduling(self):
+        """The scheduling exception is not applied to unrelated subprocesses."""
+        proc = _make_proc()
+
+        with (
+            patch("kai.transcribe.sys.platform", "darwin"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc) as exec_mock,
+        ):
+            await _run("ffmpeg", label="ffmpeg")
+
+        exec_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_macos_whisper_keeps_platform_scheduling(self):
+        """Other platforms do not invoke the macOS scheduling utility."""
+        proc = _make_proc()
+
+        with (
+            patch("kai.transcribe.sys.platform", "linux"),
+            patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=proc) as exec_mock,
+        ):
+            await _run("whisper-cli", label="whisper-cli")
+
+        exec_mock.assert_awaited_once()
+
 
 # ── transcribe_voice() ───────────────────────────────────────────────
 
@@ -132,7 +184,7 @@ class TestTranscribeVoice:
             result = await transcribe_voice(b"fake-audio", model)
 
         assert result == "Hello world"
-        assert call_count == 2
+        assert call_count == (3 if sys.platform == "darwin" else 2)
 
     @pytest.mark.asyncio
     async def test_ffmpeg_args(self, tmp_path):


### PR DESCRIPTION
## Summary

- remove macOS launchd's inherited background scheduling policy from the `whisper-cli` child process only
- leave Kai, ffmpeg, and all non-macOS transcription behavior unchanged
- retain CPU-only Whisper on macOS because the Metal path is unreliable in the system LaunchDaemon context

## Root cause

After #846 disabled Whisper's crashing Metal path, transcription moved to CPU. Kai's system LaunchDaemon is assigned macOS background scheduling, and `whisper-cli` inherits that policy. A three-second Telegram voice sample did not finish after more than 60 seconds under the inherited policy, despite completing in roughly one second outside the daemon.

Removing the background policy from the Whisper child with macOS's system `taskpolicy` utility allowed the patched production transcription function to process the exact failed Telegram audio in 7.6 seconds under an otherwise forced background context.

## Implementation

On Darwin, immediately after spawning `whisper-cli`, Kai runs:

```text
/usr/sbin/taskpolicy -B -p <whisper-pid>
```

The exception is scoped by both platform and subprocess label. Failure to invoke `taskpolicy` is logged and preserves the existing timeout behavior rather than changing other execution policy.

## Safety

- does not change the LaunchDaemon's scheduling classification
- does not elevate privileges or run as another user
- does not affect backend agent processes
- does not affect ffmpeg
- does not change Linux or other platforms
- retains the existing 30-second transcription timeout

## Verification

- `ruff check` passed for changed files
- `ruff format --check` passed for changed files
- voice/transcription tests: 43 passed
- full suite: 5,202 passed, 1 skipped
- end-to-end background-policy probe using the exact failed Telegram Ogg input: succeeded in 7.6 seconds with a 27-character transcript
