### PR TITLE
Add durable Workshop delivery authority epochs

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -408,6 +408,7 @@ No entry may use an indefinite condition such as "keep for compatibility." A gen
 | Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Planned |
 | Direct Telegram delivery from handlers, schedules, and webhooks | Durable delivery outbox and Telegram delivery adapter | Delivery outcome events preserve binding identity; retry, crash recovery, ordering, private-chat and notification-group delivery tests pass; live delivery is verified | Register the outbox worker only in an explicit cutover; remove direct Bot API sends from domain paths and delete delivery fallback flags after installed verification | Active (production-unused durable request/lease/attempt/retry/recovery, binding-aware terminal outcomes, per-binding FIFO claims, immutable streaming edit/send plans, edit-capable finalization worker, and explicit runtime owner; installed direct-chat recovery and notification-group delivery passed, while production cutover is held on authority epochs, aggregate diagnostics, commit-outcome resolution, and lifecycle integration) |
 | Operator-invoked Workshop delivery qualification CLI | Installed evidence followed by the production delivery worker | A configured direct-chat reply is prepared without sending, survives a service restart, recovers an intentionally abandoned lease, reaches Telegram once through the exact selected delivery, and records a terminal binding-aware outcome; a configured notification group resolves through its outbound-only canonical channel, receives one atomically prepared qualification message through the exact selected delivery, and does not become an inbound conversation | Remove the qualification command and its explicit-claim-only surface after the production worker has equivalent installed restart/recovery evidence and direct delivery is retired | Active (the installed direct-chat recovery and notification-group delivery gates passed on 2026-08-12; retain until equivalent production-worker evidence exists, while the command remains unregistered and incapable of draining unrelated work) |
+| Conversation-delivery authority epochs | A single durable delivery authority after direct-send rollback is retired | Activation/deactivation, restart, historical-row isolation, exact-epoch worker ownership, aggregate diagnostics, and installed rollback/reactivation evidence pass; no supported rollback crosses the direct-send/outbox boundary | Remove epoch stamping, activation/deactivation state, exact-epoch claim filters, transitional readiness output, schema columns/tables where safely migratable, and their compatibility tests | Active (production-unused authority boundary; no production epoch activation, enqueue, worker registration, or route change) |
 | Schedule firing directly into the pool or Telegram | Durable Workshop run creation | Scheduled definitions and executions survive restart and expose run/attempt state without duplicate work | Remove schedule-specific execution path; retain schedules only as authenticated run triggers | Planned |
 | GitHub and generic webhook paths that route directly to Telegram or the pool | Canonical integration commands/events plus delivery/run services | Existing GitHub group notifications, generic callers, deduplication, and secret separation pass end-to-end tests | Remove direct routing while retaining verified webhook adapters and supported external contracts | Planned |
 | Per-chat settings, files, memory references, and project selection | Principal/channel/agent/project-workspace records and artifact metadata | Existing per-user isolation, context assembly, memory provenance, file delivery, and workspace access remain equivalent | Migrate namespaces and remove Telegram-derived ownership from domain storage; retire recorded compatibility `storage_path` values when an authoritative artifact store replaces local per-chat files | Active (artifact metadata foundation and photo/document/voice shadow) |
@@ -862,3 +863,30 @@ After this foundation, conduct a sixth explicit cutover review. That review
 must verify deterministic post-error commit resolution, the locked `sessions`
 adapters, startup and shutdown wiring, aggregate diagnostics, and an executable
 rollback procedure before authorizing one production handler path.
+
+### 22.3 Conversation-delivery authority-epoch foundation
+
+The production-unused authority boundary is now implemented. Schema version 14
+adds durable authority epochs and nullable epoch ownership on outbox rows.
+Existing rows remain unclassified rather than being silently adopted. A first
+activation fails closed while any matching unclassified conversation
+finalization exists; ordinary restarts reuse the same active epoch.
+
+Atomic streaming finalization resolves the active epoch inside its existing
+transaction and stamps both the request event and outbox row. Its caller cannot
+supply an epoch. The finalization worker must be constructed with one typed
+epoch and scopes claim, per-binding ordering, lease recovery, and settlement to
+that exact still-active epoch. A later epoch therefore cannot drain work from
+a prior authority period.
+
+Deactivation refuses pending, leased, or retry-wait work. It also requires an
+explicit acknowledgement when terminal failures exist, including failures with
+uncertain-fragment evidence, and retains that evidence after acknowledgement;
+reactivation creates a new epoch. `install-status` reports only aggregate epoch,
+classification, active-status, and uncertainty counts. It exposes no epoch,
+delivery, lease, worker, Telegram, message, or provider identifiers or content.
+
+The boundary remains uncalled by production startup and handlers. No epoch is
+activated during installation, no worker is registered, and direct Telegram
+delivery remains authoritative. The next bounded step is the sixth explicit
+cutover review defined above; production wiring is still not authorized.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -65,7 +65,11 @@ from kai.config import (
 from kai.named_access import replace_named_read_access
 from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
-from kai.workshop.diagnostics import workshop_bootstrap_status, workshop_message_parity_status
+from kai.workshop.diagnostics import (
+    workshop_bootstrap_status,
+    workshop_delivery_authority_status,
+    workshop_message_parity_status,
+)
 
 # Config file written by `config`, read by `apply`.
 # Anchored to PROJECT_ROOT so it resolves correctly regardless of CWD.
@@ -6752,6 +6756,7 @@ def _cmd_status() -> None:
             expected_humans=expected_humans,
         )
     )
+    print(workshop_delivery_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_message_parity_status(Path(data_dir) / "kai.db", Path(data_dir) / "history"))
 
     # Check workspace path traversal if install.conf has a service user

