### PR TITLE
Add canonical Workshop conversation run service

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -403,9 +403,9 @@ No entry may use an indefinite condition such as "keep for compatibility." A gen
 |---|---|---|---|---|
 | Authenticated plain-text/photo/document/voice and successful assistant-result canonical shadow writes beside current history, plus non-authoritative Telegram delivery observations | Workshop event store, message/artifact projections, and durable delivery outbox | Deterministic replay, duplicate-ingress/result tests, restart tests, full media-ingress coverage, delivery parity diagnostics, and sustained parity with current history and Telegram outcomes | Remove the `workshop_inbound_recorder`, `workshop_artifact_recorder`, `workshop_outbound_recorder`, and `workshop_delivery_recorder` bot-data adapters and their fail-open handler branches; remove the transitional `workshop_message_shadowed` JSONL marker; remove `workshop_message_parity_status` and its install-status output after canonical reads and outbox delivery become authoritative; make canonical command/event transactions and the delivery outbox the sole write and delivery paths | Active (private text finalization is authoritative in the outbox; inbound/media artifacts, remaining assistant results and delivery observations, JSONL history, and parity diagnostics remain transitional) |
 | JSONL transcript writes and reads | Canonical message projection, with an explicit export facility if still useful | Canonical reads serve complete context and transcript views; migration/parity diagnostics report no unexplained divergence | Stop JSONL writes; remove production reads and dual-write recovery code; retain only a documented importer/exporter if required | Planned |
