### PR TITLE
Isolate Workshop delivery purposes

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -651,3 +651,11 @@ Only after the production-unused finalization contract passes another review sho
 - document rollback as: stop the worker, reconcile all non-terminal conversation deliveries, restore the legacy route, and prove no old delivery can replay on later activation.
 
 Installed qualification must then demonstrate one streamed short reply finalized in place with no second copy, one fragmented long reply in order, a restart between enqueue and delivery, cooperative shutdown during active work, fatal recovery from an injected worker fault, clean canonical/JSONL parity, and unchanged media, voice, GitHub notification-group, schedule, file, and command behavior.
+
+### 21.4 Durable delivery-purpose foundation
+
+The first streaming-finalization prerequisite is now implemented without production registration. Every new delivery request must identify one durable purpose: `conversation_reply` or `qualification`. Existing version-10 outbox rows migrate to `qualification`, which is the fail-safe classification for all delivery work created before normal conversation routing exists.
+
+Claims, expired-lease recovery, and per-binding ordering are purpose-scoped. A qualification row therefore cannot be claimed, recovered, or used as an ordering predecessor by a conversation worker, and the Telegram worker instance owns exactly one purpose. The installed qualification command is fixed to `qualification`; the production-unused atomic assistant-result service is fixed to `conversation_reply`. Neither accepts a purpose from an external caller.
+
+Migration, conflict, lane-isolation, recovery-isolation, and worker-exclusion tests pin this boundary. The runtime remains unregistered and normal Telegram delivery remains unchanged. The next bounded slice is canonical binding of a confirmed streaming preview to its direct channel and inbound message; it must remain production-unused and must not yet edit or send through the Workshop worker.

--- a/src/kai/workshop/__init__.py
+++ b/src/kai/workshop/__init__.py
@@ -39,8 +39,11 @@ from kai.workshop.delivery_fragments import (
     WorkshopDeliveryFragments,
 )
 from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
+    QUALIFICATION_PURPOSE,
     DeliveryClaim,
     DeliveryOutboxError,
+    DeliveryPurpose,
     DeliveryRecoveryResult,
     DeliveryRequest,
     DeliveryRequestConflictError,