--- a/src/kai/workshop/delivery_authority.py
+++ b/src/kai/workshop/delivery_authority.py
@@ -1,0 +1,212 @@
+"""Production-unused authority epochs for Workshop conversation delivery."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
+    STREAMING_FINALIZATION_CONTRACT,
+)
+from kai.workshop.domain import DeliveryAuthorityEpochId
+from kai.workshop.store import WorkshopEventStore
+
+TELEGRAM_CONVERSATION_FINALIZATION_LANE = "telegram_conversation_streaming_finalization"
+
+
+class DeliveryAuthorityError(RuntimeError):
+    """Base class for fail-closed delivery-authority errors."""
+
+
+class DeliveryAuthorityInactiveError(DeliveryAuthorityError):
+    """No active authority epoch can accept or execute conversation work."""
+
+
+class DeliveryAuthorityHistoricalWorkError(DeliveryAuthorityError):
+    """Unclassified matching work prevents a safe first activation."""
+
+
+class DeliveryAuthorityOutstandingWorkError(DeliveryAuthorityError):
+    """Non-terminal work prevents a safe authority deactivation."""
+
+
+class DeliveryAuthorityUnreconciledFailureError(DeliveryAuthorityError):
+    """Terminal failures require explicit acknowledgement before rollback."""
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryAuthorityEpoch:
+    epoch_id: DeliveryAuthorityEpochId
+    status: str
+    activated_at: datetime
+    deactivated_at: datetime | None
+    terminal_failures_acknowledged_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryAuthorityActivationResult:
+    epoch: DeliveryAuthorityEpoch
+    inserted: bool
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+class WorkshopConversationDeliveryAuthority:
+    """Own the durable activation boundary for one future Telegram route.
+
+    This service is not constructed by production startup. It deliberately
+    keeps authority activation separate from worker registration and routing.
+    """
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._store = store
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    async def activate(self) -> DeliveryAuthorityActivationResult:
+        connection = self._store.connection
+        now = self._now()
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            active = await self.active_epoch_in_transaction(required=False)
+            if active is not None:
+                await connection.commit()
+                return DeliveryAuthorityActivationResult(epoch=active, inserted=False)
+
+            async with connection.execute(
+                "SELECT COUNT(*) FROM delivery_outbox "
+                "WHERE purpose = ? AND execution_contract = ? AND authority_epoch_id IS NULL",
+                (CONVERSATION_REPLY_PURPOSE, STREAMING_FINALIZATION_CONTRACT),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None:
+                raise DeliveryAuthorityError("Historical delivery query returned no row")
+            if int(row[0]) != 0:
+                raise DeliveryAuthorityHistoricalWorkError(
+                    "Unclassified streaming-finalization work requires operator reconciliation"
+                )
+
+            epoch = DeliveryAuthorityEpoch(
+                epoch_id=DeliveryAuthorityEpochId.new(),
+                status="active",
+                activated_at=now,
+                deactivated_at=None,
+                terminal_failures_acknowledged_at=None,
+            )
+            await connection.execute(
+                "INSERT INTO delivery_authority_epochs (id, lane, status, activated_at) VALUES (?, ?, 'active', ?)",
+                (epoch.epoch_id, TELEGRAM_CONVERSATION_FINALIZATION_LANE, _format_timestamp(now)),
+            )
+            await connection.commit()
+            return DeliveryAuthorityActivationResult(epoch=epoch, inserted=True)
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def deactivate(
+        self,
+        *,
+        acknowledge_terminal_failures: bool = False,
+    ) -> DeliveryAuthorityEpoch:
+        if not isinstance(acknowledge_terminal_failures, bool):
+            raise ValueError("acknowledge_terminal_failures must be a boolean")
+        connection = self._store.connection
+        now = self._now()
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            active = await self.active_epoch_in_transaction(required=True)
+            assert active is not None
+            async with connection.execute(
+                "SELECT COUNT(*) FROM delivery_outbox "
+                "WHERE authority_epoch_id = ? AND status IN ('pending', 'leased', 'retry_wait')",
+                (active.epoch_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None:
+                raise DeliveryAuthorityError("Outstanding delivery query returned no row")
+            if int(row[0]) != 0:
+                raise DeliveryAuthorityOutstandingWorkError("Active delivery authority has non-terminal work")
+
+            async with connection.execute(
+                "SELECT COUNT(*) FROM delivery_outbox WHERE authority_epoch_id = ? AND status = 'failed'",
+                (active.epoch_id,),
+            ) as cursor:
+                failure_row = await cursor.fetchone()
+            if failure_row is None:
+                raise DeliveryAuthorityError("Terminal delivery query returned no row")
+            terminal_failures = int(failure_row[0])
+            if terminal_failures and not acknowledge_terminal_failures:
+                raise DeliveryAuthorityUnreconciledFailureError(
+                    "Terminal delivery failures require explicit acknowledgement"
+                )
+
+            timestamp = _format_timestamp(now)
+            cursor = await connection.execute(
+                "UPDATE delivery_authority_epochs SET status = 'deactivated', deactivated_at = ?, "
+                "terminal_failures_acknowledged_at = ? "
+                "WHERE id = ? AND status = 'active'",
+                (timestamp, timestamp if terminal_failures else None, active.epoch_id),
+            )
+            if cursor.rowcount != 1:
+                raise DeliveryAuthorityError("Active delivery authority changed during deactivation")
+            await connection.commit()
+            return DeliveryAuthorityEpoch(
+                epoch_id=active.epoch_id,
+                status="deactivated",
+                activated_at=active.activated_at,
+                deactivated_at=now,
+                terminal_failures_acknowledged_at=(now if terminal_failures else None),
+            )
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def active_epoch(self) -> DeliveryAuthorityEpoch:
+        epoch = await self.active_epoch_in_transaction(required=True)
+        assert epoch is not None
+        return epoch
+
+    async def active_epoch_in_transaction(
+        self,
+        *,
+        required: bool = True,
+    ) -> DeliveryAuthorityEpoch | None:
+        async with self._store.connection.execute(
+            "SELECT id, status, activated_at, deactivated_at, terminal_failures_acknowledged_at "
+            "FROM delivery_authority_epochs "
+            "WHERE lane = ? AND status = 'active' ORDER BY activated_at",
+            (TELEGRAM_CONVERSATION_FINALIZATION_LANE,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if len(rows) > 1:
+            raise DeliveryAuthorityError("Multiple active delivery-authority epochs exist")
+        if not rows:
+            if required:
+                raise DeliveryAuthorityInactiveError("Conversation delivery authority is not active")
+            return None
+        row = rows[0]
+        return DeliveryAuthorityEpoch(
+            epoch_id=DeliveryAuthorityEpochId(str(row[0])),
+            status=str(row[1]),
+            activated_at=_parse_timestamp(str(row[2])),
+            deactivated_at=_parse_timestamp(str(row[3])) if row[3] is not None else None,
+            terminal_failures_acknowledged_at=(_parse_timestamp(str(row[4])) if row[4] is not None else None),
+        )
+
+    def _now(self) -> datetime:
+        now = self._clock()
+        if now.tzinfo is None or now.utcoffset() is None:
+            raise ValueError("clock must return a timezone-aware datetime")
+        return now.astimezone(UTC)

--- a/src/kai/workshop/delivery_outbox.py
+++ b/src/kai/workshop/delivery_outbox.py
@@ -14,6 +14,7 @@ from kai.workshop.domain import (
     ChannelBindingId,
     ChannelId,
     DeliveryAttemptId,
+    DeliveryAuthorityEpochId,
     DeliveryId,
     EventEnvelope,
     EventId,
@@ -75,6 +76,7 @@ class DeliveryRequest:
     purpose: DeliveryPurpose
     occurred_at: datetime
     execution_contract: DeliveryExecutionContract = SEND_FRAGMENTS_CONTRACT
+    authority_epoch_id: DeliveryAuthorityEpochId | None = None
     max_attempts: int = 5
 
     def __post_init__(self) -> None:
@@ -86,6 +88,13 @@ class DeliveryRequest:
             raise ValueError("mode must be a lowercase identifier")
         _validate_purpose(self.purpose)
         _validate_execution_contract(self.execution_contract)
+        requires_epoch = (
+            self.purpose == CONVERSATION_REPLY_PURPOSE and self.execution_contract == STREAMING_FINALIZATION_CONTRACT
+        )
+        if requires_epoch and not isinstance(self.authority_epoch_id, DeliveryAuthorityEpochId):
+            raise ValueError("streaming conversation delivery requires a DeliveryAuthorityEpochId")
+        if not requires_epoch and self.authority_epoch_id is not None:
+            raise ValueError("authority_epoch_id is only valid for streaming conversation delivery")
         if self.occurred_at.tzinfo is None or self.occurred_at.utcoffset() is None:
             raise ValueError("occurred_at must be timezone-aware")
         if (
@@ -106,6 +115,7 @@ class DeliveryState:
     mode: str
     purpose: DeliveryPurpose
     execution_contract: DeliveryExecutionContract
+    authority_epoch_id: DeliveryAuthorityEpochId | None
     status: str
     max_attempts: int
     attempt_count: int
@@ -135,6 +145,7 @@ class DeliveryClaim:
     mode: str
     purpose: DeliveryPurpose
     execution_contract: DeliveryExecutionContract
+    authority_epoch_id: DeliveryAuthorityEpochId | None
     body: str
     lease_expires_at: datetime
 
@@ -191,6 +202,18 @@ def _validate_execution_contracts(contracts: tuple[DeliveryExecutionContract, ..
         _validate_execution_contract(contract)
 
 
+def _validate_authority_scope(
+    purposes: tuple[DeliveryPurpose, ...],
+    contracts: tuple[DeliveryExecutionContract, ...],
+    authority_epoch_id: DeliveryAuthorityEpochId | None,
+) -> None:
+    requires_epoch = CONVERSATION_REPLY_PURPOSE in purposes and STREAMING_FINALIZATION_CONTRACT in contracts
+    if requires_epoch and not isinstance(authority_epoch_id, DeliveryAuthorityEpochId):
+        raise ValueError("streaming conversation work requires an exact authority epoch")
+    if not requires_epoch and authority_epoch_id is not None:
+        raise ValueError("authority_epoch_id is only valid for streaming conversation work")
+
+
 def _delivery_purpose(value: object) -> DeliveryPurpose:
     purpose = str(value)
     _validate_purpose(purpose)
@@ -244,6 +267,16 @@ class WorkshopDeliveryOutbox:
 
         resolved = await self._resolve_target(request)
         workshop_id, channel_id, author_principal_id, transport = resolved
+        if request.authority_epoch_id is not None:
+            async with connection.execute(
+                "SELECT COUNT(*) FROM delivery_authority_epochs "
+                "WHERE id = ? AND lane = 'telegram_conversation_streaming_finalization' "
+                "AND status = 'active'",
+                (request.authority_epoch_id,),
+            ) as cursor:
+                authority_row = await cursor.fetchone()
+            if authority_row is None or int(authority_row[0]) != 1:
+                raise DeliveryRequestConflictError("Delivery authority epoch is not active")
         delivery_id = DeliveryId.derived(
             workshop_id,
             f"delivery:{request.message_id}:{request.channel_binding_id}:{request.mode}",
@@ -262,14 +295,15 @@ class WorkshopDeliveryOutbox:
                 or existing.max_attempts != request.max_attempts
                 or existing.purpose != request.purpose
                 or existing.execution_contract != request.execution_contract
+                or existing.authority_epoch_id != request.authority_epoch_id
             ):
                 raise DeliveryRequestConflictError("Delivery request identity has different semantics")
             return DeliveryRequestResult(delivery=existing, inserted=False)
 
         occurred_at = request.occurred_at.astimezone(UTC)
         streaming_finalization = request.execution_contract == STREAMING_FINALIZATION_CONTRACT
-        event_version = 3 if streaming_finalization else 2
-        event_identity_version = "v3" if streaming_finalization else "v2"
+        event_version = 4 if streaming_finalization else 2
+        event_identity_version = "v4" if streaming_finalization else "v2"
         payload: dict[str, object] = {
             "message_id": request.message_id,
             "channel_id": channel_id,
@@ -281,6 +315,7 @@ class WorkshopDeliveryOutbox:
         }
         if streaming_finalization:
             payload["execution_contract"] = request.execution_contract
+            payload["authority_epoch_id"] = request.authority_epoch_id
         event = EventEnvelope.create(
             event_id=EventId.derived(
                 workshop_id,
@@ -309,9 +344,9 @@ class WorkshopDeliveryOutbox:
         await connection.execute(
             "INSERT INTO delivery_outbox "
             "(id, workshop_id, channel_id, channel_binding_id, message_id, transport, mode, purpose, "
-            "execution_contract, "
+            "execution_contract, authority_epoch_id, "
             "status, max_attempts, attempt_count, available_at, requested_event_position, "
-            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, 0, ?, ?, ?, ?)",
+            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, 0, ?, ?, ?, ?)",
             (
                 delivery_id,
                 workshop_id,
@@ -322,6 +357,7 @@ class WorkshopDeliveryOutbox:
                 request.mode,
                 request.purpose,
                 request.execution_contract,
+                request.authority_epoch_id,
                 request.max_attempts,
                 timestamp,
                 appended.event.position,
@@ -342,10 +378,12 @@ class WorkshopDeliveryOutbox:
         transport: str | None = None,
         modes: tuple[str, ...] | None = None,
         delivery_id: DeliveryId | None = None,
+        authority_epoch_id: DeliveryAuthorityEpochId | None = None,
     ) -> DeliveryClaim | None:
         _validate_worker_id(worker_id)
         _validate_purposes(purposes)
         _validate_execution_contracts(execution_contracts)
+        _validate_authority_scope(purposes, execution_contracts, authority_epoch_id)
         if lease_duration <= timedelta(0) or lease_duration > _MAX_LEASE:
             raise ValueError("lease_duration must be positive and at most five minutes")
         if transport is not None and not _IDENTIFIER_PATTERN.fullmatch(transport):
@@ -368,6 +406,7 @@ class WorkshopDeliveryOutbox:
                 purposes=purposes,
                 execution_contracts=execution_contracts,
                 delivery_id=delivery_id,
+                authority_epoch_id=authority_epoch_id,
             )
             now_text = _format_timestamp(now)
             filters = [
@@ -378,6 +417,7 @@ class WorkshopDeliveryOutbox:
                 "SELECT 1 FROM delivery_outbox predecessor "
                 "WHERE predecessor.channel_binding_id = o.channel_binding_id "
                 "AND predecessor.purpose = o.purpose "
+                "AND predecessor.authority_epoch_id IS o.authority_epoch_id "
                 "AND predecessor.requested_event_position < o.requested_event_position "
                 "AND predecessor.status NOT IN ('succeeded', 'failed')"
                 ")",
@@ -389,6 +429,15 @@ class WorkshopDeliveryOutbox:
             contract_placeholders = ", ".join("?" for _ in execution_contracts)
             filters.append(f"o.execution_contract IN ({contract_placeholders})")
             parameters.extend(execution_contracts)
+            if authority_epoch_id is not None:
+                filters.append("o.authority_epoch_id = ?")
+                parameters.append(authority_epoch_id)
+                filters.append(
+                    "EXISTS (SELECT 1 FROM delivery_authority_epochs ae "
+                    "WHERE ae.id = o.authority_epoch_id "
+                    "AND ae.lane = 'telegram_conversation_streaming_finalization' "
+                    "AND ae.status = 'active')"
+                )
             if delivery_id is not None:
                 filters.append("o.id = ?")
                 parameters.append(delivery_id)
@@ -401,7 +450,7 @@ class WorkshopDeliveryOutbox:
                 parameters.extend(modes)
             async with connection.execute(
                 "SELECT o.id, o.workshop_id, o.channel_id, o.channel_binding_id, o.message_id, "
-                "o.transport, o.mode, o.purpose, o.execution_contract, o.attempt_count, "
+                "o.transport, o.mode, o.purpose, o.execution_contract, o.authority_epoch_id, o.attempt_count, "
                 "m.body, cb.external_channel_id "
                 "FROM delivery_outbox o "
                 "JOIN messages m ON m.id = o.message_id AND m.channel_id = o.channel_id "
@@ -417,7 +466,7 @@ class WorkshopDeliveryOutbox:
                 return None
 
             delivery_id = DeliveryId(str(row[0]))
-            attempt_number = int(row[9]) + 1
+            attempt_number = int(row[10]) + 1
             attempt_id = DeliveryAttemptId.new()
             expires_at = now + lease_duration
             expires_text = _format_timestamp(expires_at)
@@ -456,8 +505,9 @@ class WorkshopDeliveryOutbox:
                 mode=str(row[6]),
                 purpose=_delivery_purpose(row[7]),
                 execution_contract=_delivery_execution_contract(row[8]),
-                body=str(row[10]),
-                external_channel_id=str(row[11]),
+                authority_epoch_id=(DeliveryAuthorityEpochId(str(row[9])) if row[9] is not None else None),
+                body=str(row[11]),
+                external_channel_id=str(row[12]),
                 lease_expires_at=expires_at,
             )
         except Exception:
@@ -495,9 +545,11 @@ class WorkshopDeliveryOutbox:
         *,
         purposes: tuple[DeliveryPurpose, ...],
         execution_contracts: tuple[DeliveryExecutionContract, ...] = (SEND_FRAGMENTS_CONTRACT,),
+        authority_epoch_id: DeliveryAuthorityEpochId | None = None,
     ) -> DeliveryRecoveryResult:
         _validate_purposes(purposes)
         _validate_execution_contracts(execution_contracts)
+        _validate_authority_scope(purposes, execution_contracts, authority_epoch_id)
         connection = self._store.connection
         try:
             await connection.execute("BEGIN IMMEDIATE")
@@ -505,6 +557,7 @@ class WorkshopDeliveryOutbox:
                 self._now(),
                 purposes=purposes,
                 execution_contracts=execution_contracts,
+                authority_epoch_id=authority_epoch_id,
             )
             await connection.commit()
             return result
@@ -537,7 +590,8 @@ class WorkshopDeliveryOutbox:
             async with connection.execute(
                 "SELECT o.status, o.attempt_count, o.max_attempts, o.lease_id, "
                 "o.lease_expires_at, a.outcome, a.completed_at, a.error_code, "
-                "o.workshop_id, o.channel_id, o.channel_binding_id, o.message_id, o.transport, o.mode "
+                "o.workshop_id, o.channel_id, o.channel_binding_id, o.message_id, o.transport, o.mode, "
+                "o.authority_epoch_id "
                 "FROM delivery_outbox o JOIN delivery_attempts a "
                 "ON a.delivery_id = o.id AND a.id = ? WHERE o.id = ?",
                 (claim.attempt_id, claim.delivery_id),
@@ -545,6 +599,19 @@ class WorkshopDeliveryOutbox:
                 row = await cursor.fetchone()
             if row is None:
                 raise StaleDeliveryLeaseError("Delivery attempt does not exist")
+            persisted_epoch = DeliveryAuthorityEpochId(str(row[14])) if row[14] is not None else None
+            if persisted_epoch != claim.authority_epoch_id:
+                raise StaleDeliveryLeaseError("Delivery attempt does not belong to the claimed authority epoch")
+            if persisted_epoch is not None:
+                async with connection.execute(
+                    "SELECT COUNT(*) FROM delivery_authority_epochs "
+                    "WHERE id = ? AND lane = 'telegram_conversation_streaming_finalization' "
+                    "AND status = 'active'",
+                    (persisted_epoch,),
+                ) as cursor:
+                    active_epoch_row = await cursor.fetchone()
+                if active_epoch_row is None or int(active_epoch_row[0]) != 1:
+                    raise StaleDeliveryLeaseError("Delivery authority epoch is not active")
             if row[5] is not None:
                 if succeeded and row[5] == desired_outcome and row[0] == "succeeded":
                     if row[6] is None:
@@ -557,6 +624,7 @@ class WorkshopDeliveryOutbox:
                         message_id=MessageId(str(row[11])),
                         transport=str(row[12]),
                         mode=str(row[13]),
+                        authority_epoch_id=persisted_epoch,
                         attempt_number=int(row[1]),
                         status="succeeded",
                         error_code=None,
@@ -574,6 +642,7 @@ class WorkshopDeliveryOutbox:
                     purposes=(claim.purpose,),
                     execution_contracts=(claim.execution_contract,),
                     delivery_id=claim.delivery_id,
+                    authority_epoch_id=claim.authority_epoch_id,
                 )
                 await connection.commit()
                 raise StaleDeliveryLeaseError("Delivery attempt lease has expired")
@@ -646,6 +715,7 @@ class WorkshopDeliveryOutbox:
                     message_id=MessageId(str(row[11])),
                     transport=str(row[12]),
                     mode=str(row[13]),
+                    authority_epoch_id=persisted_epoch,
                     attempt_number=attempt_count,
                     status=status,
                     error_code=error_code,
@@ -665,6 +735,7 @@ class WorkshopDeliveryOutbox:
         purposes: tuple[DeliveryPurpose, ...],
         execution_contracts: tuple[DeliveryExecutionContract, ...],
         delivery_id: DeliveryId | None = None,
+        authority_epoch_id: DeliveryAuthorityEpochId | None = None,
     ) -> DeliveryRecoveryResult:
         connection = self._store.connection
         now_text = _format_timestamp(now)
@@ -672,14 +743,26 @@ class WorkshopDeliveryOutbox:
         contract_placeholders = ", ".join("?" for _ in execution_contracts)
         identity_filter = " AND id = ?" if delivery_id is not None else ""
         parameters: tuple[object, ...] = (now_text, *purposes, *execution_contracts)
+        authority_filter = " AND authority_epoch_id = ?" if authority_epoch_id is not None else ""
+        active_authority_filter = (
+            " AND EXISTS (SELECT 1 FROM delivery_authority_epochs ae "
+            "WHERE ae.id = delivery_outbox.authority_epoch_id "
+            "AND ae.lane = 'telegram_conversation_streaming_finalization' "
+            "AND ae.status = 'active')"
+            if authority_epoch_id is not None
+            else ""
+        )
+        if authority_epoch_id is not None:
+            parameters = (*parameters, authority_epoch_id)
         if delivery_id is not None:
             parameters = (*parameters, delivery_id)
         async with connection.execute(
             "SELECT id, lease_id, attempt_count, max_attempts, workshop_id, channel_id, "
-            "channel_binding_id, message_id, transport, mode FROM delivery_outbox "
+            "channel_binding_id, message_id, transport, mode, authority_epoch_id FROM delivery_outbox "
             f"WHERE status = 'leased' AND lease_expires_at <= ? "
             f"AND purpose IN ({purpose_placeholders}) "
-            f"AND execution_contract IN ({contract_placeholders}){identity_filter} "
+            f"AND execution_contract IN ({contract_placeholders}){authority_filter}"
+            f"{active_authority_filter}{identity_filter} "
             "ORDER BY requested_event_position",
             parameters,
         ) as cursor:
@@ -734,6 +817,7 @@ class WorkshopDeliveryOutbox:
                     message_id=MessageId(str(row[7])),
                     transport=str(row[8]),
                     mode=str(row[9]),
+                    authority_epoch_id=(DeliveryAuthorityEpochId(str(row[10])) if row[10] is not None else None),
                     attempt_number=int(row[2]),
                     status="failed",
                     error_code=error_code,
@@ -754,6 +838,7 @@ class WorkshopDeliveryOutbox:
         message_id: MessageId,
         transport: str,
         mode: str,
+        authority_epoch_id: DeliveryAuthorityEpochId | None,
         attempt_number: int,
         status: str,
         error_code: str | None,
@@ -771,21 +856,25 @@ class WorkshopDeliveryOutbox:
         }
         if error_code is not None:
             payload["error_code"] = error_code
+        if authority_epoch_id is not None:
+            payload["authority_epoch_id"] = authority_epoch_id
+        event_identity_version = "v3" if authority_epoch_id is not None else "v2"
+        event_version = 3 if authority_epoch_id is not None else 2
         event_type = (
             WorkshopEventType.DELIVERY_SUCCEEDED if status == "succeeded" else WorkshopEventType.DELIVERY_FAILED
         )
         event = EventEnvelope.create(
             event_id=EventId.derived(
                 workshop_id,
-                f"delivery-outcome-event:v2:{delivery_id}:{status}",
+                f"delivery-outcome-event:{event_identity_version}:{delivery_id}:{status}",
             ),
             event_type=event_type,
-            event_version=2,
+            event_version=event_version,
             workshop_id=workshop_id,
             aggregate_type="delivery",
             aggregate_id=delivery_id,
             occurred_at=occurred_at,
-            idempotency_key=f"workshop-delivery-outcome:v2:{delivery_id}:{status}",
+            idempotency_key=(f"workshop-delivery-outcome:{event_identity_version}:{delivery_id}:{status}"),
             payload=payload,
             metadata={"source": "delivery_outbox"},
         )
@@ -849,6 +938,11 @@ class WorkshopDeliveryOutbox:
             mode=str(row["mode"]),
             purpose=_delivery_purpose(row["purpose"]),
             execution_contract=_delivery_execution_contract(row["execution_contract"]),
+            authority_epoch_id=(
+                DeliveryAuthorityEpochId(str(row["authority_epoch_id"]))
+                if row["authority_epoch_id"] is not None
+                else None
+            ),
             status=str(row["status"]),
             max_attempts=int(row["max_attempts"]),
             attempt_count=int(row["attempt_count"]),

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -39,6 +39,11 @@ _PARITY_TABLES = {
     "channel_bindings",
     "workshop_memberships",
 }
+_DELIVERY_AUTHORITY_TABLES = {
+    "delivery_authority_epochs",
+    "delivery_outbox",
+    "delivery_fragments",
+}
 _TELEGRAM_SUBJECT_PATTERN = re.compile(r"^-?[0-9]+$")
 _SYNTHETIC_ASSISTANT_PATTERN = re.compile(
     r"\[(stopped by user|no response|error: .+)\]",
@@ -135,6 +140,116 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
         f"Workshop bootstrap: {state}; workshops={workshop_count}, humans={human_count}, "
         f"Telegram bindings={telegram_binding_count}, channel memberships={channel_membership_count}, "
         f"agents={agent_count}; {expectation}"
+    )
+
+
+def workshop_delivery_authority_status(db_path: Path) -> str:
+    """Describe delivery-authority readiness using aggregate, non-secret state."""
+    prefix = "Workshop delivery authority:"
+    if not db_path.is_file():
+        return f"{prefix} pending; authority schema unavailable"
+
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            connection.execute("PRAGMA query_only=ON")
+            connection.execute("BEGIN")
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            if not tables >= _DELIVERY_AUTHORITY_TABLES:
+                return f"{prefix} pending; authority schema unavailable"
+
+            epoch_count = _scalar(connection, "SELECT COUNT(*) FROM delivery_authority_epochs")
+            active_rows = connection.execute(
+                "SELECT id FROM delivery_authority_epochs WHERE status = 'active'"
+            ).fetchall()
+            active_count = len(active_rows)
+            unclassified = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM delivery_outbox "
+                "WHERE purpose = 'conversation_reply' "
+                "AND execution_contract = 'streaming_finalization' "
+                "AND authority_epoch_id IS NULL",
+            )
+            active_epoch_id = str(active_rows[0][0]) if active_count == 1 else None
+            prior_parameters: tuple[object, ...] = ()
+            prior_filter = "authority_epoch_id IS NOT NULL"
+            if active_epoch_id is not None:
+                prior_filter += " AND authority_epoch_id != ?"
+                prior_parameters = (active_epoch_id,)
+            prior_nonterminal = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM delivery_outbox WHERE "
+                f"{prior_filter} AND status IN ('pending', 'leased', 'retry_wait')",
+                prior_parameters,
+            )
+            prior_failed = _scalar(
+                connection,
+                f"SELECT COUNT(*) FROM delivery_outbox WHERE {prior_filter} AND status = 'failed'",
+                prior_parameters,
+            )
+            prior_uncertain = _scalar(
+                connection,
+                "SELECT COUNT(DISTINCT o.id) FROM delivery_outbox o "
+                "JOIN delivery_fragments f ON f.delivery_id = o.id WHERE "
+                f"{prior_filter.replace('authority_epoch_id', 'o.authority_epoch_id')} "
+                "AND o.status = 'failed' AND f.status = 'uncertain'",
+                prior_parameters,
+            )
+            unacknowledged_epochs = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM delivery_authority_epochs ae "
+                "WHERE ae.status = 'deactivated' "
+                "AND ae.terminal_failures_acknowledged_at IS NULL "
+                "AND EXISTS (SELECT 1 FROM delivery_outbox o "
+                "WHERE o.authority_epoch_id = ae.id AND o.status = 'failed')",
+            )
+
+            counts = {
+                "pending": 0,
+                "leased": 0,
+                "retrying": 0,
+                "succeeded": 0,
+                "failed": 0,
+                "uncertain": 0,
+            }
+            if active_epoch_id is not None:
+                rows = connection.execute(
+                    "SELECT o.status, EXISTS ("
+                    "SELECT 1 FROM delivery_fragments f "
+                    "WHERE f.delivery_id = o.id AND f.status = 'uncertain'"
+                    ") AS uncertain FROM delivery_outbox o WHERE o.authority_epoch_id = ?",
+                    (active_epoch_id,),
+                ).fetchall()
+                for status_value, uncertain_value in rows:
+                    status = str(status_value)
+                    if status == "failed" and int(uncertain_value):
+                        counts["uncertain"] += 1
+                    elif status == "retry_wait":
+                        counts["retrying"] += 1
+                    elif status in counts:
+                        counts[status] += 1
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error, TypeError, ValueError) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+
+    if active_count > 1 or unclassified or prior_nonterminal or unacknowledged_epochs:
+        state = "NOT READY"
+    elif active_count == 1:
+        state = "active"
+    else:
+        state = "inactive"
+    return (
+        f"{prefix} {state}; epochs={epoch_count}, unclassified={unclassified}, "
+        f"prior nonterminal={prior_nonterminal}, prior failed={prior_failed}, "
+        f"prior uncertain={prior_uncertain}, unacknowledged epochs={unacknowledged_epochs}, "
+        f"active pending={counts['pending']}, "
+        f"leased={counts['leased']}, retrying={counts['retrying']}, "
+        f"succeeded={counts['succeeded']}, failed={counts['failed']}, "
+        f"uncertain={counts['uncertain']}"
     )
 
 

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -128,6 +128,10 @@ class DeliveryAttemptId(OpaqueId):
     prefix = "dla"
 
 
+class DeliveryAuthorityEpochId(OpaqueId):
+    prefix = "dae"
+
+
 class EventId(OpaqueId):
     prefix = "evt"
 
@@ -151,6 +155,7 @@ _ID_TYPES: dict[str, type[OpaqueId]] = {
         ArtifactId,
         DeliveryId,
         DeliveryAttemptId,
+        DeliveryAuthorityEpochId,
         EventId,
     )
 }

--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from kai.telegram_utils import chunk_text
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.delivery_fragments import (
     EDIT_OPERATION,
     SEND_OPERATION,
@@ -336,6 +337,8 @@ async def record_outbound_message_with_streaming_finalization(
             message.body,
             preview_message_id=preview_message_id,
         )
+        authority_epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch_in_transaction()
+        assert authority_epoch is not None
         message_result = await _existing_outbound(store, binding, message)
         if message_result is None:
             message_result = await store.append_in_transaction(_outbound_envelope(binding, message))
@@ -353,6 +356,7 @@ async def record_outbound_message_with_streaming_finalization(
                 purpose=CONVERSATION_REPLY_PURPOSE,
                 occurred_at=message.occurred_at,
                 execution_contract=STREAMING_FINALIZATION_CONTRACT,
+                authority_epoch_id=authority_epoch.epoch_id,
                 max_attempts=5,
             )
         )

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -267,7 +267,7 @@ class CanonicalConversationProjection:
                     message_row = await cursor.fetchone()
                 if message_row is None:
                     raise ValueError("Workshop delivery message must belong to its channel")
-            elif envelope.event_version == 2:
+            elif envelope.event_version in {2, 3}:
                 channel_binding_id = _required_text(payload, "channel_binding_id")
                 async with connection.execute(
                     "SELECT 1 FROM messages m JOIN channel_bindings cb ON cb.channel_id = m.channel_id "

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 13
+WORKSHOP_SCHEMA_VERSION = 14
 
 
 @dataclass(frozen=True, slots=True)
@@ -496,6 +496,39 @@ _STREAMING_FINALIZATION_SCHEMA = SchemaMigration(
     ),
 )
 
+_DELIVERY_AUTHORITY_EPOCH_SCHEMA = SchemaMigration(
+    version=14,
+    name="conversation_delivery_authority_epochs",
+    statements=(
+        """
+        CREATE TABLE delivery_authority_epochs (
+            id TEXT PRIMARY KEY,
+            lane TEXT NOT NULL CHECK (lane = 'telegram_conversation_streaming_finalization'),
+            status TEXT NOT NULL CHECK (status IN ('active', 'deactivated')),
+            activated_at TEXT NOT NULL,
+            deactivated_at TEXT,
+            terminal_failures_acknowledged_at TEXT,
+            CHECK (
+                (status = 'active' AND deactivated_at IS NULL)
+                OR (status = 'deactivated' AND deactivated_at IS NOT NULL)
+            ),
+            CHECK (
+                status = 'deactivated' OR terminal_failures_acknowledged_at IS NULL
+            )
+        )
+        """,
+        "CREATE UNIQUE INDEX delivery_authority_epochs_active_lane_idx "
+        "ON delivery_authority_epochs (lane) WHERE status = 'active'",
+        "ALTER TABLE delivery_outbox ADD COLUMN authority_epoch_id TEXT "
+        "REFERENCES delivery_authority_epochs(id) ON DELETE RESTRICT",
+        "CREATE INDEX delivery_outbox_authority_due_idx ON delivery_outbox "
+        "(authority_epoch_id, execution_contract, purpose, status, available_at, requested_event_position)",
+        "CREATE INDEX delivery_outbox_authority_binding_order_idx ON delivery_outbox "
+        "(authority_epoch_id, execution_contract, purpose, channel_binding_id, "
+        "requested_event_position, status)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -510,6 +543,7 @@ _MIGRATIONS = (
     _DELIVERY_PURPOSE_SCHEMA,
     _TELEGRAM_STREAMING_PREVIEW_SCHEMA,
     _STREAMING_FINALIZATION_SCHEMA,
+    _DELIVERY_AUTHORITY_EPOCH_SCHEMA,
 )
 
 

--- a/src/kai/workshop/telegram_delivery.py
+++ b/src/kai/workshop/telegram_delivery.py
@@ -41,7 +41,7 @@ from kai.workshop.delivery_outbox import (
     DeliveryState,
     WorkshopDeliveryOutbox,
 )
-from kai.workshop.domain import DeliveryId
+from kai.workshop.domain import DeliveryAuthorityEpochId, DeliveryId
 
 _NUMERIC_CHAT_ID_PATTERN = re.compile(r"^-?[1-9][0-9]{0,19}$")
 _USERNAME_CHAT_ID_PATTERN = re.compile(r"^@[A-Za-z][A-Za-z0-9_]{4,31}$")
@@ -460,15 +460,19 @@ class WorkshopTelegramStreamingFinalizationWorker:
         adapter: WorkshopTelegramStreamingFinalizationAdapter,
         *,
         worker_id: str,
+        authority_epoch_id: DeliveryAuthorityEpochId,
         lease_duration: timedelta = timedelta(seconds=30),
         poll_interval: float = 1.0,
     ) -> None:
         if poll_interval <= 0 or poll_interval > 60:
             raise ValueError("poll_interval must be positive and at most 60 seconds")
+        if not isinstance(authority_epoch_id, DeliveryAuthorityEpochId):
+            raise ValueError("authority_epoch_id must be a DeliveryAuthorityEpochId")
         self._outbox = outbox
         self._fragments = fragments
         self._adapter = adapter
         self._worker_id = worker_id
+        self._authority_epoch_id = authority_epoch_id
         self._lease_duration = lease_duration
         self._poll_interval = poll_interval
 
@@ -480,6 +484,7 @@ class WorkshopTelegramStreamingFinalizationWorker:
             lease_duration=self._lease_duration,
             transport="telegram",
             modes=("text",),
+            authority_epoch_id=self._authority_epoch_id,
         )
         return await self._run_claim(claim)
 
@@ -495,6 +500,7 @@ class WorkshopTelegramStreamingFinalizationWorker:
             transport="telegram",
             modes=("text",),
             delivery_id=delivery_id,
+            authority_epoch_id=self._authority_epoch_id,
         )
         return await self._run_claim(claim)
 
@@ -502,6 +508,7 @@ class WorkshopTelegramStreamingFinalizationWorker:
         return await self._outbox.recover_expired_leases(
             purposes=(CONVERSATION_REPLY_PURPOSE,),
             execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+            authority_epoch_id=self._authority_epoch_id,
         )
 
     async def _run_claim(self, claim: DeliveryClaim | None) -> TelegramWorkResult:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4405,6 +4405,7 @@ class TestCmdStatus:
         output = capsys.readouterr().out
         assert "Installation Status" in output
         assert "Workshop bootstrap:" in output
+        assert "Workshop delivery authority:" in output
         assert "Workshop message parity:" in output
 
     def test_reports_unsupported_webhook_secret(self, tmp_path, monkeypatch, capsys):

--- a/tests/test_workshop_delivery_authority.py
+++ b/tests/test_workshop_delivery_authority.py
@@ -1,0 +1,298 @@
+"""Contracts for production-unused Workshop conversation-delivery authority epochs."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from telegram.error import BadRequest
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_authority import (
+    DeliveryAuthorityHistoricalWorkError,
+    DeliveryAuthorityInactiveError,
+    DeliveryAuthorityOutstandingWorkError,
+    DeliveryAuthorityUnreconciledFailureError,
+    WorkshopConversationDeliveryAuthority,
+)
+from kai.workshop.delivery_fragments import WorkshopDeliveryFragments
+from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
+    STREAMING_FINALIZATION_CONTRACT,
+    WorkshopDeliveryOutbox,
+)
+from kai.workshop.diagnostics import workshop_delivery_authority_status
+from kai.workshop.domain import MessageId
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.outbound import OutboundMessage, record_outbound_message_with_streaming_finalization
+from kai.workshop.store import WorkshopEventStore
+from kai.workshop.telegram_delivery import (
+    TelegramWorkOutcome,
+    WorkshopTelegramStreamingFinalizationAdapter,
+    WorkshopTelegramStreamingFinalizationWorker,
+)
+
+_NOW = datetime(2026, 8, 12, 15, 0, tzinfo=UTC)
+
+
+async def _open_with_inbound(path: Path, *, sequence: int = 1) -> tuple[WorkshopEventStore, MessageId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (BootstrapHuman("Authorized human", "admin", "telegram", "101", "101"),),
+    )
+    inbound = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="telegram",
+            update_id=str(9000 + sequence),
+            message_id=str(40 + sequence),
+            sender_subject="101",
+            channel_subject="101",
+            body=f"Hello {sequence}",
+            occurred_at=_NOW + timedelta(minutes=sequence),
+        ),
+    )
+    return store, MessageId(str(inbound.event.envelope.aggregate_id))
+
+
+async def _add_inbound(store: WorkshopEventStore, *, sequence: int) -> MessageId:
+    inbound = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="telegram",
+            update_id=str(9000 + sequence),
+            message_id=str(40 + sequence),
+            sender_subject="101",
+            channel_subject="101",
+            body=f"Hello {sequence}",
+            occurred_at=_NOW + timedelta(minutes=sequence),
+        ),
+    )
+    return MessageId(str(inbound.event.envelope.aggregate_id))
+
+
+async def _finalize(store: WorkshopEventStore, inbound_id: MessageId, *, sequence: int):
+    return await record_outbound_message_with_streaming_finalization(
+        store,
+        OutboundMessage(
+            in_reply_to_message_id=inbound_id,
+            body=f"Final answer {sequence}",
+            occurred_at=_NOW + timedelta(minutes=sequence, seconds=1),
+        ),
+    )
+
+
+class TestConversationDeliveryAuthority:
+    async def test_activation_is_idempotent_and_survives_restart(self, tmp_path: Path):
+        path = tmp_path / "kai.db"
+        store, _ = await _open_with_inbound(path)
+        first = await WorkshopConversationDeliveryAuthority(store).activate()
+        retry = await WorkshopConversationDeliveryAuthority(store).activate()
+        await store.close()
+
+        reopened = await WorkshopEventStore.open(path)
+        try:
+            after_restart = await WorkshopConversationDeliveryAuthority(reopened).activate()
+            assert first.inserted is True
+            assert retry.inserted is False
+            assert after_restart.inserted is False
+            assert retry.epoch == first.epoch == after_restart.epoch
+        finally:
+            await reopened.close()
+
+    async def test_concurrent_activation_creates_exactly_one_active_epoch(self, tmp_path: Path):
+        path = tmp_path / "kai.db"
+        initial, _ = await _open_with_inbound(path)
+        await initial.close()
+        first_store = await WorkshopEventStore.open(path)
+        second_store = await WorkshopEventStore.open(path)
+        try:
+            first, second = await asyncio.gather(
+                WorkshopConversationDeliveryAuthority(first_store).activate(),
+                WorkshopConversationDeliveryAuthority(second_store).activate(),
+            )
+            assert {first.inserted, second.inserted} == {True, False}
+            assert first.epoch == second.epoch
+            async with first_store.connection.execute(
+                "SELECT COUNT(*) FROM delivery_authority_epochs WHERE status = 'active'"
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 1
+        finally:
+            await first_store.close()
+            await second_store.close()
+
+    async def test_finalization_requires_and_internally_stamps_the_active_epoch(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            with pytest.raises(DeliveryAuthorityInactiveError):
+                await _finalize(store, inbound_id, sequence=1)
+
+            async with store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
+                assert (await cursor.fetchone())[0] == 0
+            activation = await WorkshopConversationDeliveryAuthority(store).activate()
+            result = await _finalize(store, inbound_id, sequence=1)
+
+            assert result.delivery.delivery.authority_epoch_id == activation.epoch.epoch_id
+            assert result.delivery.delivery.status == "pending"
+        finally:
+            await store.close()
+
+    async def test_nonterminal_work_blocks_deactivation_and_another_epoch_cannot_claim_it(
+        self,
+        tmp_path: Path,
+    ):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        authority = WorkshopConversationDeliveryAuthority(store)
+        activation = await authority.activate()
+        result = await _finalize(store, inbound_id, sequence=1)
+        try:
+            with pytest.raises(DeliveryAuthorityOutstandingWorkError):
+                await authority.deactivate()
+
+            unrelated_epoch = type(activation.epoch.epoch_id).new()
+            claim = await WorkshopDeliveryOutbox(store).claim_next(
+                "wrong-epoch-worker",
+                purposes=(CONVERSATION_REPLY_PURPOSE,),
+                execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+                delivery_id=result.delivery.delivery.delivery_id,
+                authority_epoch_id=unrelated_epoch,
+            )
+            assert claim is None
+            assert (await authority.active_epoch()).epoch_id == activation.epoch.epoch_id
+        finally:
+            await store.close()
+
+    async def test_deactivation_and_reactivation_never_replay_prior_epoch_work(self, tmp_path: Path):
+        store, first_inbound = await _open_with_inbound(tmp_path / "kai.db")
+        authority = WorkshopConversationDeliveryAuthority(store)
+        first_epoch = (await authority.activate()).epoch
+        first = await _finalize(store, first_inbound, sequence=1)
+        first_bot = AsyncMock()
+        first_bot.send_message.return_value = SimpleNamespace(message_id=8001)
+
+        def worker_clock() -> datetime:
+            return _NOW + timedelta(hours=1)
+
+        first_worker = WorkshopTelegramStreamingFinalizationWorker(
+            WorkshopDeliveryOutbox(store, clock=worker_clock),
+            WorkshopDeliveryFragments(store, clock=worker_clock),
+            WorkshopTelegramStreamingFinalizationAdapter(first_bot),
+            worker_id="first-authority-worker",
+            authority_epoch_id=first_epoch.epoch_id,
+        )
+        assert (await first_worker.run_delivery(first.delivery.delivery.delivery_id)).outcome == (
+            TelegramWorkOutcome.SUCCEEDED
+        )
+
+        deactivated = await authority.deactivate()
+        second_epoch = (await authority.activate()).epoch
+        second_inbound = await _add_inbound(store, sequence=2)
+        second = await _finalize(store, second_inbound, sequence=2)
+        second_bot = AsyncMock()
+        second_bot.send_message.return_value = SimpleNamespace(message_id=8002)
+        second_worker = WorkshopTelegramStreamingFinalizationWorker(
+            WorkshopDeliveryOutbox(store, clock=worker_clock),
+            WorkshopDeliveryFragments(store, clock=worker_clock),
+            WorkshopTelegramStreamingFinalizationAdapter(second_bot),
+            worker_id="second-authority-worker",
+            authority_epoch_id=second_epoch.epoch_id,
+        )
+        try:
+            assert deactivated.status == "deactivated"
+            assert second_epoch.epoch_id != first_epoch.epoch_id
+            assert second.delivery.delivery.authority_epoch_id == second_epoch.epoch_id
+            assert (await second_worker.run_once()).delivery_id == second.delivery.delivery.delivery_id
+            assert (await second_worker.run_once()).outcome == TelegramWorkOutcome.IDLE
+            assert second_bot.send_message.await_count == 1
+            assert (await WorkshopDeliveryOutbox(store).state(first.delivery.delivery.delivery_id)).status == (
+                "succeeded"
+            )
+        finally:
+            await store.close()
+
+    async def test_terminal_failure_requires_explicit_acknowledgement_before_deactivation(
+        self,
+        tmp_path: Path,
+    ):
+        path = tmp_path / "kai.db"
+        store, inbound_id = await _open_with_inbound(path)
+        authority = WorkshopConversationDeliveryAuthority(store)
+        epoch = (await authority.activate()).epoch
+        result = await _finalize(store, inbound_id, sequence=1)
+        bot = AsyncMock()
+        bot.send_message.side_effect = [BadRequest("rejected"), BadRequest("rejected")]
+
+        def worker_clock() -> datetime:
+            return _NOW + timedelta(hours=1)
+
+        worker = WorkshopTelegramStreamingFinalizationWorker(
+            WorkshopDeliveryOutbox(store, clock=worker_clock),
+            WorkshopDeliveryFragments(store, clock=worker_clock),
+            WorkshopTelegramStreamingFinalizationAdapter(bot),
+            worker_id="failed-authority-worker",
+            authority_epoch_id=epoch.epoch_id,
+        )
+        assert (await worker.run_delivery(result.delivery.delivery.delivery_id)).outcome == (TelegramWorkOutcome.FAILED)
+        with pytest.raises(DeliveryAuthorityUnreconciledFailureError):
+            await authority.deactivate()
+
+        deactivated = await authority.deactivate(acknowledge_terminal_failures=True)
+        await store.close()
+
+        assert deactivated.terminal_failures_acknowledged_at is not None
+        status = workshop_delivery_authority_status(path)
+        assert "Workshop delivery authority: inactive" in status
+        assert "prior failed=1" in status
+        assert "unacknowledged epochs=0" in status
+
+
+class TestDeliveryAuthorityDiagnostic:
+    def test_missing_schema_is_pending(self, tmp_path: Path):
+        assert workshop_delivery_authority_status(tmp_path / "missing.db") == (
+            "Workshop delivery authority: pending; authority schema unavailable"
+        )
+
+    async def test_status_reports_only_aggregate_active_work(self, tmp_path: Path):
+        path = tmp_path / "kai.db"
+        store, inbound_id = await _open_with_inbound(path)
+        activation = await WorkshopConversationDeliveryAuthority(store).activate()
+        result = await _finalize(store, inbound_id, sequence=1)
+        await store.close()
+
+        status = workshop_delivery_authority_status(path)
+        assert status == (
+            "Workshop delivery authority: active; epochs=1, unclassified=0, prior nonterminal=0, "
+            "prior failed=0, prior uncertain=0, unacknowledged epochs=0, "
+            "active pending=1, leased=0, retrying=0, succeeded=0, failed=0, uncertain=0"
+        )
+        assert str(activation.epoch.epoch_id) not in status
+        assert str(result.delivery.delivery.delivery_id) not in status
+
+    async def test_unclassified_historical_work_is_not_ready_and_blocks_activation(self, tmp_path: Path):
+        path = tmp_path / "kai.db"
+        store, inbound_id = await _open_with_inbound(path)
+        activation = await WorkshopConversationDeliveryAuthority(store).activate()
+        result = await _finalize(store, inbound_id, sequence=1)
+        await store.connection.execute(
+            "UPDATE delivery_outbox SET authority_epoch_id = NULL WHERE id = ?",
+            (result.delivery.delivery.delivery_id,),
+        )
+        await store.connection.execute(
+            "DELETE FROM delivery_authority_epochs WHERE id = ?",
+            (activation.epoch.epoch_id,),
+        )
+        await store.connection.commit()
+        try:
+            with pytest.raises(DeliveryAuthorityHistoricalWorkError):
+                await WorkshopConversationDeliveryAuthority(store).activate()
+        finally:
+            await store.close()
+
+        assert workshop_delivery_authority_status(path).startswith(
+            "Workshop delivery authority: NOT READY; epochs=0, unclassified=1"
+        )

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -173,7 +173,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 13
+        assert await workshop_store.schema_version() == 14
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -186,7 +186,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 13
+        assert await second.schema_version() == 14
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -207,7 +207,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -236,6 +236,7 @@ class TestWorkshopSchema:
                     11,
                     12,
                     13,
+                    14,
                 ]
         finally:
             await upgraded.close()
@@ -258,7 +259,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -299,7 +300,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -352,7 +353,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -396,7 +397,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -440,7 +441,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -484,7 +485,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -588,7 +589,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -701,7 +702,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -12,6 +12,7 @@ import aiosqlite
 import pytest
 
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.delivery_fragments import EDIT_OPERATION, SEND_OPERATION, WorkshopDeliveryFragments
 from kai.workshop.delivery_outbox import (
     CONVERSATION_REPLY_PURPOSE,
@@ -62,7 +63,11 @@ class _Clock:
         self.now += delta
 
 
-async def _open_with_inbound(path: Path) -> tuple[WorkshopEventStore, MessageId]:
+async def _open_with_inbound(
+    path: Path,
+    *,
+    activate_authority: bool = True,
+) -> tuple[WorkshopEventStore, MessageId]:
     store = await WorkshopEventStore.open(path)
     await bootstrap_default_workshop(
         store,
@@ -81,6 +86,8 @@ async def _open_with_inbound(path: Path) -> tuple[WorkshopEventStore, MessageId]
         ),
     )
     assert isinstance(inbound.event.envelope.aggregate_id, MessageId)
+    if activate_authority:
+        await WorkshopConversationDeliveryAuthority(store).activate()
     return store, inbound.event.envelope.aggregate_id
 
 
@@ -291,6 +298,7 @@ class TestAtomicStreamingFinalization:
                     purpose=CONVERSATION_REPLY_PURPOSE,
                     occurred_at=_NOW + timedelta(seconds=2),
                     execution_contract=STREAMING_FINALIZATION_CONTRACT,
+                    authority_epoch_id=(await WorkshopConversationDeliveryAuthority(store).active_epoch()).epoch_id,
                 )
             )
 
