### PR TITLE
Cut private Telegram text over to Workshop delivery

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -401,14 +401,14 @@ No entry may use an indefinite condition such as "keep for compatibility." A gen
 
 | Transitional mechanism | Replacement authority | Required evidence and removal gate | Retirement work | State |
 |---|---|---|---|---|
-| Authenticated plain-text/photo/document/voice and successful assistant-result canonical shadow writes beside current history, plus non-authoritative Telegram delivery observations | Workshop event store, message/artifact projections, and durable delivery outbox | Deterministic replay, duplicate-ingress/result tests, restart tests, full media-ingress coverage, delivery parity diagnostics, and sustained parity with current history and Telegram outcomes | Remove the `workshop_inbound_recorder`, `workshop_artifact_recorder`, `workshop_outbound_recorder`, and `workshop_delivery_recorder` bot-data adapters and their fail-open handler branches; remove the transitional `workshop_message_shadowed` JSONL marker; remove `workshop_message_parity_status` and its install-status output after canonical reads and outbox delivery become authoritative; make canonical command/event transactions and the delivery outbox the sole write and delivery paths | Active (inbound text/photo/document/voice, photo/document/voice artifacts, assistant results, delivery observations, read-only parity diagnostic, production-unused outbox and Telegram worker foundations) |
+| Authenticated plain-text/photo/document/voice and successful assistant-result canonical shadow writes beside current history, plus non-authoritative Telegram delivery observations | Workshop event store, message/artifact projections, and durable delivery outbox | Deterministic replay, duplicate-ingress/result tests, restart tests, full media-ingress coverage, delivery parity diagnostics, and sustained parity with current history and Telegram outcomes | Remove the `workshop_inbound_recorder`, `workshop_artifact_recorder`, `workshop_outbound_recorder`, and `workshop_delivery_recorder` bot-data adapters and their fail-open handler branches; remove the transitional `workshop_message_shadowed` JSONL marker; remove `workshop_message_parity_status` and its install-status output after canonical reads and outbox delivery become authoritative; make canonical command/event transactions and the delivery outbox the sole write and delivery paths | Active (private text finalization is authoritative in the outbox; inbound/media artifacts, remaining assistant results and delivery observations, JSONL history, and parity diagnostics remain transitional) |
 | JSONL transcript writes and reads | Canonical message projection, with an explicit export facility if still useful | Canonical reads serve complete context and transcript views; migration/parity diagnostics report no unexplained divergence | Stop JSONL writes; remove production reads and dual-write recovery code; retain only a documented importer/exporter if required | Planned |
 | Telegram `chat_id` used as internal identity, namespace, and routing key | Durable principal, channel, agent, and binding IDs | Private chats, notification-only groups, duplicate updates, and restart routing all resolve correctly through bindings | Confine Telegram IDs to external identity, transport binding, and idempotency records; remove chat-shaped domain keys | Planned |
 | `SubprocessPool` keyed by Telegram chat ID | Durable channel/agent session plus run and attempt orchestration | All five harnesses pass continuity, restart, cancellation, and isolation tests through durable identities | Remove chat-key compatibility lookup and move lifecycle ownership behind the orchestrator/runtime contract | Planned |
 | Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Planned |
-| Direct Telegram delivery from handlers, schedules, and webhooks | Durable delivery outbox and Telegram delivery adapter | Delivery outcome events preserve binding identity; retry, crash recovery, ordering, private-chat and notification-group delivery tests pass; live delivery is verified | Register the outbox worker only in an explicit cutover; remove direct Bot API sends from domain paths and delete delivery fallback flags after installed verification | Active (production-unused durable request/lease/attempt/retry/recovery, binding-aware terminal outcomes, per-binding FIFO claims, immutable streaming edit/send plans, edit-capable finalization worker, and explicit runtime owner; installed direct-chat recovery and notification-group delivery passed, while production cutover is held on authority epochs, aggregate diagnostics, commit-outcome resolution, and lifecycle integration) |
+| Direct Telegram delivery from handlers, schedules, and webhooks | Durable delivery outbox and Telegram delivery adapter | Delivery outcome events preserve binding identity; retry, crash recovery, ordering, private-chat and notification-group delivery tests pass; live delivery is verified | Remove the retained direct fallback for private text after installed cutover evidence; migrate each remaining transport path separately | Active (authenticated private-chat text with voice mode off now uses atomic streaming finalization and a supervised exact-epoch worker; installed cutover verification remains pending, while commands, media, voice, schedules, webhooks, files, groups, and definite preparation-error fallback retain existing delivery) |
 | Operator-invoked Workshop delivery qualification CLI | Installed evidence followed by the production delivery worker | A configured direct-chat reply is prepared without sending, survives a service restart, recovers an intentionally abandoned lease, reaches Telegram once through the exact selected delivery, and records a terminal binding-aware outcome; a configured notification group resolves through its outbound-only canonical channel, receives one atomically prepared qualification message through the exact selected delivery, and does not become an inbound conversation | Remove the qualification command and its explicit-claim-only surface after the production worker has equivalent installed restart/recovery evidence and direct delivery is retired | Active (the installed direct-chat recovery and notification-group delivery gates passed on 2026-08-12; retain until equivalent production-worker evidence exists, while the command remains unregistered and incapable of draining unrelated work) |
-| Conversation-delivery authority epochs | A single durable delivery authority after direct-send rollback is retired | Activation/deactivation, restart, historical-row isolation, exact-epoch worker ownership, aggregate diagnostics, and installed rollback/reactivation evidence pass; no supported rollback crosses the direct-send/outbox boundary | Remove epoch stamping, activation/deactivation state, exact-epoch claim filters, transitional readiness output, schema columns/tables where safely migratable, and their compatibility tests | Active (production-unused authority boundary; no production epoch activation, enqueue, worker registration, or route change) |
+| Conversation-delivery authority epochs | A single durable delivery authority after direct-send rollback is retired | Activation/deactivation, restart, historical-row isolation, exact-epoch worker ownership, aggregate diagnostics, and installed rollback/reactivation evidence pass; no supported rollback crosses the direct-send/outbox boundary | Remove epoch stamping, activation/deactivation state, exact-epoch claim filters, transitional readiness output, schema columns/tables where safely migratable, and their compatibility tests | Active (production startup resumes or creates the exact epoch before ingress; the first private-text cutover is live in code and awaits installed verification) |
 | Schedule firing directly into the pool or Telegram | Durable Workshop run creation | Scheduled definitions and executions survive restart and expose run/attempt state without duplicate work | Remove schedule-specific execution path; retain schedules only as authenticated run triggers | Planned |
 | GitHub and generic webhook paths that route directly to Telegram or the pool | Canonical integration commands/events plus delivery/run services | Existing GitHub group notifications, generic callers, deduplication, and secret separation pass end-to-end tests | Remove direct routing while retaining verified webhook adapters and supported external contracts | Planned |
 | Per-chat settings, files, memory references, and project selection | Principal/channel/agent/project-workspace records and artifact metadata | Existing per-user isolation, context assembly, memory provenance, file delivery, and workspace access remain equivalent | Migrate namespaces and remove Telegram-derived ownership from domain storage; retire recorded compatibility `storage_path` values when an authoritative artifact store replaces local per-chat files | Active (artifact metadata foundation and photo/document/voice shadow) |