@@ -108,6 +111,8 @@ from kai.workshop.timeline import (
 )
 
 __all__ = [
+    "CONVERSATION_REPLY_PURPOSE",
+    "QUALIFICATION_PURPOSE",
     "AgentId",
     "AppendResult",
     "ArtifactId",
@@ -131,6 +136,7 @@ __all__ = [
     "DeliveryFragmentUncertainError",
     "DeliveryId",
     "DeliveryOutboxError",
+    "DeliveryPurpose",
     "DeliveryRecoveryResult",
     "DeliveryRequest",
     "DeliveryRequestConflictError",

--- a/src/kai/workshop/delivery_outbox.py
+++ b/src/kai/workshop/delivery_outbox.py
@@ -6,6 +6,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from typing import Literal, cast
 
 import aiosqlite
 
@@ -30,6 +31,11 @@ _MAX_ATTEMPTS = 20
 _MAX_MINIMUM_RETRY_DELAY = timedelta(days=1)
 _RETRY_BASE_SECONDS = 5
 _RETRY_MAX_SECONDS = 300
+
+DeliveryPurpose = Literal["conversation_reply", "qualification"]
+CONVERSATION_REPLY_PURPOSE: DeliveryPurpose = "conversation_reply"
+QUALIFICATION_PURPOSE: DeliveryPurpose = "qualification"
+_DELIVERY_PURPOSES = frozenset({CONVERSATION_REPLY_PURPOSE, QUALIFICATION_PURPOSE})
 
 
 class DeliveryOutboxError(RuntimeError):
@@ -61,6 +67,7 @@ class DeliveryRequest:
     message_id: MessageId
     channel_binding_id: ChannelBindingId
     mode: str
+    purpose: DeliveryPurpose
     occurred_at: datetime
     max_attempts: int = 5
 
@@ -71,6 +78,7 @@ class DeliveryRequest:
             raise ValueError("channel_binding_id must be a ChannelBindingId")
         if not _IDENTIFIER_PATTERN.fullmatch(self.mode):
             raise ValueError("mode must be a lowercase identifier")
+        _validate_purpose(self.purpose)
         if self.occurred_at.tzinfo is None or self.occurred_at.utcoffset() is None:
             raise ValueError("occurred_at must be timezone-aware")
         if (
@@ -89,6 +97,7 @@ class DeliveryState:
     channel_binding_id: ChannelBindingId
     transport: str
     mode: str
+    purpose: DeliveryPurpose
     status: str
     max_attempts: int
     attempt_count: int
@@ -116,6 +125,7 @@ class DeliveryClaim:
     transport: str
     external_channel_id: str
     mode: str
+    purpose: DeliveryPurpose
     body: str
     lease_expires_at: datetime
 
@@ -146,6 +156,24 @@ def _validate_worker_id(worker_id: str) -> None:
 def _validate_error_code(error_code: str) -> None:
     if not _IDENTIFIER_PATTERN.fullmatch(error_code):
         raise ValueError("error_code must be a lowercase identifier")
+
+
+def _validate_purpose(purpose: str) -> None:
+    if purpose not in _DELIVERY_PURPOSES:
+        raise ValueError("purpose must be conversation_reply or qualification")
+
+
+def _validate_purposes(purposes: tuple[DeliveryPurpose, ...]) -> None:
+    if not purposes or len(set(purposes)) != len(purposes):
+        raise ValueError("purposes must contain unique values")
+    for purpose in purposes:
+        _validate_purpose(purpose)
+
+
+def _delivery_purpose(value: object) -> DeliveryPurpose:
+    purpose = str(value)
+    _validate_purpose(purpose)
+    return cast(DeliveryPurpose, purpose)
 
 
 def _retry_delay(attempt_number: int) -> timedelta:
@@ -205,6 +233,7 @@ class WorkshopDeliveryOutbox:
                 or existing.channel_binding_id != request.channel_binding_id
                 or existing.transport != transport
                 or existing.max_attempts != request.max_attempts
+                or existing.purpose != request.purpose
             ):
                 raise DeliveryRequestConflictError("Delivery request identity has different semantics")
             return DeliveryRequestResult(delivery=existing, inserted=False)
@@ -213,17 +242,17 @@ class WorkshopDeliveryOutbox:
         event = EventEnvelope.create(
             event_id=EventId.derived(
                 workshop_id,
-                f"delivery-request-event:{request.message_id}:{request.channel_binding_id}:{request.mode}",
+                f"delivery-request-event:v2:{request.message_id}:{request.channel_binding_id}:{request.mode}",
             ),
             event_type=WorkshopEventType.DELIVERY_REQUESTED,
-            event_version=1,
+            event_version=2,
             workshop_id=workshop_id,
             aggregate_type="delivery",
             aggregate_id=delivery_id,
             actor_principal_id=author_principal_id,
             occurred_at=occurred_at,
             idempotency_key=(
-                f"workshop-delivery-request:v1:{request.message_id}:{request.channel_binding_id}:{request.mode}"
+                f"workshop-delivery-request:v2:{request.message_id}:{request.channel_binding_id}:{request.mode}"
             ),
             payload={
                 "message_id": request.message_id,
@@ -231,6 +260,7 @@ class WorkshopDeliveryOutbox:
                 "channel_binding_id": request.channel_binding_id,
                 "transport": transport,
                 "mode": request.mode,
+                "purpose": request.purpose,
                 "max_attempts": request.max_attempts,
             },
             metadata={"source": "delivery_outbox"},
@@ -242,9 +272,9 @@ class WorkshopDeliveryOutbox:
         timestamp = _format_timestamp(occurred_at)
         await connection.execute(
             "INSERT INTO delivery_outbox "
-            "(id, workshop_id, channel_id, channel_binding_id, message_id, transport, mode, "
+            "(id, workshop_id, channel_id, channel_binding_id, message_id, transport, mode, purpose, "
             "status, max_attempts, attempt_count, available_at, requested_event_position, "
-            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, 0, ?, ?, ?, ?)",
+            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, 0, ?, ?, ?, ?)",
             (
                 delivery_id,
                 workshop_id,
@@ -253,6 +283,7 @@ class WorkshopDeliveryOutbox:
                 request.message_id,
                 transport,
                 request.mode,
+                request.purpose,
                 request.max_attempts,
                 timestamp,
                 appended.event.position,
@@ -267,12 +298,14 @@ class WorkshopDeliveryOutbox:
         self,
         worker_id: str,
         *,
+        purposes: tuple[DeliveryPurpose, ...],
         lease_duration: timedelta = timedelta(seconds=30),
         transport: str | None = None,
         modes: tuple[str, ...] | None = None,
         delivery_id: DeliveryId | None = None,
     ) -> DeliveryClaim | None:
         _validate_worker_id(worker_id)
+        _validate_purposes(purposes)
         if lease_duration <= timedelta(0) or lease_duration > _MAX_LEASE:
             raise ValueError("lease_duration must be positive and at most five minutes")
         if transport is not None and not _IDENTIFIER_PATTERN.fullmatch(transport):
@@ -290,7 +323,7 @@ class WorkshopDeliveryOutbox:
         now = self._now()
         try:
             await connection.execute("BEGIN IMMEDIATE")
-            await self._recover_expired_in_transaction(now, delivery_id=delivery_id)
+            await self._recover_expired_in_transaction(now, purposes=purposes, delivery_id=delivery_id)
             now_text = _format_timestamp(now)
             filters = [
                 "o.status IN ('pending', 'retry_wait')",
@@ -299,11 +332,15 @@ class WorkshopDeliveryOutbox:
                 "NOT EXISTS ("
                 "SELECT 1 FROM delivery_outbox predecessor "
                 "WHERE predecessor.channel_binding_id = o.channel_binding_id "
+                "AND predecessor.purpose = o.purpose "
                 "AND predecessor.requested_event_position < o.requested_event_position "
                 "AND predecessor.status NOT IN ('succeeded', 'failed')"
                 ")",
             ]
             parameters: list[object] = [now_text]
+            purpose_placeholders = ", ".join("?" for _ in purposes)
+            filters.append(f"o.purpose IN ({purpose_placeholders})")
+            parameters.extend(purposes)
             if delivery_id is not None:
                 filters.append("o.id = ?")
                 parameters.append(delivery_id)
@@ -316,7 +353,7 @@ class WorkshopDeliveryOutbox:
                 parameters.extend(modes)
             async with connection.execute(
                 "SELECT o.id, o.workshop_id, o.channel_id, o.channel_binding_id, o.message_id, "
-                "o.transport, o.mode, o.attempt_count, m.body, cb.external_channel_id "
+                "o.transport, o.mode, o.purpose, o.attempt_count, m.body, cb.external_channel_id "
                 "FROM delivery_outbox o "
                 "JOIN messages m ON m.id = o.message_id AND m.channel_id = o.channel_id "
                 "JOIN channel_bindings cb ON cb.id = o.channel_binding_id "
@@ -331,7 +368,7 @@ class WorkshopDeliveryOutbox:
                 return None
 
             delivery_id = DeliveryId(str(row[0]))
-            attempt_number = int(row[7]) + 1
+            attempt_number = int(row[8]) + 1
             attempt_id = DeliveryAttemptId.new()
             expires_at = now + lease_duration
             expires_text = _format_timestamp(expires_at)
@@ -368,8 +405,9 @@ class WorkshopDeliveryOutbox:
                 message_id=MessageId(str(row[4])),
                 transport=str(row[5]),
                 mode=str(row[6]),
-                body=str(row[8]),
-                external_channel_id=str(row[9]),
+                purpose=_delivery_purpose(row[7]),
+                body=str(row[9]),
+                external_channel_id=str(row[10]),
                 lease_expires_at=expires_at,
             )
         except Exception:
@@ -402,11 +440,16 @@ class WorkshopDeliveryOutbox:
             minimum_retry_delay=minimum_retry_delay,
         )
 
-    async def recover_expired_leases(self) -> DeliveryRecoveryResult:
+    async def recover_expired_leases(
+        self,
+        *,
+        purposes: tuple[DeliveryPurpose, ...],
+    ) -> DeliveryRecoveryResult:
+        _validate_purposes(purposes)
         connection = self._store.connection
         try:
             await connection.execute("BEGIN IMMEDIATE")
-            result = await self._recover_expired_in_transaction(self._now())
+            result = await self._recover_expired_in_transaction(self._now(), purposes=purposes)
             await connection.commit()
             return result
         except Exception:
@@ -470,7 +513,11 @@ class WorkshopDeliveryOutbox:
             if row[0] != "leased" or row[3] != claim.attempt_id:
                 raise StaleDeliveryLeaseError("Delivery attempt no longer owns the active lease")
             if row[4] is None or _parse_timestamp(str(row[4])) <= now:
-                await self._recover_expired_in_transaction(now, delivery_id=claim.delivery_id)
+                await self._recover_expired_in_transaction(
+                    now,
+                    purposes=(claim.purpose,),
+                    delivery_id=claim.delivery_id,
+                )
                 await connection.commit()
                 raise StaleDeliveryLeaseError("Delivery attempt lease has expired")
 
@@ -558,16 +605,21 @@ class WorkshopDeliveryOutbox:
         self,
         now: datetime,
         *,
+        purposes: tuple[DeliveryPurpose, ...],
         delivery_id: DeliveryId | None = None,
     ) -> DeliveryRecoveryResult:
         connection = self._store.connection
         now_text = _format_timestamp(now)
+        purpose_placeholders = ", ".join("?" for _ in purposes)
         identity_filter = " AND id = ?" if delivery_id is not None else ""
-        parameters: tuple[object, ...] = (now_text, delivery_id) if delivery_id is not None else (now_text,)
+        parameters: tuple[object, ...] = (now_text, *purposes)
+        if delivery_id is not None:
+            parameters = (*parameters, delivery_id)
         async with connection.execute(
             "SELECT id, lease_id, attempt_count, max_attempts, workshop_id, channel_id, "
             "channel_binding_id, message_id, transport, mode FROM delivery_outbox "
-            f"WHERE status = 'leased' AND lease_expires_at <= ?{identity_filter} "
+            f"WHERE status = 'leased' AND lease_expires_at <= ? "
+            f"AND purpose IN ({purpose_placeholders}){identity_filter} "
             "ORDER BY requested_event_position",
             parameters,
         ) as cursor:
@@ -727,6 +779,7 @@ class WorkshopDeliveryOutbox:
             channel_binding_id=ChannelBindingId(str(row["channel_binding_id"])),
             transport=str(row["transport"]),
             mode=str(row["mode"]),
+            purpose=_delivery_purpose(row["purpose"]),
             status=str(row["status"]),
             max_attempts=int(row["max_attempts"]),
             attempt_count=int(row["attempt_count"]),

--- a/src/kai/workshop/delivery_qualification.py
+++ b/src/kai/workshop/delivery_qualification.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from kai.workshop.delivery_outbox import (
+    QUALIFICATION_PURPOSE,
     DeliveryClaim,
     DeliveryRequest,
     DeliveryRequestResult,
@@ -75,6 +76,7 @@ class WorkshopDeliveryQualification:
                 message_id=MessageId(str(row[0])),
                 channel_binding_id=ChannelBindingId(str(row[1])),
                 mode="text",
+                purpose=QUALIFICATION_PURPOSE,
                 occurred_at=datetime.now(UTC),
                 max_attempts=3,
             )
@@ -157,6 +159,7 @@ class WorkshopDeliveryQualification:
                     message_id=message_id,
                     channel_binding_id=binding_id,
                     mode="text",
+                    purpose=QUALIFICATION_PURPOSE,
                     occurred_at=occurred_at,
                     max_attempts=3,
                 )
@@ -182,6 +185,7 @@ class WorkshopDeliveryQualification:
         """Claim exact work and exit before sending to test lease recovery."""
         claim = await self._outbox.claim_next(
             worker_id,
+            purposes=(QUALIFICATION_PURPOSE,),
             lease_duration=lease_duration,
             transport="telegram",
             modes=("text",),

--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -6,7 +6,12 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 
-from kai.workshop.delivery_outbox import DeliveryRequest, DeliveryRequestResult, WorkshopDeliveryOutbox
+from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
+    DeliveryRequest,
+    DeliveryRequestResult,
+    WorkshopDeliveryOutbox,
+)
 from kai.workshop.domain import (
     ChannelBindingId,
     ChannelId,
@@ -210,6 +215,7 @@ async def record_outbound_message_with_delivery(
                 message_id=message_id,
                 channel_binding_id=channel_binding_id,
                 mode="text",
+                purpose=CONVERSATION_REPLY_PURPOSE,
                 occurred_at=message.occurred_at,
                 max_attempts=5,
             )

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 10
+WORKSHOP_SCHEMA_VERSION = 11
 
 
 @dataclass(frozen=True, slots=True)
@@ -439,6 +439,19 @@ _DELIVERY_BINDING_ORDER_SCHEMA = SchemaMigration(
     ),
 )
 
+_DELIVERY_PURPOSE_SCHEMA = SchemaMigration(
+    version=11,
+    name="durable_delivery_purpose",
+    statements=(
+        "ALTER TABLE delivery_outbox ADD COLUMN purpose TEXT NOT NULL "
+        "DEFAULT 'qualification' CHECK (purpose IN ('conversation_reply', 'qualification'))",
+        "CREATE INDEX delivery_outbox_purpose_due_idx "
+        "ON delivery_outbox (purpose, status, available_at, requested_event_position)",
+        "CREATE INDEX delivery_outbox_purpose_binding_order_idx "
+        "ON delivery_outbox (purpose, channel_binding_id, requested_event_position, status)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -450,6 +463,7 @@ _MIGRATIONS = (
     _DELIVERY_FRAGMENT_SCHEMA,
     _BINDING_AWARE_DELIVERY_SCHEMA,
     _DELIVERY_BINDING_ORDER_SCHEMA,
+    _DELIVERY_PURPOSE_SCHEMA,
 )
 
 

--- a/src/kai/workshop/telegram_delivery.py
+++ b/src/kai/workshop/telegram_delivery.py
@@ -26,7 +26,13 @@ from telegram.warnings import PTBDeprecationWarning
 
 from kai.telegram_utils import chunk_text
 from kai.workshop.delivery_fragments import DeliveryFragment, WorkshopDeliveryFragments
-from kai.workshop.delivery_outbox import DeliveryClaim, DeliveryState, WorkshopDeliveryOutbox
+from kai.workshop.delivery_outbox import (
+    DeliveryClaim,
+    DeliveryPurpose,
+    DeliveryRecoveryResult,
+    DeliveryState,
+    WorkshopDeliveryOutbox,
+)
 from kai.workshop.domain import DeliveryId
 
 _NUMERIC_CHAT_ID_PATTERN = re.compile(r"^-?[1-9][0-9]{0,19}$")
@@ -219,6 +225,7 @@ class WorkshopTelegramDeliveryWorker:
         adapter: WorkshopTelegramDeliveryAdapter,
         *,
         worker_id: str,
+        purpose: DeliveryPurpose,
         lease_duration: timedelta = timedelta(seconds=30),
         poll_interval: float = 1.0,
     ) -> None:
@@ -228,12 +235,14 @@ class WorkshopTelegramDeliveryWorker:
         self._fragments = fragments
         self._adapter = adapter
         self._worker_id = worker_id
+        self._purpose: DeliveryPurpose = purpose
         self._lease_duration = lease_duration
         self._poll_interval = poll_interval
 
     async def run_once(self) -> TelegramWorkResult:
         claim = await self._outbox.claim_next(
             self._worker_id,
+            purposes=(self._purpose,),
             lease_duration=self._lease_duration,
             transport="telegram",
             modes=("text",),
@@ -246,12 +255,17 @@ class WorkshopTelegramDeliveryWorker:
             raise ValueError("delivery_id must be a DeliveryId")
         claim = await self._outbox.claim_next(
             self._worker_id,
+            purposes=(self._purpose,),
             lease_duration=self._lease_duration,
             transport="telegram",
             modes=("text",),
             delivery_id=delivery_id,
         )
         return await self._run_claim(claim)
+
+    async def recover_expired_leases(self) -> DeliveryRecoveryResult:
+        """Recover only work in this worker's explicitly assigned purpose lanes."""
+        return await self._outbox.recover_expired_leases(purposes=(self._purpose,))
 
     async def _run_claim(self, claim: DeliveryClaim | None) -> TelegramWorkResult:
         if claim is None:

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -14,7 +14,12 @@ from telegram.error import TelegramError
 
 from kai.config import DATA_DIR, load_config
 from kai.workshop.delivery_fragments import WorkshopDeliveryFragments
-from kai.workshop.delivery_outbox import DeliveryState, DeliveryTargetNotFoundError, WorkshopDeliveryOutbox
+from kai.workshop.delivery_outbox import (
+    QUALIFICATION_PURPOSE,
+    DeliveryState,
+    DeliveryTargetNotFoundError,
+    WorkshopDeliveryOutbox,
+)
 from kai.workshop.delivery_qualification import DeliveryQualificationError, WorkshopDeliveryQualification
 from kai.workshop.domain import DeliveryId
 from kai.workshop.store import WorkshopEventStore
@@ -134,6 +139,7 @@ async def _run(args: argparse.Namespace) -> int:
                     WorkshopDeliveryFragments(store),
                     WorkshopTelegramDeliveryAdapter(bot),
                     worker_id=worker_id,
+                    purpose=QUALIFICATION_PURPOSE,
                 )
                 result = await worker.run_delivery(delivery_id)
         except TelegramError as exc:

--- a/tests/test_workshop_delivery_fragments.py
+++ b/tests/test_workshop_delivery_fragments.py
@@ -11,6 +11,7 @@ import pytest
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.delivery_fragments import DeliveryFragmentPlanConflictError, WorkshopDeliveryFragments
 from kai.workshop.delivery_outbox import (
+    QUALIFICATION_PURPOSE,
     DeliveryRequest,
     IncompleteDeliveryFragmentsError,
     UnsettledDeliveryFragmentError,
@@ -89,6 +90,7 @@ async def _open_with_delivery(
             message_id=message_id,
             channel_binding_id=binding_id,
             mode="text",
+            purpose=QUALIFICATION_PURPOSE,
             occurred_at=_NOW,
         )
     )
@@ -100,7 +102,7 @@ class TestDeliveryFragmentPlan:
         clock = _Clock()
         store, outbox, fragments = await _open_with_delivery(tmp_path / "kai.db", clock)
         try:
-            claim = await outbox.claim_next("worker-1")
+            claim = await outbox.claim_next("worker-1", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
 
             first = await fragments.prepare(claim, ("first", "second"))
@@ -117,7 +119,7 @@ class TestDeliveryFragmentPlan:
         clock = _Clock()
         store, outbox, fragments = await _open_with_delivery(tmp_path / "kai.db", clock)
         try:
-            claim = await outbox.claim_next("worker-1")
+            claim = await outbox.claim_next("worker-1", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
             await fragments.prepare(claim, ("first", "second"))
             first = await fragments.begin_next(claim)
@@ -138,7 +140,7 @@ class TestDeliveryFragmentPlan:
         clock = _Clock()
         store, outbox, fragments = await _open_with_delivery(tmp_path / "kai.db", clock)
         try:
-            claim = await outbox.claim_next("worker-1")
+            claim = await outbox.claim_next("worker-1", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
             await fragments.prepare(claim, ("first", "second"))
             assert await fragments.begin_next(claim) is not None
@@ -155,7 +157,9 @@ class TestDeliveryFragmentRecovery:
         clock = _Clock()
         store, outbox, fragments = await _open_with_delivery(tmp_path / "kai.db", clock)
         try:
-            first_claim = await outbox.claim_next("worker-1", lease_duration=timedelta(seconds=10))
+            first_claim = await outbox.claim_next(
+                "worker-1", purposes=(QUALIFICATION_PURPOSE,), lease_duration=timedelta(seconds=10)
+            )
             assert first_claim is not None
             await fragments.prepare(first_claim, ("first", "second"))
             first = await fragments.begin_next(first_claim)
@@ -163,8 +167,8 @@ class TestDeliveryFragmentRecovery:
             await fragments.mark_sent(first_claim, first, external_message_id=1001)
 
             clock.advance(timedelta(seconds=10))
-            assert (await outbox.recover_expired_leases()).requeued == 1
-            second_claim = await outbox.claim_next("worker-2")
+            assert (await outbox.recover_expired_leases(purposes=(QUALIFICATION_PURPOSE,))).requeued == 1
+            second_claim = await outbox.claim_next("worker-2", purposes=(QUALIFICATION_PURPOSE,))
             assert second_claim is not None and second_claim.attempt_number == 2
             await fragments.prepare(second_claim, ("first", "second"))
             resumed = await fragments.begin_next(second_claim)
@@ -185,13 +189,15 @@ class TestDeliveryFragmentRecovery:
         clock = _Clock()
         store, outbox, fragments = await _open_with_delivery(tmp_path / "kai.db", clock)
         try:
-            claim = await outbox.claim_next("worker-1", lease_duration=timedelta(seconds=10))
+            claim = await outbox.claim_next(
+                "worker-1", purposes=(QUALIFICATION_PURPOSE,), lease_duration=timedelta(seconds=10)
+            )
             assert claim is not None
             await fragments.prepare(claim, ("first", "second"))
             assert await fragments.begin_next(claim) is not None
 
             clock.advance(timedelta(seconds=10))
-            recovered = await outbox.recover_expired_leases()
+            recovered = await outbox.recover_expired_leases(purposes=(QUALIFICATION_PURPOSE,))
             state = await outbox.state(claim.delivery_id)
             persisted = await fragments.fragments(claim.delivery_id)
 
@@ -200,7 +206,7 @@ class TestDeliveryFragmentRecovery:
             assert state.status == "failed"
             assert state.last_error_code == "delivery_send_uncertain"
             assert persisted[0].status == "uncertain"
-            assert await outbox.claim_next("worker-2") is None
+            assert await outbox.claim_next("worker-2", purposes=(QUALIFICATION_PURPOSE,)) is None
         finally:
             await store.close()
 
@@ -208,7 +214,7 @@ class TestDeliveryFragmentRecovery:
         clock = _Clock()
         store, outbox, fragments = await _open_with_delivery(tmp_path / "kai.db", clock)
         try:
-            claim = await outbox.claim_next("worker-1")
+            claim = await outbox.claim_next("worker-1", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
             await fragments.prepare(claim, ("first", "second"))
             first = await fragments.begin_next(claim)

--- a/tests/test_workshop_delivery_outbox.py
+++ b/tests/test_workshop_delivery_outbox.py
@@ -12,6 +12,8 @@ import pytest
 
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
+    QUALIFICATION_PURPOSE,
     DeliveryRequest,
     DeliveryRequestConflictError,
     DeliveryTargetNotFoundError,
@@ -158,12 +160,14 @@ def _request(
     binding_id: ChannelBindingId,
     *,
     mode: str = "text",
+    purpose=QUALIFICATION_PURPOSE,
     max_attempts: int = 5,
 ) -> DeliveryRequest:
     return DeliveryRequest(
         message_id=message_id,
         channel_binding_id=binding_id,
         mode=mode,
+        purpose=purpose,
         occurred_at=_NOW,
         max_attempts=max_attempts,
     )
@@ -195,12 +199,15 @@ class TestDeliveryRequests:
             ]
             assert len(events) == 1
             assert events[0].position == result.delivery.requested_event_position
+            assert events[0].envelope.event_version == 2
+            assert result.delivery.purpose == QUALIFICATION_PURPOSE
             assert events[0].envelope.payload == {
                 "message_id": message_id,
                 "channel_id": result.delivery.channel_id,
                 "channel_binding_id": binding_id,
                 "transport": "telegram",
                 "mode": "text",
+                "purpose": QUALIFICATION_PURPOSE,
                 "max_attempts": 5,
             }
             async with store.connection.execute("SELECT COUNT(*) FROM delivery_attempts") as cursor:
@@ -233,6 +240,16 @@ class TestDeliveryRequests:
             await outbox.request_delivery(_request(message_id, binding_id, max_attempts=5))
             with pytest.raises(DeliveryRequestConflictError):
                 await outbox.request_delivery(_request(message_id, binding_id, max_attempts=4))
+        finally:
+            await store.close()
+
+    async def test_duplicate_request_with_changed_purpose_fails_closed(self, tmp_path: Path):
+        store, message_id, binding_id = await _open_with_outbound(tmp_path / "kai.db")
+        try:
+            outbox = WorkshopDeliveryOutbox(store)
+            await outbox.request_delivery(_request(message_id, binding_id))
+            with pytest.raises(DeliveryRequestConflictError):
+                await outbox.request_delivery(_request(message_id, binding_id, purpose=CONVERSATION_REPLY_PURPOSE))
         finally:
             await store.close()
 
@@ -292,7 +309,7 @@ class TestDeliveryOutcomes:
         outbox = WorkshopDeliveryOutbox(store, clock=_Clock())
         try:
             requested = await outbox.request_delivery(_request(message_id, binding_id))
-            claim = await outbox.claim_next("telegram-worker")
+            claim = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
 
             succeeded = await outbox.mark_succeeded(claim)
@@ -336,7 +353,7 @@ class TestDeliveryOutcomes:
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         try:
             requested = await outbox.request_delivery(_request(message_id, binding_id, max_attempts=2))
-            first = await outbox.claim_next("telegram-worker")
+            first = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert first is not None
             retry = await outbox.mark_failed(first, retryable=True, error_code="network_timeout")
             assert retry.status == "retry_wait"
@@ -348,7 +365,7 @@ class TestDeliveryOutcomes:
             ]
 
             clock.advance(timedelta(seconds=5))
-            second = await outbox.claim_next("telegram-worker")
+            second = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert second is not None
             failed = await outbox.mark_failed(second, retryable=True, error_code="network_timeout")
             assert failed.status == "failed"
@@ -375,7 +392,7 @@ class TestDeliveryOutcomes:
         outbox = WorkshopDeliveryOutbox(store, clock=_Clock())
         try:
             requested = await outbox.request_delivery(_request(message_id, binding_id))
-            claim = await outbox.claim_next("telegram-worker")
+            claim = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
             await store.connection.execute(
                 "CREATE TRIGGER reject_delivery_success BEFORE INSERT ON event_log "
@@ -405,10 +422,10 @@ class TestDeliveryOutcomes:
             direct = await outbox.request_delivery(_request(message_id, direct_binding_id))
             group = await outbox.request_delivery(_request(message_id, group_binding_id))
 
-            first = await outbox.claim_next("telegram-worker")
+            first = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert first is not None
             await outbox.mark_succeeded(first)
-            second = await outbox.claim_next("telegram-worker")
+            second = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert second is not None
             await outbox.mark_succeeded(second)
             await store.project_pending(CanonicalConversationProjection())
@@ -442,7 +459,7 @@ class TestDeliveryOutcomes:
                 ),
             )
             requested = await outbox.request_delivery(_request(message_id, binding_id))
-            claim = await outbox.claim_next("telegram-worker")
+            claim = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
             await outbox.mark_succeeded(claim)
 
@@ -497,6 +514,35 @@ class TestDeliveryOutcomes:
 
 
 class TestDeliveryOrdering:
+    async def test_purpose_lanes_do_not_claim_or_block_each_other(self, tmp_path: Path):
+        store, first_message_id, binding_id = await _open_with_outbound(tmp_path / "kai.db")
+        second_message_id = await _add_outbound(store, 1)
+        outbox = WorkshopDeliveryOutbox(store, clock=_Clock())
+        try:
+            qualification = await outbox.request_delivery(_request(first_message_id, binding_id))
+            conversation = await outbox.request_delivery(
+                _request(second_message_id, binding_id, purpose=CONVERSATION_REPLY_PURPOSE)
+            )
+
+            conversation_claim = await outbox.claim_next(
+                "conversation-worker",
+                purposes=(CONVERSATION_REPLY_PURPOSE,),
+            )
+            assert conversation_claim is not None
+            assert conversation_claim.delivery_id == conversation.delivery.delivery_id
+            assert conversation_claim.purpose == CONVERSATION_REPLY_PURPOSE
+            assert (await outbox.state(qualification.delivery.delivery_id)).status == "pending"
+
+            qualification_claim = await outbox.claim_next(
+                "qualification-worker",
+                purposes=(QUALIFICATION_PURPOSE,),
+            )
+            assert qualification_claim is not None
+            assert qualification_claim.delivery_id == qualification.delivery.delivery_id
+            assert qualification_claim.purpose == QUALIFICATION_PURPOSE
+        finally:
+            await store.close()
+
     async def test_concurrent_workers_cannot_overtake_on_one_binding(self, tmp_path: Path):
         path = tmp_path / "kai.db"
         store, first_message_id, binding_id = await _open_with_outbound(path)
@@ -507,15 +553,19 @@ class TestDeliveryOrdering:
         second_store = await WorkshopEventStore.open(path)
         try:
             first_claim, competing_claim = await asyncio.gather(
-                outbox.claim_next("worker-1"),
-                WorkshopDeliveryOutbox(second_store, clock=_Clock()).claim_next("worker-2"),
+                outbox.claim_next("worker-1", purposes=(QUALIFICATION_PURPOSE,)),
+                WorkshopDeliveryOutbox(second_store, clock=_Clock()).claim_next(
+                    "worker-2", purposes=(QUALIFICATION_PURPOSE,)
+                ),
             )
             claims = [claim for claim in (first_claim, competing_claim) if claim is not None]
             assert len(claims) == 1
             assert claims[0].delivery_id == first_request.delivery.delivery_id
 
             await outbox.mark_succeeded(claims[0])
-            next_claim = await WorkshopDeliveryOutbox(second_store, clock=_Clock()).claim_next("worker-2")
+            next_claim = await WorkshopDeliveryOutbox(second_store, clock=_Clock()).claim_next(
+                "worker-2", purposes=(QUALIFICATION_PURPOSE,)
+            )
             assert next_claim is not None
             assert next_claim.delivery_id == second_request.delivery.delivery_id
         finally:
@@ -530,18 +580,18 @@ class TestDeliveryOrdering:
         try:
             first_request = await outbox.request_delivery(_request(first_message_id, binding_id))
             second_request = await outbox.request_delivery(_request(second_message_id, binding_id))
-            first_claim = await outbox.claim_next("telegram-worker")
+            first_claim = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert first_claim is not None
             await outbox.mark_failed(first_claim, retryable=True, error_code="network_timeout")
 
-            assert await outbox.claim_next("telegram-worker") is None
+            assert await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,)) is None
             clock.advance(timedelta(seconds=5))