@@ -340,6 +348,7 @@ class TestStreamingFinalizationWorkerIsolation:
                 _outbound(inbound_id),
             )
             outbox = WorkshopDeliveryOutbox(store, clock=clock)
+            authority_epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch()
             assert (
                 await outbox.claim_next(
                     "send-only-worker",
@@ -355,6 +364,7 @@ class TestStreamingFinalizationWorkerIsolation:
                 execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
                 lease_duration=timedelta(seconds=10),
                 delivery_id=finalization.delivery.delivery.delivery_id,
+                authority_epoch_id=authority_epoch.epoch_id,
             )
             assert claim is not None
             clock.advance(timedelta(seconds=10))
@@ -369,6 +379,7 @@ class TestStreamingFinalizationWorkerIsolation:
             recovered = await outbox.recover_expired_leases(
                 purposes=(CONVERSATION_REPLY_PURPOSE,),
                 execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+                authority_epoch_id=authority_epoch.epoch_id,
             )
             assert recovered.requeued == 1 and recovered.failed == 0
             assert (await outbox.state(claim.delivery_id)).status == "retry_wait"
@@ -388,7 +399,10 @@ class TestStreamingFinalizationMigration:
         with monkeypatch.context() as migration_context:
             migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 12)
             migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:12])