-| Telegram `chat_id` used as internal identity, namespace, and routing key | Durable principal, channel, agent, and binding IDs | Private chats, notification-only groups, duplicate updates, and restart routing all resolve correctly through bindings | Confine Telegram IDs to external identity, transport binding, and idempotency records; remove chat-shaped domain keys | Planned |
-| `SubprocessPool` keyed by Telegram chat ID | Durable channel/agent session plus run and attempt orchestration | All five harnesses pass continuity, restart, cancellation, and isolation tests through durable identities | Remove chat-key compatibility lookup and move lifecycle ownership behind the orchestrator/runtime contract | Planned |
-| Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Planned |
+| Telegram `chat_id` used as internal identity, namespace, and routing key | Durable principal, channel, agent, and binding IDs | Private chats, notification-only groups, duplicate updates, and restart routing all resolve correctly through bindings | Confine Telegram IDs to external identity, transport binding, and idempotency records; remove chat-shaped domain keys | Active (authoritative private text now enters execution by canonical message ID, but the compatibility resolver still derives the current pool key from the human principal's protected Telegram identity; settings, locks, history, files, memory, and excluded routes remain chat-keyed) |
+| `SubprocessPool` keyed by Telegram chat ID | Durable channel/agent session plus run and attempt orchestration | All five harnesses pass continuity, restart, cancellation, and isolation tests through durable identities | Remove chat-key compatibility lookup and move lifecycle ownership behind the orchestrator/runtime contract | Active (a canonical conversation-run service hides the private-text pool lookup behind a temporary compatibility resolution; the pool and all five harness processes remain keyed by that resolved integer) |
+| Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Active (authoritative private text invokes through the canonical conversation-run service using only its inbound `MessageId`; media, voice-enabled text, commands, schedules, integrations, and the future Workshop client are not yet migrated, and durable run/attempt state does not yet exist) |
 | Direct Telegram delivery from handlers, schedules, and webhooks | Durable delivery outbox and Telegram delivery adapter | Delivery outcome events preserve binding identity; retry, crash recovery, ordering, private-chat and notification-group delivery tests pass; live delivery is verified | Migrate each remaining transport path separately; the private-text direct fallback is retired | Active (authenticated private-chat text with voice mode off uses atomic streaming finalization and a supervised exact-epoch worker and now fails closed rather than demoting to direct/shadow delivery; commands, media, voice, schedules, webhooks, files, and groups retain existing delivery) |
 | Operator-invoked Workshop delivery qualification CLI | Installed evidence followed by the production delivery worker | A configured direct-chat reply is prepared without sending, survives a service restart, recovers an intentionally abandoned lease, reaches Telegram once through the exact selected delivery, and records a terminal binding-aware outcome; a configured notification group resolves through its outbound-only canonical channel, receives one atomically prepared qualification message through the exact selected delivery, and does not become an inbound conversation | Remove the qualification command and its explicit-claim-only surface after the production worker has equivalent installed restart/recovery evidence and direct delivery is retired | Active (the installed direct-chat recovery and notification-group delivery gates passed on 2026-08-12; retain until equivalent production-worker evidence exists, while the command remains unregistered and incapable of draining unrelated work) |
 | Conversation-delivery authority epochs | A single durable delivery authority after direct-send rollback is retired | Activation/deactivation, restart, historical-row isolation, exact-epoch worker ownership, aggregate diagnostics, and installed rollback/reactivation evidence pass; no supported rollback crosses the direct-send/outbox boundary | Remove epoch stamping, activation/deactivation state, exact-epoch claim filters, transitional readiness output, schema columns/tables where safely migratable, and their compatibility tests | Active (production startup resumes or creates the exact epoch before ingress; installed private-text streaming, all-send, fragmentation, restart/no-replay, aggregate authority, and parity checks passed on 2026-08-12) |
@@ -1005,3 +1005,49 @@ This retirement is scoped to the authoritative private-text route. The shadow
 recorders and direct-delivery implementation remain transitional dependencies
 for explicitly excluded routes until each receives its own authority review and
 cutover.
+
+## 25. Canonical conversation-run service boundary
+
+**Implementation date:** 2026-08-12
+
+The authoritative private-text path now enters backend execution through a
+transport-neutral service request containing only the canonical inbound
+`MessageId`. The service resolves and validates the durable human author,
+channel membership, workshop, and exactly one attached agent. The Telegram
+handler can no longer supply an agent identity, backend identity, model, or
+pool key for this path.
+
+The existing `SubprocessPool` still requires an integer key to preserve the
+five qualified harnesses, their protected per-user configuration, session
+continuity, workspace selection, and OS-user execution. A deliberately private
+compatibility resolution therefore maps the canonical human principal's
+protected Telegram external identity to that key. The prepared run returned to
+the handler exposes only canonical IDs and normalized stream/workspace methods;
+it does not expose the compatibility key. This is an adapter, not a new source
+of identity authority.
+
+The boundary is intentionally narrow:
+
+- it is production-used only by authenticated private-chat text whose canonical
+  inbound write succeeded;
+- the existing private-text durable Telegram finalization and fail-closed
+  delivery behavior is unchanged;
+- text with voice output, media, commands, jobs, integrations, and notification
+  channels retain their current execution paths;
+- process locks, settings, JSONL history, memory, and the live harness pool
+  remain keyed by their existing compatibility identity;
+- no durable `run`, `attempt`, lease, cancellation, or normalized lifecycle
+  events are created by this service yet;
+- no Workshop desktop/web endpoint is registered by this change.
+
+Automated contracts require one canonical human channel member, exactly one
+attached agent, exactly one valid compatibility identity, resolver-message
+identity preservation, hidden pool-key delegation, handler invocation by
+canonical message ID, and unchanged private-text delivery authority.
+
+The next bounded milestone is a production-unused durable run lifecycle behind
+this service: accept one authorized canonical message as one run, record stable
+accepted/started/completed/failed/cancelled facts without harness-specific
+payloads, and prove deterministic replay. It must not move process ownership,
+register a Workshop client endpoint, or change Telegram delivery in the same
+step.

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -83,6 +83,7 @@ from kai.telegram_utils import chunk_text
 from kai.transcribe import TranscriptionError, transcribe_voice
 from kai.tts import DEFAULT_VOICE, VOICES, TTSError, synthesize_speech
 from kai.workshop.artifacts import InboundArtifact
+from kai.workshop.conversation_runs import PreparedConversationRun, WorkshopConversationRunService
 from kai.workshop.domain import MessageId
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
@@ -4611,9 +4612,9 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     """
     Handle plain text messages — the primary interaction path.
 
-    Logs the message, acquires the per-chat lock, sets the crash recovery
-    flag, sends the prompt to Claude, and delegates to _handle_response()
-    for streaming and delivery.
+    Logs the message, acquires the per-chat lock, and delegates accepted
+    private text to the canonical Workshop run service. Telegram remains the
+    renderer; the run service owns canonical execution-target resolution.
     """
     if not update.message or not update.message.text:
         return
@@ -4654,7 +4655,21 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 update.message.message_id,
             )
     pool = _get_pool(context)