@@ -886,7 +886,85 @@ reactivation creates a new epoch. `install-status` reports only aggregate epoch,
 classification, active-status, and uncertainty counts. It exposes no epoch,
 delivery, lease, worker, Telegram, message, or provider identifiers or content.
 
-The boundary remains uncalled by production startup and handlers. No epoch is
-activated during installation, no worker is registered, and direct Telegram
-delivery remains authoritative. The next bounded step is the sixth explicit
-cutover review defined above; production wiring is still not authorized.
+This foundation was production-unused when introduced. Section 23 records the
+subsequent cutover decision and the narrow production wiring that now consumes
+it.
+
+## 23. Sixth canonical conversation authority review and first cutover
+
+**Review date:** 2026-08-12
+
+**Scope:** Whether the completed authority-epoch boundary, deterministic
+finalization transaction, exact-epoch worker, aggregate diagnostic, and
+lifecycle owner are sufficient to replace direct final delivery for one
+authenticated private-chat plain-text path.
+
+**Decision:** **Authorize and implement the first production cutover.** The
+remaining work was production assembly rather than another missing domain
+foundation. The cutover is deliberately narrow:
+
+- only `handle_message` can select it;
+- the Telegram chat must be the authenticated user's private chat;
+- canonical inbound recording must have succeeded;
+- voice mode must be off;
+- commands, groups, photos, documents, voice messages, text-plus-voice,
+  voice-only, schedules, GitHub and generic webhooks, and files retain their
+  existing paths.
+
+Production startup opens a dedicated Workshop store, transactionally resumes
+or creates the single conversation-delivery authority epoch, recovers its
+expired leases, and starts the supervised finalization worker before webhook
+or polling ingress begins. Unexpected worker exit is service-fatal. Shutdown
+stops ingress, cooperatively stops the worker, closes its store, and only then
+closes the Telegram application and shared session database.
+
+The handler binds a confirmed streaming preview only after Telegram returns a
+positive message ID. On successful agent completion it uses the locked session
+adapter to atomically persist the canonical assistant message, exact-epoch
+delivery request, and immutable edit/send plan. Once that commit is confirmed,
+the handler performs no direct final send or shadow delivery observation. The
+worker edits the preview or sends the planned fragments.
+
+An SQLite error is resolved by repeating the deterministic operation while the
+session write lock is still held. The retry either creates work rolled back by
+the first attempt or observes the already-committed identical state. If that
+resolution also fails, the outcome is classified as uncertain and the handler
+refuses direct fallback, returning only a bounded operational notice. A
+definite preview or finalization preparation error retains the current direct
+delivery path so an isolated canonical failure does not make Kai unusable.
+
+### 23.1 Rollback contract
+
+Rollback must not cross authority periods:
+
+1. stop Telegram ingress and the Kai service;
+2. inspect `make install-status` and reconcile every active pending, leased,
+   retrying, failed, or uncertain conversation delivery;
+3. run `python -m kai workshop delivery-authority deactivate` as the deployed
+   database owner, adding `--acknowledge-terminal-failures` only after reviewing
+   retained terminal evidence;
+4. restore the prior direct-delivery build;
+5. before any later reactivation, verify that prior non-terminal and
+   unacknowledged counts are zero.
+
+Deactivation refuses non-terminal work and never deletes or reassigns rows. A
+future activation creates a new epoch, so its worker cannot replay prior-epoch
+work.
+
+### 23.2 Required installed evidence
+
+The code cutover is not considered qualified until the deployed system proves:
+
+- startup reports an active authority epoch and clean aggregate counts;
+- one short streamed reply is finalized in place with no second copy;
+- one response without a preview and one fragmented response arrive once and
+  in order;
+- restart recovery delivers committed work without replaying confirmed
+  fragments;
+- media, voice, commands, GitHub notification-group delivery, schedules, and
+  files remain unchanged;
+- canonical projection and JSONL parity remain clean.
+
+After that evidence, the next implementation milestone is removal of the
+private-text direct fallback and its shadow-delivery compatibility branch—not
+another delivery foundation.

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import time
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
@@ -77,6 +78,7 @@ from kai.config import (
 from kai.history import LogEntry, log_message
 from kai.locks import get_lock, get_stop_event
 from kai.pool import SubprocessPool
+from kai.sessions import WorkshopFinalizationCommitUncertainError
 from kai.telegram_utils import chunk_text
 from kai.transcribe import TranscriptionError, transcribe_voice
 from kai.tts import DEFAULT_VOICE, VOICES, TTSError, synthesize_speech
@@ -84,6 +86,7 @@ from kai.workshop.artifacts import InboundArtifact
 from kai.workshop.domain import MessageId
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
+from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
 from kai.workspace_utils import is_workspace_allowed
 
 _UPLOAD_ROOT_MODE = 0o711
@@ -132,6 +135,14 @@ log = logging.getLogger(__name__)
 # Telegram rate-limits message edits; 2 seconds keeps us safely below the limit
 # while still giving the user a sense of streaming output.
 EDIT_INTERVAL = 2.0
+
+
+class ResponseDeliveryRoute(StrEnum):
+    """Explicit final-delivery authority selected by an ingress handler."""
+
+    LEGACY = "legacy"
+    WORKSHOP_PRIVATE_TEXT = "workshop_private_text"
+
 
 # Flag file written while processing a message. If the process crashes mid-response,
 # main.py detects this file at startup and notifies the user to resend. Lives under
@@ -4661,6 +4672,11 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 model,
                 user_log=user_log,
                 workshop_inbound_message_id=workshop_inbound_message_id,
+                delivery_route=(
+                    ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT
+                    if chat_id == _user_id(update)
+                    else ResponseDeliveryRoute.LEGACY
+                ),
             )
         finally:
             _clear_responding(chat_id)
@@ -4680,6 +4696,7 @@ async def _handle_response(
     model: str,
     user_log: LogEntry | None = None,
     workshop_inbound_message_id: MessageId | None = None,
+    delivery_route: ResponseDeliveryRoute = ResponseDeliveryRoute.LEGACY,
 ) -> None:
     """
     Stream Claude's response and deliver it to the user.
@@ -4709,6 +4726,8 @@ async def _handle_response(
         model: Current model name (for session tracking).
     """
     assert update.message is not None
+    if not isinstance(delivery_route, ResponseDeliveryRoute):
+        raise ValueError("delivery_route must be a ResponseDeliveryRoute")
     # Check voice mode before starting
     config: Config = context.bot_data["config"]
     reader_user = _upload_reader_user(context, chat_id)
