### PR TITLE
Add durable Workshop run lifecycle foundation

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -80,7 +80,8 @@ The outer process is already a control plane in the practical sense: it authenti
 | Accepted inbound Telegram work | `telegram_update_queue` in [`sessions.py`](src/kai/sessions.py) | Telegram update ID | Strong Telegram-specific durability pattern; not yet a general command inbox. |
 | Transcript | Per-user/date JSONL in [`history.py`](src/kai/history.py) | Chat ID + timestamp | No stable message ID, channel ID, thread ID, edit lineage, delivery state, or transactional relation to SQLite. |
 | Harness session metadata | `sessions` table plus live backend instance | Chat ID | The stored session ID is used for statistics and clearing; process/session reconstruction still belongs to the live backend. |
-| Active harness process | `SubprocessPool` in [`pool.py`](src/kai/pool.py) | Chat ID | One implicit agent process per conversation key; no durable agent, run, attempt, lease, or worker identity. |
+| Durable run lifecycle | Workshop event log and replayed `runs` projection | Run ID | Production-unused accepted/started/completed/failed/cancelled facts exist, but live execution does not create them and attempts are not yet modeled. |
+| Active harness process | `SubprocessPool` in [`pool.py`](src/kai/pool.py) | Chat ID | One implicit agent process per conversation key; durable agent and run identities now exist but are not connected to process, attempt, lease, or worker ownership. |
 | User settings | Generic `settings` rows in [`sessions.py`](src/kai/sessions.py) | Namespaced strings containing chat ID | Flexible but not typed, versioned, or attached to transport-independent principals/channels. |
 | Scheduled jobs | `jobs` table and APScheduler registration | Integer job ID + chat ID | Job definitions survive restart, but executions are not durable runs with attempts and event history. |
 | Project workspace selection | Settings, `allowed_workspaces`, `workspace_history`, static configuration | Chat ID + filesystem path | A project workspace is not a first-class durable object and is coupled to the current chat. |
@@ -287,8 +288,13 @@ Identifiers should be opaque, globally unique strings. Telegram numeric identifi
 - `delivery.requested`
 - `delivery.succeeded`
 - `delivery.failed`
+- `run.accepted`
+- `run.started`
+- `run.completed`
+- `run.failed`
+- `run.cancelled`
 
-The delivery foundation now adds only the request and outcome facts the system can define consistently; mutable leases and attempts remain operational outbox state rather than replayed collaboration events. Run event families should be designed before execution becomes authoritative. The schema should not invent detailed tool or backend-worker events that the current harnesses cannot yet emit consistently.
+The delivery foundation adds only the request and outcome facts the system can define consistently; mutable leases and attempts remain operational outbox state rather than replayed collaboration events. The initial run family likewise records only backend-neutral lifecycle facts. The schema must not invent detailed tool or backend-worker events that the current harnesses cannot yet emit consistently.
 
 ### 11.3 Small PR sequence
 
