### PR TITLE
Retire private-text direct delivery fallback

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1,8 +1,8 @@
 # Kai Workshop: Phase 0 Implementation Map
 
-**Status:** Active migration plan; canonical conversation shadow implemented, production authority held
+**Status:** Active migration plan; first canonical conversation delivery authority live
 **Date:** 2026-08-12
-**Scope:** Map the current Kai implementation onto the proposed Kai Workshop architecture without changing production behavior.
+**Scope:** Map and execute the current Kai implementation's migration onto the proposed Kai Workshop architecture.
 
 ## 1. Naming and scope
 
@@ -406,9 +406,9 @@ No entry may use an indefinite condition such as "keep for compatibility." A gen
 | Telegram `chat_id` used as internal identity, namespace, and routing key | Durable principal, channel, agent, and binding IDs | Private chats, notification-only groups, duplicate updates, and restart routing all resolve correctly through bindings | Confine Telegram IDs to external identity, transport binding, and idempotency records; remove chat-shaped domain keys | Planned |
 | `SubprocessPool` keyed by Telegram chat ID | Durable channel/agent session plus run and attempt orchestration | All five harnesses pass continuity, restart, cancellation, and isolation tests through durable identities | Remove chat-key compatibility lookup and move lifecycle ownership behind the orchestrator/runtime contract | Planned |
 | Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Planned |
-| Direct Telegram delivery from handlers, schedules, and webhooks | Durable delivery outbox and Telegram delivery adapter | Delivery outcome events preserve binding identity; retry, crash recovery, ordering, private-chat and notification-group delivery tests pass; live delivery is verified | Remove the retained direct fallback for private text after installed cutover evidence; migrate each remaining transport path separately | Active (authenticated private-chat text with voice mode off now uses atomic streaming finalization and a supervised exact-epoch worker; installed cutover verification remains pending, while commands, media, voice, schedules, webhooks, files, groups, and definite preparation-error fallback retain existing delivery) |
+| Direct Telegram delivery from handlers, schedules, and webhooks | Durable delivery outbox and Telegram delivery adapter | Delivery outcome events preserve binding identity; retry, crash recovery, ordering, private-chat and notification-group delivery tests pass; live delivery is verified | Migrate each remaining transport path separately; the private-text direct fallback is retired | Active (authenticated private-chat text with voice mode off uses atomic streaming finalization and a supervised exact-epoch worker and now fails closed rather than demoting to direct/shadow delivery; commands, media, voice, schedules, webhooks, files, and groups retain existing delivery) |
 | Operator-invoked Workshop delivery qualification CLI | Installed evidence followed by the production delivery worker | A configured direct-chat reply is prepared without sending, survives a service restart, recovers an intentionally abandoned lease, reaches Telegram once through the exact selected delivery, and records a terminal binding-aware outcome; a configured notification group resolves through its outbound-only canonical channel, receives one atomically prepared qualification message through the exact selected delivery, and does not become an inbound conversation | Remove the qualification command and its explicit-claim-only surface after the production worker has equivalent installed restart/recovery evidence and direct delivery is retired | Active (the installed direct-chat recovery and notification-group delivery gates passed on 2026-08-12; retain until equivalent production-worker evidence exists, while the command remains unregistered and incapable of draining unrelated work) |
-| Conversation-delivery authority epochs | A single durable delivery authority after direct-send rollback is retired | Activation/deactivation, restart, historical-row isolation, exact-epoch worker ownership, aggregate diagnostics, and installed rollback/reactivation evidence pass; no supported rollback crosses the direct-send/outbox boundary | Remove epoch stamping, activation/deactivation state, exact-epoch claim filters, transitional readiness output, schema columns/tables where safely migratable, and their compatibility tests | Active (production startup resumes or creates the exact epoch before ingress; the first private-text cutover is live in code and awaits installed verification) |
+| Conversation-delivery authority epochs | A single durable delivery authority after direct-send rollback is retired | Activation/deactivation, restart, historical-row isolation, exact-epoch worker ownership, aggregate diagnostics, and installed rollback/reactivation evidence pass; no supported rollback crosses the direct-send/outbox boundary | Remove epoch stamping, activation/deactivation state, exact-epoch claim filters, transitional readiness output, schema columns/tables where safely migratable, and their compatibility tests | Active (production startup resumes or creates the exact epoch before ingress; installed private-text streaming, all-send, fragmentation, restart/no-replay, aggregate authority, and parity checks passed on 2026-08-12) |
 | Schedule firing directly into the pool or Telegram | Durable Workshop run creation | Scheduled definitions and executions survive restart and expose run/attempt state without duplicate work | Remove schedule-specific execution path; retain schedules only as authenticated run triggers | Planned |
 | GitHub and generic webhook paths that route directly to Telegram or the pool | Canonical integration commands/events plus delivery/run services | Existing GitHub group notifications, generic callers, deduplication, and secret separation pass end-to-end tests | Remove direct routing while retaining verified webhook adapters and supported external contracts | Planned |
 | Per-chat settings, files, memory references, and project selection | Principal/channel/agent/project-workspace records and artifact metadata | Existing per-user isolation, context assembly, memory provenance, file delivery, and workspace access remain equivalent | Migrate namespaces and remove Telegram-derived ownership from domain storage; retire recorded compatibility `storage_path` values when an authoritative artifact store replaces local per-chat files | Active (artifact metadata foundation and photo/document/voice shadow) |
