### PR TITLE
Execute Workshop streaming finalization safely

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -730,3 +730,48 @@ restart, apply the established Markdown fallback to both sends and edits, and
 classify deleted/uneditable targets and ambiguous edit/send outcomes without
 automatic duplicate delivery. It must remain unregistered until another
 explicit cutover review.
+
+### 21.7 Streaming-finalization execution foundation
+
+The production-unused Telegram finalization adapter and worker now execute the
+immutable operation plan without widening the existing send-only worker. The
+new worker is fixed to `conversation_reply`, `streaming_finalization`, Telegram,
+and text work. It cannot claim qualification rows or `send_fragments` work; the
+existing worker remains unable to claim streaming-finalization rows.
+
+For an edit operation, the adapter uses the canonical binding's Telegram target
+and the persisted positive preview message ID. It applies Kai's Markdown-first,
+plain-text-fallback presentation behavior. Telegram's explicit "message is not
+modified" response confirms that the desired terminal snapshot already exists
+and completes the distinct edit operation. A deleted or uneditable target
+fails permanently with a sanitized edit-specific code; it never falls back to
+sending a duplicate message. Successful edit evidence must identify the exact
+persisted target message.
+
+Confirmed fragment progress is monotonic. After a successful edit, a retry or
+restart skips that edit and resumes at the first pending continuation send. A
+rate limit can retry only an operation proven not to have taken effect. Timeout,
+network ambiguity, invalid success evidence, cancellation, or lease expiry
+after an operation enters `sending` becomes terminal `uncertain` state and is
+never retried automatically. Lease recovery distinguishes uncertain edits from
+uncertain sends in its non-secret error classification.
+
+Automated contracts cover exact edit targeting, Markdown fallback, an already
+identical terminal snapshot, deleted/uneditable previews, mismatched success
+evidence, edit and continuation-send ambiguity, short edit-only replies,
+edit-plus-send fragmentation order, all-send plans, retry and restart after a
+confirmed edit, crash recovery, and execution-contract and purpose isolation.
+
+The adapter and worker remain unregistered. No production handler imports or
+calls them, no live delivery route changes, and normal Telegram, media, voice,
+commands, schedules, GitHub/generic webhooks, files, and notification-group
+behavior remain authoritative on their existing paths.
+
+The next bounded step is a fifth explicit cutover review. It must decide
+whether the complete production-unused finalization boundary is sufficient to
+wire one authenticated direct-chat plain-text path and its dedicated worker
+store/runtime, or whether another installed qualification path is required
+first. The review must resolve startup handling of historical conversation
+work, non-secret diagnostics and reconciliation, fail-closed user-visible
+errors, shutdown ordering, and rollback before authorizing any production
+registration.