-            version_twelve, inbound_id = await _open_with_inbound(path)
+            version_twelve, inbound_id = await _open_with_inbound(
+                path,
+                activate_authority=False,
+            )
             outbound = await record_outbound_message(version_twelve, _outbound(inbound_id))
             message_id = MessageId(str(outbound.event.envelope.aggregate_id))
             async with version_twelve.connection.execute(
@@ -452,7 +466,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:
@@ -462,5 +476,9 @@ class TestStreamingFinalizationMigration:
                 (delivery_id,),
             ) as cursor:
                 assert tuple(await cursor.fetchone()) == (SEND_OPERATION, None)
+            async with upgraded.connection.execute(
+                "SELECT authority_epoch_id FROM delivery_outbox WHERE id = ?", (delivery_id,)
+            ) as cursor:
+                assert (await cursor.fetchone())[0] is None
         finally:
             await upgraded.close()

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -361,7 +361,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 13
+            assert await upgraded.schema_version() == 14
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_telegram_delivery.py
+++ b/tests/test_workshop_telegram_delivery.py
@@ -71,6 +71,7 @@ def _claim(
         mode=mode,
         purpose=QUALIFICATION_PURPOSE,
         execution_contract=SEND_FRAGMENTS_CONTRACT,
+        authority_epoch_id=None,
         body=body,
         lease_expires_at=_NOW + timedelta(seconds=30),
     )