-            retry_claim = await outbox.claim_next("telegram-worker")
+            retry_claim = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert retry_claim is not None
             assert retry_claim.delivery_id == first_request.delivery.delivery_id
             await outbox.mark_failed(retry_claim, retryable=False, error_code="provider_rejected")
 
-            next_claim = await outbox.claim_next("telegram-worker")
+            next_claim = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert next_claim is not None
             assert next_claim.delivery_id == second_request.delivery.delivery_id
         finally:
@@ -555,12 +605,12 @@ class TestDeliveryOrdering:
             first_request = await outbox.request_delivery(_request(first_message_id, binding_id, mode="text"))
             second_request = await outbox.request_delivery(_request(second_message_id, binding_id, mode="photo"))
 
-            assert await outbox.claim_next("photo-worker", modes=("photo",)) is None
-            first_claim = await outbox.claim_next("text-worker", modes=("text",))
+            assert await outbox.claim_next("photo-worker", purposes=(QUALIFICATION_PURPOSE,), modes=("photo",)) is None
+            first_claim = await outbox.claim_next("text-worker", purposes=(QUALIFICATION_PURPOSE,), modes=("text",))
             assert first_claim is not None
             assert first_claim.delivery_id == first_request.delivery.delivery_id
             await outbox.mark_succeeded(first_claim)
