### PR TITLE
Test memory integration without Hugging Face network access

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,18 @@ from unittest.mock import patch
 
 import pytest
 
+# Test runs must never make model-registry requests. Memory integration
+# tests use the already-cached embedding model; tests/test_memory.py skips
+# those cases with a clear reason when the cache is not populated. These
+# overrides must precede the first mem0/transformers/huggingface_hub import
+# because each library snapshots its offline setting at import time.
+os.environ["HF_HUB_OFFLINE"] = "1"
+os.environ["TRANSFORMERS_OFFLINE"] = "1"
+# Mem0 otherwise starts a PostHog client and flushes anonymous telemetry at
+# interpreter exit. Test isolation covers outbound telemetry as well as model
+# lookup, and disabling it also avoids an unnecessary telemetry Qdrant store.
+os.environ["MEM0_TELEMETRY"] = "false"
+
 # Hard override (NOT setdefault). A dev who happens to run the
 # suite with `MEM0_DIR=$HOME/.mem0` exported in their shell is the
 # exact scenario this fix targets; respecting an inherited value

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -120,8 +120,35 @@ try:
 except ImportError:
     _HAS_MEM0 = False
 
-# Skip integration tests when mem0ai is not installed
-integration = pytest.mark.skipif(not _HAS_MEM0, reason="mem0ai not installed")
+
+def _memory_model_is_cached() -> bool:
+    """Check the test embedding model without permitting network access."""
+    if not _HAS_MEM0:
+        return False
+    try:
+        from huggingface_hub import snapshot_download
+
+        snapshot_download(
+            "sentence-transformers/all-MiniLM-L6-v2",
+            local_files_only=True,
+        )
+    except Exception:
+        return False
+    return True
+
+
+_HAS_MEMORY_MODEL = _memory_model_is_cached()
+
+# Real-memory tests are optional. They may use a previously populated cache,
+# but a test invocation never downloads model data or probes Hugging Face.
+integration = pytest.mark.skipif(
+    not _HAS_MEM0 or not _HAS_MEMORY_MODEL,
+    reason=(
+        "mem0ai is not installed"
+        if not _HAS_MEM0
+        else "all-MiniLM-L6-v2 is not cached; initialize Kai memory once before running integration tests"
+    ),
+)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

- force Hugging Face Hub and Transformers offline mode before test collection imports Mem0
- disable Mem0/PostHog telemetry for the test process
- run real-memory tests from the existing local embedding-model cache only
- skip real-memory cases with a clear explanation when that cache is absent
- leave production memory initialization and its intentional first-run model download unchanged

## Why

When the optional memory extra is installed locally, Mem0's Sentence Transformers initialization performs Hugging Face metadata requests even when `all-MiniLM-L6-v2` is already cached. Offline or restricted runs then wait through retries and can cascade into unrelated fixture failures.

Tests should be deterministic and must not initiate model downloads, registry probes, or telemetry uploads.

## Behavior

- cached model: real-memory tests run normally without external memory-related network access
- missing cache: only the 18 real-memory cases skip; unit tests continue
- production: unchanged

## Tests

- cached model: `.venv/bin/python -m pytest tests/test_memory.py -q` — 216 passed
- empty cache: `HF_HOME=/private/tmp/kai-hf-empty-cache .venv/bin/python -m pytest tests/test_memory.py -q` — 198 passed, 18 skipped
- broad suite: `.venv/bin/python -m pytest tests/ --ignore=tests/test_warnings.py -q` — 5261 passed, 1 skipped
- `make check`
- `make typecheck`

`tests/test_warnings.py` launches a nested pytest process containing local aiohttp servers; it was excluded from the broad sandboxed run because nested socket binding is denied here. Its guarded files are otherwise covered by the broad run, and CI can execute the nested check normally.