-    model = pool.get_model(chat_id)
+    delivery_route = (
+        ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT if chat_id == _user_id(update) else ResponseDeliveryRoute.LEGACY
+    )
+    workshop_run: PreparedConversationRun | None = None
+    if delivery_route == ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT and workshop_inbound_message_id is not None:
+        run_service: WorkshopConversationRunService | None = context.bot_data.get("workshop_conversation_run_service")
+        if run_service is not None:
+            try:
+                workshop_run = await run_service.prepare(workshop_inbound_message_id)
+            except Exception:
+                log.exception(
+                    "Workshop conversation run preparation failed (inbound_message_id=%s)",
+                    workshop_inbound_message_id,
+                )
+    model = workshop_run.model if workshop_run is not None else pool.get_model(chat_id)
 
     was_queued = await _notify_if_queued(update, chat_id)
     lock = await _acquire_lock_or_kill(chat_id, pool, update)
@@ -4672,11 +4687,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 model,
                 user_log=user_log,
                 workshop_inbound_message_id=workshop_inbound_message_id,
-                delivery_route=(
-                    ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT
-                    if chat_id == _user_id(update)
-                    else ResponseDeliveryRoute.LEGACY
-                ),
+                delivery_route=delivery_route,
+                workshop_run=workshop_run,
             )
         finally:
             _clear_responding(chat_id)