-            second_claim = await outbox.claim_next("photo-worker", modes=("photo",))
+            second_claim = await outbox.claim_next("photo-worker", purposes=(QUALIFICATION_PURPOSE,), modes=("photo",))
             assert second_claim is not None
             assert second_claim.delivery_id == second_request.delivery.delivery_id
         finally:
@@ -574,10 +624,10 @@ class TestDeliveryOrdering:
             direct = await outbox.request_delivery(_request(message_id, direct_binding_id))
             group = await outbox.request_delivery(_request(message_id, group_binding_id))
 
-            direct_claim = await outbox.claim_next("worker-1")
+            direct_claim = await outbox.claim_next("worker-1", purposes=(QUALIFICATION_PURPOSE,))
             assert direct_claim is not None
             assert direct_claim.delivery_id == direct.delivery.delivery_id
-            group_claim = await outbox.claim_next("worker-2")
+            group_claim = await outbox.claim_next("worker-2", purposes=(QUALIFICATION_PURPOSE,))
             assert group_claim is not None
             assert group_claim.delivery_id == group.delivery.delivery_id
         finally:
@@ -585,6 +635,46 @@ class TestDeliveryOrdering:
 
 
 class TestDeliveryClaims:
+    async def test_recovery_is_scoped_to_worker_purpose(self, tmp_path: Path):
+        store, message_id, private_binding = await _open_with_outbound(tmp_path / "kai.db")
+        group_binding = await _add_group_binding(store, message_id)
+        clock = _Clock()
+        outbox = WorkshopDeliveryOutbox(store, clock=clock)
+        qualification = await outbox.request_delivery(_request(message_id, private_binding))
+        conversation = await outbox.request_delivery(
+            _request(message_id, group_binding, purpose=CONVERSATION_REPLY_PURPOSE)
+        )
+        try:
+            assert (
+                await outbox.claim_next(
+                    "qualification-worker",
+                    purposes=(QUALIFICATION_PURPOSE,),
+                    delivery_id=qualification.delivery.delivery_id,
+                    lease_duration=timedelta(seconds=5),
+                )
+                is not None
+            )
+            assert (
+                await outbox.claim_next(
+                    "conversation-worker",
+                    purposes=(CONVERSATION_REPLY_PURPOSE,),
+                    delivery_id=conversation.delivery.delivery_id,
+                    lease_duration=timedelta(seconds=5),
+                )
+                is not None
+            )
+            clock.advance(timedelta(seconds=5))
+
+            recovered = await outbox.recover_expired_leases(
+                purposes=(CONVERSATION_REPLY_PURPOSE,),
+            )
+
+            assert recovered.requeued == 1
+            assert (await outbox.state(conversation.delivery.delivery_id)).status == "retry_wait"
+            assert (await outbox.state(qualification.delivery.delivery_id)).status == "leased"
+        finally:
+            await store.close()
+
     async def test_exact_claim_never_drains_other_due_work(self, tmp_path: Path):
         store, message_id, private_binding = await _open_with_outbound(tmp_path / "kai.db")
         group_binding = await _add_group_binding(store, message_id)
@@ -593,6 +683,7 @@ class TestDeliveryClaims:
         try:
             claim = await WorkshopDeliveryOutbox(store).claim_next(
                 "qualification-worker",
+                purposes=(QUALIFICATION_PURPOSE,),
                 delivery_id=group.delivery.delivery_id,
                 transport="telegram",
                 modes=("text",),
@@ -614,11 +705,13 @@ class TestDeliveryClaims:
         try:
             private_claim = await outbox.claim_next(
                 "private-worker",
+                purposes=(QUALIFICATION_PURPOSE,),
                 delivery_id=private.delivery.delivery_id,
                 lease_duration=timedelta(seconds=5),
             )
             group_claim = await outbox.claim_next(
                 "group-worker",
+                purposes=(QUALIFICATION_PURPOSE,),
                 delivery_id=group.delivery.delivery_id,
                 lease_duration=timedelta(seconds=5),
             )
@@ -628,6 +721,7 @@ class TestDeliveryClaims:
 
             recovered_group = await outbox.claim_next(
                 "qualification-worker",
+                purposes=(QUALIFICATION_PURPOSE,),
                 delivery_id=group.delivery.delivery_id,
             )
 
@@ -645,6 +739,7 @@ class TestDeliveryClaims:
         try:
             claim = await WorkshopDeliveryOutbox(store).claim_next(
                 "qualification-worker",
+                purposes=(QUALIFICATION_PURPOSE,),
                 delivery_id=second.delivery.delivery_id,
             )
 
@@ -662,8 +757,10 @@ class TestDeliveryClaims:
         second_store = await WorkshopEventStore.open(path)
         try:
             first, second = await asyncio.gather(
-                WorkshopDeliveryOutbox(store, clock=clock).claim_next("worker-1"),
-                WorkshopDeliveryOutbox(second_store, clock=clock).claim_next("worker-2"),
+                WorkshopDeliveryOutbox(store, clock=clock).claim_next("worker-1", purposes=(QUALIFICATION_PURPOSE,)),
+                WorkshopDeliveryOutbox(second_store, clock=clock).claim_next(
+                    "worker-2", purposes=(QUALIFICATION_PURPOSE,)
+                ),
             )
             claims = [claim for claim in (first, second) if claim is not None]
             assert len(claims) == 1
@@ -686,15 +783,15 @@ class TestDeliveryClaims:
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         try:
             requested = await outbox.request_delivery(_request(message_id, binding_id))
-            first = await outbox.claim_next("telegram-worker")
+            first = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert first is not None
             failed = await outbox.mark_failed(first, retryable=True, error_code="network_timeout")
             assert failed.status == "retry_wait"
             assert failed.available_at == _NOW + timedelta(seconds=5)
-            assert await outbox.claim_next("telegram-worker") is None
+            assert await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,)) is None
 
             clock.advance(timedelta(seconds=5))
-            second = await outbox.claim_next("telegram-worker")
+            second = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert second is not None
             assert second.delivery_id == requested.delivery.delivery_id
             assert second.attempt_number == 2
@@ -712,12 +809,12 @@ class TestDeliveryClaims:
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         try:
             await outbox.request_delivery(_request(message_id, binding_id, max_attempts=1))
-            claim = await outbox.claim_next("telegram-worker")
+            claim = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
             failed = await outbox.mark_failed(claim, retryable=True, error_code="network_timeout")
             assert failed.status == "failed"
             assert failed.completed_at == _NOW
-            assert await outbox.claim_next("telegram-worker") is None
+            assert await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,)) is None
         finally:
             await store.close()
 
@@ -727,7 +824,7 @@ class TestDeliveryClaims:
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         try:
             await outbox.request_delivery(_request(message_id, binding_id))