--- a/tests/test_workshop_telegram_streaming_finalization.py
+++ b/tests/test_workshop_telegram_streaming_finalization.py
@@ -13,6 +13,7 @@ from telegram.constants import ParseMode
 from telegram.error import BadRequest, NetworkError, RetryAfter, TimedOut
 
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.delivery_fragments import (
     EDIT_OPERATION,
     SEND_OPERATION,
@@ -32,6 +33,7 @@ from kai.workshop.domain import (
     ChannelBindingId,
     ChannelId,
     DeliveryAttemptId,
+    DeliveryAuthorityEpochId,
     DeliveryId,
     MessageId,
     WorkshopId,
@@ -83,6 +85,7 @@ def _claim(*, execution_contract=STREAMING_FINALIZATION_CONTRACT) -> DeliveryCla
         mode="text",
         purpose=CONVERSATION_REPLY_PURPOSE,
         execution_contract=execution_contract,
+        authority_epoch_id=DeliveryAuthorityEpochId.new(),
         body="Final answer",
         lease_expires_at=_NOW + timedelta(seconds=30),
     )
@@ -127,6 +130,7 @@ async def _open_with_inbound(path: Path) -> tuple[WorkshopEventStore, MessageId]
             occurred_at=_NOW,
         ),
     )
+    await WorkshopConversationDeliveryAuthority(store).activate()
     return store, MessageId(str(inbound.event.envelope.aggregate_id))
 
 