@@ -4697,6 +4709,7 @@ async def _handle_response(
     user_log: LogEntry | None = None,
     workshop_inbound_message_id: MessageId | None = None,
     delivery_route: ResponseDeliveryRoute = ResponseDeliveryRoute.LEGACY,
+    workshop_run: PreparedConversationRun | None = None,
 ) -> None:
     """
     Stream Claude's response and deliver it to the user.
@@ -4739,6 +4752,7 @@ async def _handle_response(
     workshop_delivery_candidate = (
         workshop_delivery_requested
         and workshop_inbound_message_id is not None
+        and workshop_run is not None
         and context.bot_data.get("workshop_streaming_preview_recorder") is not None
         and context.bot_data.get("workshop_streaming_finalizer") is not None
     )
@@ -4791,7 +4805,12 @@ async def _handle_response(
 
         # Stream events from Claude. Pass chat_id so the inner Claude
         # can include it in API calls for correct multi-user routing.
-        async for event in pool.send(prompt, chat_id=chat_id):
+        event_stream = (
+            workshop_run.stream(prompt)
+            if workshop_delivery_candidate and workshop_run is not None
+            else pool.send(prompt, chat_id=chat_id)
+        )
+        async for event in event_stream:
             # Check for /stop between stream chunks
             if stop_event.is_set():
                 stop_event.clear()
@@ -5135,7 +5154,10 @@ async def _handle_response(
         # let a /workspace switch that lands during the ingestion
         # delay re-route the exchange's facts to a project the
         # conversation never touched.
-        ingest_workspace = str(await pool.get_effective_workspace(chat_id))
+        if workshop_delivery_candidate and workshop_run is not None:
+            ingest_workspace = str(await workshop_run.effective_workspace())
+        else:
+            ingest_workspace = str(await pool.get_effective_workspace(chat_id))
         task = asyncio.create_task(_ingest_memory())
         _pending_memory_tasks.add(task)
         task.add_done_callback(_pending_memory_tasks.discard)
@@ -5237,9 +5259,14 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
     app.bot_data["workshop_delivery_recorder"] = sessions.record_workshop_delivery_observation
     app.bot_data["workshop_streaming_preview_recorder"] = sessions.record_workshop_streaming_preview
     app.bot_data["workshop_streaming_finalizer"] = sessions.record_workshop_streaming_finalization
-    app.bot_data["pool"] = SubprocessPool(
+    pool = SubprocessPool(
         config=config,
         services_info=services.get_available_services(),
+    )
+    app.bot_data["pool"] = pool
+    app.bot_data["workshop_conversation_run_service"] = WorkshopConversationRunService(
+        pool,
+        sessions.resolve_workshop_conversation_run,
     )
 
     # Default every recognized command to sensitive. `/start` and `/help`

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -50,6 +50,11 @@ from kai.workshop.bootstrap import (
     BootstrapResult,
     bootstrap_default_workshop,
 )
+from kai.workshop.conversation_runs import (
+    CompatibilityConversationRunResolution,
+    resolve_canonical_conversation_run,
+)
+from kai.workshop.domain import MessageId
 from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.outbound import (
     DeliveryObservation,
@@ -349,6 +354,17 @@ async def record_workshop_inbound_message(message: InboundMessage) -> AppendResu
     async with _workshop_event_lock:
         store = WorkshopEventStore.from_initialized_connection(_get_db())
         return await record_inbound_message(store, message)
+
+
+async def resolve_workshop_conversation_run(
+    inbound_message_id: MessageId,
+) -> CompatibilityConversationRunResolution:
+    """Resolve one canonical inbound message for transport-neutral execution."""
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        store = WorkshopEventStore.from_initialized_connection(_get_db())
+        return await resolve_canonical_conversation_run(store, inbound_message_id)
 
 
 async def record_workshop_inbound_artifact(

--- a/src/kai/workshop/conversation_runs.py
+++ b/src/kai/workshop/conversation_runs.py
@@ -1,0 +1,146 @@
+"""Transport-neutral preparation and execution of canonical conversation runs."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from kai.backend import StreamEvent
+from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, WorkshopId
+from kai.workshop.store import WorkshopEventStore
+
+type AgentPrompt = str | list[dict[str, str]]
+_TELEGRAM_USER_ID_PATTERN = re.compile(r"^[1-9][0-9]*$")
+
+
+class ConversationRunUnavailableError(LookupError):
+    """A canonical inbound message cannot resolve one authorized run target."""
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalConversationRunTarget:
+    """Canonical identities for one inbound human message and attached agent."""
+
+    inbound_message_id: MessageId
+    workshop_id: WorkshopId
+    channel_id: ChannelId
+    requested_by_principal_id: PrincipalId
+    agent_id: AgentId
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityConversationRunResolution:
+    """Canonical target plus the private key required by the current pool."""
+
+    target: CanonicalConversationRunTarget
+    _legacy_pool_key: int = field(repr=False, compare=False)
+
+
+class ConversationPool(Protocol):
+    """The narrow existing-pool surface hidden behind the run service."""
+
+    def get_model(self, chat_id: int) -> str: ...
+
+    def send(self, prompt: AgentPrompt, *, chat_id: int) -> AsyncIterator[StreamEvent]: ...
+
+    async def get_effective_workspace(self, chat_id: int) -> Path: ...
+
+
+async def resolve_canonical_conversation_run(
+    store: WorkshopEventStore,
+    inbound_message_id: MessageId,
+) -> CompatibilityConversationRunResolution:
+    """Resolve a human-authored message to exactly one channel agent.
+
+    The public run request contains only a canonical message ID. During the
+    migration, the resolved human's Telegram identity supplies the existing
+    pool/config key internally. A caller cannot provide or override that key.
+    """
+    if not isinstance(inbound_message_id, MessageId):
+        raise ValueError("inbound_message_id must be a MessageId")
+
+    async with store.connection.execute(
+        "SELECT c.workshop_id, m.channel_id, m.author_principal_id, ca.agent_id "
+        "FROM messages m "
+        "JOIN channels c ON c.id = m.channel_id "
+        "JOIN principals p ON p.id = m.author_principal_id AND p.kind = 'human' "
+        "JOIN channel_memberships cm ON cm.channel_id = m.channel_id "
+        "AND cm.principal_id = m.author_principal_id "
+        "JOIN channel_agents ca ON ca.channel_id = m.channel_id "
+        "WHERE m.id = ?",
+        (inbound_message_id,),
+    ) as cursor:
+        target_rows = list(await cursor.fetchall())
+    if len(target_rows) != 1:
+        raise ConversationRunUnavailableError(
+            "Inbound message must resolve to one human channel member and one attached agent"
+        )
+
+    requested_by_principal_id = PrincipalId(str(target_rows[0][2]))
+    async with store.connection.execute(
+        "SELECT external_subject FROM external_identities WHERE principal_id = ? AND provider = 'telegram'",
+        (requested_by_principal_id,),
+    ) as cursor:
+        identity_rows = list(await cursor.fetchall())
+    if len(identity_rows) != 1:
+        raise ConversationRunUnavailableError("Canonical human requires exactly one Telegram compatibility identity")
+    external_subject = str(identity_rows[0][0])
+    if not _TELEGRAM_USER_ID_PATTERN.fullmatch(external_subject):
+        raise ConversationRunUnavailableError("Telegram compatibility identity is not a positive user ID")
+
+    return CompatibilityConversationRunResolution(
+        target=CanonicalConversationRunTarget(
+            inbound_message_id=inbound_message_id,
+            workshop_id=WorkshopId(str(target_rows[0][0])),
+            channel_id=ChannelId(str(target_rows[0][1])),
+            requested_by_principal_id=requested_by_principal_id,
+            agent_id=AgentId(str(target_rows[0][3])),
+        ),
+        _legacy_pool_key=int(external_subject),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedConversationRun:
+    """One canonical run prepared against the current compatibility runtime."""
+
+    target: CanonicalConversationRunTarget
+    model: str
+    _pool: ConversationPool = field(repr=False, compare=False)
+    _legacy_pool_key: int = field(repr=False, compare=False)
+
+    async def stream(self, prompt: AgentPrompt) -> AsyncIterator[StreamEvent]:
+        """Stream normalized harness events without exposing the pool key."""
+        async for event in self._pool.send(prompt, chat_id=self._legacy_pool_key):
+            yield event
+
+    async def effective_workspace(self) -> Path:
+        """Return the run's effective project workspace through the adapter."""
+        return await self._pool.get_effective_workspace(self._legacy_pool_key)
+
+
+class WorkshopConversationRunService:
+    """Prepare canonical conversation runs independently of an ingress client."""
+
+    def __init__(
+        self,
+        pool: ConversationPool,
+        resolver: Callable[[MessageId], Awaitable[CompatibilityConversationRunResolution]],
+    ) -> None:
+        self._pool = pool
+        self._resolver = resolver
+
+    async def prepare(self, inbound_message_id: MessageId) -> PreparedConversationRun:
+        resolution = await self._resolver(inbound_message_id)
+        target = resolution.target
+        if target.inbound_message_id != inbound_message_id:
+            raise ConversationRunUnavailableError("Run resolver returned a different inbound message")
+        return PreparedConversationRun(
+            target=target,
+            model=self._pool.get_model(resolution._legacy_pool_key),
+            _pool=self._pool,
+            _legacy_pool_key=resolution._legacy_pool_key,
+        )

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -82,7 +82,12 @@ from kai.config import PROVIDER_MODELS, Config, UserConfig, get_default_model_fo
 from kai.review import CollectionWarning, PRReviewResult
 from kai.tts import DEFAULT_VOICE, VOICES
 from kai.workshop.artifacts import InboundArtifact
-from kai.workshop.domain import MessageId
+from kai.workshop.conversation_runs import (
+    CanonicalConversationRunTarget,
+    PreparedConversationRun,
+    WorkshopConversationRunService,
+)
+from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, WorkshopId
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
 from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
@@ -742,6 +747,7 @@ class TestCreateBotTransportMode:
         assert app.bot_data["workshop_delivery_recorder"] is sessions.record_workshop_delivery_observation
         assert app.bot_data["workshop_streaming_preview_recorder"] is sessions.record_workshop_streaming_preview
         assert app.bot_data["workshop_streaming_finalizer"] is sessions.record_workshop_streaming_finalization
+        assert isinstance(app.bot_data["workshop_conversation_run_service"], WorkshopConversationRunService)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -2773,6 +2779,11 @@ class TestHandleMessage:
         inbound_id = MessageId("msg_00000000000000000000000000000001")
         recorder.return_value.event.envelope.aggregate_id = inbound_id
         ctx.bot_data["workshop_inbound_recorder"] = recorder
+        prepared_run = MagicMock(spec=PreparedConversationRun)
+        prepared_run.model = "gpt-5.6-sol"
+        run_service = MagicMock(spec=WorkshopConversationRunService)
+        run_service.prepare = AsyncMock(return_value=prepared_run)
+        ctx.bot_data["workshop_conversation_run_service"] = run_service
         with (
             patch("kai.bot.is_totp_configured", return_value=False),
             patch("kai.bot._handle_response", new_callable=AsyncMock) as response,
@@ -2796,6 +2807,8 @@ class TestHandleMessage:
         )
         assert response.await_args.kwargs["workshop_inbound_message_id"] == inbound_id
         assert response.await_args.kwargs["delivery_route"] == ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT
+        run_service.prepare.assert_awaited_once_with(inbound_id)
+        assert response.await_args.kwargs["workshop_run"] is prepared_run
 
     @pytest.mark.asyncio
     async def test_does_not_record_when_totp_denies_message(self):
@@ -3698,6 +3711,21 @@ class TestHandleResponse:
         ctx.bot_data["workshop_streaming_finalizer"] = finalizer
         return preview, finalizer
 
+    @staticmethod
+    def _prepared_workshop_run(pool, inbound_message_id: MessageId) -> PreparedConversationRun:
+        return PreparedConversationRun(
+            target=CanonicalConversationRunTarget(
+                inbound_message_id=inbound_message_id,
+                workshop_id=WorkshopId("wsp_00000000000000000000000000000001"),
+                channel_id=ChannelId("chn_00000000000000000000000000000001"),
+                requested_by_principal_id=PrincipalId("prn_00000000000000000000000000000001"),
+                agent_id=AgentId("agt_00000000000000000000000000000001"),
+            ),
+            model="sonnet",
+            _pool=pool,
+            _legacy_pool_key=12345,
+        )
+
     @pytest.mark.asyncio
     async def test_workshop_private_text_commits_without_direct_send_or_shadow_observation(self):
         from kai.bot import _handle_response
@@ -3724,6 +3752,7 @@ class TestHandleResponse:
                 "sonnet",
                 workshop_inbound_message_id=inbound_id,
                 delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+                workshop_run=self._prepared_workshop_run(pool, inbound_id),
             )
 
         finalizer.assert_awaited_once()