-            claim = await outbox.claim_next("telegram-worker")
+            claim = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
 
             failed = await outbox.mark_failed(
@@ -748,10 +845,12 @@ class TestDeliveryClaims:
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         try:
             await outbox.request_delivery(_request(message_id, binding_id))
-            stale = await outbox.claim_next("worker-1", lease_duration=timedelta(seconds=10))
+            stale = await outbox.claim_next(
+                "worker-1", purposes=(QUALIFICATION_PURPOSE,), lease_duration=timedelta(seconds=10)
+            )
             assert stale is not None
             clock.advance(timedelta(seconds=10))
-            current = await outbox.claim_next("worker-2")
+            current = await outbox.claim_next("worker-2", purposes=(QUALIFICATION_PURPOSE,))
             assert current is not None
             assert current.attempt_number == 2
             with pytest.raises(StaleDeliveryLeaseError):
@@ -766,7 +865,9 @@ class TestDeliveryClaims:
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         try:
             await outbox.request_delivery(_request(message_id, binding_id))
-            expired = await outbox.claim_next("worker-1", lease_duration=timedelta(seconds=10))
+            expired = await outbox.claim_next(
+                "worker-1", purposes=(QUALIFICATION_PURPOSE,), lease_duration=timedelta(seconds=10)
+            )
             assert expired is not None
             clock.advance(timedelta(seconds=10))
 
@@ -785,14 +886,18 @@ class TestDeliveryRecovery:
         clock = _Clock()
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         requested = await outbox.request_delivery(_request(message_id, binding_id))
-        claim = await outbox.claim_next("worker-before-restart", lease_duration=timedelta(seconds=10))
+        claim = await outbox.claim_next(
+            "worker-before-restart", purposes=(QUALIFICATION_PURPOSE,), lease_duration=timedelta(seconds=10)
+        )
         assert claim is not None
         await store.close()
 
         clock.advance(timedelta(seconds=10))
         reopened = await WorkshopEventStore.open(path)
         try:
-            recovered = await WorkshopDeliveryOutbox(reopened, clock=clock).recover_expired_leases()
+            recovered = await WorkshopDeliveryOutbox(reopened, clock=clock).recover_expired_leases(
+                purposes=(QUALIFICATION_PURPOSE,)
+            )
             assert recovered.requeued == 1
             assert recovered.failed == 0
             state = await WorkshopDeliveryOutbox(reopened, clock=clock).state(requested.delivery.delivery_id)
@@ -812,14 +917,18 @@ class TestDeliveryRecovery:
         clock = _Clock()
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         requested = await outbox.request_delivery(_request(message_id, binding_id, max_attempts=1))
-        claim = await outbox.claim_next("worker-before-restart", lease_duration=timedelta(seconds=10))
+        claim = await outbox.claim_next(
+            "worker-before-restart", purposes=(QUALIFICATION_PURPOSE,), lease_duration=timedelta(seconds=10)
+        )
         assert claim is not None
         await store.close()
 
         clock.advance(timedelta(seconds=10))
         reopened = await WorkshopEventStore.open(path)
         try:
-            recovered = await WorkshopDeliveryOutbox(reopened, clock=clock).recover_expired_leases()
+            recovered = await WorkshopDeliveryOutbox(reopened, clock=clock).recover_expired_leases(
+                purposes=(QUALIFICATION_PURPOSE,)
+            )
             assert recovered.requeued == 0
             assert recovered.failed == 1
             assert (await WorkshopDeliveryOutbox(reopened).state(requested.delivery.delivery_id)).status == "failed"
@@ -842,7 +951,7 @@ class TestDeliveryRecovery:
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         try:
             requested = await outbox.request_delivery(_request(message_id, binding_id))
-            claim = await outbox.claim_next("telegram-worker")
+            claim = await outbox.claim_next("telegram-worker", purposes=(QUALIFICATION_PURPOSE,))
             assert claim is not None
 
             await store.rebuild_projection(CanonicalConversationProjection())

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -172,10 +172,12 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 10
+        assert await workshop_store.schema_version() == 11
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
+        assert "delivery_outbox_purpose_due_idx" in indexes
+        assert "delivery_outbox_purpose_binding_order_idx" in indexes
 
     async def test_schema_migration_is_idempotent(self, tmp_path: Path):
         path = tmp_path / "workshop.db"
@@ -183,7 +185,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 10
+        assert await second.schema_version() == 11
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -204,7 +206,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 10
+            assert await upgraded.schema_version() == 11
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -219,7 +221,7 @@ class TestWorkshopSchema:
             async with upgraded.connection.execute(
                 "SELECT version FROM workshop_schema_migrations ORDER BY version"
             ) as cursor:
-                assert [row[0] for row in await cursor.fetchall()] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                assert [row[0] for row in await cursor.fetchall()] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
         finally:
             await upgraded.close()
 
@@ -241,7 +243,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 10
+            assert await upgraded.schema_version() == 11
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -282,7 +284,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 10
+            assert await upgraded.schema_version() == 11
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -335,7 +337,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 10
+            assert await upgraded.schema_version() == 11
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -379,7 +381,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 10
+            assert await upgraded.schema_version() == 11
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -423,7 +425,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 10
+            assert await upgraded.schema_version() == 11
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -467,7 +469,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 10
+            assert await upgraded.schema_version() == 11
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -571,12 +573,125 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 10
+            assert await upgraded.schema_version() == 11
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
             ) as cursor:
                 assert tuple(await cursor.fetchone()) == (message_id, None, "telegram", "text", "succeeded")