@@ -405,7 +411,7 @@ No entry may use an indefinite condition such as "keep for compatibility." A gen
 | JSONL transcript writes and reads | Canonical message projection, with an explicit export facility if still useful | Canonical reads serve complete context and transcript views; migration/parity diagnostics report no unexplained divergence | Stop JSONL writes; remove production reads and dual-write recovery code; retain only a documented importer/exporter if required | Planned |
 | Telegram `chat_id` used as internal identity, namespace, and routing key | Durable principal, channel, agent, and binding IDs | Private chats, notification-only groups, duplicate updates, and restart routing all resolve correctly through bindings | Confine Telegram IDs to external identity, transport binding, and idempotency records; remove chat-shaped domain keys | Active (authoritative private text now enters execution by canonical message ID, but the compatibility resolver still derives the current pool key from the human principal's protected Telegram identity; settings, locks, history, files, memory, and excluded routes remain chat-keyed) |
 | `SubprocessPool` keyed by Telegram chat ID | Durable channel/agent session plus run and attempt orchestration | All five harnesses pass continuity, restart, cancellation, and isolation tests through durable identities | Remove chat-key compatibility lookup and move lifecycle ownership behind the orchestrator/runtime contract | Active (a canonical conversation-run service hides the private-text pool lookup behind a temporary compatibility resolution; the pool and all five harness processes remain keyed by that resolved integer) |
-| Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Active (authoritative private text invokes through the canonical conversation-run service using only its inbound `MessageId`; media, voice-enabled text, commands, schedules, integrations, and the future Workshop client are not yet migrated, and durable run/attempt state does not yet exist) |
+| Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Active (authoritative private text invokes through the canonical conversation-run service using only its inbound `MessageId`; a transport-neutral durable run lifecycle now exists production-unused, but live execution does not yet record it; media, voice-enabled text, commands, schedules, integrations, and the future Workshop client remain unmigrated, and attempts do not yet exist) |
 | Direct Telegram delivery from handlers, schedules, and webhooks | Durable delivery outbox and Telegram delivery adapter | Delivery outcome events preserve binding identity; retry, crash recovery, ordering, private-chat and notification-group delivery tests pass; live delivery is verified | Migrate each remaining transport path separately; the private-text direct fallback is retired | Active (authenticated private-chat text with voice mode off uses atomic streaming finalization and a supervised exact-epoch worker and now fails closed rather than demoting to direct/shadow delivery; commands, media, voice, schedules, webhooks, files, and groups retain existing delivery) |
 | Operator-invoked Workshop delivery qualification CLI | Installed evidence followed by the production delivery worker | A configured direct-chat reply is prepared without sending, survives a service restart, recovers an intentionally abandoned lease, reaches Telegram once through the exact selected delivery, and records a terminal binding-aware outcome; a configured notification group resolves through its outbound-only canonical channel, receives one atomically prepared qualification message through the exact selected delivery, and does not become an inbound conversation | Remove the qualification command and its explicit-claim-only surface after the production worker has equivalent installed restart/recovery evidence and direct delivery is retired | Active (the installed direct-chat recovery and notification-group delivery gates passed on 2026-08-12; retain until equivalent production-worker evidence exists, while the command remains unregistered and incapable of draining unrelated work) |
 | Conversation-delivery authority epochs | A single durable delivery authority after direct-send rollback is retired | Activation/deactivation, restart, historical-row isolation, exact-epoch worker ownership, aggregate diagnostics, and installed rollback/reactivation evidence pass; no supported rollback crosses the direct-send/outbox boundary | Remove epoch stamping, activation/deactivation state, exact-epoch claim filters, transitional readiness output, schema columns/tables where safely migratable, and their compatibility tests | Active (production startup resumes or creates the exact epoch before ingress; installed private-text streaming, all-send, fragmentation, restart/no-replay, aggregate authority, and parity checks passed on 2026-08-12) |
@@ -1036,8 +1042,9 @@ The boundary is intentionally narrow:
   channels retain their current execution paths;
 - process locks, settings, JSONL history, memory, and the live harness pool
   remain keyed by their existing compatibility identity;
-- no durable `run`, `attempt`, lease, cancellation, or normalized lifecycle
-  events are created by this service yet;
+- the production conversation service does not yet create the durable run
+  lifecycle facts defined in section 26, and attempts and execution leases do
+  not yet exist;
 - no Workshop desktop/web endpoint is registered by this change.
 
 Automated contracts require one canonical human channel member, exactly one
@@ -1045,9 +1052,59 @@ attached agent, exactly one valid compatibility identity, resolver-message
 identity preservation, hidden pool-key delegation, handler invocation by
 canonical message ID, and unchanged private-text delivery authority.
 
-The next bounded milestone is a production-unused durable run lifecycle behind
-this service: accept one authorized canonical message as one run, record stable
-accepted/started/completed/failed/cancelled facts without harness-specific
-payloads, and prove deterministic replay. It must not move process ownership,
-register a Workshop client endpoint, or change Telegram delivery in the same
-step.
+Section 26 records the completed production-unused durable run lifecycle that
+now sits behind this boundary.
+
+## 26. Production-unused durable run lifecycle
+
+**Implementation date:** 2026-08-12
+
+Schema version 15 adds a canonical `RunId`, a replayed `runs` projection, and
+five version-1 lifecycle facts: `run.accepted`, `run.started`, `run.completed`,
+`run.failed`, and `run.cancelled`. One human-authored inbound `MessageId`
+deterministically identifies at most one run. Acceptance resolves the canonical
+human membership, channel, workshop, and exactly one attached agent without
+requiring a Telegram identity or accepting any caller-selected execution
+identity.
+
+The lifecycle state machine is deliberately small:
+
+```text
+accepted --> started --> completed
+    |           |  +--> failed
+    +-----------+-----> cancelled
+```
+
+The requesting human is the recorded actor for acceptance and cancellation.
+The attached agent principal is the recorded actor for start, completion, and
+failure. Terminal failures and cancellations persist only bounded lowercase
+classification codes; provider messages, prompts, output text, credentials,
+transport IDs, executable paths, and harness-specific payloads are excluded.
+Lifecycle timestamps cannot precede their prior canonical fact.
+
+Deterministic event IDs and idempotency keys make acceptance and every
+transition safely repeatable. Retrying an earlier transition after a later
+state returns its original event and current run state. Conflicting terminal
+facts, invalid ordering, unknown runs, ambiguous canonical agent attachment,
+actor mismatch, malformed payloads, and time reversal fail closed. The
+canonical projection rebuilds complete run state from position zero alongside
+the conversation records on which it depends.
+
+This foundation is production-unused:
+
+- `main.py`, `bot.py`, the conversation-run service, and all client APIs do not
+  construct or call `WorkshopRunLifecycle`;
+- it starts no process or worker and owns no lease, attempt, backend session,
+  workspace, credential, or delivery;
+- it does not alter Telegram ingress, streaming, outbox finalization, JSONL,
+  memory, media, commands, schedules, integrations, or any backend driver;
+- upgrading creates an empty `runs` table and advances the canonical projection
+  version; existing conversations replay without synthesizing historical runs.
+
+The next bounded step is an explicit run-authority cutover review. It must
+decide the atomic boundary between inbound acceptance, run acceptance, backend
+start, terminal run state, canonical assistant output, and durable delivery;
+define what restart can truthfully recover when a local harness process is not
+durable; and specify cancellation semantics before the live private-text path
+may emit any run facts. Attempt and worker identity should remain a later slice
+unless that review proves they are required for truthful activation.

--- a/src/kai/workshop/conversation_runs.py
+++ b/src/kai/workshop/conversation_runs.py
@@ -49,16 +49,11 @@ class ConversationPool(Protocol):
     async def get_effective_workspace(self, chat_id: int) -> Path: ...
 
 
-async def resolve_canonical_conversation_run(
+async def resolve_canonical_conversation_target(
     store: WorkshopEventStore,
     inbound_message_id: MessageId,
-) -> CompatibilityConversationRunResolution:
-    """Resolve a human-authored message to exactly one channel agent.
-
-    The public run request contains only a canonical message ID. During the
-    migration, the resolved human's Telegram identity supplies the existing
-    pool/config key internally. A caller cannot provide or override that key.
-    """
+) -> CanonicalConversationRunTarget:
+    """Resolve a human-authored message to exactly one canonical channel agent."""
     if not isinstance(inbound_message_id, MessageId):
         raise ValueError("inbound_message_id must be a MessageId")
 
@@ -79,10 +74,29 @@ async def resolve_canonical_conversation_run(
             "Inbound message must resolve to one human channel member and one attached agent"
         )
 
-    requested_by_principal_id = PrincipalId(str(target_rows[0][2]))
+    return CanonicalConversationRunTarget(
+        inbound_message_id=inbound_message_id,
+        workshop_id=WorkshopId(str(target_rows[0][0])),
+        channel_id=ChannelId(str(target_rows[0][1])),
+        requested_by_principal_id=PrincipalId(str(target_rows[0][2])),
+        agent_id=AgentId(str(target_rows[0][3])),
+    )
+
+
+async def resolve_canonical_conversation_run(
+    store: WorkshopEventStore,
+    inbound_message_id: MessageId,
+) -> CompatibilityConversationRunResolution:
+    """Resolve a canonical target plus the current private pool adapter key.
+
+    The public run request contains only a canonical message ID. During the
+    migration, the resolved human's Telegram identity supplies the existing
+    pool/config key internally. A caller cannot provide or override that key.
+    """
+    target = await resolve_canonical_conversation_target(store, inbound_message_id)
     async with store.connection.execute(
         "SELECT external_subject FROM external_identities WHERE principal_id = ? AND provider = 'telegram'",
-        (requested_by_principal_id,),
+        (target.requested_by_principal_id,),
     ) as cursor:
         identity_rows = list(await cursor.fetchall())
     if len(identity_rows) != 1:
@@ -92,13 +106,7 @@ async def resolve_canonical_conversation_run(
         raise ConversationRunUnavailableError("Telegram compatibility identity is not a positive user ID")
 
     return CompatibilityConversationRunResolution(
-        target=CanonicalConversationRunTarget(
-            inbound_message_id=inbound_message_id,
-            workshop_id=WorkshopId(str(target_rows[0][0])),
-            channel_id=ChannelId(str(target_rows[0][1])),
-            requested_by_principal_id=requested_by_principal_id,
-            agent_id=AgentId(str(target_rows[0][3])),
-        ),
+        target=target,
         _legacy_pool_key=int(external_subject),
     )
 

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -19,7 +19,7 @@ _AGGREGATE_TYPE_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
 class WorkshopEventType(StrEnum):
-    """The collaboration-only vocabulary supported by the first schema."""
+    """The backend-neutral canonical fact vocabulary supported by Workshop."""
 
     WORKSHOP_CREATED = "workshop.created"
     WORKSHOP_MEMBER_ADDED = "workshop.member_added"
@@ -35,6 +35,11 @@ class WorkshopEventType(StrEnum):
     DELIVERY_REQUESTED = "delivery.requested"
     DELIVERY_SUCCEEDED = "delivery.succeeded"
     DELIVERY_FAILED = "delivery.failed"
+    RUN_ACCEPTED = "run.accepted"
+    RUN_STARTED = "run.started"
+    RUN_COMPLETED = "run.completed"
+    RUN_FAILED = "run.failed"
+    RUN_CANCELLED = "run.cancelled"
 
 
 class OpaqueId(str):
@@ -132,6 +137,10 @@ class DeliveryAuthorityEpochId(OpaqueId):
     prefix = "dae"
 
 
+class RunId(OpaqueId):
+    prefix = "run"
+
+
 class EventId(OpaqueId):
     prefix = "evt"
 
@@ -156,6 +165,7 @@ _ID_TYPES: dict[str, type[OpaqueId]] = {
         DeliveryId,
         DeliveryAttemptId,
         DeliveryAuthorityEpochId,
+        RunId,
         EventId,
     )
 }

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -3,17 +3,19 @@
 from __future__ import annotations
 
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import aiosqlite
 
-from kai.workshop.domain import WorkshopEventType
+from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, RunId, WorkshopEventType, WorkshopId
 from kai.workshop.store import StoredEvent
 
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 _IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 _MEDIA_TYPE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9!#$&^_.+-]*/[a-z0-9][a-z0-9!#$&^_.+-]*$")
+_RUN_TERMINAL_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 
 
 def _required_text(payload: dict[str, Any], key: str) -> str:
@@ -23,6 +25,151 @@ def _required_text(payload: dict[str, Any], key: str) -> str:
     return value
 
 
+def _parse_projection_timestamp(value: object) -> datetime:
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _require_exact_payload(payload: dict[str, Any], keys: set[str]) -> None:
+    if set(payload) != keys:
+        raise ValueError(f"Workshop event payload must contain exactly {sorted(keys)!r}")
+
+
+async def _apply_run_event(connection: aiosqlite.Connection, event: StoredEvent) -> None:
+    envelope = event.envelope
+    if not isinstance(envelope.aggregate_id, RunId) or envelope.aggregate_type != "run":
+        raise ValueError("Workshop run events require a typed run aggregate")
+
+    occurred_at = envelope.occurred_at.isoformat()
+    payload = envelope.payload
+    if envelope.event_type == WorkshopEventType.RUN_ACCEPTED:
+        _require_exact_payload(
+            payload,
+            {"inbound_message_id", "channel_id", "requested_by_principal_id", "agent_id"},
+        )
+        inbound_message_id = MessageId(_required_text(payload, "inbound_message_id"))
+        channel_id = ChannelId(_required_text(payload, "channel_id"))
+        requested_by = PrincipalId(_required_text(payload, "requested_by_principal_id"))
+        agent_id = AgentId(_required_text(payload, "agent_id"))
+        async with connection.execute(
+            "SELECT c.workshop_id, m.channel_id, m.author_principal_id, ca.agent_id, m.created_at "
+            "FROM messages m "
+            "JOIN principals p ON p.id = m.author_principal_id AND p.kind = 'human' "
+            "JOIN channels c ON c.id = m.channel_id "
+            "JOIN channel_memberships cm ON cm.channel_id = m.channel_id "
+            "AND cm.principal_id = m.author_principal_id "
+            "JOIN channel_agents ca ON ca.channel_id = m.channel_id "
+            "JOIN agents a ON a.id = ca.agent_id AND a.workshop_id = c.workshop_id "
+            "WHERE m.id = ?",
+            (inbound_message_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        expected = (envelope.workshop_id, channel_id, requested_by, agent_id)
+        if len(rows) != 1 or tuple(rows[0][:4]) != expected:
+            raise ValueError("Workshop run must match one human message and attached channel agent")
+        inbound_created_at = _parse_projection_timestamp(rows[0][4])
+        if envelope.occurred_at < inbound_created_at:
+            raise ValueError("Workshop run cannot be accepted before its inbound message")
+        if envelope.actor_principal_id != requested_by:
+            raise ValueError("Workshop run acceptance actor must be its requesting human")
+        await connection.execute(
+            "INSERT INTO runs "
+            "(id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
+            "inbound_message_id, status, accepted_at, last_event_position) "
+            "VALUES (?, ?, ?, ?, ?, ?, 'accepted', ?, ?)",
+            (
+                envelope.aggregate_id,
+                envelope.workshop_id,
+                channel_id,
+                requested_by,
+                agent_id,
+                inbound_message_id,
+                occurred_at,
+                event.position,
+            ),
+        )
+        return
+
+    async with connection.execute(
+        "SELECT r.workshop_id, r.status, r.requested_by_principal_id, a.principal_id, "
+        "r.accepted_at, r.started_at "
+        "FROM runs r JOIN agents a ON a.id = r.agent_id WHERE r.id = ?",
+        (envelope.aggregate_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None or WorkshopId(str(row[0])) != envelope.workshop_id:
+        raise ValueError("Workshop run transition references an unknown run")
+    status = str(row[1])
+    requested_by = PrincipalId(str(row[2]))
+    agent_principal = PrincipalId(str(row[3]))
+    accepted_at = _parse_projection_timestamp(row[4])
+    started_at = None if row[5] is None else _parse_projection_timestamp(row[5])
+
+    if envelope.event_type == WorkshopEventType.RUN_STARTED:
+        _require_exact_payload(payload, set())
+        if status != "accepted" or envelope.actor_principal_id != agent_principal or envelope.occurred_at < accepted_at:
+            raise ValueError("Workshop run can start only once through its attached agent")
+        await connection.execute(
+            "UPDATE runs SET status = 'started', started_at = ?, last_event_position = ? WHERE id = ?",
+            (occurred_at, event.position, envelope.aggregate_id),
+        )
+        return
+
+    if envelope.event_type == WorkshopEventType.RUN_COMPLETED:
+        _require_exact_payload(payload, set())
+        if (
+            status != "started"
+            or envelope.actor_principal_id != agent_principal
+            or started_at is None
+            or envelope.occurred_at < started_at
+        ):
+            raise ValueError("Workshop run can complete only from started through its attached agent")
+        await connection.execute(
+            "UPDATE runs SET status = 'completed', terminal_at = ?, last_event_position = ? WHERE id = ?",
+            (occurred_at, event.position, envelope.aggregate_id),
+        )
+        return
+
+    if envelope.event_type == WorkshopEventType.RUN_FAILED:
+        _require_exact_payload(payload, {"failure_code"})
+        failure_code = _required_text(payload, "failure_code")
+        if not _RUN_TERMINAL_CODE_PATTERN.fullmatch(failure_code):
+            raise ValueError("Workshop run failure_code must be a lowercase identifier")
+        if (
+            status != "started"
+            or envelope.actor_principal_id != agent_principal
+            or started_at is None
+            or envelope.occurred_at < started_at
+        ):
+            raise ValueError("Workshop run can fail only from started through its attached agent")
+        await connection.execute(
+            "UPDATE runs SET status = 'failed', terminal_at = ?, terminal_code = ?, "
+            "last_event_position = ? WHERE id = ?",
+            (occurred_at, failure_code, event.position, envelope.aggregate_id),
+        )
+        return
+
+    if envelope.event_type == WorkshopEventType.RUN_CANCELLED:
+        _require_exact_payload(payload, {"cancellation_code"})
+        cancellation_code = _required_text(payload, "cancellation_code")
+        if not _RUN_TERMINAL_CODE_PATTERN.fullmatch(cancellation_code):
+            raise ValueError("Workshop run cancellation_code must be a lowercase identifier")
+        lifecycle_floor = started_at if started_at is not None else accepted_at
+        if (
+            status not in {"accepted", "started"}
+            or envelope.actor_principal_id != requested_by
+            or envelope.occurred_at < lifecycle_floor
+        ):
+            raise ValueError("Workshop run can be cancelled only while nonterminal by its requesting human")
+        await connection.execute(
+            "UPDATE runs SET status = 'cancelled', terminal_at = ?, terminal_code = ?, "
+            "last_event_position = ? WHERE id = ?",
+            (occurred_at, cancellation_code, event.position, envelope.aggregate_id),
+        )
+        return
+
+    raise ValueError(f"Unsupported Workshop run event: {envelope.event_type}")
+
+
 class CanonicalConversationProjection:
     """Rebuild the initial Workshop collaboration records from events."""
 
@@ -30,12 +177,15 @@ class CanonicalConversationProjection:
     # Artifact events were not emitted before artifact support existed, so
     # adding their first handler does not change replay of any prior event.
     # Keep the version stable to avoid an unnecessary production rebuild.
-    version = 4
+    version = 5
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
+        async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
+            existing_tables = {str(row[0]) for row in await cursor.fetchall()}
         for table in (
             "deliveries",
             "artifacts",
+            "runs",
             "messages",
             "channel_agents",
             "channel_bindings",
@@ -47,12 +197,23 @@ class CanonicalConversationProjection:
             "principals",
             "workshops",
         ):
-            await connection.execute(f"DELETE FROM {table}")
+            if table in existing_tables:
+                await connection.execute(f"DELETE FROM {table}")
 
     async def apply(self, connection: aiosqlite.Connection, event: StoredEvent) -> None:
         envelope = event.envelope
         payload = envelope.payload
         occurred_at = envelope.occurred_at.isoformat()
+
+        if envelope.event_type in {
+            WorkshopEventType.RUN_ACCEPTED,
+            WorkshopEventType.RUN_STARTED,
+            WorkshopEventType.RUN_COMPLETED,
+            WorkshopEventType.RUN_FAILED,
+            WorkshopEventType.RUN_CANCELLED,
+        }:
+            await _apply_run_event(connection, event)
+            return
 
         if envelope.event_type == WorkshopEventType.WORKSHOP_CREATED:
             await connection.execute(

--- a/src/kai/workshop/run_lifecycle.py
+++ b/src/kai/workshop/run_lifecycle.py
@@ -1,0 +1,377 @@
+"""Production-unused durable lifecycle for canonical Workshop runs."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from kai.workshop.conversation_runs import resolve_canonical_conversation_target
+from kai.workshop.domain import (
+    AgentId,
+    ChannelId,
+    EventEnvelope,
+    EventId,
+    MessageId,
+    PrincipalId,
+    RunId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import StoredEvent, WorkshopEventStore
+
+_TERMINAL_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+class RunStatus(StrEnum):
+    ACCEPTED = "accepted"
+    STARTED = "started"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class RunLifecycleError(RuntimeError):
+    """Base error for a rejected durable run operation."""
+
+
+class RunNotFoundError(RunLifecycleError, LookupError):
+    """A typed run ID does not identify a durable run."""
+
+
+class InvalidRunTransitionError(RunLifecycleError):
+    """The requested lifecycle transition is not valid from current state."""
+
+
+class RunLifecycleConflictError(RunLifecycleError):
+    """A deterministic lifecycle identity was reused with different facts."""
+
+
+@dataclass(frozen=True, slots=True)
+class DurableRun:
+    run_id: RunId
+    workshop_id: WorkshopId
+    channel_id: ChannelId
+    requested_by_principal_id: PrincipalId
+    agent_id: AgentId
+    inbound_message_id: MessageId
+    status: RunStatus
+    accepted_at: datetime
+    started_at: datetime | None
+    terminal_at: datetime | None
+    terminal_code: str | None
+    last_event_position: int
+
+
+@dataclass(frozen=True, slots=True)
+class RunLifecycleResult:
+    run: DurableRun
+    event: StoredEvent
+    changed: bool
+
+
+def _require_timestamp(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("occurred_at must be timezone-aware")
+    return value.astimezone(UTC)
+
+
+def _require_terminal_code(value: str, *, field_name: str) -> str:
+    if not isinstance(value, str) or not _TERMINAL_CODE_PATTERN.fullmatch(value):
+        raise ValueError(f"{field_name} must be a lowercase identifier of at most 64 characters")
+    return value
+
+
+def _parse_timestamp(value: object) -> datetime:
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _optional_timestamp(value: object) -> datetime | None:
+    return None if value is None else _parse_timestamp(value)
+
+
+async def _load_run(store: WorkshopEventStore, run_id: RunId) -> DurableRun | None:
+    async with store.connection.execute(
+        "SELECT id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
+        "inbound_message_id, status, accepted_at, started_at, terminal_at, terminal_code, "
+        "last_event_position FROM runs WHERE id = ?",
+        (run_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        return None
+    return DurableRun(
+        run_id=RunId(str(row[0])),
+        workshop_id=WorkshopId(str(row[1])),
+        channel_id=ChannelId(str(row[2])),
+        requested_by_principal_id=PrincipalId(str(row[3])),
+        agent_id=AgentId(str(row[4])),
+        inbound_message_id=MessageId(str(row[5])),
+        status=RunStatus(str(row[6])),
+        accepted_at=_parse_timestamp(row[7]),
+        started_at=_optional_timestamp(row[8]),
+        terminal_at=_optional_timestamp(row[9]),
+        terminal_code=str(row[10]) if row[10] is not None else None,
+        last_event_position=int(row[11]),
+    )
+
+
+async def _load_run_by_inbound_message(
+    store: WorkshopEventStore,
+    inbound_message_id: MessageId,
+) -> DurableRun | None:
+    async with store.connection.execute(
+        "SELECT id FROM runs WHERE inbound_message_id = ?",
+        (inbound_message_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    return None if row is None else await _load_run(store, RunId(str(row[0])))
+
+
+async def _agent_principal_id(store: WorkshopEventStore, run: DurableRun) -> PrincipalId:
+    async with store.connection.execute(
+        "SELECT principal_id FROM agents WHERE id = ? AND workshop_id = ?",
+        (run.agent_id, run.workshop_id),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        raise RunLifecycleConflictError("Durable run no longer resolves its attached agent principal")
+    return PrincipalId(str(row[0]))
+
+
+def _event_key(run_id: RunId, status: RunStatus) -> str:
+    return f"workshop-run:v1:{run_id}:{status}"
+
+
+def _event_type(status: RunStatus) -> WorkshopEventType:
+    return {
+        RunStatus.ACCEPTED: WorkshopEventType.RUN_ACCEPTED,
+        RunStatus.STARTED: WorkshopEventType.RUN_STARTED,
+        RunStatus.COMPLETED: WorkshopEventType.RUN_COMPLETED,
+        RunStatus.FAILED: WorkshopEventType.RUN_FAILED,
+        RunStatus.CANCELLED: WorkshopEventType.RUN_CANCELLED,
+    }[status]
+
+
+async def _existing_event(
+    store: WorkshopEventStore,
+    *,
+    run: DurableRun,
+    status: RunStatus,
+    actor_principal_id: PrincipalId,
+    payload: dict[str, object],
+) -> StoredEvent | None:
+    key = _event_key(run.run_id, status)
+    existing = await store.event_by_idempotency_key(key)
+    if existing is None:
+        return None
+    envelope = existing.envelope
+    if (
+        envelope.event_type != _event_type(status)
+        or envelope.event_version != 1
+        or envelope.workshop_id != run.workshop_id
+        or envelope.aggregate_type != "run"
+        or envelope.aggregate_id != run.run_id
+        or envelope.actor_principal_id != actor_principal_id
+        or envelope.payload != payload
+    ):
+        raise RunLifecycleConflictError(f"Durable run event identity for {status} has conflicting facts")
+    return existing
+
+
+class WorkshopRunLifecycle:
+    """Create and transition canonical runs without invoking a backend.
+
+    Nothing constructs this service in production yet. Its only authority is
+    durable event and projection state; it owns no process, worker, or client
+    endpoint.
+    """
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def state(self, run_id: RunId) -> DurableRun:
+        if not isinstance(run_id, RunId):
+            raise ValueError("run_id must be a RunId")
+        run = await _load_run(self._store, run_id)
+        if run is None:
+            raise RunNotFoundError("Durable Workshop run was not found")
+        return run
+
+    async def accept(self, inbound_message_id: MessageId, *, occurred_at: datetime) -> RunLifecycleResult:
+        if not isinstance(inbound_message_id, MessageId):
+            raise ValueError("inbound_message_id must be a MessageId")
+        occurred_at = _require_timestamp(occurred_at)
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            existing_run = await _load_run_by_inbound_message(self._store, inbound_message_id)
+            if existing_run is not None:
+                existing_payload: dict[str, object] = {
+                    "inbound_message_id": existing_run.inbound_message_id,
+                    "channel_id": existing_run.channel_id,
+                    "requested_by_principal_id": existing_run.requested_by_principal_id,
+                    "agent_id": existing_run.agent_id,
+                }
+                existing_event = await _existing_event(
+                    self._store,
+                    run=existing_run,
+                    status=RunStatus.ACCEPTED,
+                    actor_principal_id=existing_run.requested_by_principal_id,
+                    payload=existing_payload,
+                )
+                if existing_event is None:
+                    raise RunLifecycleConflictError("Durable run is missing its acceptance event")
+                await connection.commit()
+                return RunLifecycleResult(run=existing_run, event=existing_event, changed=False)
+
+            target = await resolve_canonical_conversation_target(self._store, inbound_message_id)
+            run_id = RunId.derived(target.workshop_id, f"conversation:{inbound_message_id}")
+            payload: dict[str, object] = {
+                "inbound_message_id": target.inbound_message_id,
+                "channel_id": target.channel_id,
+                "requested_by_principal_id": target.requested_by_principal_id,
+                "agent_id": target.agent_id,
+            }
+            event = EventEnvelope.create(
+                event_id=EventId.derived(run_id, "accepted"),
+                event_type=WorkshopEventType.RUN_ACCEPTED,
+                event_version=1,
+                workshop_id=target.workshop_id,
+                aggregate_type="run",
+                aggregate_id=run_id,
+                actor_principal_id=target.requested_by_principal_id,
+                occurred_at=occurred_at,
+                idempotency_key=_event_key(run_id, RunStatus.ACCEPTED),
+                payload=payload,
+                metadata={"source": "workshop_run_lifecycle"},
+            )
+            appended = await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(projection)
+            run = await _load_run(self._store, run_id)
+            if run is None:
+                raise RunLifecycleConflictError("Accepted run was not projected")
+            await connection.commit()
+            return RunLifecycleResult(run=run, event=appended.event, changed=appended.inserted)
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def start(self, run_id: RunId, *, occurred_at: datetime) -> RunLifecycleResult:
+        return await self._transition(run_id, RunStatus.STARTED, occurred_at=occurred_at, terminal_code=None)
+
+    async def complete(self, run_id: RunId, *, occurred_at: datetime) -> RunLifecycleResult:
+        return await self._transition(run_id, RunStatus.COMPLETED, occurred_at=occurred_at, terminal_code=None)
+
+    async def fail(
+        self,
+        run_id: RunId,
+        *,
+        failure_code: str,
+        occurred_at: datetime,
+    ) -> RunLifecycleResult:
+        return await self._transition(
+            run_id,
+            RunStatus.FAILED,
+            occurred_at=occurred_at,
+            terminal_code=_require_terminal_code(failure_code, field_name="failure_code"),
+        )
+
+    async def cancel(
+        self,
+        run_id: RunId,
+        *,
+        cancellation_code: str,
+        occurred_at: datetime,
+    ) -> RunLifecycleResult:
+        return await self._transition(
+            run_id,
+            RunStatus.CANCELLED,
+            occurred_at=occurred_at,
+            terminal_code=_require_terminal_code(cancellation_code, field_name="cancellation_code"),
+        )
+
+    async def _transition(
+        self,
+        run_id: RunId,
+        status: RunStatus,
+        *,
+        occurred_at: datetime,
+        terminal_code: str | None,
+    ) -> RunLifecycleResult:
+        if not isinstance(run_id, RunId):
+            raise ValueError("run_id must be a RunId")
+        occurred_at = _require_timestamp(occurred_at)
+        if status not in {RunStatus.STARTED, RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED}:
+            raise ValueError("Unsupported durable run transition")
+
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            run = await _load_run(self._store, run_id)
+            if run is None:
+                raise RunNotFoundError("Durable Workshop run was not found")
+            actor = (
+                run.requested_by_principal_id
+                if status == RunStatus.CANCELLED
+                else await _agent_principal_id(self._store, run)
+            )
+            payload: dict[str, object]
+            if status == RunStatus.FAILED:
+                assert terminal_code is not None
+                payload = {"failure_code": terminal_code}
+            elif status == RunStatus.CANCELLED:
+                assert terminal_code is not None
+                payload = {"cancellation_code": terminal_code}
+            else:
+                payload = {}
+
+            existing_event = await _existing_event(
+                self._store,
+                run=run,
+                status=status,
+                actor_principal_id=actor,
+                payload=payload,
+            )
+            if existing_event is not None:
+                await connection.commit()
+                return RunLifecycleResult(run=run, event=existing_event, changed=False)
+
+            allowed_from = {
+                RunStatus.STARTED: {RunStatus.ACCEPTED},
+                RunStatus.COMPLETED: {RunStatus.STARTED},
+                RunStatus.FAILED: {RunStatus.STARTED},
+                RunStatus.CANCELLED: {RunStatus.ACCEPTED, RunStatus.STARTED},
+            }[status]
+            if run.status not in allowed_from:
+                raise InvalidRunTransitionError(f"Cannot transition durable run from {run.status} to {status}")
+
+            event = EventEnvelope.create(
+                event_id=EventId.derived(run.run_id, str(status)),
+                event_type=_event_type(status),
+                event_version=1,
+                workshop_id=run.workshop_id,
+                aggregate_type="run",
+                aggregate_id=run.run_id,
+                actor_principal_id=actor,
+                occurred_at=occurred_at,
+                idempotency_key=_event_key(run.run_id, status),
+                payload=payload,
+                metadata={"source": "workshop_run_lifecycle"},
+            )
+            appended = await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(projection)
+            updated = await _load_run(self._store, run.run_id)
+            if updated is None:
+                raise RunLifecycleConflictError("Transitioned run was not projected")
+            await connection.commit()
+            return RunLifecycleResult(run=updated, event=appended.event, changed=appended.inserted)
+        except Exception:
+            await connection.rollback()
+            raise

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 14
+WORKSHOP_SCHEMA_VERSION = 15
 
 
 @dataclass(frozen=True, slots=True)
@@ -529,6 +529,48 @@ _DELIVERY_AUTHORITY_EPOCH_SCHEMA = SchemaMigration(
     ),
 )
 
+_DURABLE_RUN_LIFECYCLE_SCHEMA = SchemaMigration(
+    version=15,
+    name="durable_workshop_run_lifecycle",
+    statements=(
+        """
+        CREATE TABLE runs (
+            id TEXT PRIMARY KEY,
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            requested_by_principal_id TEXT NOT NULL
+                REFERENCES principals(id) ON DELETE RESTRICT,
+            agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE RESTRICT,
+            inbound_message_id TEXT NOT NULL UNIQUE
+                REFERENCES messages(id) ON DELETE RESTRICT,
+            status TEXT NOT NULL CHECK (
+                status IN ('accepted', 'started', 'completed', 'failed', 'cancelled')
+            ),
+            accepted_at TEXT NOT NULL,
+            started_at TEXT,
+            terminal_at TEXT,
+            terminal_code TEXT,
+            last_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            CHECK (
+                (status = 'accepted' AND started_at IS NULL
+                    AND terminal_at IS NULL AND terminal_code IS NULL)
+                OR (status = 'started' AND started_at IS NOT NULL
+                    AND terminal_at IS NULL AND terminal_code IS NULL)
+                OR (status = 'completed' AND started_at IS NOT NULL
+                    AND terminal_at IS NOT NULL AND terminal_code IS NULL)
+                OR (status = 'failed' AND started_at IS NOT NULL
+                    AND terminal_at IS NOT NULL AND terminal_code IS NOT NULL)
+                OR (status = 'cancelled' AND terminal_at IS NOT NULL
+                    AND terminal_code IS NOT NULL)
+            )
+        )
+        """,
+        "CREATE INDEX runs_channel_status_idx ON runs (channel_id, status, accepted_at)",
+        "CREATE INDEX runs_agent_status_idx ON runs (agent_id, status, accepted_at)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -544,6 +586,7 @@ _MIGRATIONS = (
     _TELEGRAM_STREAMING_PREVIEW_SCHEMA,
     _STREAMING_FINALIZATION_SCHEMA,
     _DELIVERY_AUTHORITY_EPOCH_SCHEMA,
+    _DURABLE_RUN_LIFECYCLE_SCHEMA,
 )
 
 

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -267,7 +267,7 @@ class TestArtifactShadowRecording:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 4
+            assert checkpoint.version == 5
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -80,7 +80,7 @@ class TestWorkshopIdentifiers:
 
 
 class TestEventEnvelope:
-    def test_initial_event_vocabulary_is_collaboration_only(self):
+    def test_event_vocabulary_includes_canonical_collaboration_and_run_lifecycle(self):
         assert {event_type.value for event_type in WorkshopEventType} == {
             "workshop.created",
             "workshop.member_added",
@@ -96,6 +96,11 @@ class TestEventEnvelope:
             "delivery.requested",
             "delivery.succeeded",
             "delivery.failed",
+            "run.accepted",
+            "run.started",
+            "run.completed",
+            "run.failed",
+            "run.cancelled",
         }
 
     def test_create_builds_a_versioned_transport_independent_envelope(self):
@@ -168,12 +173,13 @@ class TestWorkshopSchema:
             "delivery_attempts",
             "delivery_fragments",
             "telegram_streaming_previews",
+            "runs",
             "event_log",
             "projection_checkpoints",
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 14
+        assert await workshop_store.schema_version() == 15
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -186,7 +192,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 14
+        assert await second.schema_version() == 15
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -207,7 +213,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -237,6 +243,7 @@ class TestWorkshopSchema:
                     12,
                     13,
                     14,
+                    15,
                 ]
         finally:
             await upgraded.close()
@@ -259,7 +266,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -300,7 +307,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -353,7 +360,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -397,7 +404,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -441,7 +448,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -485,7 +492,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -589,7 +596,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -702,7 +709,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -1,0 +1,363 @@
+"""Contracts for the production-unused durable Workshop run lifecycle."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.domain import (
+    AgentId,
+    ChannelAgentId,
+    EventEnvelope,
+    MessageId,
+    PrincipalId,
+    RunId,
+    WorkshopEventType,
+)
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_lifecycle import (
+    InvalidRunTransitionError,
+    RunLifecycleConflictError,
+    RunNotFoundError,
+    RunStatus,
+    WorkshopRunLifecycle,
+)
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 8, 12, 16, 0, tzinfo=UTC)
+
+
+async def _open_with_inbound(path: Path) -> tuple[WorkshopEventStore, MessageId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="desktop",
+                external_subject="human-1",
+                external_channel_id="human-1",
+            ),
+        ),
+    )
+    inbound = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="desktop",
+            update_id="command-1",
+            message_id="message-1",
+            sender_subject="human-1",
+            channel_subject="human-1",
+            body="Perform one durable unit of work",
+            occurred_at=_NOW,
+        ),
+    )
+    message_id = inbound.event.envelope.aggregate_id
+    assert isinstance(message_id, MessageId)
+    return store, message_id
+
+
+class TestDurableRunAcceptance:
+    async def test_rejects_acceptance_before_inbound_message(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            with pytest.raises(ValueError, match="before its inbound message"):
+                await lifecycle.accept(inbound_id, occurred_at=_NOW - timedelta(seconds=1))
+
+            async with store.connection.execute("SELECT COUNT(*) FROM runs") as cursor:
+                assert (await cursor.fetchone())[0] == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM event_log WHERE event_type = 'run.accepted'"
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 0
+        finally:
+            await store.close()
+
+    async def test_accepts_canonical_message_without_telegram_identity(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+
+            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+
+            assert accepted.changed is True
+            assert isinstance(accepted.run.run_id, RunId)
+            assert accepted.run.inbound_message_id == inbound_id
+            assert accepted.run.status == RunStatus.ACCEPTED
+            assert accepted.run.started_at is None
+            assert accepted.run.terminal_at is None
+            assert accepted.event.envelope.event_type == WorkshopEventType.RUN_ACCEPTED
+            assert accepted.event.envelope.actor_principal_id == accepted.run.requested_by_principal_id
+            assert accepted.event.envelope.payload == {
+                "agent_id": accepted.run.agent_id,
+                "channel_id": accepted.run.channel_id,
+                "inbound_message_id": inbound_id,
+                "requested_by_principal_id": accepted.run.requested_by_principal_id,
+            }
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM external_identities WHERE provider = 'telegram'"
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 0
+        finally:
+            await store.close()
+
+    async def test_accept_retry_returns_original_event_and_current_state(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            first = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+            await lifecycle.start(first.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
+
+            retry = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(hours=1))
+
+            assert retry.changed is False
+            assert retry.event.position == first.event.position
+            assert retry.run.status == RunStatus.STARTED
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM event_log WHERE event_type = 'run.accepted'"
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 1
+        finally:
+            await store.close()
+
+    async def test_accept_retry_uses_durable_fact_after_attachment_policy_changes(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            first = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+            second_principal = PrincipalId.new()
+            second_agent = AgentId.new()
+            await store.connection.execute(
+                "INSERT INTO principals (id, kind, display_name, created_at) VALUES (?, 'agent', 'Second agent', ?)",
+                (second_principal, _NOW.isoformat()),
+            )
+            await store.connection.execute(
+                "INSERT INTO agents (id, workshop_id, principal_id, name, created_at) "
+                "VALUES (?, ?, ?, 'Second agent', ?)",
+                (second_agent, first.run.workshop_id, second_principal, _NOW.isoformat()),
+            )
+            await store.connection.execute(
+                "INSERT INTO channel_agents (id, channel_id, agent_id, created_at) VALUES (?, ?, ?, ?)",
+                (ChannelAgentId.new(), first.run.channel_id, second_agent, _NOW.isoformat()),
+            )
+            await store.connection.commit()
+
+            retry = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(hours=1))
+
+            assert retry.changed is False
+            assert retry.run.agent_id == first.run.agent_id
+            assert retry.event.position == first.event.position
+        finally:
+            await store.close()
+
+
+class TestDurableRunTransitions:
+    async def test_rejects_transition_before_prior_lifecycle_fact(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=2))
+
+            with pytest.raises(ValueError, match="start only once"):
+                await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=1))
+
+            assert (await lifecycle.state(accepted.run.run_id)).status == RunStatus.ACCEPTED
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM event_log WHERE event_type = 'run.started'"
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 0
+        finally:
+            await store.close()
+
+    async def test_completes_only_after_start_and_retries_prior_transition(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+            started = await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
+            completed = await lifecycle.complete(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=3))
+            start_retry = await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(hours=1))
+
+            assert started.run.status == RunStatus.STARTED
+            assert completed.run.status == RunStatus.COMPLETED
+            assert completed.run.started_at == _NOW + timedelta(seconds=2)
+            assert completed.run.terminal_at == _NOW + timedelta(seconds=3)
+            assert completed.run.terminal_code is None
+            assert start_retry.changed is False
+            assert start_retry.event.position == started.event.position
+            assert start_retry.run.status == RunStatus.COMPLETED
+        finally:
+            await store.close()
+
+    async def test_failure_records_only_stable_code(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+            await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
+
+            failed = await lifecycle.fail(
+                accepted.run.run_id,
+                failure_code="authentication_required",
+                occurred_at=_NOW + timedelta(seconds=3),
+            )
+
+            assert failed.run.status == RunStatus.FAILED
+            assert failed.run.terminal_code == "authentication_required"
+            assert failed.event.envelope.payload == {"failure_code": "authentication_required"}
+            assert "provider" not in failed.event.envelope.payload_json
+            assert "error" not in failed.event.envelope.payload_json
+        finally:
+            await store.close()
+
+    @pytest.mark.parametrize("start_first", [False, True])
+    async def test_requesting_human_can_cancel_nonterminal_run(self, tmp_path: Path, start_first: bool):
+        store, inbound_id = await _open_with_inbound(tmp_path / f"kai-{start_first}.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+            if start_first:
+                await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
+
+            cancelled = await lifecycle.cancel(
+                accepted.run.run_id,
+                cancellation_code="requested_by_human",
+                occurred_at=_NOW + timedelta(seconds=3),
+            )
+
+            assert cancelled.run.status == RunStatus.CANCELLED
+            assert cancelled.run.terminal_code == "requested_by_human"
+            assert cancelled.event.envelope.actor_principal_id == accepted.run.requested_by_principal_id
+        finally:
+            await store.close()
+
+    async def test_invalid_and_conflicting_terminal_transitions_fail_closed(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+            with pytest.raises(InvalidRunTransitionError, match="accepted to completed"):
+                await lifecycle.complete(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
+
+            await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=3))
+            await lifecycle.fail(
+                accepted.run.run_id,
+                failure_code="backend_unavailable",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+            with pytest.raises(RunLifecycleConflictError, match="conflicting facts"):
+                await lifecycle.fail(
+                    accepted.run.run_id,
+                    failure_code="authentication_required",
+                    occurred_at=_NOW + timedelta(seconds=5),
+                )
+            with pytest.raises(InvalidRunTransitionError, match="failed to cancelled"):
+                await lifecycle.cancel(
+                    accepted.run.run_id,
+                    cancellation_code="requested_by_human",
+                    occurred_at=_NOW + timedelta(seconds=6),
+                )
+        finally:
+            await store.close()
+
+    async def test_rejects_unknown_run_and_unbounded_terminal_code(self, tmp_path: Path):
+        store, _ = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            with pytest.raises(RunNotFoundError):
+                await lifecycle.start(RunId.new(), occurred_at=_NOW)
+            with pytest.raises(ValueError, match="lowercase identifier"):
+                await lifecycle.fail(RunId.new(), failure_code="Raw provider error!", occurred_at=_NOW)
+        finally:
+            await store.close()
+
+
+class TestDurableRunReplay:
+    async def test_canonical_rebuild_restores_lifecycle_exactly(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+            await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
+            before = (
+                await lifecycle.fail(
+                    accepted.run.run_id,
+                    failure_code="backend_unavailable",
+                    occurred_at=_NOW + timedelta(seconds=3),
+                )
+            ).run
+            await store.connection.execute("DELETE FROM runs")
+            await store.connection.commit()
+
+            checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
+            after = await lifecycle.state(accepted.run.run_id)
+
+            assert checkpoint.version == 5
+            assert after == before
+        finally:
+            await store.close()
+
+    async def test_projection_rejects_completion_without_start(self, tmp_path: Path):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            lifecycle = WorkshopRunLifecycle(store)
+            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+            async with store.connection.execute(
+                "SELECT principal_id FROM agents WHERE id = ?",
+                (accepted.run.agent_id,),
+            ) as cursor:
+                agent_principal_id = PrincipalId(str((await cursor.fetchone())[0]))
+            await store.append(
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.RUN_COMPLETED,
+                    event_version=1,
+                    workshop_id=accepted.run.workshop_id,
+                    aggregate_type="run",
+                    aggregate_id=accepted.run.run_id,
+                    actor_principal_id=agent_principal_id,
+                    occurred_at=_NOW + timedelta(seconds=2),
+                    payload={},
+                )
+            )
+
+            with pytest.raises(ValueError, match="complete only from started"):
+                await store.project_pending(CanonicalConversationProjection())
+
+            assert (await lifecycle.state(accepted.run.run_id)).status == RunStatus.ACCEPTED
+        finally:
+            await store.close()
+
+
+class TestDurableRunMigration:
+    async def test_version_fourteen_database_adds_empty_run_projection(self, tmp_path: Path, monkeypatch):
+        from kai.workshop import schema
+
+        path = tmp_path / "kai.db"
+        with monkeypatch.context() as migration_context:
+            migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 14)
+            migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:14])
+            version_fourteen = await WorkshopEventStore.open(path)
+            await version_fourteen.connection.execute(
+                "INSERT INTO workshops (id, name, created_at) "
+                "VALUES ('wsp_00000000000000000000000000000001', 'Existing', ?)",
+                (_NOW.isoformat(),),
+            )
+            await version_fourteen.connection.commit()
+            await version_fourteen.close()
+
+        upgraded = await WorkshopEventStore.open(path)
+        try:
+            assert await upgraded.schema_version() == 15
+            assert "runs" in await upgraded.schema_tables()
+            async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:
+                assert (await cursor.fetchone())[0] == "Existing"
+            async with upgraded.connection.execute("SELECT COUNT(*) FROM runs") as cursor:
+                assert (await cursor.fetchone())[0] == 0
+        finally:
+            await upgraded.close()

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -466,7 +466,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -361,7 +361,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 14
+            assert await upgraded.schema_version() == 15
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"