@@ -3764,6 +3793,7 @@ class TestHandleResponse:
                 "sonnet",
                 workshop_inbound_message_id=inbound_id,
                 delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+                workshop_run=self._prepared_workshop_run(pool, inbound_id),
             )
 
         bound = preview.await_args.args[0]
@@ -3801,6 +3831,7 @@ class TestHandleResponse:
                 "sonnet",
                 workshop_inbound_message_id=inbound_id,
                 delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+                workshop_run=self._prepared_workshop_run(pool, inbound_id),
             )
 
         finalizer.assert_awaited_once()
@@ -3874,6 +3905,7 @@ class TestHandleResponse:
                 "sonnet",
                 workshop_inbound_message_id=inbound_id,
                 delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+                workshop_run=self._prepared_workshop_run(pool, inbound_id),
             )
 
         preview.assert_awaited_once()
@@ -3919,6 +3951,7 @@ class TestHandleResponse:
                 "sonnet",
                 workshop_inbound_message_id=inbound_id,
                 delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+                workshop_run=self._prepared_workshop_run(pool, inbound_id),
             )
 
         preview.assert_awaited_once()
@@ -3955,6 +3988,7 @@ class TestHandleResponse:
                 "sonnet",
                 workshop_inbound_message_id=inbound_id,
                 delivery_route=ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT,