+        finally:
+            await upgraded.close()
+
+    async def test_version_ten_outbox_rows_migrate_as_qualification_work(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        from kai.workshop import schema
+        from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+        from kai.workshop.inbound import InboundMessage, record_inbound_message
+        from kai.workshop.outbound import OutboundMessage, record_outbound_message
+
+        path = tmp_path / "workshop.db"
+        timestamp = "2026-08-12T12:00:00.000000Z"
+        with monkeypatch.context() as migration_context:
+            migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 10)
+            migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:10])
+            version_ten = await WorkshopEventStore.open(path)
+            await bootstrap_default_workshop(
+                version_ten,
+                (
+                    BootstrapHuman(
+                        display_name="Existing human",
+                        role="admin",
+                        transport="telegram",
+                        external_subject="101",
+                        external_channel_id="101",
+                    ),
+                ),
+            )
+            inbound = await record_inbound_message(
+                version_ten,
+                InboundMessage(
+                    transport="telegram",
+                    update_id="9001",
+                    message_id="42",
+                    sender_subject="101",
+                    channel_subject="101",
+                    body="Existing inbound",
+                    occurred_at=datetime(2026, 8, 12, 12, 0, tzinfo=UTC),
+                ),
+            )
+            outbound = await record_outbound_message(
+                version_ten,
+                OutboundMessage(
+                    in_reply_to_message_id=MessageId(str(inbound.event.envelope.aggregate_id)),
+                    body="Existing reply",
+                    occurred_at=datetime(2026, 8, 12, 12, 0, tzinfo=UTC),
+                ),
+            )
+            message_id = MessageId(str(outbound.event.envelope.aggregate_id))
+            async with version_ten.connection.execute(
+                "SELECT c.workshop_id, m.channel_id, cb.id, m.author_principal_id "
+                "FROM messages m JOIN channels c ON c.id = m.channel_id "
+                "JOIN channel_bindings cb ON cb.channel_id = m.channel_id "
+                "WHERE m.id = ? AND cb.transport = 'telegram'",
+                (message_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            assert row is not None
+            workshop_id = WorkshopId(str(row[0]))
+            channel_id = ChannelId(str(row[1]))
+            binding_id = str(row[2])
+            delivery_id = DeliveryId.derived(workshop_id, f"delivery:{message_id}:{binding_id}:text")
+            requested = await version_ten.append(
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.DELIVERY_REQUESTED,
+                    event_version=1,
+                    workshop_id=workshop_id,
+                    aggregate_type="delivery",
+                    aggregate_id=delivery_id,
+                    actor_principal_id=PrincipalId(str(row[3])),
+                    occurred_at=datetime(2026, 8, 12, 12, 0, tzinfo=UTC),
+                    payload={
+                        "message_id": message_id,
+                        "channel_id": channel_id,
+                        "channel_binding_id": binding_id,
+                        "transport": "telegram",
+                        "mode": "text",
+                        "max_attempts": 3,
+                    },
+                )
+            )
+            await version_ten.connection.execute(
+                "INSERT INTO delivery_outbox "
+                "(id, workshop_id, channel_id, channel_binding_id, message_id, transport, mode, "
+                "status, max_attempts, attempt_count, available_at, requested_event_position, "
+                "created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, 'telegram', 'text', 'pending', 3, 0, ?, ?, ?, ?)",
+                (
+                    delivery_id,
+                    workshop_id,
+                    channel_id,
+                    binding_id,
+                    message_id,
+                    timestamp,
+                    requested.event.position,
+                    timestamp,
+                    timestamp,
+                ),
+            )
+            await version_ten.connection.commit()
+            await version_ten.close()
+
+        upgraded = await WorkshopEventStore.open(path)
+        try:
+            assert await upgraded.schema_version() == 11
+            async with upgraded.connection.execute(
+                "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
+                (delivery_id,),
+            ) as cursor:
+                assert tuple(await cursor.fetchone()) == ("qualification", "pending", 0)
         finally:
             await upgraded.close()
 

--- a/tests/test_workshop_outbound.py
+++ b/tests/test_workshop_outbound.py
@@ -11,6 +11,7 @@ import pytest
 
 from kai import sessions
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_outbox import CONVERSATION_REPLY_PURPOSE
 from kai.workshop.domain import (
     ChannelBindingId,
     EventEnvelope,
@@ -181,6 +182,7 @@ class TestAtomicOutboundDelivery:
             assert result.delivery.delivery.message_id == result.message.event.envelope.aggregate_id
             assert result.delivery.delivery.transport == "telegram"
             assert result.delivery.delivery.mode == "text"
+            assert result.delivery.delivery.purpose == CONVERSATION_REPLY_PURPOSE
             assert result.delivery.delivery.status == "pending"
             assert result.delivery.delivery.attempt_count == 0
             async with store.connection.execute(

--- a/tests/test_workshop_telegram_delivery.py
+++ b/tests/test_workshop_telegram_delivery.py
@@ -14,7 +14,13 @@ from telegram.error import BadRequest, Forbidden, InvalidToken, NetworkError, Re
 
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.delivery_fragments import DeliveryFragment, WorkshopDeliveryFragments
-from kai.workshop.delivery_outbox import DeliveryClaim, DeliveryRequest, WorkshopDeliveryOutbox
+from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
+    QUALIFICATION_PURPOSE,
+    DeliveryClaim,
+    DeliveryRequest,
+    WorkshopDeliveryOutbox,
+)
 from kai.workshop.domain import (
     ChannelBindingId,
     ChannelId,
@@ -58,6 +64,7 @@ def _claim(
         transport=transport,
         external_channel_id=external_channel_id,
         mode=mode,
+        purpose=QUALIFICATION_PURPOSE,
         body=body,
         lease_expires_at=_NOW + timedelta(seconds=30),
     )
@@ -97,6 +104,7 @@ def _worker(
         WorkshopDeliveryFragments(store),
         WorkshopTelegramDeliveryAdapter(bot),
         worker_id="telegram-worker-1",
+        purpose=QUALIFICATION_PURPOSE,
         poll_interval=poll_interval,
     )
 
@@ -158,12 +166,14 @@ async def _request(
     binding_id: ChannelBindingId,
     *,
     mode: str = "text",
+    purpose=QUALIFICATION_PURPOSE,
 ) -> DeliveryId:
     result = await WorkshopDeliveryOutbox(store).request_delivery(
         DeliveryRequest(
             message_id=message_id,
             channel_binding_id=binding_id,
             mode=mode,
+            purpose=purpose,
             occurred_at=_NOW,
         )
     )
@@ -324,6 +334,25 @@ class TestWorkshopTelegramDeliveryAdapter:
 
 
 class TestWorkshopTelegramDeliveryWorker:
+    async def test_qualification_worker_cannot_drain_conversation_work(self, tmp_path: Path):
+        store, message_id, binding_id = await _open_with_outbound(tmp_path / "kai.db")
+        delivery_id = await _request(
+            store,
+            message_id,
+            binding_id,
+            purpose=CONVERSATION_REPLY_PURPOSE,
+        )
+        bot = _successful_bot()
+        worker = _worker(store, bot)
+        try:
+            result = await worker.run_once()
+
+            assert result.outcome == TelegramWorkOutcome.IDLE
+            assert (await WorkshopDeliveryOutbox(store).state(delivery_id)).status == "pending"
+            bot.send_message.assert_not_awaited()
+        finally:
+            await store.close()
+
     async def test_explicit_delivery_does_not_drain_other_binding(self, tmp_path: Path):
         store, message_id, private_binding = await _open_with_outbound(tmp_path / "kai.db")
         group_binding = await _add_group_binding(store, message_id)


### PR DESCRIPTION
## Summary

- add a required durable purpose to Workshop delivery work: `conversation_reply` or `qualification`
- migrate all pre-existing outbox rows to the fail-safe `qualification` purpose
- scope claims, expired-lease recovery, and per-binding ordering to explicit purpose lanes
- bind installed qualification paths to `qualification` and the production-unused atomic reply service to `conversation_reply`
- keep the Telegram delivery worker single-purpose and production-unregistered

## Why

The fourth Workshop authority review found that starting a future production worker could drain delivery rows created only for installed qualification. A claim filter alone would also be insufficient: an older qualification row on the same Telegram binding could block a later conversation reply through the existing ordering rule.

This PR establishes the isolation boundary before any production routing changes. Qualification work cannot be claimed or recovered by a conversation worker, and it cannot act as an ordering predecessor in the conversation lane.

## Migration behavior

Workshop schema version 11 adds the constrained `delivery_outbox.purpose` column and purpose-aware indexes. Existing version-10 rows receive `qualification`, which accurately describes all outbox work created before normal conversation delivery exists and prevents a future worker from sending old test work.

New `delivery.requested` events are version 2 and record the purpose. Retrying an existing delivery with a different purpose fails closed as a semantic conflict.

## Behavior and safety

- no production handler uses the atomic reply-and-delivery service
- no production startup code imports or starts the Workshop Telegram worker/runtime
- current Telegram replies, media, voice, commands, schedules, files, and GitHub notifications are unchanged
- the installed qualification CLI remains restricted to qualification work
- the implementation map records this completed prerequisite and the next bounded, production-unused preview-binding slice

## Tests

- `make check`
- `make typecheck`
- focused Workshop delivery, migration, qualification, outbound, and Telegram tests: 161 passed
- full suite: 5,329 passed, 1 skipped

New coverage includes version-10 migration classification, purpose conflicts, independent ordered lanes, purpose-scoped lease recovery, and proof that a qualification worker cannot drain conversation work.