@@ -968,3 +968,40 @@ The code cutover is not considered qualified until the deployed system proves:
 After that evidence, the next implementation milestone is removal of the
 private-text direct fallback and its shadow-delivery compatibility branch—not
 another delivery foundation.
+
+## 24. Private-text fallback retirement
+
+**Review date:** 2026-08-12
+
+**Evidence:** The installed cutover produced one in-place streamed response,
+one no-preview response, and one two-fragment response with a clean boundary
+between numbered items 91 and 92. A service restart replayed no confirmed
+fragment and the next response arrived once. The authoritative diagnostic then
+reported one active epoch, four succeeded deliveries, zero pending, leased,
+retrying, failed, or uncertain deliveries, no prior-epoch work, exact canonical
+projection parity, and no missing or unmatched JSONL records. Existing installed
+outbox qualification had already exercised abandoned-lease recovery, while the
+exact-epoch conversation worker's committed-work recovery remains pinned by its
+integrated restart tests. Route-selection tests and the deliberately narrow
+production selector preserve previously verified command, media, voice, file,
+group, schedule, and webhook behavior.
+
+**Decision:** **Retire direct and shadow fallback for the authoritative private
+text route.** Once an authenticated private-chat text request with voice mode
+off selects Workshop delivery, it may not demote back to legacy delivery:
+
+- missing canonical inbound identity or runtime adapters stop before backend
+  invocation and return a bounded operational notice;
+- a definite streaming-preview binding failure replaces the non-final preview
+  with a bounded notice and stops;
+- a definite finalization failure replaces an existing preview, or sends one
+  bounded notice when no preview exists, and stops;
+- an uncertain finalization result continues to refuse a resend because the
+  durable commit may already exist;
+- none of these branches writes an outbound shadow result, delivery observation,
+  or direct copy of the agent response.
+
+This retirement is scoped to the authoritative private-text route. The shadow
+recorders and direct-delivery implementation remain transitional dependencies
+for explicitly excluded routes until each receives its own authority review and
+cutover.

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -4735,13 +4735,30 @@ async def _handle_response(
     if config.tts_enabled:
         voice_mode = await sessions.get_setting(f"voice_mode:{chat_id}") or "off"
     voice_only = voice_mode == "only"
+    workshop_delivery_requested = delivery_route == ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT and voice_mode == "off"
     workshop_delivery_candidate = (
-        delivery_route == ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT
-        and voice_mode == "off"
+        workshop_delivery_requested
         and workshop_inbound_message_id is not None
         and context.bot_data.get("workshop_streaming_preview_recorder") is not None
         and context.bot_data.get("workshop_streaming_finalizer") is not None
     )
+    if workshop_delivery_requested and not workshop_delivery_candidate:
+        log.error(
+            "Workshop authoritative delivery prerequisites are unavailable; refusing direct fallback "
+            "(inbound_message_id=%s)",
+            workshop_inbound_message_id,
+        )
+        log_message(
+            direction="assistant",
+            chat_id=chat_id,
+            text="[error: durable delivery preparation failed]",
+            reader_user=reader_user,
+        )
+        await _reply_safe(
+            update.message,
+            "Kai could not safely prepare durable delivery for this reply. Please try again.",
+        )
+        return
 
     # Keep activity indicator visible until the response completes.
     # Telegram hides the typing indicator after ~5 seconds, so we
@@ -4822,12 +4839,21 @@ async def _handle_response(
                             )
                         )
                     except Exception:
-                        workshop_delivery_candidate = False
                         log.exception(
-                            "Workshop streaming-preview binding failed; retaining direct delivery "
+                            "Workshop streaming-preview binding failed; refusing direct fallback "
                             "(inbound_message_id=%s)",
                             workshop_inbound_message_id,
                         )
+                        log_message(
+                            direction="assistant",
+                            chat_id=chat_id,
+                            text="[error: durable delivery preparation failed]",
+                            reader_user=reader_user,
+                        )
+                        notice = "Kai could not safely prepare durable delivery for this reply. Please try again."
+                        if not await _edit_message_safe(live_msg, notice):
+                            await _reply_safe(update.message, notice)
+                        return
             elif now - last_edit_time >= EDIT_INTERVAL:
                 await _edit_message_safe(live_msg, publishable)
                 last_edit_time = now
@@ -4900,16 +4926,19 @@ async def _handle_response(
         await sessions.save_session(chat_id, final_response.session_id, model)
 
     final_text = final_response.text
-    # Capture the assistant LogEntry so the provenance writer can stamp
-    # the exact JSONL ts/date/sha256 the line landed with. None means
-    # the append failed (logged by log_message itself); the extraction
-    # path then skips provenance stamping for this exchange.
-    assistant_log = log_message(
-        direction="assistant",
-        chat_id=chat_id,
-        text=final_text,
-        reader_user=reader_user,
-    )
+    # Authoritative Workshop replies enter JSONL only after their durable
+    # finalization commit is confirmed. Legacy routes retain their existing
+    # write timing. None means the append failed (logged by log_message itself);
+    # the extraction path then skips provenance stamping for this exchange.
+    if workshop_delivery_candidate:
+        assistant_log = None
+    else:
+        assistant_log = log_message(
+            direction="assistant",
+            chat_id=chat_id,
+            text=final_text,
+            reader_user=reader_user,
+        )
 
     workshop_outbound_message_id: MessageId | None = None
     workshop_delivery_committed = False
@@ -4934,6 +4963,14 @@ async def _handle_response(
                 workshop_inbound_message_id,
                 exc_info=True,
             )
+            # Preserve the answer for reconciliation: the durable transaction
+            # may already contain the identical canonical assistant message.
+            log_message(
+                direction="assistant",
+                chat_id=chat_id,
+                text=final_text,
+                reader_user=reader_user,
+            )
             await _reply_safe(
                 update.message,
                 "Kai could not safely confirm final delivery. The reply was not sent again to avoid a duplicate.",
@@ -4941,9 +4978,27 @@ async def _handle_response(
             return
         except Exception:
             log.exception(
-                "Workshop authoritative finalization failed; retaining direct delivery (inbound_message_id=%s)",
+                "Workshop authoritative finalization failed; refusing direct fallback (inbound_message_id=%s)",
                 workshop_inbound_message_id,
             )
+            log_message(
+                direction="assistant",
+                chat_id=chat_id,
+                text="[error: durable delivery finalization failed]",
+                reader_user=reader_user,
+            )
+            notice = "Kai could not safely finalize durable delivery for this reply. Please try again."
+            if live_msg is None or not await _edit_message_safe(live_msg, notice):
+                await _reply_safe(update.message, notice)
+            return
+
+    if workshop_delivery_candidate:
+        assistant_log = log_message(
+            direction="assistant",
+            chat_id=chat_id,
+            text=final_text,
+            reader_user=reader_user,
+        )
 
     outbound_recorder = context.bot_data.get("workshop_outbound_recorder")
     if not workshop_delivery_committed and workshop_inbound_message_id is not None and outbound_recorder is not None:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3774,21 +3774,22 @@ class TestHandleResponse:
         direct_edit.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_definite_workshop_failure_retains_direct_delivery(self):
+    async def test_definite_workshop_failure_refuses_direct_delivery(self):
         from kai.bot import _handle_response
 
         inbound_id = MessageId("msg_00000000000000000000000000000001")
         outbound_id = MessageId("msg_00000000000000000000000000000002")
         update = _make_update()
         pool = _make_mock_claude()
-        pool.send = MagicMock(return_value=_fake_stream(_done_event("Fallback answer")))
+        pool.send = MagicMock(return_value=_fake_stream(_done_event("Durable answer")))
         ctx = _make_context(pool=pool)
         _, finalizer = self._install_workshop_finalizer(ctx, outbound_id)
         finalizer.side_effect = RuntimeError("definite preparation failure")
         outbound, _ = self._install_workshop_recorders(ctx, outbound_id)
+        patches = self._base_patches()
 
         with (
-            patch.multiple("kai.bot", **self._base_patches()),
+            patch.multiple("kai.bot", **patches),
             patch("kai.bot._send_response", new_callable=AsyncMock) as direct_send,
         ):
             await _handle_response(
@@ -3803,8 +3804,130 @@ class TestHandleResponse:
             )
 
         finalizer.assert_awaited_once()
-        direct_send.assert_awaited_once_with(update, "Fallback answer")
-        outbound.assert_awaited_once()
+        direct_send.assert_not_awaited()
+        outbound.assert_not_awaited()
+        assert "could not safely finalize durable delivery" in update.message.reply_text.await_args.args[0]
+        assert patches["log_message"].call_args.kwargs["text"] == "[error: durable delivery finalization failed]"
+
+    @pytest.mark.asyncio
+    async def test_workshop_private_text_without_canonical_inbound_refuses_agent_and_direct_delivery(self):
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        pool = _make_mock_claude()
+        ctx = _make_context(pool=pool)
+        self._install_workshop_finalizer(ctx, MessageId("msg_00000000000000000000000000000002"))
+        patches = self._base_patches()
+
+        with (
+            patch.multiple("kai.bot", **patches),
+            patch("kai.bot._send_response", new_callable=AsyncMock) as direct_send,
+        ):
+            await _handle_response(
+                update,
+                ctx,
+                12345,
+                "test",
+                pool,
+                "sonnet",
+                workshop_inbound_message_id=None,
+                delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+            )
+
+        pool.send.assert_not_called()
+        direct_send.assert_not_awaited()
+        assert "could not safely prepare durable delivery" in update.message.reply_text.await_args.args[0]
+        assert patches["log_message"].call_args.kwargs["text"] == "[error: durable delivery preparation failed]"
+
+    @pytest.mark.asyncio
+    async def test_workshop_preview_binding_failure_replaces_preview_with_notice_and_stops(self):
+        from kai.bot import _handle_response
+
+        inbound_id = MessageId("msg_00000000000000000000000000000001")
+        outbound_id = MessageId("msg_00000000000000000000000000000002")
+        update = _make_update()
+        live_message = MagicMock(message_id=7001)
+        update.message.reply_text = AsyncMock(return_value=live_message)
+        pool = _make_mock_claude()
+        pool.send = MagicMock(
+            return_value=_fake_stream(
+                _text_event("Stable streamed sentence."),
+                _done_event("Final durable answer."),
+            )
+        )
+        ctx = _make_context(pool=pool)
+        preview, finalizer = self._install_workshop_finalizer(ctx, outbound_id)
+        preview.side_effect = RuntimeError("preview binding failed")
+        patches = self._base_patches()
+
+        with (
+            patch.multiple("kai.bot", **patches),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock, return_value=True) as direct_edit,
+            patch("kai.bot._send_response", new_callable=AsyncMock) as direct_send,
+        ):
+            await _handle_response(
+                update,
+                ctx,
+                12345,
+                "test",
+                pool,
+                "sonnet",
+                workshop_inbound_message_id=inbound_id,
+                delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+            )
+
+        preview.assert_awaited_once()
+        finalizer.assert_not_awaited()
+        direct_send.assert_not_awaited()
+        direct_edit.assert_awaited_once()
+        assert "could not safely prepare durable delivery" in direct_edit.await_args.args[1]
+        assert patches["log_message"].call_args.kwargs["text"] == "[error: durable delivery preparation failed]"
+
+    @pytest.mark.asyncio
+    async def test_workshop_finalization_failure_replaces_bound_preview_without_direct_answer(self):
+        from kai.bot import _handle_response
+
+        inbound_id = MessageId("msg_00000000000000000000000000000001")
+        outbound_id = MessageId("msg_00000000000000000000000000000002")
+        update = _make_update()
+        live_message = MagicMock(message_id=7001)
+        update.message.reply_text = AsyncMock(return_value=live_message)
+        pool = _make_mock_claude()
+        pool.send = MagicMock(
+            return_value=_fake_stream(
+                _text_event("Stable streamed sentence."),
+                _done_event("Undelivered durable answer."),
+            )
+        )
+        ctx = _make_context(pool=pool)
+        preview, finalizer = self._install_workshop_finalizer(ctx, outbound_id)
+        finalizer.side_effect = RuntimeError("finalization failed")
+        outbound, delivery = self._install_workshop_recorders(ctx, outbound_id)
+        patches = self._base_patches()
+
+        with (
+            patch.multiple("kai.bot", **patches),
+            patch("kai.bot._edit_message_safe", new_callable=AsyncMock, return_value=True) as direct_edit,
+            patch("kai.bot._send_response", new_callable=AsyncMock) as direct_send,
+        ):
+            await _handle_response(
+                update,
+                ctx,
+                12345,
+                "test",
+                pool,
+                "sonnet",
+                workshop_inbound_message_id=inbound_id,
+                delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+            )
+
+        preview.assert_awaited_once()
+        finalizer.assert_awaited_once()
+        direct_send.assert_not_awaited()
+        outbound.assert_not_awaited()
+        delivery.assert_not_awaited()
+        assert "could not safely finalize durable delivery" in direct_edit.await_args.args[1]
+        assert patches["log_message"].call_args.kwargs["text"] == "[error: durable delivery finalization failed]"
 
     @pytest.mark.asyncio
     async def test_uncertain_workshop_commit_refuses_duplicate_direct_send(self):
@@ -3869,6 +3992,31 @@ class TestHandleResponse:
 
         finalizer.assert_not_awaited()
         update.message.reply_text.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_legacy_route_does_not_retry_failed_jsonl_append(self):
+        from kai.bot import _handle_response
+
+        update = _make_update()
+        pool = _make_mock_claude()
+        pool.send = MagicMock(return_value=_fake_stream(_done_event("Legacy answer")))
+        ctx = _make_context(pool=pool)
+        patches = self._base_patches()
+        patches["log_message"].return_value = None
+
+        with patch.multiple("kai.bot", **patches):
+            await _handle_response(
+                update,
+                ctx,
+                12345,
+                "test",
+                pool,
+                "sonnet",
+                delivery_route=ResponseDeliveryRoute.LEGACY,
+            )
+
+        patches["log_message"].assert_called_once()
+        assert patches["log_message"].call_args.kwargs["text"] == "Legacy answer"
 
     @pytest.mark.asyncio
     async def test_shadows_successful_assistant_result_and_text_delivery(self):


### PR DESCRIPTION
## Summary

- retire the direct and shadow fallback for the now-authoritative private Telegram text route
- fail closed before backend invocation when canonical delivery prerequisites are missing
- replace a non-final preview with a bounded operational notice after definite binding or finalization failure
- delay the private-text JSONL assistant entry until the durable finalization commit is confirmed
- retain current delivery and shadow behavior for every route outside the private-text cutover

## Why

The installed #867 cutover has now passed its required live qualification:

- one streamed reply finalized in place without a duplicate
- one no-preview reply arrived once
- one long reply arrived as two ordered fragments, split cleanly between items 91 and 92
- a service restart replayed no confirmed fragment and the next reply arrived once
- `install-status` reported one active epoch, four succeeded deliveries, no pending, leased, retrying, failed, or uncertain deliveries, no prior-epoch work, exact canonical projection parity, and no missing or unmatched JSONL records

Keeping a definite-error branch that demoted an authoritative request back to outbound shadow recording and direct Telegram delivery would preserve two possible authorities after the cutover. This PR removes that transitional branch.

## Failure behavior

Once an authenticated private-chat text request with voice mode off selects Workshop delivery:

- missing canonical inbound identity or runtime adapters stop before the backend runs;
- preview-binding failure replaces the preview with an operational notice and stops;
- definite finalization failure replaces an existing preview, or sends one notice when no preview exists, and stops;
- uncertain commit outcome continues to refuse a resend because the durable transaction may already exist;
- no failure branch sends the agent answer directly or writes outbound/delivery shadow facts.

Synthetic JSONL error markers preserve attempted-turn history without representing an undelivered agent answer as delivered. The uncertain-commit branch retains the answer for reconciliation because the identical canonical transaction may already have committed.

## Unchanged paths

Commands, groups, photos, documents, voice messages, text-plus-voice, voice-only output, schedules, webhooks, files, and notification groups retain their existing direct and transitional shadow behavior. A regression test pins legacy JSONL append timing, including its existing no-retry behavior after an append failure.

## Tests

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q`

Result: `5408 passed, 1 skipped`