@@ -157,7 +161,7 @@ async def _prepare_finalization(
     return store, result.delivery.delivery.delivery_id
 
 
-def _worker(
+async def _worker(
     store: WorkshopEventStore,
     bot: AsyncMock,
     *,
@@ -165,11 +169,13 @@ def _worker(
     lease_duration: timedelta = timedelta(seconds=30),
 ) -> WorkshopTelegramStreamingFinalizationWorker:
     effective_clock = clock or _Clock(_NOW + timedelta(seconds=3))
+    authority_epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch()
     return WorkshopTelegramStreamingFinalizationWorker(
         WorkshopDeliveryOutbox(store, clock=effective_clock),
         WorkshopDeliveryFragments(store, clock=effective_clock),
         WorkshopTelegramStreamingFinalizationAdapter(bot),
         worker_id="telegram-finalization-worker",
+        authority_epoch_id=authority_epoch.epoch_id,
         lease_duration=lease_duration,
         poll_interval=0.01,
     )
@@ -323,7 +329,7 @@ class TestTelegramStreamingFinalizationWorker:
         bot = AsyncMock()
         bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
         try:
-            result = await _worker(store, bot).run_delivery(delivery_id)
+            result = await (await _worker(store, bot)).run_delivery(delivery_id)
             persisted = await WorkshopDeliveryFragments(store).fragments(delivery_id)
 
             assert result.outcome == TelegramWorkOutcome.SUCCEEDED
@@ -342,7 +348,7 @@ class TestTelegramStreamingFinalizationWorker:
         bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
         bot.send_message.return_value = SimpleNamespace(message_id=8001)
         try:
-            result = await _worker(store, bot).run_once()
+            result = await (await _worker(store, bot)).run_once()
             persisted = await WorkshopDeliveryFragments(store).fragments(delivery_id)
 
             assert result.outcome == TelegramWorkOutcome.SUCCEEDED
@@ -366,7 +372,7 @@ class TestTelegramStreamingFinalizationWorker:
             SimpleNamespace(message_id=8002),
         ]
         try:
-            assert (await _worker(store, bot).run_once()).outcome == TelegramWorkOutcome.SUCCEEDED
+            assert (await (await _worker(store, bot)).run_once()).outcome == TelegramWorkOutcome.SUCCEEDED
             persisted = await WorkshopDeliveryFragments(store).fragments(delivery_id)
             assert [item.operation for item in persisted] == [SEND_OPERATION, SEND_OPERATION]
             assert [item.external_message_id for item in persisted] == ["8001", "8002"]
@@ -387,7 +393,7 @@ class TestTelegramStreamingFinalizationWorker:
         first_bot = AsyncMock()
         first_bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
         first_bot.send_message.side_effect = RetryAfter(timedelta(seconds=1))
-        first = await _worker(store, first_bot, clock=clock).run_once()
+        first = await (await _worker(store, first_bot, clock=clock)).run_once()
         assert first.outcome == TelegramWorkOutcome.RETRY_SCHEDULED
         assert [item.status for item in await WorkshopDeliveryFragments(store).fragments(delivery_id)] == [
             "sent",
@@ -400,7 +406,7 @@ class TestTelegramStreamingFinalizationWorker:
         second_bot = AsyncMock()
         second_bot.send_message.return_value = SimpleNamespace(message_id=8001)
         try:
-            second = await _worker(reopened, second_bot, clock=clock).run_delivery(delivery_id)
+            second = await (await _worker(reopened, second_bot, clock=clock)).run_delivery(delivery_id)
 
             assert second.outcome == TelegramWorkOutcome.SUCCEEDED
             assert second.attempt_number == 2
@@ -419,7 +425,7 @@ class TestTelegramStreamingFinalizationWorker:
             BadRequest("message to edit not found"),
             BadRequest("message to edit not found"),
         ]
-        worker = _worker(store, bot)
+        worker = await _worker(store, bot)
         try:
             result = await worker.run_once()
 
@@ -436,7 +442,7 @@ class TestTelegramStreamingFinalizationWorker:
         store, delivery_id = await _prepare_finalization(tmp_path / "kai.db")
         bot = AsyncMock()
         bot.edit_message_text.side_effect = TimedOut()
-        worker = _worker(store, bot)
+        worker = await _worker(store, bot)
         try:
             result = await worker.run_once()
 
@@ -457,7 +463,7 @@ class TestTelegramStreamingFinalizationWorker:
         bot = AsyncMock()
         bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
         bot.send_message.side_effect = TimedOut()
-        worker = _worker(store, bot)
+        worker = await _worker(store, bot)
         try:
             result = await worker.run_once()
             persisted = await WorkshopDeliveryFragments(store).fragments(delivery_id)
@@ -479,12 +485,14 @@ class TestTelegramStreamingFinalizationWorker:
         clock = _Clock(_NOW + timedelta(seconds=3))
         outbox = WorkshopDeliveryOutbox(store, clock=clock)
         fragments = WorkshopDeliveryFragments(store, clock=clock)
+        authority_epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch()
         claim = await outbox.claim_next(
             "crashed-finalization-worker",
             purposes=(CONVERSATION_REPLY_PURPOSE,),
             execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
             lease_duration=timedelta(seconds=10),
             delivery_id=delivery_id,
+            authority_epoch_id=authority_epoch.epoch_id,
         )
         assert claim is not None
         started = await fragments.begin_next(claim)
@@ -498,6 +506,7 @@ class TestTelegramStreamingFinalizationWorker:
             recovered = await recovered_outbox.recover_expired_leases(
                 purposes=(CONVERSATION_REPLY_PURPOSE,),
                 execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+                authority_epoch_id=authority_epoch.epoch_id,
             )
             state = await recovered_outbox.state(delivery_id)
 
@@ -538,7 +547,7 @@ class TestTelegramStreamingFinalizationWorker:
         )
         bot = AsyncMock()
         try:
-            assert (await _worker(store, bot).run_once()).outcome == TelegramWorkOutcome.IDLE
+            assert (await (await _worker(store, bot)).run_once()).outcome == TelegramWorkOutcome.IDLE
             assert (await WorkshopDeliveryOutbox(store).state(delivery.delivery.delivery_id)).status == "pending"
             bot.edit_message_text.assert_not_awaited()
             bot.send_message.assert_not_awaited()


### PR DESCRIPTION
## Summary

- add a durable, typed authority epoch for the future Telegram conversation-finalization lane
- stamp new streaming-finalization requests atomically with the currently active epoch
- require workers to claim, recover, and settle work only for their exact still-active epoch
- add aggregate, non-secret authority readiness information to `make install-status`
- record the transitional boundary and its explicit retirement criteria in the Workshop implementation map

## Why

The future Workshop delivery worker must not overlap ambiguously with the current direct Telegram delivery path. A restart-safe authority boundary is needed before any production cutover can be considered. Process-local flags are insufficient because they cannot distinguish work created under different authority periods or prevent a later worker from draining older work.

This PR establishes that boundary without activating it in production.

## Durable contract

Schema version 14 adds:

- `delivery_authority_epochs`, with at most one active epoch for the conversation-finalization lane
- nullable `delivery_outbox.authority_epoch_id`, deliberately leaving historical rows unclassified
- indexes for exact-epoch due-work selection and per-binding ordering

Activation is transactional and idempotent across restarts and concurrent attempts. First activation fails closed if matching historical outbox work is unclassified; it never silently adopts those rows.

Atomic streaming finalization resolves the active epoch inside the same database transaction that records the canonical outbound message and delivery request. Callers cannot choose or inject an epoch.

The streaming-finalization worker now requires a typed epoch at construction and uses that exact epoch for:

- claims
- predecessor ordering
- expired-lease recovery
- targeted delivery execution
- terminal settlement

An inactive or different epoch cannot drain or complete the work.

Deactivation refuses non-terminal work. If the epoch contains terminal failures, including failures with uncertain-fragment evidence, an operator must explicitly acknowledge them before deactivation. The evidence remains durable after acknowledgement. A later activation creates a new epoch and cannot replay prior-epoch work.

## Operator diagnostic

`make install-status` now includes one aggregate authority line reporting:

- active/inactive/not-ready state
- epoch and unclassified-work counts
- prior non-terminal, failed, uncertain, and unacknowledged counts
- active pending, leased, retrying, succeeded, failed, and uncertain counts

It does not expose epoch IDs, delivery IDs, lease IDs, worker IDs, Telegram identifiers, message content, or provider errors.

## Production safety

This remains a production-unused foundation:

- installation does not activate an epoch
- startup does not activate an epoch
- no production worker is registered
- no handler or live Telegram route calls the new authority service
- current direct Telegram delivery remains authoritative

The implementation map requires a separate sixth cutover review before any production wiring is authorized.

## Tests

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q`

Result: `5392 passed, 1 skipped`

New contracts cover idempotent restart, concurrent activation, fail-closed inactive enqueue, internal epoch stamping, exact-epoch isolation, non-terminal deactivation refusal, explicit terminal-failure acknowledgement, rollback/reactivation without replay, unclassified historical work, and aggregate non-secret diagnostics.