+                workshop_run=self._prepared_workshop_run(pool, inbound_id),
             )
 
         direct_send.assert_not_awaited()

--- a/tests/test_workshop_conversation_runs.py
+++ b/tests/test_workshop_conversation_runs.py
@@ -1,0 +1,184 @@
+"""Contracts for transport-neutral canonical Workshop conversation runs."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kai.backend import AgentResponse, StreamEvent
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.conversation_runs import (
+    CanonicalConversationRunTarget,
+    CompatibilityConversationRunResolution,
+    ConversationRunUnavailableError,
+    WorkshopConversationRunService,
+    resolve_canonical_conversation_run,
+)
+from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, WorkshopId
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 8, 12, 12, 0, tzinfo=UTC)
+
+
+async def _canonical_inbound(store: WorkshopEventStore, telegram_id: int = 101) -> MessageId:
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Authorized Human",
+                role="admin",
+                transport="telegram",
+                external_subject=str(telegram_id),
+                external_channel_id=str(telegram_id),
+            ),
+        ),
+    )
+    result = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="telegram",
+            update_id="9001",
+            message_id="42",
+            sender_subject=str(telegram_id),
+            channel_subject=str(telegram_id),
+            body="Run this canonical message",
+            occurred_at=_NOW,
+        ),
+    )
+    aggregate_id = result.event.envelope.aggregate_id
+    assert isinstance(aggregate_id, MessageId)
+    return aggregate_id
+
+
+async def _events() -> AsyncIterator[StreamEvent]:
+    yield StreamEvent(
+        text_so_far="Done.",
+        done=True,
+        response=AgentResponse(text="Done.", success=True),
+    )
+
+
+class TestCanonicalRunResolution:
+    async def test_resolves_human_message_channel_and_attached_agent(self, tmp_path: Path):
+        store = await WorkshopEventStore.open(tmp_path / "kai.db")
+        try:
+            inbound_id = await _canonical_inbound(store, telegram_id=101)
+
+            resolution = await resolve_canonical_conversation_run(store, inbound_id)
+            target = resolution.target
+
+            assert target.inbound_message_id == inbound_id
+            assert isinstance(target.workshop_id, WorkshopId)
+            assert isinstance(target.channel_id, ChannelId)
+            assert isinstance(target.requested_by_principal_id, PrincipalId)
+            assert isinstance(target.agent_id, AgentId)
+            assert resolution._legacy_pool_key == 101
+        finally:
+            await store.close()
+
+    async def test_rejects_unknown_message(self, tmp_path: Path):
+        store = await WorkshopEventStore.open(tmp_path / "kai.db")
+        try:
+            await _canonical_inbound(store)
+
+            with pytest.raises(ConversationRunUnavailableError, match="one human channel member"):
+                await resolve_canonical_conversation_run(store, MessageId.new())
+        finally:
+            await store.close()
+
+    async def test_rejects_missing_compatibility_identity(self, tmp_path: Path):
+        store = await WorkshopEventStore.open(tmp_path / "kai.db")
+        try:
+            inbound_id = await _canonical_inbound(store)
+            await store.connection.execute("DELETE FROM external_identities")
+            await store.connection.commit()
+
+            with pytest.raises(ConversationRunUnavailableError, match="exactly one Telegram"):
+                await resolve_canonical_conversation_run(store, inbound_id)
+        finally:
+            await store.close()
+
+    async def test_rejects_multiple_attached_agents(self, tmp_path: Path):
+        store = await WorkshopEventStore.open(tmp_path / "kai.db")
+        try:
+            inbound_id = await _canonical_inbound(store)
+            target = (await resolve_canonical_conversation_run(store, inbound_id)).target
+            second_principal = PrincipalId.new()
+            second_agent = AgentId.new()
+            await store.connection.execute(
+                "INSERT INTO principals (id, kind, display_name, created_at) VALUES (?, 'agent', 'Other', ?)",
+                (second_principal, _NOW.isoformat()),
+            )
+            await store.connection.execute(
+                "INSERT INTO agents (id, workshop_id, principal_id, name, created_at) VALUES (?, ?, ?, 'Other', ?)",
+                (second_agent, target.workshop_id, second_principal, _NOW.isoformat()),
+            )
+            await store.connection.execute(
+                "INSERT INTO channel_agents (id, channel_id, agent_id, created_at) VALUES (?, ?, ?, ?)",
+                ("cag_00000000000000000000000000000002", target.channel_id, second_agent, _NOW.isoformat()),
+            )
+            await store.connection.commit()
+
+            with pytest.raises(ConversationRunUnavailableError, match="one attached agent"):
+                await resolve_canonical_conversation_run(store, inbound_id)
+        finally:
+            await store.close()
+
+
+class TestWorkshopConversationRunService:
+    async def test_hides_compatibility_key_behind_canonical_request(self):
+        inbound_id = MessageId.new()
+        target = CompatibilityConversationRunResolution(
+            target=CanonicalConversationRunTarget(
+                inbound_message_id=inbound_id,
+                workshop_id=WorkshopId.new(),
+                channel_id=ChannelId.new(),
+                requested_by_principal_id=PrincipalId.new(),
+                agent_id=AgentId.new(),
+            ),
+            _legacy_pool_key=101,
+        )
+        resolver = AsyncMock(return_value=target)
+        pool = MagicMock()
+        pool.get_model.return_value = "gpt-5.6-sol"
+        pool.send.return_value = _events()
+        pool.get_effective_workspace = AsyncMock(return_value=Path("/srv/project"))
+        service = WorkshopConversationRunService(pool, resolver)
+
+        prepared = await service.prepare(inbound_id)
+        events = [event async for event in prepared.stream("hello")]
+        workspace = await prepared.effective_workspace()
+
+        resolver.assert_awaited_once_with(inbound_id)
+        pool.get_model.assert_called_once_with(101)
+        pool.send.assert_called_once_with("hello", chat_id=101)
+        pool.get_effective_workspace.assert_awaited_once_with(101)
+        assert prepared.target.inbound_message_id == inbound_id
+        assert prepared.model == "gpt-5.6-sol"
+        assert events[0].response is not None and events[0].response.text == "Done."
+        assert workspace == Path("/srv/project")
+
+    async def test_rejects_resolver_substitution(self):
+        requested_id = MessageId.new()
+        target = CompatibilityConversationRunResolution(
+            target=CanonicalConversationRunTarget(
+                inbound_message_id=MessageId.new(),
+                workshop_id=WorkshopId.new(),
+                channel_id=ChannelId.new(),
+                requested_by_principal_id=PrincipalId.new(),
+                agent_id=AgentId.new(),
+            ),
+            _legacy_pool_key=101,
+        )
+        pool = MagicMock()
+        service = WorkshopConversationRunService(pool, AsyncMock(return_value=target))
+
+        with pytest.raises(ConversationRunUnavailableError, match="different inbound message"):
+            await service.prepare(requested_id)
+
+        pool.get_model.assert_not_called()


### PR DESCRIPTION
## Summary

- add a transport-neutral Workshop conversation-run service whose public request is only a canonical inbound `MessageId`
- resolve and validate the canonical human author, channel membership, workshop, and exactly one attached agent before execution
- confine the current Telegram-derived `SubprocessPool` key to a private compatibility resolution while preserving all five qualified backend harnesses
- route the already-authoritative authenticated private-text path through the prepared run for model selection, streaming, and effective-workspace capture
- retain existing execution paths for voice-enabled text, media, commands, jobs, integrations, notification groups, and every other excluded route
- record the new boundary and its explicit limitations in the Workshop transition ledger

## Security and authority properties

- the Telegram handler cannot choose an agent ID, backend ID, model, or pool key for the migrated path
- the run resolver requires a human-authored canonical message, the author's channel membership, and exactly one attached agent
- missing, ambiguous, substituted, or invalid resolution fails the existing authoritative private-text route closed before backend invocation
- the prepared run exposes canonical Workshop identities and normalized stream/workspace operations; the compatibility key remains inside the adapter
- existing durable Telegram finalization, exact-epoch worker ownership, and no-direct-fallback behavior are unchanged

## Deliberate non-goals

- no durable `run` or `attempt` records or lifecycle events yet
- no process/runtime ownership changes and no changes to the five backend drivers
- no Workshop desktop/web endpoint registration
- no migration of chat-keyed locks, settings, JSONL history, memory, files, or excluded Telegram routes

## Tests

- `make check`
- `make typecheck`
- focused conversation-run and authoritative private-text contracts: 19 passed
- full suite: 5,414 passed, 1 skipped

## Next bounded milestone

Add a production-unused durable run lifecycle behind this service, with stable accepted/started/completed/failed/cancelled facts and deterministic replay, without changing Telegram delivery or process ownership in the same step.