### PR DESCRIPTION
## Summary

- add a canonical `RunId` and durable `run.accepted`, `run.started`, `run.completed`, `run.failed`, and `run.cancelled` facts
- add schema v15 with a replayable `runs` projection and a deliberately small lifecycle service
- split canonical conversation-target resolution from the existing Telegram compatibility lookup
- document the production-unused boundary and the required run-authority cutover review

## Why

Workshop now invokes private-text execution through a canonical conversation service, but live process state is still ephemeral and keyed through the compatibility runtime. Before changing production behavior, Workshop needs a durable, transport-neutral vocabulary for what can be stated truthfully about a run.

This PR establishes that vocabulary without activating it in Telegram, the backend pool, or any Workshop client.

## Lifecycle contract

The state machine is intentionally bounded:

```text
accepted -> started -> completed
    |          |  +-> failed
    +----------+---> cancelled
```

- one human-authored inbound canonical message deterministically identifies at most one run
- acceptance resolves the canonical workshop, channel, requesting human, and exactly one attached agent
- the requesting human records acceptance and cancellation
- the accepted agent principal records start, completion, and failure
- timestamps cannot move backward across lifecycle facts
- failures and cancellations store only bounded lowercase classification codes, never raw provider errors, prompts, output, credentials, paths, or transport identifiers
- deterministic IDs and idempotency keys make retries return the original event and current run state
- invalid ordering, conflicting terminal facts, ambiguous attachment, actor mismatch, malformed payloads, and unknown runs fail closed

