### PR TITLE
Own Workshop Telegram delivery lifecycle

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -579,13 +579,17 @@ This decision also keeps transport coverage bounded. Direct Telegram sends remai
 
 ### 20.1 Next bounded implementation milestone
 
-Add a production-unused Telegram delivery runtime owner around the existing worker. The owner should:
+The production-unused Telegram delivery runtime owner now wraps the existing worker. It:
 
-- create at most one worker task and expose an explicit ready state;
-- recover expired leases before reporting ready;
-- surface an unexpected worker exit or exception instead of silently leaving Kai healthy;
-- stop new polling during shutdown and await the worker's current serialized iteration without cancelling an in-flight external send;
-- make repeated or out-of-order start/stop calls deterministic;
-- remain uncalled by `main.py`, enqueue no production work, and preserve all direct Telegram behavior.
+- creates at most one worker task and exposes an explicit ready state;
+- recovers expired leases before reporting ready;
+- surfaces an unexpected worker exit or exception instead of silently leaving Kai healthy;
+- stops new polling during shutdown and awaits the worker's current serialized iteration without cancelling an in-flight external send;
+- makes repeated or out-of-order start/stop calls deterministic;
+- remains uncalled by `main.py`, enqueues no production work, and preserves all direct Telegram behavior.
 
-Tests should cover clean startup, recovery-before-ready ordering, duplicate start rejection, idle and active graceful shutdown, fault propagation, and the absence of any worker task when the owner is never explicitly started. Once that contract is complete, conduct a focused cutover review for one normal direct-chat text-reply path. GitHub notification routing, schedules, files, and voice remain separate later cutovers.
+Automated contracts cover clean startup, recovery-before-ready ordering, duplicate start rejection, idle and active graceful shutdown, fault propagation, and the absence of any worker task when the owner is never explicitly started. No production startup or routing code imports or starts the owner.
+
+### 20.2 Next bounded review
+
+Conduct a focused cutover review for one normal direct-chat text-reply path. The review must define how Kai's application lifecycle will supervise the owner and how one reply path will switch atomically from canonical result creation to durable delivery without double-sending. GitHub notification routing, schedules, files, and voice remain separate later cutovers.

--- a/src/kai/workshop/__init__.py
+++ b/src/kai/workshop/__init__.py
@@ -92,6 +92,12 @@ from kai.workshop.telegram_delivery import (
     WorkshopTelegramDeliveryAdapter,
     WorkshopTelegramDeliveryWorker,
 )