@@ -4716,6 +4735,13 @@ async def _handle_response(
     if config.tts_enabled:
         voice_mode = await sessions.get_setting(f"voice_mode:{chat_id}") or "off"
     voice_only = voice_mode == "only"
+    workshop_delivery_candidate = (
+        delivery_route == ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT
+        and voice_mode == "off"
+        and workshop_inbound_message_id is not None
+        and context.bot_data.get("workshop_streaming_preview_recorder") is not None
+        and context.bot_data.get("workshop_streaming_finalizer") is not None
+    )
 
     # Keep activity indicator visible until the response completes.
     # Telegram hides the typing indicator after ~5 seconds, so we
@@ -4785,6 +4811,23 @@ async def _handle_response(
                 live_msg = await _reply_safe(update.message, _truncate_for_telegram(publishable))
                 last_edit_time = now
                 last_edit_text = publishable
+                if workshop_delivery_candidate:
+                    preview_recorder = context.bot_data["workshop_streaming_preview_recorder"]
+                    try:
+                        await preview_recorder(
+                            ConfirmedTelegramStreamingPreview(
+                                inbound_message_id=workshop_inbound_message_id,
+                                external_message_id=live_msg.message_id,
+                                confirmed_at=datetime.now(UTC),
+                            )
+                        )
+                    except Exception:
+                        workshop_delivery_candidate = False
+                        log.exception(
+                            "Workshop streaming-preview binding failed; retaining direct delivery "
+                            "(inbound_message_id=%s)",
+                            workshop_inbound_message_id,
+                        )
             elif now - last_edit_time >= EDIT_INTERVAL:
                 await _edit_message_safe(live_msg, publishable)
                 last_edit_time = now
@@ -4869,8 +4912,41 @@ async def _handle_response(
     )
 
     workshop_outbound_message_id: MessageId | None = None
+    workshop_delivery_committed = False
+    if workshop_delivery_candidate:
+        finalizer = context.bot_data["workshop_streaming_finalizer"]
+        try:
+            finalization_result = await finalizer(
+                OutboundMessage(
+                    in_reply_to_message_id=workshop_inbound_message_id,
+                    body=final_text,
+                    occurred_at=datetime.now(UTC),
+                )
+            )
+            aggregate_id = finalization_result.message.event.envelope.aggregate_id
+            if not isinstance(aggregate_id, MessageId):
+                raise RuntimeError("Workshop finalizer returned a non-message aggregate")
+            workshop_outbound_message_id = aggregate_id
+            workshop_delivery_committed = True
+        except WorkshopFinalizationCommitUncertainError:
+            log.critical(
+                "Workshop finalization commit outcome is uncertain; refusing direct fallback (inbound_message_id=%s)",
+                workshop_inbound_message_id,
+                exc_info=True,
+            )
+            await _reply_safe(
+                update.message,
+                "Kai could not safely confirm final delivery. The reply was not sent again to avoid a duplicate.",
+            )
+            return
+        except Exception:
+            log.exception(
+                "Workshop authoritative finalization failed; retaining direct delivery (inbound_message_id=%s)",
+                workshop_inbound_message_id,
+            )
+
     outbound_recorder = context.bot_data.get("workshop_outbound_recorder")
-    if workshop_inbound_message_id is not None and outbound_recorder is not None:
+    if not workshop_delivery_committed and workshop_inbound_message_id is not None and outbound_recorder is not None:
         try:
             outbound_result = await outbound_recorder(
                 OutboundMessage(
@@ -5009,6 +5085,9 @@ async def _handle_response(
         _pending_memory_tasks.add(task)
         task.add_done_callback(_pending_memory_tasks.discard)
 
+    if workshop_delivery_committed:
+        return
+
     # Voice-only mode: synthesize and send voice, fall back to text on failure
     if voice_only and final_text:
         voice_name = await sessions.get_setting(f"voice_name:{chat_id}") or DEFAULT_VOICE
@@ -5101,6 +5180,8 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
     app.bot_data["workshop_artifact_recorder"] = sessions.record_workshop_inbound_artifact
     app.bot_data["workshop_outbound_recorder"] = sessions.record_workshop_outbound_message
     app.bot_data["workshop_delivery_recorder"] = sessions.record_workshop_delivery_observation
+    app.bot_data["workshop_streaming_preview_recorder"] = sessions.record_workshop_streaming_preview
+    app.bot_data["workshop_streaming_finalizer"] = sessions.record_workshop_streaming_finalization
     app.bot_data["pool"] = SubprocessPool(
         config=config,
         services_info=services.get_available_services(),

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -46,6 +46,7 @@ from kai import cron, services, sessions, webhook
 from kai.bot import create_bot
 from kai.config import DATA_DIR, PROJECT_ROOT, _read_protected_file, load_config
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
+from kai.workshop.telegram_delivery_runtime import WorkshopTelegramConversationDeliveryService
 
 
 def _workshop_bootstrap_humans(config) -> tuple[BootstrapHuman, ...]:
@@ -307,6 +308,7 @@ def _start() -> None:
         load_db_registry(await sessions.get_memory_project_rows())
 
         app = create_bot(config, use_webhook=use_webhook)
+        conversation_delivery: WorkshopTelegramConversationDeliveryService | None = None
 
         # Determine the default user (admin or first user) for per-user
         # data migrations and workspace restoration. users.yaml is
@@ -405,6 +407,15 @@ def _start() -> None:
             # Reload scheduled jobs from the database into APScheduler
             await cron.init_jobs(app)
 
+            # Activate exactly one durable authority epoch and recover its
+            # conversation-finalization work on a dedicated SQLite connection
+            # before either webhook or polling ingress can accept updates.
+            conversation_delivery = await WorkshopTelegramConversationDeliveryService.open_and_start(
+                config.session_db_path,
+                app.bot,
+            )
+            logging.info("Workshop Telegram conversation delivery is ready")
+
             # Start the HTTP server (always runs - serves scheduling API, GitHub
             # webhooks, file exchange, and health check regardless of transport mode).
             # In webhook mode, this also registers the Telegram webhook with the API.
@@ -474,7 +485,10 @@ def _start() -> None:
                     old_flag.unlink(missing_ok=True)
 
             logging.info("Kai is running. Press Ctrl+C to stop.")
-            await asyncio.Event().wait()  # Block forever until shutdown signal
+            # The delivery worker is part of service health. Unexpected worker
+            # exit reaches the top-level crash path instead of leaving a loaded
+            # Kai process that can accept replies it cannot deliver.
+            await conversation_delivery.wait()
         finally:
             # Shutdown in reverse order of startup
             await webhook.stop()
@@ -482,6 +496,13 @@ def _start() -> None:
             # since the Updater was suppressed at build time)
             if not use_webhook and app.updater:
                 await app.updater.stop()
+            if conversation_delivery is not None:
+                try:
+                    await conversation_delivery.stop()
+                except Exception:
+                    # If wait() already exposed a worker failure, retain that
+                    # original exception while still completing shutdown.
+                    logging.exception("Workshop Telegram conversation delivery stopped with an error")
             await app.stop()
             await app.bot_data["pool"].shutdown()
             await app.shutdown()

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -54,11 +54,18 @@ from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.outbound import (
     DeliveryObservation,
     OutboundMessage,
+    OutboundStreamingFinalizationResult,
     record_delivery_observation,
     record_outbound_message,
+    record_outbound_message_with_streaming_finalization,
 )
 from kai.workshop.schema import migrate_workshop_schema
 from kai.workshop.store import AppendResult, WorkshopEventStore
+from kai.workshop.streaming_preview import (
+    ConfirmedTelegramStreamingPreview,
+    TelegramStreamingPreviewBinding,
+    bind_confirmed_telegram_streaming_preview,
+)
 
 if TYPE_CHECKING:
     from kai.config import Config, WorkspaceConfig
@@ -68,6 +75,10 @@ log = logging.getLogger(__name__)
 # Module-level database connection, initialized by init_db() at startup
 _db: aiosqlite.Connection | None = None
 _workshop_event_lock: asyncio.Lock | None = None
+
+
+class WorkshopFinalizationCommitUncertainError(RuntimeError):
+    """The canonical reply transaction could not be resolved safely."""
 
 
 class TelegramUpdateQueueRow(TypedDict):
@@ -360,6 +371,44 @@ async def record_workshop_outbound_message(message: OutboundMessage) -> AppendRe
     async with _workshop_event_lock:
         store = WorkshopEventStore.from_initialized_connection(_get_db())
         return await record_outbound_message(store, message)
+
+
+async def record_workshop_streaming_preview(
+    preview: ConfirmedTelegramStreamingPreview,
+) -> TelegramStreamingPreviewBinding:
+    """Serialize one confirmed non-final Telegram preview binding."""
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        store = WorkshopEventStore.from_initialized_connection(_get_db())
+        return await bind_confirmed_telegram_streaming_preview(store, preview)
+
+
+async def record_workshop_streaming_finalization(
+    message: OutboundMessage,
+) -> OutboundStreamingFinalizationResult:
+    """Atomically record one authoritative reply and its delivery plan.
+
+    An SQLite error may have happened while the commit result was crossing the
+    driver boundary. Repeating the deterministic operation on the same locked
+    connection resolves both outcomes: it either creates the rolled-back work
+    or observes the already-committed message, delivery, and fragment plan.
+    A second failure is reported as uncertain so the handler never falls back
+    to a direct send that could duplicate committed outbox work.
+    """
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        store = WorkshopEventStore.from_initialized_connection(_get_db())
+        try:
+            return await record_outbound_message_with_streaming_finalization(store, message)
+        except aiosqlite.Error:
+            try:
+                return await record_outbound_message_with_streaming_finalization(store, message)
+            except Exception as resolution_error:
+                raise WorkshopFinalizationCommitUncertainError(
+                    "Could not determine whether the Workshop reply transaction committed"
+                ) from resolution_error
 
 
 async def record_workshop_delivery_observation(observation: DeliveryObservation) -> AppendResult:

--- a/src/kai/workshop/delivery_authority.py
+++ b/src/kai/workshop/delivery_authority.py
@@ -1,4 +1,4 @@
-"""Production-unused authority epochs for Workshop conversation delivery."""
+"""Durable authority epochs for Workshop conversation delivery."""
 
 from __future__ import annotations
 
@@ -62,8 +62,9 @@ def _parse_timestamp(value: str) -> datetime:
 class WorkshopConversationDeliveryAuthority:
     """Own the durable activation boundary for one future Telegram route.
 
-    This service is not constructed by production startup. It deliberately
-    keeps authority activation separate from worker registration and routing.
+    Production startup activates or resumes one epoch before Telegram ingress.
+    The separate service remains usable by operator tooling and tests without
+    implicitly constructing a delivery worker.
     """
 
     def __init__(

--- a/src/kai/workshop/delivery_fragments.py
+++ b/src/kai/workshop/delivery_fragments.py
@@ -1,4 +1,4 @@
-"""Durable per-fragment progress for production-unused Workshop delivery."""
+"""Durable per-fragment progress for Workshop delivery."""
 
 from __future__ import annotations
 

--- a/src/kai/workshop/delivery_outbox.py
+++ b/src/kai/workshop/delivery_outbox.py
@@ -234,9 +234,9 @@ def _retry_delay(attempt_number: int) -> timedelta:
 class WorkshopDeliveryOutbox:
     """Durable delivery state with lease-based, at-least-once work claims.
 
-    Only explicit qualification and production-unused application services use
-    this class. Existing direct Telegram delivery remains authoritative until
-    a later cutover registers a production worker.
+    Production private-text finalization and explicit qualification use this
+    class. Other Telegram paths retain their existing delivery behavior until
+    separately bounded cutovers move them.
     """
 
     def __init__(

--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -309,10 +309,10 @@ async def record_outbound_message_with_streaming_finalization(
 ) -> OutboundStreamingFinalizationResult:
     """Atomically persist a reply, delivery request, and immutable operation plan.
 
-    This service is deliberately production-unused. Its only routing input is
-    the canonical inbound message ID. It resolves the direct Telegram binding
-    and any confirmed non-final preview internally, and it neither sends nor
-    edits Telegram.
+    The authenticated private-text route calls this service after agent
+    completion. Its only routing input is the canonical inbound message ID. It
+    resolves the direct Telegram binding and any confirmed non-final preview
+    internally, and it neither sends nor edits Telegram itself.
     """
     connection = store.connection
     try:

--- a/src/kai/workshop/streaming_preview.py
+++ b/src/kai/workshop/streaming_preview.py
@@ -1,4 +1,4 @@
-"""Durable, production-unused Telegram streaming-preview bindings."""
+"""Durable Telegram streaming-preview bindings."""
 
 from __future__ import annotations
 

--- a/src/kai/workshop/telegram_delivery.py
+++ b/src/kai/workshop/telegram_delivery.py
@@ -1,4 +1,4 @@
-"""Production-unused Telegram adapter and worker for Workshop delivery claims."""
+"""Telegram adapters and workers for durable Workshop delivery claims."""
 
 from __future__ import annotations
 
@@ -57,7 +57,7 @@ class TelegramSentMessage(Protocol):
 
 
 class TelegramTextBot(Protocol):
-    """The Bot API surface needed by the production-unused text adapter."""
+    """The Bot API surface needed by the durable text adapters."""
 
     async def send_message(
         self,

--- a/src/kai/workshop/telegram_delivery_runtime.py
+++ b/src/kai/workshop/telegram_delivery_runtime.py
@@ -1,12 +1,23 @@
-"""Production-unused lifecycle ownership for Workshop Telegram delivery."""
+"""Lifecycle ownership for Workshop Telegram delivery."""
 
 from __future__ import annotations
 
 import asyncio
 from enum import StrEnum
-from typing import Protocol
+from pathlib import Path
+from typing import Protocol, cast
 
-from kai.workshop.delivery_outbox import DeliveryRecoveryResult
+from telegram import Bot
+
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.delivery_fragments import WorkshopDeliveryFragments
+from kai.workshop.delivery_outbox import DeliveryRecoveryResult, WorkshopDeliveryOutbox
+from kai.workshop.store import WorkshopEventStore
+from kai.workshop.telegram_delivery import (
+    TelegramTextBot,
+    WorkshopTelegramStreamingFinalizationAdapter,
+    WorkshopTelegramStreamingFinalizationWorker,
+)
 
 
 class _DeliveryLeaseRecovery(Protocol):
@@ -18,7 +29,7 @@ class _TelegramDeliveryWorkerLoop(Protocol):
 
 
 class TelegramDeliveryRuntimeState(StrEnum):
-    """Observable lifecycle state for the production-unused runtime owner."""
+    """Observable lifecycle state for the delivery runtime owner."""
 
     STOPPED = "stopped"
     STARTING = "starting"
@@ -38,8 +49,8 @@ class TelegramDeliveryWorkerExitedError(RuntimeError):
 class WorkshopTelegramDeliveryRuntime:
     """Own exactly one recoverable Telegram worker task when explicitly started.
 
-    Nothing constructs or starts this owner in production yet. It defines the
-    lifecycle boundary a later, separately reviewed cutover can register.
+    Production uses this owner for the conversation-finalization worker. The
+    qualification worker remains operator-invoked and outside this runtime.
     """
 
     def __init__(
@@ -194,3 +205,63 @@ class WorkshopTelegramDeliveryRuntime:
         if failure is not None:
             self._failure = failure
             self._state = TelegramDeliveryRuntimeState.FAILED
+
+
+class WorkshopTelegramConversationDeliveryService:
+    """Own the active authority epoch, dedicated store, and worker runtime."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        runtime: WorkshopTelegramDeliveryRuntime,
+    ) -> None:
+        self._store = store
+        self._runtime = runtime
+        self._closed = False
+
+    @classmethod
+    async def open_and_start(
+        cls,
+        database_path: Path,
+        bot: Bot,
+        *,
+        worker_id: str = "kai-telegram-conversation-finalization",
+    ) -> WorkshopTelegramConversationDeliveryService:
+        """Activate authority and recover work before returning ready."""
+        store = await WorkshopEventStore.open(database_path)
+        try:
+            epoch = (await WorkshopConversationDeliveryAuthority(store).activate()).epoch
+            outbox = WorkshopDeliveryOutbox(store)
+            worker = WorkshopTelegramStreamingFinalizationWorker(
+                outbox,
+                WorkshopDeliveryFragments(store),
+                WorkshopTelegramStreamingFinalizationAdapter(cast(TelegramTextBot, bot)),
+                worker_id=worker_id,
+                authority_epoch_id=epoch.epoch_id,
+            )
+            runtime = WorkshopTelegramDeliveryRuntime(worker, worker)
+            await runtime.start()
+        except BaseException:
+            await store.close()
+            raise
+        return cls(store, runtime)
+
+    @property
+    def ready(self) -> bool:
+        return not self._closed and self._runtime.ready
+
+    @property
+    def runtime(self) -> WorkshopTelegramDeliveryRuntime:
+        return self._runtime
+
+    async def wait(self) -> None:
+        await self._runtime.wait()
+
+    async def stop(self) -> None:
+        if self._closed:
+            return
+        try:
+            await self._runtime.stop()
+        finally:
+            self._closed = True
+            await self._store.close()

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -13,6 +13,10 @@ from telegram import Bot
 from telegram.error import TelegramError
 
 from kai.config import DATA_DIR, load_config
+from kai.workshop.delivery_authority import (
+    DeliveryAuthorityError,
+    WorkshopConversationDeliveryAuthority,
+)
 from kai.workshop.delivery_fragments import WorkshopDeliveryFragments
 from kai.workshop.delivery_outbox import (
     QUALIFICATION_PURPOSE,
@@ -58,6 +62,22 @@ def _parser() -> argparse.ArgumentParser:
     )
     interrupted.add_argument("--delivery-id", required=True)
     interrupted.add_argument("--lease-seconds", type=int, default=5, choices=range(1, 301), metavar="1..300")
+
+    authority = commands.add_parser(
+        "delivery-authority",
+        help="inspect or deactivate the live conversation-delivery authority",
+    )
+    authority_actions = authority.add_subparsers(dest="action", required=True)
+    authority_actions.add_parser("status")
+    deactivate = authority_actions.add_parser(
+        "deactivate",
+        help="deactivate only after all non-terminal work is reconciled",
+    )
+    deactivate.add_argument(
+        "--acknowledge-terminal-failures",
+        action="store_true",
+        help="explicitly acknowledge retained terminal failure evidence",
+    )
     return parser
 
 
@@ -93,8 +113,21 @@ def _qualification_database(data_dir: Path) -> Path:
 
 async def _run(args: argparse.Namespace) -> int:
     store = await WorkshopEventStore.open(_qualification_database(DATA_DIR))
-    qualification = WorkshopDeliveryQualification(store)
     try:
+        if args.command == "delivery-authority":
+            authority = WorkshopConversationDeliveryAuthority(store)
+            if args.action == "status":
+                active = await authority.active_epoch_in_transaction(required=False)
+                print(f"Conversation delivery authority: {'active' if active is not None else 'inactive'}")
+                return 0
+            await authority.deactivate(
+                acknowledge_terminal_failures=args.acknowledge_terminal_failures,
+            )
+            print("Conversation delivery authority: deactivated")
+            print("No delivery work was deleted or reassigned.")
+            return 0
+
+        qualification = WorkshopDeliveryQualification(store)
         if args.action == "prepare":
             result = await qualification.prepare(args.telegram_user_id)
             _print_state(result.delivery)
@@ -165,6 +198,8 @@ def cli(args: list[str]) -> None:
     parsed = _parser().parse_args(args)
     try:
         code = asyncio.run(_run(parsed))
+    except DeliveryAuthorityError as exc:
+        raise SystemExit(f"Workshop delivery authority failed: {exc}") from exc
     except (DeliveryQualificationError, DeliveryTargetNotFoundError) as exc:
         raise SystemExit(f"Workshop delivery qualification failed: {exc}") from exc
     raise SystemExit(code)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -22,6 +22,7 @@ from kai import sessions
 from kai.backend import AgentResponse, StreamEvent
 from kai.bot import (
     _QUEUED_MESSAGE_MARKER,
+    ResponseDeliveryRoute,
     _acquire_lock_or_kill,
     _backend_name_for_instance,
     _clear_responding,
@@ -84,6 +85,7 @@ from kai.workshop.artifacts import InboundArtifact
 from kai.workshop.domain import MessageId
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
+from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
 from kai.workspace_utils import is_workspace_allowed
 
 # ── _backend_name_for_instance ───────────────────────────────────────
@@ -738,6 +740,8 @@ class TestCreateBotTransportMode:
         assert app.bot_data["workshop_artifact_recorder"] is sessions.record_workshop_inbound_artifact
         assert app.bot_data["workshop_outbound_recorder"] is sessions.record_workshop_outbound_message
         assert app.bot_data["workshop_delivery_recorder"] is sessions.record_workshop_delivery_observation
+        assert app.bot_data["workshop_streaming_preview_recorder"] is sessions.record_workshop_streaming_preview
+        assert app.bot_data["workshop_streaming_finalizer"] is sessions.record_workshop_streaming_finalization
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -2758,6 +2762,7 @@ class TestHandleMessage:
         ):
             await handle_message(update, ctx)
         mock_resp.assert_called_once()
+        assert mock_resp.await_args.kwargs["delivery_route"] == ResponseDeliveryRoute.LEGACY
         mock_log.assert_called_once()
 
     @pytest.mark.asyncio
@@ -2790,6 +2795,7 @@ class TestHandleMessage:
             )
         )
         assert response.await_args.kwargs["workshop_inbound_message_id"] == inbound_id
+        assert response.await_args.kwargs["delivery_route"] == ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT
 
     @pytest.mark.asyncio
     async def test_does_not_record_when_totp_denies_message(self):
@@ -3682,6 +3688,187 @@ class TestHandleResponse:
         ctx.bot_data["workshop_outbound_recorder"] = outbound
         ctx.bot_data["workshop_delivery_recorder"] = delivery
         return outbound, delivery
+
+    @staticmethod
+    def _install_workshop_finalizer(ctx, message_id: MessageId):
+        preview = AsyncMock()
+        finalizer = AsyncMock()
+        finalizer.return_value.message.event.envelope.aggregate_id = message_id
+        ctx.bot_data["workshop_streaming_preview_recorder"] = preview
+        ctx.bot_data["workshop_streaming_finalizer"] = finalizer
+        return preview, finalizer
+
+    @pytest.mark.asyncio
+    async def test_workshop_private_text_commits_without_direct_send_or_shadow_observation(self):
+        from kai.bot import _handle_response
+
+        inbound_id = MessageId("msg_00000000000000000000000000000001")
+        outbound_id = MessageId("msg_00000000000000000000000000000002")
+        update = _make_update()
+        pool = _make_mock_claude()
+        pool.send = MagicMock(return_value=_fake_stream(_done_event("Durable answer")))
+        ctx = _make_context(pool=pool)
+        _, finalizer = self._install_workshop_finalizer(ctx, outbound_id)
+        outbound, delivery = self._install_workshop_recorders(ctx, outbound_id)
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._send_response", new_callable=AsyncMock) as direct_send,
+        ):
+            await _handle_response(
+                update,
+                ctx,
+                12345,
+                "test",
+                pool,
+                "sonnet",
+                workshop_inbound_message_id=inbound_id,
+                delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+            )
+
+        finalizer.assert_awaited_once()
+        assert finalizer.await_args.args[0].body == "Durable answer"
+        direct_send.assert_not_awaited()
+        outbound.assert_not_awaited()
+        delivery.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_workshop_streaming_preview_is_bound_and_final_edit_is_left_to_worker(self):
+        from kai.bot import _handle_response
+
+        inbound_id = MessageId("msg_00000000000000000000000000000001")
+        outbound_id = MessageId("msg_00000000000000000000000000000002")
+        update = _make_update()
+        live_message = MagicMock(message_id=7001)
+        update.message.reply_text = AsyncMock(return_value=live_message)
+        pool = _make_mock_claude()
+        pool.send = MagicMock(
+            return_value=_fake_stream(
+                _text_event("Stable streamed sentence."),
+                _done_event("Final durable answer."),
+            )
+        )
+        ctx = _make_context(pool=pool)
+        preview, finalizer = self._install_workshop_finalizer(ctx, outbound_id)
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock) as direct_edit,
+        ):
+            await _handle_response(
+                update,
+                ctx,
+                12345,
+                "test",
+                pool,
+                "sonnet",
+                workshop_inbound_message_id=inbound_id,
+                delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+            )
+
+        bound = preview.await_args.args[0]
+        assert isinstance(bound, ConfirmedTelegramStreamingPreview)
+        assert bound.inbound_message_id == inbound_id
+        assert bound.external_message_id == 7001
+        finalizer.assert_awaited_once()
+        direct_edit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_definite_workshop_failure_retains_direct_delivery(self):
+        from kai.bot import _handle_response
+
+        inbound_id = MessageId("msg_00000000000000000000000000000001")
+        outbound_id = MessageId("msg_00000000000000000000000000000002")
+        update = _make_update()
+        pool = _make_mock_claude()
+        pool.send = MagicMock(return_value=_fake_stream(_done_event("Fallback answer")))
+        ctx = _make_context(pool=pool)
+        _, finalizer = self._install_workshop_finalizer(ctx, outbound_id)
+        finalizer.side_effect = RuntimeError("definite preparation failure")
+        outbound, _ = self._install_workshop_recorders(ctx, outbound_id)
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._send_response", new_callable=AsyncMock) as direct_send,
+        ):
+            await _handle_response(
+                update,
+                ctx,
+                12345,
+                "test",
+                pool,
+                "sonnet",
+                workshop_inbound_message_id=inbound_id,
+                delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+            )
+
+        finalizer.assert_awaited_once()
+        direct_send.assert_awaited_once_with(update, "Fallback answer")
+        outbound.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_uncertain_workshop_commit_refuses_duplicate_direct_send(self):
+        from kai.bot import _handle_response
+
+        inbound_id = MessageId("msg_00000000000000000000000000000001")
+        outbound_id = MessageId("msg_00000000000000000000000000000002")
+        update = _make_update()
+        pool = _make_mock_claude()
+        pool.send = MagicMock(return_value=_fake_stream(_done_event("Possibly committed answer")))
+        ctx = _make_context(pool=pool)
+        _, finalizer = self._install_workshop_finalizer(ctx, outbound_id)
+        finalizer.side_effect = sessions.WorkshopFinalizationCommitUncertainError("unknown")
+
+        with (
+            patch.multiple("kai.bot", **self._base_patches()),
+            patch("kai.bot._send_response", new_callable=AsyncMock) as direct_send,
+        ):
+            await _handle_response(
+                update,
+                ctx,
+                12345,
+                "test",
+                pool,
+                "sonnet",
+                workshop_inbound_message_id=inbound_id,
+                delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+            )
+
+        direct_send.assert_not_awaited()
+        assert "avoid a duplicate" in update.message.reply_text.await_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_text_plus_voice_never_enters_workshop_text_cutover(self):
+        from kai.bot import _handle_response
+
+        inbound_id = MessageId("msg_00000000000000000000000000000001")
+        outbound_id = MessageId("msg_00000000000000000000000000000002")
+        update = _make_update()
+        pool = _make_mock_claude()
+        pool.send = MagicMock(return_value=_fake_stream(_done_event("Text and voice")))
+        ctx = _make_context(config=_make_config(tts_enabled=True), pool=pool)
+        _, finalizer = self._install_workshop_finalizer(ctx, outbound_id)
+        self._install_workshop_recorders(ctx, outbound_id)
+        patches = self._base_patches()
+        patches["sessions"].get_setting = AsyncMock(return_value="on")
+
+        with (
+            patch.multiple("kai.bot", **patches),
+            patch("kai.bot.synthesize_speech", new_callable=AsyncMock, return_value=b"audio"),
+        ):
+            await _handle_response(
+                update,
+                ctx,
+                12345,
+                "test",
+                pool,
+                "sonnet",
+                workshop_inbound_message_id=inbound_id,
+                delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+            )
+
+        finalizer.assert_not_awaited()
+        update.message.reply_text.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_shadows_successful_assistant_result_and_text_delivery(self):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -2,12 +2,16 @@
 
 import sqlite3
 import stat
+from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import aiosqlite
 import pytest
 
 from kai import sessions
+from kai.workshop.domain import MessageId
+from kai.workshop.outbound import OutboundMessage
 
 
 @pytest.fixture
@@ -52,6 +56,44 @@ class TestSessions:
 
     async def test_get_stats_unknown(self, db):
         assert await sessions.get_stats(999) is None
+
+
+class TestWorkshopFinalizationAdapter:
+    async def test_sqlite_error_is_resolved_by_deterministic_retry(self, db):
+        message = OutboundMessage(
+            in_reply_to_message_id=MessageId("msg_00000000000000000000000000000001"),
+            body="Answer",
+            occurred_at=datetime(2026, 8, 12, tzinfo=UTC),
+        )
+        expected = object()
+        recorder = AsyncMock(side_effect=[aiosqlite.OperationalError("commit result lost"), expected])
+
+        with patch("kai.sessions.record_outbound_message_with_streaming_finalization", recorder):
+            result = await sessions.record_workshop_streaming_finalization(message)
+
+        assert result is expected
+        assert recorder.await_count == 2
+
+    async def test_second_failure_is_classified_as_commit_uncertain(self, db):
+        message = OutboundMessage(
+            in_reply_to_message_id=MessageId("msg_00000000000000000000000000000001"),
+            body="Answer",
+            occurred_at=datetime(2026, 8, 12, tzinfo=UTC),
+        )
+        recorder = AsyncMock(
+            side_effect=[
+                aiosqlite.OperationalError("commit result lost"),
+                aiosqlite.OperationalError("resolution unavailable"),
+            ]
+        )
+
+        with (
+            patch("kai.sessions.record_outbound_message_with_streaming_finalization", recorder),
+            pytest.raises(sessions.WorkshopFinalizationCommitUncertainError),
+        ):
+            await sessions.record_workshop_streaming_finalization(message)
+
+        assert recorder.await_count == 2
 
 
 class TestTelegramUpdateQueue:

--- a/tests/test_workshop_delivery_authority.py
+++ b/tests/test_workshop_delivery_authority.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from argparse import Namespace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,6 +12,7 @@ from unittest.mock import AsyncMock
 import pytest
 from telegram.error import BadRequest
 
+from kai import workshop_cli
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.delivery_authority import (
     DeliveryAuthorityHistoricalWorkError,
@@ -296,3 +298,43 @@ class TestDeliveryAuthorityDiagnostic:
         assert workshop_delivery_authority_status(path).startswith(
             "Workshop delivery authority: NOT READY; epochs=0, unclassified=1"
         )
+
+
+class TestDeliveryAuthorityOperatorCLI:
+    async def test_status_and_clean_deactivation_expose_no_epoch_identifier(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        capsys,
+    ):
+        path = tmp_path / "kai.db"
+        store = await WorkshopEventStore.open(path)
+        activation = await WorkshopConversationDeliveryAuthority(store).activate()
+        await store.close()
+        monkeypatch.setattr(workshop_cli, "DATA_DIR", tmp_path)
+
+        assert await workshop_cli._run(Namespace(command="delivery-authority", action="status")) == 0
+        status_output = capsys.readouterr().out
+        assert "Conversation delivery authority: active" in status_output
+        assert str(activation.epoch.epoch_id) not in status_output
+
+        assert (
+            await workshop_cli._run(
+                Namespace(
+                    command="delivery-authority",
+                    action="deactivate",
+                    acknowledge_terminal_failures=False,
+                )
+            )
+            == 0
+        )
+        assert "Conversation delivery authority: deactivated" in capsys.readouterr().out
+
+        reopened = await WorkshopEventStore.open(path)
+        try:
+            assert (
+                await WorkshopConversationDeliveryAuthority(reopened).active_epoch_in_transaction(required=False)
+                is None
+            )
+        finally:
+            await reopened.close()

--- a/tests/test_workshop_delivery_qualification.py
+++ b/tests/test_workshop_delivery_qualification.py
@@ -162,6 +162,19 @@ class TestDeliveryQualificationCLI:
         with pytest.raises(SystemExit):
             workshop_cli._parser().parse_args(["delivery-qualification"])
 
+    def test_authority_requires_an_explicit_action(self):
+        with pytest.raises(SystemExit):
+            workshop_cli._parser().parse_args(["delivery-authority"])
+
+    def test_authority_deactivation_acknowledgement_is_explicit(self):
+        without_ack = workshop_cli._parser().parse_args(["delivery-authority", "deactivate"])
+        with_ack = workshop_cli._parser().parse_args(
+            ["delivery-authority", "deactivate", "--acknowledge-terminal-failures"]
+        )
+
+        assert without_ack.acknowledge_terminal_failures is False
+        assert with_ack.acknowledge_terminal_failures is True
+
     def test_prepare_requires_a_telegram_user(self):
         with pytest.raises(SystemExit):
             workshop_cli._parser().parse_args(["delivery-qualification", "prepare"])

--- a/tests/test_workshop_direct_text_cutover.py
+++ b/tests/test_workshop_direct_text_cutover.py
@@ -1,0 +1,88 @@
+"""Integrated shared-writer/dedicated-worker contract for the first cutover."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from kai import sessions
+from kai.workshop.bootstrap import BootstrapHuman
+from kai.workshop.domain import MessageId
+from kai.workshop.inbound import InboundMessage
+from kai.workshop.outbound import OutboundMessage
+from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
+from kai.workshop.telegram_delivery_runtime import WorkshopTelegramConversationDeliveryService
+
+_NOW = datetime(2026, 1, 1, 18, 0, tzinfo=UTC)
+
+
+async def test_shared_finalizer_and_dedicated_worker_finalize_one_preview_without_send(tmp_path: Path):
+    database = tmp_path / "kai.db"
+    await sessions.init_db(database)
+    service: WorkshopTelegramConversationDeliveryService | None = None
+    try:
+        await sessions.bootstrap_workshop_foundation((BootstrapHuman("Operator", "admin", "telegram", "101", "101"),))
+        inbound = await sessions.record_workshop_inbound_message(
+            InboundMessage(
+                transport="telegram",
+                update_id="9001",
+                message_id="41",
+                sender_subject="101",
+                channel_subject="101",
+                body="Hello",
+                occurred_at=_NOW,
+            )
+        )
+        inbound_id = inbound.event.envelope.aggregate_id
+        assert isinstance(inbound_id, MessageId)
+
+        bot = AsyncMock()
+        bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
+        service = await WorkshopTelegramConversationDeliveryService.open_and_start(database, bot)
+        await sessions.record_workshop_streaming_preview(
+            ConfirmedTelegramStreamingPreview(
+                inbound_message_id=inbound_id,
+                external_message_id=7001,
+                confirmed_at=_NOW + timedelta(seconds=1),
+            )
+        )
+        finalization = await sessions.record_workshop_streaming_finalization(
+            OutboundMessage(
+                in_reply_to_message_id=inbound_id,
+                body="Durable final answer",
+                occurred_at=_NOW + timedelta(seconds=2),
+            )
+        )
+
+        for _ in range(200):
+            async with sessions._get_db().execute(
+                "SELECT status FROM delivery_outbox WHERE id = ?",
+                (finalization.delivery.delivery.delivery_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is not None and row[0] == "succeeded":
+                break
+            await asyncio.sleep(0.01)
+        else:
+            async with sessions._get_db().execute(
+                "SELECT status, last_error_code FROM delivery_outbox WHERE id = ?",
+                (finalization.delivery.delivery.delivery_id,),
+            ) as cursor:
+                unresolved = tuple(await cursor.fetchone())
+            raise AssertionError(
+                "Dedicated Workshop worker did not settle the cutover delivery: "
+                f"state={unresolved}, runtime_failure={service.runtime.failure!r}"
+            )
+
+        bot.edit_message_text.assert_awaited_once()
+        assert bot.edit_message_text.await_args.kwargs["chat_id"] == 101
+        assert bot.edit_message_text.await_args.kwargs["message_id"] == 7001
+        assert bot.edit_message_text.await_args.kwargs["text"] == "Durable final answer"
+        bot.send_message.assert_not_awaited()
+    finally:
+        if service is not None:
+            await service.stop()
+        await sessions.close_db()

--- a/tests/test_workshop_telegram_delivery_runtime.py
+++ b/tests/test_workshop_telegram_delivery_runtime.py
@@ -1,16 +1,21 @@
-"""Lifecycle contracts for the production-unused Telegram delivery owner."""
+"""Lifecycle contracts for the Workshop Telegram delivery owner."""
 
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.delivery_outbox import DeliveryRecoveryResult
+from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery_runtime import (
     TelegramDeliveryRuntimeState,
     TelegramDeliveryRuntimeStateError,
     TelegramDeliveryWorkerExitedError,
+    WorkshopTelegramConversationDeliveryService,
     WorkshopTelegramDeliveryRuntime,
 )
 
@@ -207,3 +212,24 @@ async def test_recovery_failure_prevents_readiness_and_worker_creation():
     with pytest.raises(RuntimeError, match="lease recovery failed"):
         await runtime.stop()
     assert runtime.state == TelegramDeliveryRuntimeState.STOPPED
+
+
+async def test_conversation_service_activates_once_and_reuses_epoch_after_restart(tmp_path: Path):
+    database = tmp_path / "kai.db"
+    bot = AsyncMock()
+
+    first_service = await WorkshopTelegramConversationDeliveryService.open_and_start(database, bot)
+    assert first_service.ready
+    observer = await WorkshopEventStore.open(database)
+    first_epoch = await WorkshopConversationDeliveryAuthority(observer).active_epoch()
+    await observer.close()
+    await first_service.stop()
+
+    second_service = await WorkshopTelegramConversationDeliveryService.open_and_start(database, bot)
+    assert second_service.ready
+    observer = await WorkshopEventStore.open(database)
+    second_epoch = await WorkshopConversationDeliveryAuthority(observer).active_epoch()
+    await observer.close()
+    await second_service.stop()
+
+    assert second_epoch.epoch_id == first_epoch.epoch_id


### PR DESCRIPTION
## Summary

- cut authenticated private-chat plain-text replies with voice mode off over to durable Workshop finalization
- start and supervise one exact-authority-epoch Telegram finalization worker before accepting ingress
- bind confirmed streaming previews and atomically commit the canonical reply, delivery request, and immutable edit/send plan
- resolve ambiguous SQLite commit results deterministically and refuse duplicate direct fallback when resolution fails
- add operator authority status/deactivation commands and a concrete rollback contract

## This is a production authority change

This PR crosses the first user-visible Workshop boundary. For an authenticated Telegram private text message, when canonical inbound recording succeeds and voice mode is off, the final reply is no longer finalized directly by the handler. The handler atomically commits durable Workshop delivery work and the supervised worker edits the streaming preview or sends the planned fragments.

The following paths remain unchanged:

- commands
- Telegram groups
- photos and documents
- voice messages
- text-plus-voice and voice-only output
- schedules
- GitHub and generic webhooks
- file delivery
- notification-group delivery

## Startup and health

Production startup now:

1. opens a dedicated Workshop store connection for delivery;
2. transactionally resumes or creates the single conversation-delivery authority epoch;
3. recovers expired leases for that exact epoch;
4. starts the supervised finalization worker;
5. only then starts webhook or polling ingress.

Unexpected worker exit reaches Kai's fatal top-level path rather than leaving a loaded service unable to deliver replies. Shutdown stops ingress, cooperatively stops the worker, closes its dedicated store, and then closes the Telegram application and shared session database.

## Handler authority and duplicate prevention

`handle_message` passes an explicit typed delivery route only when the Telegram chat ID equals the authenticated human's ID. `_handle_response` additionally requires:

- voice mode `off`;
- a successfully recorded canonical inbound message;
- the installed preview and finalization adapters.

After Telegram confirms a streaming-preview message ID, Kai binds it to the canonical inbound message without accepting a destination from the handler. On agent completion, the locked session adapter commits the canonical assistant message, exact-epoch outbox request, and immutable edit/send plan in one transaction.

Once that transaction is confirmed, the handler performs no direct final edit/send and writes no shadow delivery observation. The worker owns finalization.

If an SQLite error may have obscured the commit result, the adapter repeats the deterministic operation while the session write lock remains held. The retry either creates rolled-back work or observes the identical committed state. If the resolution attempt also fails, Kai sends only a bounded operational notice and refuses a direct resend that could duplicate committed work.

A definite preview-binding or finalization-preparation failure retains the current direct delivery path, preserving availability without creating two authorities for a confirmed outbox transaction.

## Operator rollback

The implementation map records the rollback sequence. After stopping Kai and reconciling all aggregate delivery counts, the deployed database owner can inspect or deactivate authority with:

```bash
python -m kai workshop \
    delivery-authority \
    status
```

```bash
python -m kai workshop \
    delivery-authority \
    deactivate
```

Deactivation refuses pending, leased, or retry-wait work. Terminal failures require the explicit `--acknowledge-terminal-failures` option. No delivery work is deleted or reassigned, and a later activation creates a new epoch that cannot claim prior-epoch rows.

## Tests

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q`

Result: `5404 passed, 1 skipped`

Focused and integrated contracts cover:

- private-text route selection and group exclusion
- voice-mode exclusion
- preview binding and worker-owned final edit
- no handler direct send or shadow observation after durable commit
- definite preparation fallback
- unresolved commit fail-closed behavior
- deterministic SQLite outcome retry
- authority reuse across service restart
- startup recovery before worker readiness
- worker fault propagation and cooperative shutdown
- shared canonical writer plus dedicated worker connection finalizing one preview without a second send
- operator status and clean deactivation without exposing epoch identifiers

## Installed verification after merge

This cutover remains pending installed qualification until the deployed system demonstrates a short streamed reply finalized in place without a second copy, an all-send reply, ordered fragmentation, restart recovery, clean aggregate authority counts, clean canonical/JSONL parity, and unchanged non-cutover paths.