## Durable projection

Schema version 15 adds `runs`, keyed by `RunId`, with a unique inbound message and event position. Canonical projection version 5 rebuilds the full run state from the event log alongside the conversation facts it depends on.

Upgrading an existing installation creates an empty run projection. It does not synthesize historical runs or alter current execution.

## Production boundary

`WorkshopRunLifecycle` is deliberately unregistered:

- no production module constructs or calls it
- it starts no backend process or worker
- it owns no attempt, lease, session, workspace, credential, or delivery
- Telegram ingress, streaming, delivery authority, commands, media, schedules, integrations, JSONL, memory, and all five backend drivers are unchanged

The existing conversation-run resolver still supplies the protected Telegram pool key for the current live path. The new pure target resolver exists so durable acceptance itself has no Telegram dependency.

## Next bounded decision

Before live private text emits these facts, perform the documented run-authority cutover review. That review must define the atomic boundary among inbound acceptance, durable run acceptance, backend start, canonical assistant output, terminal state, cancellation, restart truth, and delivery. Attempts and worker ownership remain a later slice unless the review demonstrates they are required for truthful activation.

## Validation

- `make check`
- `make typecheck`
- `make module-sizes`
- all Workshop tests: `397 passed`
- full suite: `5428 passed, 1 skipped`
- `git diff --check`