+from kai.workshop.telegram_delivery_runtime import (
+    TelegramDeliveryRuntimeState,
+    TelegramDeliveryRuntimeStateError,
+    TelegramDeliveryWorkerExitedError,
+    WorkshopTelegramDeliveryRuntime,
+)
 from kai.workshop.timeline import (
     ChannelTimelineAuthorizer,
     TimelineAccessDeniedError,
@@ -152,6 +158,9 @@ __all__ = [
     "StoredEvent",
     "TelegramDeliveryContractError",
     "TelegramDeliveryFailure",
+    "TelegramDeliveryRuntimeState",
+    "TelegramDeliveryRuntimeStateError",
+    "TelegramDeliveryWorkerExitedError",
     "TelegramSentMessage",
     "TelegramTextBot",
     "TelegramWorkOutcome",
@@ -173,6 +182,7 @@ __all__ = [
     "WorkshopId",
     "WorkshopMembershipId",
     "WorkshopTelegramDeliveryAdapter",
+    "WorkshopTelegramDeliveryRuntime",
     "WorkshopTelegramDeliveryWorker",
     "read_channel_timeline",
     "record_inbound_artifact",

--- a/src/kai/workshop/telegram_delivery_runtime.py
+++ b/src/kai/workshop/telegram_delivery_runtime.py
@@ -1,0 +1,196 @@
+"""Production-unused lifecycle ownership for Workshop Telegram delivery."""
+
+from __future__ import annotations
+
+import asyncio
+from enum import StrEnum
+from typing import Protocol
+
+from kai.workshop.delivery_outbox import DeliveryRecoveryResult
+
+
+class _DeliveryLeaseRecovery(Protocol):
+    async def recover_expired_leases(self) -> DeliveryRecoveryResult: ...
+
+
+class _TelegramDeliveryWorkerLoop(Protocol):
+    async def run(self, stop_event: asyncio.Event) -> None: ...
+
+
+class TelegramDeliveryRuntimeState(StrEnum):
+    """Observable lifecycle state for the production-unused runtime owner."""
+
+    STOPPED = "stopped"
+    STARTING = "starting"
+    READY = "ready"
+    STOPPING = "stopping"
+    FAILED = "failed"
+
+
+class TelegramDeliveryRuntimeStateError(RuntimeError):
+    """The requested runtime transition is not valid in the current state."""
+
+
+class TelegramDeliveryWorkerExitedError(RuntimeError):
+    """The owned worker task exited without a shutdown request."""
+
+
+class WorkshopTelegramDeliveryRuntime:
+    """Own exactly one recoverable Telegram worker task when explicitly started.
+
+    Nothing constructs or starts this owner in production yet. It defines the
+    lifecycle boundary a later, separately reviewed cutover can register.
+    """
+
+    def __init__(
+        self,
+        recovery: _DeliveryLeaseRecovery,
+        worker: _TelegramDeliveryWorkerLoop,
+    ) -> None:
+        self._recovery = recovery
+        self._worker = worker
+        self._lock = asyncio.Lock()
+        self._state = TelegramDeliveryRuntimeState.STOPPED
+        self._stop_event: asyncio.Event | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._failure: BaseException | None = None
+        self._recovery_result: DeliveryRecoveryResult | None = None
+
+    @property
+    def state(self) -> TelegramDeliveryRuntimeState:
+        return self._state
+
+    @property
+    def ready(self) -> bool:
+        return self._state == TelegramDeliveryRuntimeState.READY
+
+    @property
+    def has_worker_task(self) -> bool:
+        """Whether this owner currently retains a worker task, running or done."""
+        return self._task is not None
+
+    @property
+    def failure(self) -> BaseException | None:
+        return self._failure
+
+    @property
+    def recovery_result(self) -> DeliveryRecoveryResult | None:
+        return self._recovery_result
+
+    async def start(self) -> DeliveryRecoveryResult:
+        """Recover abandoned work, then create the single owned worker task."""
+        async with self._lock:
+            if self._state != TelegramDeliveryRuntimeState.STOPPED:
+                raise TelegramDeliveryRuntimeStateError(
+                    f"Telegram delivery runtime cannot start while {self._state.value}"
+                )
+
+            self._state = TelegramDeliveryRuntimeState.STARTING
+            self._failure = None
+            self._recovery_result = None
+            try:
+                recovered = await self._recovery.recover_expired_leases()
+            except asyncio.CancelledError:
+                self._state = TelegramDeliveryRuntimeState.STOPPED
+                raise
+            except Exception as error:
+                self._failure = error
+                self._state = TelegramDeliveryRuntimeState.FAILED
+                raise
+
+            stop_event = asyncio.Event()
+            task = asyncio.create_task(
+                self._worker.run(stop_event),
+                name="kai-workshop-telegram-delivery",
+            )
+            self._stop_event = stop_event
+            self._task = task
+            self._recovery_result = recovered
+            self._state = TelegramDeliveryRuntimeState.READY
+            task.add_done_callback(self._worker_done)
+            return recovered
+
+    async def wait(self) -> None:
+        """Wait for the worker and propagate any unexpected termination."""
+        task = self._task
+        if task is None:
+            if self._failure is not None:
+                raise self._failure
+            raise TelegramDeliveryRuntimeStateError("Telegram delivery runtime has no worker task")
+
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            if not task.cancelled():
+                raise
+        except Exception:
+            pass
+        self._record_completion(task)
+        if self._failure is not None:
+            raise self._failure
+
+    async def stop(self) -> None:
+        """Cooperatively stop polling and await the current serialized iteration."""
+        async with self._lock:
+            if self._state == TelegramDeliveryRuntimeState.STOPPED:
+                return
+
+            task = self._task
+            stop_event = self._stop_event
+            if task is not None and task.done() and self._failure is None:
+                # Preserve an exit that happened immediately before shutdown;
+                # setting the event first would misclassify it as intentional.
+                self._record_completion(task, stop_was_requested=False)
+            self._state = TelegramDeliveryRuntimeState.STOPPING
+            if stop_event is not None:
+                stop_event.set()
+
+        if task is not None:
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                if not task.cancelled():
+                    # Cancelling the stop caller must not cancel the worker.
+                    raise
+            except Exception:
+                pass
+            self._record_completion(task)
+
+        async with self._lock:
+            failure = self._failure
+            if task is self._task:
+                self._task = None
+                self._stop_event = None
+            self._state = TelegramDeliveryRuntimeState.STOPPED
+
+        if failure is not None:
+            raise failure
+
+    def _worker_done(self, task: asyncio.Task[None]) -> None:
+        self._record_completion(task)
+
+    def _record_completion(
+        self,
+        task: asyncio.Task[None],
+        *,
+        stop_was_requested: bool | None = None,
+    ) -> None:
+        if task is not self._task or not task.done():
+            return
+
+        if stop_was_requested is None:
+            stop_was_requested = self._stop_event is not None and self._stop_event.is_set()
+        if task.cancelled():
+            failure: BaseException | None = TelegramDeliveryWorkerExitedError(
+                "Telegram delivery worker was cancelled outside its runtime owner"
+            )
+        else:
+            failure = task.exception()
+            if failure is None and not stop_was_requested:
+                failure = TelegramDeliveryWorkerExitedError(
+                    "Telegram delivery worker exited without a shutdown request"
+                )
+
+        if failure is not None:
+            self._failure = failure
+            self._state = TelegramDeliveryRuntimeState.FAILED

--- a/tests/test_workshop_telegram_delivery_runtime.py
+++ b/tests/test_workshop_telegram_delivery_runtime.py
@@ -1,0 +1,209 @@
+"""Lifecycle contracts for the production-unused Telegram delivery owner."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from kai.workshop.delivery_outbox import DeliveryRecoveryResult
+from kai.workshop.telegram_delivery_runtime import (
+    TelegramDeliveryRuntimeState,
+    TelegramDeliveryRuntimeStateError,
+    TelegramDeliveryWorkerExitedError,
+    WorkshopTelegramDeliveryRuntime,
+)
+
+
+class _ControlledRecovery:
+    def __init__(self, *, result: DeliveryRecoveryResult | None = None) -> None:
+        self.result = result or DeliveryRecoveryResult(requeued=0, failed=0)
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.release.set()
+        self.calls = 0
+        self.error: Exception | None = None
+
+    async def recover_expired_leases(self) -> DeliveryRecoveryResult:
+        self.calls += 1
+        self.entered.set()
+        await self.release.wait()
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class _ControlledWorker:
+    def __init__(self, *, active: bool = False) -> None:
+        self.active = active
+        self.started = asyncio.Event()
+        self.iteration_started = asyncio.Event()
+        self.release_iteration = asyncio.Event()
+        self.cancelled = False
+        self.calls = 0
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        self.calls += 1
+        self.started.set()
+        try:
+            if self.active:
+                self.iteration_started.set()
+                await self.release_iteration.wait()
+            await stop_event.wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
+class _FaultingWorker:
+    def __init__(self, *, exit_normally: bool = False) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.exit_normally = exit_normally
+        self.error = RuntimeError("delivery worker failed")
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        del stop_event
+        self.started.set()
+        await self.release.wait()
+        if not self.exit_normally:
+            raise self.error
+
+
+async def test_owner_creates_no_task_until_explicitly_started():
+    recovery = _ControlledRecovery()
+    worker = _ControlledWorker()
+    runtime = WorkshopTelegramDeliveryRuntime(recovery, worker)
+
+    assert runtime.state == TelegramDeliveryRuntimeState.STOPPED
+    assert not runtime.ready
+    assert not runtime.has_worker_task
+    assert runtime.failure is None
+    assert runtime.recovery_result is None
+
+    await runtime.stop()
+
+    assert recovery.calls == 0
+    assert worker.calls == 0
+    assert not runtime.has_worker_task
+
+
+async def test_start_recovers_before_ready_and_starts_exactly_one_worker():
+    recovered = DeliveryRecoveryResult(requeued=2, failed=1)
+    recovery = _ControlledRecovery(result=recovered)
+    recovery.release.clear()
+    worker = _ControlledWorker()
+    runtime = WorkshopTelegramDeliveryRuntime(recovery, worker)
+
+    start_task = asyncio.create_task(runtime.start())
+    await recovery.entered.wait()
+    assert runtime.state == TelegramDeliveryRuntimeState.STARTING
+    assert not runtime.ready
+    assert not runtime.has_worker_task
+    assert worker.calls == 0
+
+    recovery.release.set()
+    assert await start_task == recovered
+    assert runtime.ready
+    assert runtime.recovery_result == recovered
+    assert runtime.has_worker_task
+    await worker.started.wait()
+    assert worker.calls == 1
+
+    with pytest.raises(TelegramDeliveryRuntimeStateError, match="cannot start while ready"):
+        await runtime.start()
+
+    await runtime.stop()
+    assert runtime.state == TelegramDeliveryRuntimeState.STOPPED
+    assert not runtime.has_worker_task
+
+
+async def test_idle_shutdown_is_cooperative_and_repeatable():
+    recovery = _ControlledRecovery()
+    worker = _ControlledWorker()
+    runtime = WorkshopTelegramDeliveryRuntime(recovery, worker)
+    await runtime.start()
+    await worker.started.wait()
+
+    await asyncio.gather(runtime.stop(), runtime.stop())
+    await runtime.stop()
+
+    assert runtime.state == TelegramDeliveryRuntimeState.STOPPED
+    assert not runtime.has_worker_task
+    assert not worker.cancelled
+
+
+async def test_active_shutdown_awaits_iteration_without_cancelling_worker():
+    recovery = _ControlledRecovery()
+    worker = _ControlledWorker(active=True)
+    runtime = WorkshopTelegramDeliveryRuntime(recovery, worker)
+    await runtime.start()
+    await worker.iteration_started.wait()
+
+    stop_task = asyncio.create_task(runtime.stop())
+    await asyncio.sleep(0)
+    assert runtime.state == TelegramDeliveryRuntimeState.STOPPING
+    assert not stop_task.done()
+    assert not worker.cancelled
+
+    worker.release_iteration.set()
+    await stop_task
+    assert runtime.state == TelegramDeliveryRuntimeState.STOPPED
+    assert not runtime.has_worker_task
+    assert not worker.cancelled
+
+
+async def test_worker_exception_is_visible_to_supervisor_and_stop():
+    recovery = _ControlledRecovery()
+    worker = _FaultingWorker()
+    runtime = WorkshopTelegramDeliveryRuntime(recovery, worker)
+    await runtime.start()
+    await worker.started.wait()
+    worker.release.set()
+
+    with pytest.raises(RuntimeError, match="delivery worker failed") as wait_error:
+        await runtime.wait()
+    assert wait_error.value is worker.error
+    assert runtime.state == TelegramDeliveryRuntimeState.FAILED
+    assert runtime.failure is worker.error
+
+    with pytest.raises(RuntimeError, match="delivery worker failed"):
+        await runtime.stop()
+    assert runtime.state == TelegramDeliveryRuntimeState.STOPPED
+    assert not runtime.has_worker_task
+
+
+async def test_normal_worker_exit_without_stop_is_a_visible_failure():
+    recovery = _ControlledRecovery()
+    worker = _FaultingWorker(exit_normally=True)
+    runtime = WorkshopTelegramDeliveryRuntime(recovery, worker)
+    await runtime.start()
+    await worker.started.wait()
+    worker.release.set()
+
+    with pytest.raises(TelegramDeliveryWorkerExitedError, match="without a shutdown request"):
+        await runtime.wait()
+    assert runtime.state == TelegramDeliveryRuntimeState.FAILED
+
+    with pytest.raises(TelegramDeliveryWorkerExitedError):
+        await runtime.stop()
+
+
+async def test_recovery_failure_prevents_readiness_and_worker_creation():
+    recovery = _ControlledRecovery()
+    recovery.error = RuntimeError("lease recovery failed")
+    worker = _ControlledWorker()
+    runtime = WorkshopTelegramDeliveryRuntime(recovery, worker)
+
+    with pytest.raises(RuntimeError, match="lease recovery failed") as start_error:
+        await runtime.start()
+    assert start_error.value is recovery.error
+    assert runtime.state == TelegramDeliveryRuntimeState.FAILED
+    assert runtime.failure is recovery.error
+    assert not runtime.ready
+    assert not runtime.has_worker_task
+    assert worker.calls == 0
+
+    with pytest.raises(RuntimeError, match="lease recovery failed"):
+        await runtime.stop()
+    assert runtime.state == TelegramDeliveryRuntimeState.STOPPED


### PR DESCRIPTION
## Summary

- add a production-unused lifecycle owner for the Workshop Telegram delivery worker
- recover expired delivery leases before exposing the runtime as ready
- own at most one worker task and reject duplicate starts deterministically
- surface unexpected worker exits and exceptions through observable state and `wait()`
- stop cooperatively, awaiting an active serialized iteration without cancelling an in-flight Telegram send
- document the completed lifecycle boundary and the next focused cutover review

## Safety boundary

- no import or registration was added to `main.py`
- no production handler starts the runtime
- no production work is enqueued by this owner
- existing direct Telegram replies, GitHub notifications, schedules, files, and voice delivery are unchanged
- a later PR still requires an explicit authority review before any direct-chat text path can cut over

## Tests

- `make check`
- `make typecheck`
- `python -m pytest -q tests/test_workshop_telegram_delivery_runtime.py tests/test_workshop_telegram_delivery.py` — 35 passed
- `python -m pytest -q tests/test_workshop*.py` — 304 passed
- `python -m pytest tests/ -q -x --tb=long` — 5,324 passed, 1 skipped

The lifecycle tests cover no implicit task creation, recovery-before-ready ordering, duplicate start rejection, repeatable idle shutdown, active graceful shutdown without cancellation, worker exception propagation, unexpected normal exit, and recovery failure before task creation.