--- a/src/kai/workshop/__init__.py
+++ b/src/kai/workshop/__init__.py
@@ -110,6 +110,8 @@ from kai.workshop.telegram_delivery import (
     TelegramWorkResult,
     WorkshopTelegramDeliveryAdapter,
     WorkshopTelegramDeliveryWorker,
+    WorkshopTelegramStreamingFinalizationAdapter,
+    WorkshopTelegramStreamingFinalizationWorker,
 )
 from kai.workshop.telegram_delivery_runtime import (
     TelegramDeliveryRuntimeState,
@@ -219,6 +221,8 @@ __all__ = [
     "WorkshopTelegramDeliveryAdapter",
     "WorkshopTelegramDeliveryRuntime",
     "WorkshopTelegramDeliveryWorker",
+    "WorkshopTelegramStreamingFinalizationAdapter",
+    "WorkshopTelegramStreamingFinalizationWorker",
     "bind_confirmed_telegram_streaming_preview",
     "read_channel_timeline",
     "record_inbound_artifact",

--- a/src/kai/workshop/delivery_outbox.py
+++ b/src/kai/workshop/delivery_outbox.py
@@ -690,22 +690,30 @@ class WorkshopDeliveryOutbox:
             delivery_id = DeliveryId(str(row[0]))
             attempt_id = DeliveryAttemptId(str(row[1]))
             async with connection.execute(
-                "SELECT COUNT(*) FROM delivery_fragments WHERE delivery_id = ? AND status IN ('sending', 'uncertain')",
+                "SELECT operation FROM delivery_fragments "
+                "WHERE delivery_id = ? AND status IN ('sending', 'uncertain') ORDER BY fragment_index",
                 (delivery_id,),
             ) as cursor:
-                uncertain_row = await cursor.fetchone()
-            send_uncertain = uncertain_row is not None and int(uncertain_row[0]) > 0
-            if send_uncertain:
+                uncertain_rows = list(await cursor.fetchall())
+            external_effect_uncertain = bool(uncertain_rows)
+            if external_effect_uncertain:
                 await connection.execute(
                     "UPDATE delivery_fragments SET status = 'uncertain', updated_at = ? "
                     "WHERE delivery_id = ? AND status = 'sending'",
                     (now_text, delivery_id),
                 )
-            terminal = send_uncertain or int(row[2]) >= int(row[3])
+            terminal = external_effect_uncertain or int(row[2]) >= int(row[3])
             status = "failed" if terminal else "retry_wait"
             completed_at = now_text if terminal else None
-            attempt_outcome = "failed" if send_uncertain else "lease_expired"
-            error_code = "delivery_send_uncertain" if send_uncertain else "lease_expired"
+            attempt_outcome = "failed" if external_effect_uncertain else "lease_expired"
+            uncertain_operations = {str(fragment_row[0]) for fragment_row in uncertain_rows}
+            if uncertain_operations == {"edit"}:
+                uncertainty_code = "delivery_edit_uncertain"
+            elif uncertain_operations == {"send"}:
+                uncertainty_code = "delivery_send_uncertain"
+            else:
+                uncertainty_code = "delivery_effect_uncertain"
+            error_code = uncertainty_code if external_effect_uncertain else "lease_expired"
             await connection.execute(
                 "UPDATE delivery_attempts SET completed_at = ?, outcome = ?, "
                 "error_code = ? WHERE id = ? AND completed_at IS NULL",

--- a/src/kai/workshop/telegram_delivery.py
+++ b/src/kai/workshop/telegram_delivery.py
@@ -25,9 +25,16 @@ from telegram.error import (
 from telegram.warnings import PTBDeprecationWarning
 
 from kai.telegram_utils import chunk_text
-from kai.workshop.delivery_fragments import DeliveryFragment, WorkshopDeliveryFragments
+from kai.workshop.delivery_fragments import (
+    EDIT_OPERATION,
+    SEND_OPERATION,
+    DeliveryFragment,
+    WorkshopDeliveryFragments,
+)
 from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
     SEND_FRAGMENTS_CONTRACT,
+    STREAMING_FINALIZATION_CONTRACT,
     DeliveryClaim,
     DeliveryPurpose,
     DeliveryRecoveryResult,
@@ -56,6 +63,15 @@ class TelegramTextBot(Protocol):
         self,
         *,
         chat_id: int | str,
+        text: str,
+        parse_mode: str | None = None,
+    ) -> TelegramSentMessage: ...
+
+    async def edit_message_text(
+        self,
+        *,
+        chat_id: int | str,
+        message_id: int,
         text: str,
         parse_mode: str | None = None,
     ) -> TelegramSentMessage: ...
@@ -171,6 +187,26 @@ def _telegram_fragments(body: str) -> tuple[str, ...]:
     return fragments
 
 
+def _telegram_message_not_modified(error: BadRequest) -> bool:
+    return "message is not modified" in str(error).lower()
+
+
+def _classify_telegram_edit_error(error: TelegramError) -> TelegramDeliveryFailure:
+    classified = _classify_telegram_error(error)
+    error_code = {
+        "telegram_bad_request": "telegram_edit_rejected",
+        "telegram_timeout_uncertain": "telegram_edit_timeout_uncertain",
+        "telegram_network_uncertain": "telegram_edit_network_uncertain",
+        "telegram_error_uncertain": "telegram_edit_error_uncertain",
+    }.get(classified.error_code, classified.error_code)
+    return TelegramDeliveryFailure(
+        retryable=classified.retryable,
+        error_code=error_code,
+        minimum_retry_delay=classified.minimum_retry_delay,
+        ambiguous=classified.ambiguous,
+    )
+
+
 class WorkshopTelegramDeliveryAdapter:
     """Deliver one durably selected Telegram text fragment."""
 
@@ -213,6 +249,71 @@ class WorkshopTelegramDeliveryAdapter:
             raise TelegramDeliveryFailure(
                 retryable=False,
                 error_code="telegram_response_invalid",
+                ambiguous=True,
+            )
+        return message_id
+
+
+class WorkshopTelegramStreamingFinalizationAdapter:
+    """Execute one immutable edit-or-send finalization operation."""
+
+    def __init__(self, bot: TelegramTextBot) -> None:
+        self._bot = bot
+        self._send_adapter = WorkshopTelegramDeliveryAdapter(bot)
+
+    async def deliver_fragment(self, claim: DeliveryClaim, fragment: DeliveryFragment) -> int:
+        if not isinstance(claim, DeliveryClaim):
+            raise ValueError("claim must be a DeliveryClaim")
+        if not isinstance(fragment, DeliveryFragment) or fragment.delivery_id != claim.delivery_id:
+            raise ValueError("fragment must belong to the claimed delivery")
+        if claim.execution_contract != STREAMING_FINALIZATION_CONTRACT:
+            raise TelegramDeliveryContractError("telegram_execution_contract_mismatch")
+        if claim.transport != "telegram":
+            raise TelegramDeliveryContractError("telegram_transport_mismatch")
+        if claim.mode != "text":
+            raise TelegramDeliveryContractError("telegram_mode_unsupported")
+        if not fragment.body or len(fragment.body) > _TELEGRAM_TEXT_LIMIT:
+            raise TelegramDeliveryContractError("telegram_text_size_unsupported")
+
+        if fragment.operation == SEND_OPERATION and fragment.target_external_message_id is None:
+            return await self._send_adapter.deliver_fragment(claim, fragment)
+        if fragment.operation != EDIT_OPERATION or fragment.target_external_message_id is None:
+            raise TelegramDeliveryContractError("telegram_operation_unsupported")
+
+        target_message_id = fragment.target_external_message_id
+        if not isinstance(target_message_id, int) or isinstance(target_message_id, bool) or target_message_id <= 0:
+            raise TelegramDeliveryContractError("telegram_edit_target_invalid")
+        target = _telegram_target(claim.external_channel_id)
+        try:
+            edited = await self._bot.edit_message_text(
+                chat_id=target,
+                message_id=target_message_id,
+                text=fragment.body,
+                parse_mode=ParseMode.MARKDOWN,
+            )
+        except BadRequest as error:
+            if _telegram_message_not_modified(error):
+                return target_message_id
+            try:
+                edited = await self._bot.edit_message_text(
+                    chat_id=target,
+                    message_id=target_message_id,
+                    text=fragment.body,
+                )
+            except BadRequest as fallback_error:
+                if _telegram_message_not_modified(fallback_error):
+                    return target_message_id
+                raise _classify_telegram_edit_error(fallback_error) from fallback_error
+            except TelegramError as fallback_error:
+                raise _classify_telegram_edit_error(fallback_error) from fallback_error
+        except TelegramError as error:
+            raise _classify_telegram_edit_error(error) from error
+
+        message_id = getattr(edited, "message_id", None)
+        if not isinstance(message_id, int) or isinstance(message_id, bool) or message_id != target_message_id:
+            raise TelegramDeliveryFailure(
+                retryable=False,
+                error_code="telegram_edit_response_invalid",
                 ambiguous=True,
             )
         return message_id
@@ -333,6 +434,129 @@ class WorkshopTelegramDeliveryWorker:
                 await self._fragments.mark_uncertain(claim, fragment)
             else:
                 await self._fragments.release_after_definitive_failure(claim, fragment)
+        state = await self._outbox.mark_failed(
+            claim,
+            retryable=failure.retryable and not failure.ambiguous,
+            error_code=failure.error_code,
+            minimum_retry_delay=failure.minimum_retry_delay,
+        )
+        return TelegramWorkResult(
+            outcome=(
+                TelegramWorkOutcome.RETRY_SCHEDULED if state.status == "retry_wait" else TelegramWorkOutcome.FAILED
+            ),
+            delivery_id=claim.delivery_id,
+            attempt_number=claim.attempt_number,
+            error_code=failure.error_code,
+        )
+
+
+class WorkshopTelegramStreamingFinalizationWorker:
+    """Execute only durable conversation streaming-finalization plans."""
+
+    def __init__(
+        self,
+        outbox: WorkshopDeliveryOutbox,
+        fragments: WorkshopDeliveryFragments,
+        adapter: WorkshopTelegramStreamingFinalizationAdapter,
+        *,
+        worker_id: str,
+        lease_duration: timedelta = timedelta(seconds=30),
+        poll_interval: float = 1.0,
+    ) -> None:
+        if poll_interval <= 0 or poll_interval > 60:
+            raise ValueError("poll_interval must be positive and at most 60 seconds")
+        self._outbox = outbox
+        self._fragments = fragments
+        self._adapter = adapter
+        self._worker_id = worker_id
+        self._lease_duration = lease_duration
+        self._poll_interval = poll_interval
+
+    async def run_once(self) -> TelegramWorkResult:
+        claim = await self._outbox.claim_next(
+            self._worker_id,
+            purposes=(CONVERSATION_REPLY_PURPOSE,),
+            execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+            lease_duration=self._lease_duration,
+            transport="telegram",
+            modes=("text",),
+        )
+        return await self._run_claim(claim)
+
+    async def run_delivery(self, delivery_id: DeliveryId) -> TelegramWorkResult:
+        """Run one exact finalization delivery without draining other work."""
+        if not isinstance(delivery_id, DeliveryId):
+            raise ValueError("delivery_id must be a DeliveryId")
+        claim = await self._outbox.claim_next(
+            self._worker_id,
+            purposes=(CONVERSATION_REPLY_PURPOSE,),
+            execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+            lease_duration=self._lease_duration,
+            transport="telegram",
+            modes=("text",),
+            delivery_id=delivery_id,
+        )
+        return await self._run_claim(claim)
+
+    async def recover_expired_leases(self) -> DeliveryRecoveryResult:
+        return await self._outbox.recover_expired_leases(
+            purposes=(CONVERSATION_REPLY_PURPOSE,),
+            execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+        )
+
+    async def _run_claim(self, claim: DeliveryClaim | None) -> TelegramWorkResult:
+        if claim is None:
+            return TelegramWorkResult(outcome=TelegramWorkOutcome.IDLE)
+        if claim.execution_contract != STREAMING_FINALIZATION_CONTRACT:
+            raise RuntimeError("Finalization worker claimed another execution contract")
+
+        while True:
+            fragment = await self._fragments.begin_next(claim)
+            if fragment is None:
+                state = await self._outbox.mark_succeeded(claim)
+                return self._success_result(claim, state)
+            try:
+                external_message_id = await self._adapter.deliver_fragment(claim, fragment)
+            except TelegramDeliveryFailure as failure:
+                return await self._settle_failure(claim, fragment, failure)
+            await self._fragments.mark_sent(
+                claim,
+                fragment,
+                external_message_id=external_message_id,
+            )
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        if not isinstance(stop_event, asyncio.Event):
+            raise ValueError("stop_event must be an asyncio.Event")
+        while not stop_event.is_set():
+            result = await self.run_once()
+            if result.outcome != TelegramWorkOutcome.IDLE:
+                continue
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=self._poll_interval)
+            except TimeoutError:
+                pass
+
+    @staticmethod
+    def _success_result(claim: DeliveryClaim, state: DeliveryState) -> TelegramWorkResult:
+        if state.status != "succeeded":
+            raise RuntimeError("Successful Telegram finalization did not reach succeeded outbox state")
+        return TelegramWorkResult(
+            outcome=TelegramWorkOutcome.SUCCEEDED,
+            delivery_id=claim.delivery_id,
+            attempt_number=claim.attempt_number,
+        )
+
+    async def _settle_failure(
+        self,
+        claim: DeliveryClaim,
+        fragment: DeliveryFragment,
+        failure: TelegramDeliveryFailure,
+    ) -> TelegramWorkResult:
+        if failure.ambiguous:
+            await self._fragments.mark_uncertain(claim, fragment)
+        else:
+            await self._fragments.release_after_definitive_failure(claim, fragment)
         state = await self._outbox.mark_failed(
             claim,
             retryable=failure.retryable and not failure.ambiguous,

--- a/tests/test_workshop_telegram_streaming_finalization.py
+++ b/tests/test_workshop_telegram_streaming_finalization.py
@@ -1,0 +1,546 @@
+"""Production-unused Telegram execution contracts for streaming finalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.constants import ParseMode
+from telegram.error import BadRequest, NetworkError, RetryAfter, TimedOut
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_fragments import (
+    EDIT_OPERATION,
+    SEND_OPERATION,
+    DeliveryFragment,
+    WorkshopDeliveryFragments,
+)
+from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
+    QUALIFICATION_PURPOSE,
+    STREAMING_FINALIZATION_CONTRACT,
+    DeliveryClaim,
+    DeliveryPurpose,
+    DeliveryRequest,
+    WorkshopDeliveryOutbox,
+)
+from kai.workshop.domain import (
+    ChannelBindingId,
+    ChannelId,
+    DeliveryAttemptId,
+    DeliveryId,
+    MessageId,
+    WorkshopId,
+)
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.outbound import (
+    OutboundMessage,
+    record_outbound_message,
+    record_outbound_message_with_streaming_finalization,
+)
+from kai.workshop.store import WorkshopEventStore
+from kai.workshop.streaming_preview import (
+    ConfirmedTelegramStreamingPreview,
+    bind_confirmed_telegram_streaming_preview,
+)
+from kai.workshop.telegram_delivery import (
+    TelegramDeliveryContractError,
+    TelegramDeliveryFailure,
+    TelegramWorkOutcome,
+    WorkshopTelegramStreamingFinalizationAdapter,
+    WorkshopTelegramStreamingFinalizationWorker,
+)
+
+_NOW = datetime(2026, 8, 12, 13, 30, tzinfo=UTC)
+
+
+@dataclass
+class _Clock:
+    now: datetime = _NOW
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, delta: timedelta) -> None:
+        self.now += delta
+
+
+def _claim(*, execution_contract=STREAMING_FINALIZATION_CONTRACT) -> DeliveryClaim:
+    return DeliveryClaim(
+        delivery_id=DeliveryId.new(),
+        attempt_id=DeliveryAttemptId.new(),
+        attempt_number=1,
+        workshop_id=WorkshopId.new(),
+        channel_id=ChannelId.new(),
+        channel_binding_id=ChannelBindingId.new(),
+        message_id=MessageId.new(),
+        transport="telegram",
+        external_channel_id="101",
+        mode="text",
+        purpose=CONVERSATION_REPLY_PURPOSE,
+        execution_contract=execution_contract,
+        body="Final answer",
+        lease_expires_at=_NOW + timedelta(seconds=30),
+    )
+
+
+def _fragment(
+    claim: DeliveryClaim,
+    *,
+    operation=EDIT_OPERATION,
+    target_external_message_id: int | None = 7001,
+    body: str = "Final answer",
+) -> DeliveryFragment:
+    return DeliveryFragment(
+        delivery_id=claim.delivery_id,
+        fragment_index=0,
+        fragment_count=1,
+        body=body,
+        status="sending",
+        attempt_id=claim.attempt_id,
+        external_message_id=None,
+        sent_at=None,
+        operation=operation,
+        target_external_message_id=target_external_message_id,
+    )
+
+
+async def _open_with_inbound(path: Path) -> tuple[WorkshopEventStore, MessageId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (BootstrapHuman("Authorized human", "admin", "telegram", "101", "101"),),
+    )
+    inbound = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="telegram",
+            update_id="9001",
+            message_id="42",
+            sender_subject="101",
+            channel_subject="101",
+            body="Hello",
+            occurred_at=_NOW,
+        ),
+    )
+    return store, MessageId(str(inbound.event.envelope.aggregate_id))
+
+
+async def _prepare_finalization(
+    path: Path,
+    *,
+    body: str = "Final answer",
+    preview_message_id: int | None = 7001,
+) -> tuple[WorkshopEventStore, DeliveryId]:
+    store, inbound_id = await _open_with_inbound(path)
+    if preview_message_id is not None:
+        await bind_confirmed_telegram_streaming_preview(
+            store,
+            ConfirmedTelegramStreamingPreview(
+                inbound_message_id=inbound_id,
+                external_message_id=preview_message_id,
+                confirmed_at=_NOW + timedelta(seconds=1),
+            ),
+        )
+    result = await record_outbound_message_with_streaming_finalization(
+        store,
+        OutboundMessage(
+            in_reply_to_message_id=inbound_id,
+            body=body,
+            occurred_at=_NOW + timedelta(seconds=2),
+        ),
+    )
+    return store, result.delivery.delivery.delivery_id
+
+
+def _worker(
+    store: WorkshopEventStore,
+    bot: AsyncMock,
+    *,
+    clock: _Clock | None = None,
+    lease_duration: timedelta = timedelta(seconds=30),
+) -> WorkshopTelegramStreamingFinalizationWorker:
+    effective_clock = clock or _Clock(_NOW + timedelta(seconds=3))
+    return WorkshopTelegramStreamingFinalizationWorker(
+        WorkshopDeliveryOutbox(store, clock=effective_clock),
+        WorkshopDeliveryFragments(store, clock=effective_clock),
+        WorkshopTelegramStreamingFinalizationAdapter(bot),
+        worker_id="telegram-finalization-worker",
+        lease_duration=lease_duration,
+        poll_interval=0.01,
+    )
+
+
+class TestTelegramStreamingFinalizationAdapter:
+    async def test_edits_the_exact_confirmed_message_with_markdown(self):
+        bot = AsyncMock()
+        bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
+        claim = _claim()
+
+        result = await WorkshopTelegramStreamingFinalizationAdapter(bot).deliver_fragment(
+            claim,
+            _fragment(claim),
+        )
+
+        assert result == 7001
+        bot.edit_message_text.assert_awaited_once_with(
+            chat_id=101,
+            message_id=7001,
+            text="Final answer",
+            parse_mode=ParseMode.MARKDOWN,
+        )
+        bot.send_message.assert_not_awaited()
+
+    async def test_edit_markdown_rejection_retries_once_as_plain_text(self):
+        bot = AsyncMock()
+        bot.edit_message_text.side_effect = [
+            BadRequest("can't parse entities"),
+            SimpleNamespace(message_id=7001),
+        ]
+        claim = _claim()
+
+        assert (
+            await WorkshopTelegramStreamingFinalizationAdapter(bot).deliver_fragment(
+                claim,
+                _fragment(claim),
+            )
+            == 7001
+        )
+        assert bot.edit_message_text.await_args_list[0].kwargs["parse_mode"] == ParseMode.MARKDOWN
+        assert bot.edit_message_text.await_args_list[1].kwargs == {
+            "chat_id": 101,
+            "message_id": 7001,
+            "text": "Final answer",
+        }
+
+    async def test_already_identical_terminal_snapshot_is_confirmed_without_a_second_call(self):
+        bot = AsyncMock()
+        bot.edit_message_text.side_effect = BadRequest("Message is not modified")
+        claim = _claim()
+
+        assert (
+            await WorkshopTelegramStreamingFinalizationAdapter(bot).deliver_fragment(
+                claim,
+                _fragment(claim),
+            )
+            == 7001
+        )
+        assert bot.edit_message_text.await_count == 1
+
+    async def test_deleted_or_uneditable_preview_is_a_sanitized_permanent_failure(self):
+        bot = AsyncMock()
+        bot.edit_message_text.side_effect = [
+            BadRequest("message to edit not found"),
+            BadRequest("message to edit not found"),
+        ]
+        claim = _claim()
+
+        with pytest.raises(TelegramDeliveryFailure) as raised:
+            await WorkshopTelegramStreamingFinalizationAdapter(bot).deliver_fragment(
+                claim,
+                _fragment(claim),
+            )
+
+        assert raised.value.error_code == "telegram_edit_rejected"
+        assert raised.value.retryable is False
+        assert raised.value.ambiguous is False
+        assert str(raised.value) == "telegram_edit_rejected"
+
+    @pytest.mark.parametrize(
+        ("error", "error_code"),
+        [
+            (TimedOut(), "telegram_edit_timeout_uncertain"),
+            (NetworkError("reset"), "telegram_edit_network_uncertain"),
+        ],
+    )
+    async def test_edit_transport_ambiguity_is_operation_specific(self, error, error_code):
+        bot = AsyncMock()
+        bot.edit_message_text.side_effect = error
+        claim = _claim()
+
+        with pytest.raises(TelegramDeliveryFailure) as raised:
+            await WorkshopTelegramStreamingFinalizationAdapter(bot).deliver_fragment(
+                claim,
+                _fragment(claim),
+            )
+
+        assert raised.value.error_code == error_code
+        assert raised.value.ambiguous is True
+        assert raised.value.retryable is False
+
+    async def test_edit_success_with_mismatched_message_evidence_is_ambiguous(self):
+        bot = AsyncMock()
+        bot.edit_message_text.return_value = SimpleNamespace(message_id=7999)
+        claim = _claim()
+
+        with pytest.raises(TelegramDeliveryFailure) as raised:
+            await WorkshopTelegramStreamingFinalizationAdapter(bot).deliver_fragment(
+                claim,
+                _fragment(claim),
+            )
+
+        assert raised.value.error_code == "telegram_edit_response_invalid"
+        assert raised.value.ambiguous is True
+
+    async def test_edit_rate_limit_is_retryable_only_after_a_definitive_rejection(self, monkeypatch):
+        monkeypatch.setenv("PTB_TIMEDELTA", "1")
+        bot = AsyncMock()
+        bot.edit_message_text.side_effect = RetryAfter(timedelta(seconds=7))
+        claim = _claim()
+
+        with pytest.raises(TelegramDeliveryFailure) as raised:
+            await WorkshopTelegramStreamingFinalizationAdapter(bot).deliver_fragment(
+                claim,
+                _fragment(claim),
+            )
+
+        assert raised.value.error_code == "telegram_rate_limited"
+        assert raised.value.retryable is True
+        assert raised.value.ambiguous is False
+        assert raised.value.minimum_retry_delay == timedelta(seconds=7)
+
+    async def test_adapter_rejects_another_execution_contract_before_telegram(self):
+        bot = AsyncMock()
+        claim = _claim(execution_contract="send_fragments")
+
+        with pytest.raises(TelegramDeliveryContractError, match="telegram_execution_contract_mismatch"):
+            await WorkshopTelegramStreamingFinalizationAdapter(bot).deliver_fragment(
+                claim,
+                _fragment(claim),
+            )
+
+        bot.edit_message_text.assert_not_awaited()
+        bot.send_message.assert_not_awaited()
+
+
+class TestTelegramStreamingFinalizationWorker:
+    async def test_short_preview_is_finalized_in_place(self, tmp_path: Path):
+        store, delivery_id = await _prepare_finalization(tmp_path / "kai.db")
+        bot = AsyncMock()
+        bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
+        try:
+            result = await _worker(store, bot).run_delivery(delivery_id)
+            persisted = await WorkshopDeliveryFragments(store).fragments(delivery_id)
+
+            assert result.outcome == TelegramWorkOutcome.SUCCEEDED
+            assert (await WorkshopDeliveryOutbox(store).state(delivery_id)).status == "succeeded"
+            assert [(item.operation, item.status, item.external_message_id) for item in persisted] == [
+                (EDIT_OPERATION, "sent", "7001")
+            ]
+            bot.send_message.assert_not_awaited()
+        finally:
+            await store.close()
+
+    async def test_long_reply_edits_then_sends_continuations_in_order(self, tmp_path: Path):
+        body = "A" * 4096 + "\n" + "B" * 20
+        store, delivery_id = await _prepare_finalization(tmp_path / "kai.db", body=body)
+        bot = AsyncMock()
+        bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
+        bot.send_message.return_value = SimpleNamespace(message_id=8001)
+        try:
+            result = await _worker(store, bot).run_once()
+            persisted = await WorkshopDeliveryFragments(store).fragments(delivery_id)
+
+            assert result.outcome == TelegramWorkOutcome.SUCCEEDED
+            assert [item.operation for item in persisted] == [EDIT_OPERATION, SEND_OPERATION]
+            assert [item.external_message_id for item in persisted] == ["7001", "8001"]
+            assert bot.edit_message_text.await_args.kwargs["text"] == "A" * 4096
+            assert bot.send_message.await_args.kwargs["text"] == "B" * 20
+        finally:
+            await store.close()
+
+    async def test_no_preview_executes_an_all_send_plan(self, tmp_path: Path):
+        body = "A" * 4096 + "\n" + "B" * 20
+        store, delivery_id = await _prepare_finalization(
+            tmp_path / "kai.db",
+            body=body,
+            preview_message_id=None,
+        )
+        bot = AsyncMock()
+        bot.send_message.side_effect = [
+            SimpleNamespace(message_id=8001),
+            SimpleNamespace(message_id=8002),
+        ]
+        try:
+            assert (await _worker(store, bot).run_once()).outcome == TelegramWorkOutcome.SUCCEEDED
+            persisted = await WorkshopDeliveryFragments(store).fragments(delivery_id)
+            assert [item.operation for item in persisted] == [SEND_OPERATION, SEND_OPERATION]
+            assert [item.external_message_id for item in persisted] == ["8001", "8002"]
+            bot.edit_message_text.assert_not_awaited()
+        finally:
+            await store.close()
+
+    async def test_restart_skips_confirmed_edit_and_resumes_continuation_send(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("PTB_TIMEDELTA", "1")
+        path = tmp_path / "kai.db"
+        body = "A" * 4096 + "\n" + "B" * 20
+        store, delivery_id = await _prepare_finalization(path, body=body)
+        clock = _Clock(_NOW + timedelta(seconds=3))
+        first_bot = AsyncMock()
+        first_bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
+        first_bot.send_message.side_effect = RetryAfter(timedelta(seconds=1))
+        first = await _worker(store, first_bot, clock=clock).run_once()
+        assert first.outcome == TelegramWorkOutcome.RETRY_SCHEDULED
+        assert [item.status for item in await WorkshopDeliveryFragments(store).fragments(delivery_id)] == [
+            "sent",
+            "pending",
+        ]
+        await store.close()
+
+        clock.advance(timedelta(seconds=5))
+        reopened = await WorkshopEventStore.open(path)
+        second_bot = AsyncMock()
+        second_bot.send_message.return_value = SimpleNamespace(message_id=8001)
+        try:
+            second = await _worker(reopened, second_bot, clock=clock).run_delivery(delivery_id)
+
+            assert second.outcome == TelegramWorkOutcome.SUCCEEDED
+            assert second.attempt_number == 2
+            second_bot.edit_message_text.assert_not_awaited()
+            second_bot.send_message.assert_awaited_once()
+            assert [
+                item.external_message_id for item in await WorkshopDeliveryFragments(reopened).fragments(delivery_id)
+            ] == ["7001", "8001"]
+        finally:
+            await reopened.close()
+
+    async def test_deleted_preview_fails_terminally_without_a_send_fallback(self, tmp_path: Path):
+        store, delivery_id = await _prepare_finalization(tmp_path / "kai.db")
+        bot = AsyncMock()
+        bot.edit_message_text.side_effect = [
+            BadRequest("message to edit not found"),
+            BadRequest("message to edit not found"),
+        ]
+        worker = _worker(store, bot)
+        try:
+            result = await worker.run_once()
+
+            assert result.outcome == TelegramWorkOutcome.FAILED
+            assert result.error_code == "telegram_edit_rejected"
+            assert (await WorkshopDeliveryOutbox(store).state(delivery_id)).status == "failed"
+            assert (await WorkshopDeliveryFragments(store).fragments(delivery_id))[0].status == "pending"
+            assert (await worker.run_once()).outcome == TelegramWorkOutcome.IDLE
+            bot.send_message.assert_not_awaited()
+        finally:
+            await store.close()
+
+    async def test_ambiguous_edit_is_terminal_and_never_retried(self, tmp_path: Path):
+        store, delivery_id = await _prepare_finalization(tmp_path / "kai.db")
+        bot = AsyncMock()
+        bot.edit_message_text.side_effect = TimedOut()
+        worker = _worker(store, bot)
+        try:
+            result = await worker.run_once()
+
+            assert result.outcome == TelegramWorkOutcome.FAILED
+            assert result.error_code == "telegram_edit_timeout_uncertain"
+            assert (await WorkshopDeliveryFragments(store).fragments(delivery_id))[0].status == "uncertain"
+            assert (await worker.run_once()).outcome == TelegramWorkOutcome.IDLE
+            assert bot.edit_message_text.await_count == 1
+        finally:
+            await store.close()
+
+    async def test_ambiguous_continuation_send_preserves_confirmed_edit_and_never_retries(
+        self,
+        tmp_path: Path,
+    ):
+        body = "A" * 4096 + "\n" + "B" * 20
+        store, delivery_id = await _prepare_finalization(tmp_path / "kai.db", body=body)
+        bot = AsyncMock()
+        bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
+        bot.send_message.side_effect = TimedOut()
+        worker = _worker(store, bot)
+        try:
+            result = await worker.run_once()
+            persisted = await WorkshopDeliveryFragments(store).fragments(delivery_id)
+
+            assert result.outcome == TelegramWorkOutcome.FAILED
+            assert result.error_code == "telegram_timeout_uncertain"
+            assert [(item.operation, item.status) for item in persisted] == [
+                (EDIT_OPERATION, "sent"),
+                (SEND_OPERATION, "uncertain"),
+            ]
+            assert (await worker.run_once()).outcome == TelegramWorkOutcome.IDLE
+            assert bot.edit_message_text.await_count == 1
+            assert bot.send_message.await_count == 1
+        finally:
+            await store.close()
+
+    async def test_expired_inflight_edit_recovers_as_terminal_edit_uncertainty(self, tmp_path: Path):
+        store, delivery_id = await _prepare_finalization(tmp_path / "kai.db")
+        clock = _Clock(_NOW + timedelta(seconds=3))
+        outbox = WorkshopDeliveryOutbox(store, clock=clock)
+        fragments = WorkshopDeliveryFragments(store, clock=clock)
+        claim = await outbox.claim_next(
+            "crashed-finalization-worker",
+            purposes=(CONVERSATION_REPLY_PURPOSE,),
+            execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+            lease_duration=timedelta(seconds=10),
+            delivery_id=delivery_id,
+        )
+        assert claim is not None
+        started = await fragments.begin_next(claim)
+        assert started is not None and started.operation == EDIT_OPERATION
+        await store.close()
+
+        clock.advance(timedelta(seconds=10))
+        reopened = await WorkshopEventStore.open(tmp_path / "kai.db")
+        recovered_outbox = WorkshopDeliveryOutbox(reopened, clock=clock)
+        try:
+            recovered = await recovered_outbox.recover_expired_leases(
+                purposes=(CONVERSATION_REPLY_PURPOSE,),
+                execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+            )
+            state = await recovered_outbox.state(delivery_id)
+
+            assert recovered.failed == 1 and recovered.requeued == 0
+            assert state.status == "failed"
+            assert state.last_error_code == "delivery_edit_uncertain"
+            assert (await WorkshopDeliveryFragments(reopened).fragments(delivery_id))[0].status == "uncertain"
+        finally:
+            await reopened.close()
+
+    @pytest.mark.parametrize("purpose", [CONVERSATION_REPLY_PURPOSE, QUALIFICATION_PURPOSE])
+    async def test_worker_cannot_claim_send_fragment_or_qualification_work(
+        self,
+        tmp_path: Path,
+        purpose: DeliveryPurpose,
+    ):
+        store, inbound_id = await _open_with_inbound(tmp_path / f"{purpose}.db")
+        outbound = await record_outbound_message(
+            store,
+            OutboundMessage(inbound_id, "Legacy send", _NOW + timedelta(seconds=2)),
+        )
+        message_id = MessageId(str(outbound.event.envelope.aggregate_id))
+        async with store.connection.execute(
+            "SELECT cb.id FROM channel_bindings cb JOIN messages m ON m.channel_id = cb.channel_id "
+            "WHERE m.id = ? AND cb.transport = 'telegram'",
+            (message_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        delivery = await WorkshopDeliveryOutbox(store).request_delivery(
+            DeliveryRequest(
+                message_id=message_id,
+                channel_binding_id=ChannelBindingId(str(row[0])),
+                mode="text",
+                purpose=purpose,
+                occurred_at=_NOW + timedelta(seconds=2),
+            )
+        )
+        bot = AsyncMock()
+        try:
+            assert (await _worker(store, bot).run_once()).outcome == TelegramWorkOutcome.IDLE
+            assert (await WorkshopDeliveryOutbox(store).state(delivery.delivery.delivery_id)).status == "pending"
+            bot.edit_message_text.assert_not_awaited()
+            bot.send_message.assert_not_awaited()
+        finally:
+            await store.close()


### PR DESCRIPTION
## Summary

- add a production-unused Telegram adapter that executes immutable streaming-finalization edit and send operations
- add a separate worker fixed to conversation replies under the `streaming_finalization` execution contract
- preserve confirmed operation progress across retry and restart
- classify uncertain lease recovery by edit versus send operation
- document the completed execution foundation and require another explicit cutover review before production registration

## Telegram behavior

- edit the exact persisted preview message in the canonical Telegram binding
- use Markdown first and retry once as plain text, matching Kai's established presentation behavior
- accept Telegram's explicit `message is not modified` response as confirmation that the terminal snapshot already exists
- require successful edit evidence to identify the exact target message
- fail permanently when a preview was deleted or cannot be edited; never replace it with an automatic duplicate send
- execute continuation sends only after the edit has been durably confirmed

## Recovery and ambiguity

- confirmed edits and sends are skipped after retry or process restart
- definitive rate limits release only the current operation for bounded retry
- timeout, network ambiguity, invalid success evidence, cancellation, or lease expiry after entering `sending` becomes terminal uncertainty
- an uncertain edit is reported as `delivery_edit_uncertain`; an uncertain send retains `delivery_send_uncertain`
- neither ambiguous operation is automatically retried

## Isolation and production safety

- the new worker claims only `conversation_reply` + `streaming_finalization` + Telegram text work
- it cannot claim qualification rows or legacy `send_fragments` work
- the existing worker remains unable to claim streaming-finalization work
- no production handler, startup path, runtime registration, CLI command, or live delivery route uses the new classes
- current Telegram replies, media, voice, commands, schedules, GitHub/generic webhooks, files, and notification-group delivery remain unchanged

## Verification

- `make check`
- `make typecheck`
- focused finalization adapter/worker tests: 19 passed
- focused Workshop delivery and lifecycle suite: 107 passed
- full suite: 5,383 passed, 1 skipped
