### PR TITLE
Add fenced Workshop run execution authority

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -80,7 +80,7 @@ The outer process is already a control plane in the practical sense: it authenti
 | Accepted inbound Telegram work | `telegram_update_queue` in [`sessions.py`](src/kai/sessions.py) | Telegram update ID | Strong Telegram-specific durability pattern; not yet a general command inbox. |
 | Transcript | Per-user/date JSONL in [`history.py`](src/kai/history.py) | Chat ID + timestamp | No stable message ID, channel ID, thread ID, edit lineage, delivery state, or transactional relation to SQLite. |
 | Harness session metadata | `sessions` table plus live backend instance | Chat ID | The stored session ID is used for statistics and clearing; process/session reconstruction still belongs to the live backend. |
-| Durable run lifecycle | Workshop event log and replayed `runs` projection | Run ID | Production-unused accepted/started/completed/failed/cancelled facts exist; the cutover review holds live activation until attempts, cancellation intent, result atomicity, and replay suppression exist. |
+| Durable run lifecycle | Workshop event log plus replayed `runs` and `run_attempts` projections | Run ID + attempt ID | Production-unused acceptance and fenced execution authority exist; the cutover review still holds live activation until atomic acceptance, terminal-result finalization, user-visible failure/cancellation outcomes, and replay suppression are integrated. |
 | Active harness process | `SubprocessPool` in [`pool.py`](src/kai/pool.py) | Chat ID | One implicit agent process per conversation key; durable agent and run identities now exist but are not connected to process, attempt, lease, or worker ownership. |
 | User settings | Generic `settings` rows in [`sessions.py`](src/kai/sessions.py) | Namespaced strings containing chat ID | Flexible but not typed, versioned, or attached to transport-independent principals/channels. |
 | Scheduled jobs | `jobs` table and APScheduler registration | Integer job ID + chat ID | Job definitions survive restart, but executions are not durable runs with attempts and event history. |
@@ -1042,9 +1042,9 @@ The boundary is intentionally narrow:
   channels retain their current execution paths;
 - process locks, settings, JSONL history, memory, and the live harness pool
   remain keyed by their existing compatibility identity;
-- the production conversation service does not yet create the durable run
-  lifecycle facts defined in section 26, and attempts and execution leases do
-  not yet exist;
+- the production conversation service does not yet create the durable run or
+  attempt facts defined in sections 26 and 28; the execution authority and
+  leases exist only as production-unused contracts;
 - no Workshop desktop/web endpoint is registered by this change.
 
 Automated contracts require one canonical human channel member, exactly one
@@ -1067,7 +1067,7 @@ human membership, channel, workshop, and exactly one attached agent without
 requiring a Telegram identity or accepting any caller-selected execution
 identity.
 
-The lifecycle state machine is deliberately small:
+The version-1 lifecycle state machine was deliberately small:
 
 ```text
 accepted --> started --> completed
@@ -1075,31 +1075,36 @@ accepted --> started --> completed
     +-----------+-----> cancelled
 ```
 
-The requesting human is the recorded actor for acceptance and cancellation.
-The attached agent principal is the recorded actor for start, completion, and
-failure. Terminal failures and cancellations persist only bounded lowercase
-classification codes; provider messages, prompts, output text, credentials,
-transport IDs, executable paths, and harness-specific payloads are excluded.
-Lifecycle timestamps cannot precede their prior canonical fact.
+The requesting human is the recorded actor for acceptance. Version-1 events
+remain replayable, but their direct transition helper was removed when schema
+version 16 introduced the execution authority in section 28. New cancellation
+is a human-authored request followed by an execution-authority acknowledgement;
+new start and terminal facts require a fenced attempt. Terminal failures and
+cancellations persist only bounded lowercase classification codes; provider
+messages, prompts, output text, credentials, transport IDs, executable paths,
+and harness-specific payloads are excluded. Lifecycle timestamps cannot
+precede their prior canonical fact.
 
-Deterministic event IDs and idempotency keys make acceptance and every
-transition safely repeatable. Retrying an earlier transition after a later
-state returns its original event and current run state. Conflicting terminal
-facts, invalid ordering, unknown runs, ambiguous canonical agent attachment,
-actor mismatch, malformed payloads, and time reversal fail closed. The
-canonical projection rebuilds complete run state from position zero alongside
-the conversation records on which it depends.
+Deterministic event IDs and idempotency keys make acceptance repeatable.
+Execution transition idempotency and arbitration now belong exclusively to the
+fenced authority described in section 28. Conflicting terminal facts, invalid
+ordering, unknown runs, ambiguous canonical agent attachment, actor mismatch,
+malformed payloads, and time reversal fail closed. The canonical projection
+rebuilds complete run state from position zero alongside the conversation
+records on which it depends.
 
 This foundation is production-unused:
 
 - `main.py`, `bot.py`, the conversation-run service, and all client APIs do not
-  construct or call `WorkshopRunLifecycle`;
+  construct or call `WorkshopRunLifecycle` or
+  `WorkshopRunExecutionAuthority`;
 - it starts no process or worker and owns no lease, attempt, backend session,
   workspace, credential, or delivery;
 - it does not alter Telegram ingress, streaming, outbox finalization, JSONL,
   memory, media, commands, schedules, integrations, or any backend driver;
-- upgrading creates an empty `runs` table and advances the canonical projection
-  version; existing conversations replay without synthesizing historical runs.
+- schema version 15 created an empty `runs` table; version 16 adds empty attempt
+  state and nullable authority columns. Existing conversations replay without
+  synthesizing historical runs or attempts.
 
 The explicit run-authority cutover review is complete in section 27. It holds
 live activation and proves that attempt identity is required for truthful
@@ -1215,9 +1220,9 @@ run facts exist. Activation requires these corrections:
 | Stable failure classification | Backend-native errors map conservatively to bounded backend-neutral categories | Pass as a building block |
 | Durable final delivery | Canonical result and exact-epoch streaming-finalization plan recover without duplicate final delivery | Pass, production-used |
 | Atomic inbound acceptance | Inbound message and run acceptance currently use separate service calls | Blocker |
-| Attempt authority and ownership | No attempt ID, owner, lease, or may-have-executed recovery state exists | Blocker |
-| Cancellation intent and acknowledgement | `/stop` uses a volatile event and immediate process kill; no durable request/acknowledgement race exists | Blocker |
-| Terminal result atomicity | Run completion is not part of the canonical result/finalization transaction | Blocker |
+| Attempt authority and ownership | Typed attempts, exclusive active ownership, leases, monotonic fencing, and conservative expiry recovery are replayed and tested | Pass, production-unused |
+| Cancellation intent and acknowledgement | Human request and fenced acknowledgement are separate facts with one terminal arbiter; live `/stop` is not integrated | Pass as a production-unused foundation; integration blocker remains |
+| Terminal result atomicity | Completion must reference a canonical result, but result creation, delivery request, and completion are not yet one transaction | Blocker |
 | Terminal replay suppression | Replayed ingress has no run-state guard before backend invocation | Blocker |
 | Installed qualification | No live run facts should exist until all preceding blockers pass in automated review | Not yet applicable |
 
@@ -1247,3 +1252,63 @@ Do not add a generic background execution worker or wire Telegram in this
 slice. After the foundation passes, conduct a second run-authority review of
 the atomic inbound/acceptance adapter and terminal-result finalization
 integration before authorizing any live lifecycle facts.
+
+## 28. Production-unused fenced run execution authority
+
+**Implementation date:** 2026-08-12
+
+Schema version 16 and canonical projection version 6 implement the bounded
+foundation required by section 27 without registering a worker or altering any
+live conversation path.
+
+Each accepted run may have at most one active `run_attempt`. An attempt records
+a typed attempt ID, monotonically increasing attempt sequence and fence token,
+one opaque execution-owner ID, a bounded renewable lease, and the protected
+backend/provider/model selection resolved from installation policy. It records
+the execution contract identifier but never a command, executable path,
+credential, prompt, output, or native backend error. Callers cannot supply the
+selection, and a resolved backend must exist in the protected registry set.
+
+The authority boundary is conservative:
+
+- a lease grant is pre-dispatch and may expire back to an accepted run;
+- `run.started` version 2 is emitted atomically with `run_attempt.started` at
+  the may-have-executed boundary;
+- an expired pre-dispatch grant may receive a new, higher fence;
+- an expired started attempt becomes `execution_interrupted`, atomically fails
+  its run, and cannot be automatically redispatched;
+- renewals advance a lease version, so an older claim cannot start or settle;
+- completion, failure, and confirmed cancellation require the exact active
+  owner, fence, and lease version and race through one SQLite transaction;
+- successful completion identifies one canonical agent result replying to the
+  run's inbound message;
+- human cancellation intent leaves the run nonterminal until the fenced owner
+  confirms that execution stopped.
+
+Deterministic event identities make exact retries return prior authority facts
+while conflicting retries fail closed. Projection rules independently verify
+actor, run, attempt, selection shape, lease ordering, cancellation intent,
+result-message authorship, and terminal ordering. Rebuild tests restore the
+same run and attempt state from position zero. Migration, stale-owner,
+renewal, pre/post-dispatch expiry, protected selection, canonical result,
+terminal conflict, and cancellation/completion race tests pin the contract.
+
+The earlier lifecycle service now owns acceptance only. Its unfenced direct
+start/complete/fail/cancel methods were removed so future wiring cannot choose
+between competing transition authorities. Version-1 events remain replayable
+for schema compatibility, although no production path emitted them.
+
+This remains production-unused. No production module imports or constructs the
+execution authority; it starts no process, owns no worker, and changes no
+Telegram, backend, memory, media, command, schedule, integration, history, or
+delivery behavior.
+
+### 28.1 Next bounded milestone
+
+Conduct the second run-authority integration review promised by section 27.
+Specify the atomic command boundary for canonical inbound plus acceptance and
+the atomic terminal boundary for canonical result or bounded failure outcome,
+exact-epoch delivery work, and run settlement. The review must also define
+terminal replay suppression and how the existing per-conversation lock maps to
+one active attempt. Do not activate live run facts or add a generic execution
+worker until that review closes every remaining blocker.

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -37,9 +37,18 @@ class WorkshopEventType(StrEnum):
     DELIVERY_FAILED = "delivery.failed"
     RUN_ACCEPTED = "run.accepted"
     RUN_STARTED = "run.started"
+    RUN_CANCELLATION_REQUESTED = "run.cancellation_requested"
     RUN_COMPLETED = "run.completed"
     RUN_FAILED = "run.failed"
     RUN_CANCELLED = "run.cancelled"
+    RUN_ATTEMPT_GRANTED = "run_attempt.granted"
+    RUN_ATTEMPT_STARTED = "run_attempt.started"
+    RUN_ATTEMPT_LEASE_RENEWED = "run_attempt.lease_renewed"
+    RUN_ATTEMPT_EXPIRED = "run_attempt.expired"
+    RUN_ATTEMPT_INTERRUPTED = "run_attempt.interrupted"
+    RUN_ATTEMPT_COMPLETED = "run_attempt.completed"
+    RUN_ATTEMPT_FAILED = "run_attempt.failed"
+    RUN_ATTEMPT_CANCELLED = "run_attempt.cancelled"
 
 
 class OpaqueId(str):
@@ -141,6 +150,14 @@ class RunId(OpaqueId):
     prefix = "run"
 
 
+class RunAttemptId(OpaqueId):
+    prefix = "rat"
+
+
+class RunExecutionOwnerId(OpaqueId):
+    prefix = "reo"
+
+
 class EventId(OpaqueId):
     prefix = "evt"
 
@@ -166,6 +183,8 @@ _ID_TYPES: dict[str, type[OpaqueId]] = {
         DeliveryAttemptId,
         DeliveryAuthorityEpochId,
         RunId,
+        RunAttemptId,
+        RunExecutionOwnerId,
         EventId,
     )
 }

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -9,13 +9,25 @@ from typing import Any
 
 import aiosqlite
 
-from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, RunId, WorkshopEventType, WorkshopId
+from kai.workshop.domain import (
+    AgentId,
+    ChannelId,
+    MessageId,
+    PrincipalId,
+    RunAttemptId,
+    RunExecutionOwnerId,
+    RunId,
+    WorkshopEventType,
+    WorkshopId,
+)
 from kai.workshop.store import StoredEvent
 
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 _IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 _MEDIA_TYPE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9!#$&^_.+-]*/[a-z0-9][a-z0-9!#$&^_.+-]*$")
 _RUN_TERMINAL_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_EXECUTION_IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_MODEL_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 
 
 def _required_text(payload: dict[str, Any], key: str) -> str:
@@ -91,7 +103,8 @@ async def _apply_run_event(connection: aiosqlite.Connection, event: StoredEvent)
 
     async with connection.execute(
         "SELECT r.workshop_id, r.status, r.requested_by_principal_id, a.principal_id, "
-        "r.accepted_at, r.started_at "
+        "r.accepted_at, r.started_at, r.inbound_message_id, "
+        "r.cancellation_requested_at, r.cancellation_code, r.channel_id "
         "FROM runs r JOIN agents a ON a.id = r.agent_id WHERE r.id = ?",
         (envelope.aggregate_id,),
     ) as cursor:
@@ -103,9 +116,43 @@ async def _apply_run_event(connection: aiosqlite.Connection, event: StoredEvent)
     agent_principal = PrincipalId(str(row[3]))
     accepted_at = _parse_projection_timestamp(row[4])
     started_at = None if row[5] is None else _parse_projection_timestamp(row[5])
+    inbound_message_id = MessageId(str(row[6]))
+    cancellation_requested_at = row[7]
+
+    if envelope.event_type == WorkshopEventType.RUN_CANCELLATION_REQUESTED:
+        _require_exact_payload(payload, {"cancellation_code"})
+        cancellation_code = _required_text(payload, "cancellation_code")
+        if not _RUN_TERMINAL_CODE_PATTERN.fullmatch(cancellation_code):
+            raise ValueError("Workshop run cancellation_code must be a lowercase identifier")
+        if status not in {"accepted", "started"} or envelope.actor_principal_id != requested_by:
+            raise ValueError("Workshop cancellation can be requested only for a nonterminal run by its human")
+        lifecycle_floor = started_at if started_at is not None else accepted_at
+        if envelope.occurred_at < lifecycle_floor:
+            raise ValueError("Workshop cancellation request cannot precede current run state")
+        if cancellation_requested_at is not None:
+            raise ValueError("Workshop run already has a cancellation request")
+        await connection.execute(
+            "UPDATE runs SET cancellation_requested_at = ?, cancellation_code = ?, "
+            "last_event_position = ? WHERE id = ?",
+            (occurred_at, cancellation_code, event.position, envelope.aggregate_id),
+        )
+        return
 
     if envelope.event_type == WorkshopEventType.RUN_STARTED:
-        _require_exact_payload(payload, set())
+        if envelope.event_version == 1:
+            _require_exact_payload(payload, set())
+        elif envelope.event_version == 2:
+            _require_exact_payload(payload, {"attempt_id"})
+            attempt_transition_at = await _require_run_attempt(
+                connection,
+                RunAttemptId(_required_text(payload, "attempt_id")),
+                envelope.aggregate_id,
+                {"started"},
+            )
+            if envelope.occurred_at < attempt_transition_at:
+                raise ValueError("Workshop run cannot start before its execution attempt")
+        else:
+            raise ValueError("Unsupported Workshop run.started event version")
         if status != "accepted" or envelope.actor_principal_id != agent_principal or envelope.occurred_at < accepted_at:
             raise ValueError("Workshop run can start only once through its attached agent")
         await connection.execute(
@@ -115,7 +162,30 @@ async def _apply_run_event(connection: aiosqlite.Connection, event: StoredEvent)
         return
 
     if envelope.event_type == WorkshopEventType.RUN_COMPLETED:
-        _require_exact_payload(payload, set())
+        result_message_id: MessageId | None = None
+        if envelope.event_version == 1:
+            _require_exact_payload(payload, set())
+        elif envelope.event_version == 2:
+            _require_exact_payload(payload, {"attempt_id", "result_message_id"})
+            attempt_transition_at = await _require_run_attempt(
+                connection,
+                RunAttemptId(_required_text(payload, "attempt_id")),
+                envelope.aggregate_id,
+                {"completed"},
+            )
+            if envelope.occurred_at < attempt_transition_at:
+                raise ValueError("Workshop run cannot complete before its execution attempt")
+            result_message_id = MessageId(_required_text(payload, "result_message_id"))
+            async with connection.execute(
+                "SELECT COUNT(*) FROM messages WHERE id = ? AND channel_id = ? "
+                "AND author_principal_id = ? AND reply_to_message_id = ?",
+                (result_message_id, ChannelId(str(row[9])), agent_principal, inbound_message_id),
+            ) as cursor:
+                result_row = await cursor.fetchone()
+            if result_row is None or int(result_row[0]) != 1:
+                raise ValueError("Workshop completed run must reference its canonical agent result")
+        else:
+            raise ValueError("Unsupported Workshop run.completed event version")
         if (
             status != "started"
             or envelope.actor_principal_id != agent_principal
@@ -124,13 +194,26 @@ async def _apply_run_event(connection: aiosqlite.Connection, event: StoredEvent)
         ):
             raise ValueError("Workshop run can complete only from started through its attached agent")
         await connection.execute(
-            "UPDATE runs SET status = 'completed', terminal_at = ?, last_event_position = ? WHERE id = ?",
-            (occurred_at, event.position, envelope.aggregate_id),
+            "UPDATE runs SET status = 'completed', terminal_at = ?, result_message_id = ?, "
+            "last_event_position = ? WHERE id = ?",
+            (occurred_at, result_message_id, event.position, envelope.aggregate_id),
         )
         return
 
     if envelope.event_type == WorkshopEventType.RUN_FAILED:
-        _require_exact_payload(payload, {"failure_code"})
+        expected_keys = {"failure_code"} if envelope.event_version == 1 else {"attempt_id", "failure_code"}
+        if envelope.event_version not in {1, 2}:
+            raise ValueError("Unsupported Workshop run.failed event version")
+        _require_exact_payload(payload, expected_keys)
+        if envelope.event_version == 2:
+            attempt_transition_at = await _require_run_attempt(
+                connection,
+                RunAttemptId(_required_text(payload, "attempt_id")),
+                envelope.aggregate_id,
+                {"failed", "interrupted"},
+            )
+            if envelope.occurred_at < attempt_transition_at:
+                raise ValueError("Workshop run cannot fail before its execution attempt")
         failure_code = _required_text(payload, "failure_code")
         if not _RUN_TERMINAL_CODE_PATTERN.fullmatch(failure_code):
             raise ValueError("Workshop run failure_code must be a lowercase identifier")
@@ -149,17 +232,30 @@ async def _apply_run_event(connection: aiosqlite.Connection, event: StoredEvent)
         return
 
     if envelope.event_type == WorkshopEventType.RUN_CANCELLED:
-        _require_exact_payload(payload, {"cancellation_code"})
+        expected_keys = {"cancellation_code"} if envelope.event_version == 1 else {"attempt_id", "cancellation_code"}
+        if envelope.event_version not in {1, 2}:
+            raise ValueError("Unsupported Workshop run.cancelled event version")
+        _require_exact_payload(payload, expected_keys)
         cancellation_code = _required_text(payload, "cancellation_code")
         if not _RUN_TERMINAL_CODE_PATTERN.fullmatch(cancellation_code):
             raise ValueError("Workshop run cancellation_code must be a lowercase identifier")
         lifecycle_floor = started_at if started_at is not None else accepted_at
-        if (
-            status not in {"accepted", "started"}
-            or envelope.actor_principal_id != requested_by
-            or envelope.occurred_at < lifecycle_floor
-        ):
-            raise ValueError("Workshop run can be cancelled only while nonterminal by its requesting human")
+        if envelope.event_version == 1:
+            valid_actor = envelope.actor_principal_id == requested_by
+        else:
+            attempt_transition_at = await _require_run_attempt(
+                connection,
+                RunAttemptId(_required_text(payload, "attempt_id")),
+                envelope.aggregate_id,
+                {"cancelled"},
+            )
+            if envelope.occurred_at < attempt_transition_at:
+                raise ValueError("Workshop run cannot cancel before its execution attempt")
+            valid_actor = envelope.actor_principal_id == agent_principal and cancellation_requested_at is not None
+            if cancellation_code != str(row[8]):
+                raise ValueError("Workshop cancellation acknowledgement must match its request code")
+        if status not in {"accepted", "started"} or not valid_actor or envelope.occurred_at < lifecycle_floor:
+            raise ValueError("Workshop run cancellation acknowledgement is not authorized")
         await connection.execute(
             "UPDATE runs SET status = 'cancelled', terminal_at = ?, terminal_code = ?, "
             "last_event_position = ? WHERE id = ?",
@@ -170,14 +266,242 @@ async def _apply_run_event(connection: aiosqlite.Connection, event: StoredEvent)
     raise ValueError(f"Unsupported Workshop run event: {envelope.event_type}")
 
 
+async def _require_run_attempt(
+    connection: aiosqlite.Connection,
+    attempt_id: RunAttemptId,
+    run_id: RunId,
+    statuses: set[str],
+) -> datetime:
+    async with connection.execute(
+        "SELECT status, started_at, terminal_at FROM run_attempts WHERE id = ? AND run_id = ?",
+        (attempt_id, run_id),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None or str(row[0]) not in statuses:
+        raise ValueError("Workshop run transition does not match its execution attempt")
+    transition_at = row[2] if row[2] is not None else row[1]
+    if transition_at is None:
+        raise ValueError("Workshop run attempt is missing its transition timestamp")
+    return _parse_projection_timestamp(transition_at)
+
+
+def _execution_text(payload: dict[str, Any], key: str, *, pattern: re.Pattern[str] | None = None) -> str:
+    value = _required_text(payload, key)
+    if (
+        len(value) > 128
+        or value != value.strip()
+        or any(character.isspace() and character != " " for character in value)
+    ):
+        raise ValueError(f"Workshop execution {key} is not bounded text")
+    if pattern is not None and not pattern.fullmatch(value):
+        raise ValueError(f"Workshop execution {key} is not a valid identifier")
+    return value
+
+
+async def _apply_run_attempt_event(connection: aiosqlite.Connection, event: StoredEvent) -> None:
+    envelope = event.envelope
+    if not isinstance(envelope.aggregate_id, RunAttemptId) or envelope.aggregate_type != "run_attempt":
+        raise ValueError("Workshop run-attempt events require a typed attempt aggregate")
+    if envelope.event_version != 1:
+        raise ValueError("Unsupported Workshop run-attempt event version")
+    payload = envelope.payload
+    occurred_at = envelope.occurred_at
+    occurred_text = occurred_at.isoformat()
+
+    if envelope.event_type == WorkshopEventType.RUN_ATTEMPT_GRANTED:
+        _require_exact_payload(
+            payload,
+            {
+                "run_id",
+                "attempt_sequence",
+                "owner_id",
+                "fence_token",
+                "backend",
+                "provider",
+                "model",
+                "execution_contract",
+                "lease_version",
+                "lease_expires_at",
+            },
+        )
+        run_id = RunId(_required_text(payload, "run_id"))
+        owner_id = RunExecutionOwnerId(_required_text(payload, "owner_id"))
+        sequence = payload["attempt_sequence"]
+        fence_token = payload["fence_token"]
+        lease_version = payload["lease_version"]
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value <= 0
+            for value in (sequence, fence_token, lease_version)
+        ):
+            raise ValueError("Workshop attempt sequence, fence, and lease version must be positive integers")
+        if sequence != fence_token or lease_version != 1:
+            raise ValueError("Initial Workshop attempt fencing state is invalid")
+        backend = _execution_text(payload, "backend", pattern=_EXECUTION_IDENTIFIER_PATTERN)
+        provider_value = payload["provider"]
+        if provider_value is not None and (
+            not isinstance(provider_value, str) or not _EXECUTION_IDENTIFIER_PATTERN.fullmatch(provider_value)
+        ):
+            raise ValueError("Workshop execution provider is not a valid identifier")
+        provider = str(provider_value) if provider_value is not None else None
+        model = _execution_text(payload, "model", pattern=_MODEL_IDENTIFIER_PATTERN)
+        execution_contract = _execution_text(payload, "execution_contract", pattern=_EXECUTION_IDENTIFIER_PATTERN)
+        lease_expires_at = _parse_projection_timestamp(payload["lease_expires_at"])
+        if lease_expires_at <= occurred_at:
+            raise ValueError("Workshop attempt lease must expire after it is granted")
+        async with connection.execute(
+            "SELECT r.workshop_id, r.status, r.accepted_at, r.cancellation_requested_at, a.principal_id, "
+            "COALESCE(MAX(ra.attempt_sequence), 0) "
+            "FROM runs r JOIN agents a ON a.id = r.agent_id "
+            "LEFT JOIN run_attempts ra ON ra.run_id = r.id WHERE r.id = ? GROUP BY r.id",
+            (run_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if (
+            row is None
+            or WorkshopId(str(row[0])) != envelope.workshop_id
+            or str(row[1]) != "accepted"
+            or row[3] is not None
+            or envelope.actor_principal_id != PrincipalId(str(row[4]))
+            or occurred_at < _parse_projection_timestamp(row[2])
+            or sequence != int(row[5]) + 1
+        ):
+            raise ValueError("Workshop attempt grant is not authorized for this accepted run")
+        await connection.execute(
+            "INSERT INTO run_attempts "
+            "(id, run_id, attempt_sequence, owner_id, fence_token, status, backend, provider, model, "
+            "execution_contract, lease_version, granted_at, lease_expires_at, last_event_position) "
+            "VALUES (?, ?, ?, ?, ?, 'granted', ?, ?, ?, ?, 1, ?, ?, ?)",
+            (
+                envelope.aggregate_id,
+                run_id,
+                sequence,
+                owner_id,
+                fence_token,
+                backend,
+                provider,
+                model,
+                execution_contract,
+                occurred_text,
+                lease_expires_at.isoformat(),
+                event.position,
+            ),
+        )
+        return
+
+    run_id = RunId(_required_text(payload, "run_id"))
+    owner_id = RunExecutionOwnerId(_required_text(payload, "owner_id"))
+    fence_token = payload.get("fence_token")
+    lease_version = payload.get("lease_version")
+    if (
+        isinstance(fence_token, bool)
+        or not isinstance(fence_token, int)
+        or isinstance(lease_version, bool)
+        or not isinstance(lease_version, int)
+    ):
+        raise ValueError("Workshop attempt fence and lease version must be integers")
+    async with connection.execute(
+        "SELECT ra.run_id, ra.status, ra.owner_id, ra.fence_token, ra.lease_version, "
+        "ra.lease_expires_at, ra.granted_at, ra.started_at, r.workshop_id, "
+        "r.cancellation_requested_at, a.principal_id "
+        "FROM run_attempts ra JOIN runs r ON r.id = ra.run_id "
+        "JOIN agents a ON a.id = r.agent_id WHERE ra.id = ?",
+        (envelope.aggregate_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if (
+        row is None
+        or RunId(str(row[0])) != run_id
+        or RunExecutionOwnerId(str(row[2])) != owner_id
+        or int(row[3]) != fence_token
+        or WorkshopId(str(row[8])) != envelope.workshop_id
+        or envelope.actor_principal_id != PrincipalId(str(row[10]))
+    ):
+        raise ValueError("Workshop attempt event does not match its fenced owner")
+    status = str(row[1])
+    current_lease_version = int(row[4])
+    lease_expires_at = _parse_projection_timestamp(row[5])
+    granted_at = _parse_projection_timestamp(row[6])
+    attempt_started_at = None if row[7] is None else _parse_projection_timestamp(row[7])
+
+    if envelope.event_type == WorkshopEventType.RUN_ATTEMPT_STARTED:
+        _require_exact_payload(payload, {"run_id", "owner_id", "fence_token", "lease_version"})
+        if (
+            status != "granted"
+            or lease_version != current_lease_version
+            or occurred_at < granted_at
+            or occurred_at >= lease_expires_at
+            or row[9] is not None
+        ):
+            raise ValueError("Workshop attempt cannot start without a current grant")
+        await connection.execute(
+            "UPDATE run_attempts SET status = 'started', started_at = ?, last_event_position = ? WHERE id = ?",
+            (occurred_text, event.position, envelope.aggregate_id),
+        )
+        return
+
+    if envelope.event_type == WorkshopEventType.RUN_ATTEMPT_LEASE_RENEWED:
+        _require_exact_payload(
+            payload,
+            {"run_id", "owner_id", "fence_token", "lease_version", "lease_expires_at"},
+        )
+        new_expiry = _parse_projection_timestamp(payload["lease_expires_at"])
+        if (
+            status not in {"granted", "started"}
+            or lease_version != current_lease_version + 1
+            or occurred_at < (attempt_started_at or granted_at)
+            or occurred_at >= lease_expires_at
+            or new_expiry <= lease_expires_at
+        ):
+            raise ValueError("Workshop attempt lease renewal is stale or does not extend authority")
+        await connection.execute(
+            "UPDATE run_attempts SET lease_version = ?, lease_expires_at = ?, last_event_position = ? WHERE id = ?",
+            (lease_version, new_expiry.isoformat(), event.position, envelope.aggregate_id),
+        )
+        return
+
+    terminal_specs: dict[str, tuple[set[str], str, str | None, bool]] = {
+        WorkshopEventType.RUN_ATTEMPT_EXPIRED: ({"granted"}, "expired", "lease_expired", True),
+        WorkshopEventType.RUN_ATTEMPT_INTERRUPTED: ({"started"}, "interrupted", "execution_interrupted", True),
+        WorkshopEventType.RUN_ATTEMPT_COMPLETED: ({"started"}, "completed", None, False),
+        WorkshopEventType.RUN_ATTEMPT_FAILED: ({"started"}, "failed", None, False),
+        WorkshopEventType.RUN_ATTEMPT_CANCELLED: ({"granted", "started"}, "cancelled", None, False),
+    }
+    spec = terminal_specs.get(envelope.event_type)
+    if spec is None:
+        raise ValueError(f"Unsupported Workshop run-attempt event: {envelope.event_type}")
+    allowed, terminal_status, fixed_code, requires_expiry = spec
+    expected = {"run_id", "owner_id", "fence_token", "lease_version"}
+    if fixed_code is not None or terminal_status in {"failed", "cancelled"}:
+        expected.add("terminal_code")
+    _require_exact_payload(payload, expected)
+    terminal_code = fixed_code
+    if "terminal_code" in payload:
+        terminal_code = _required_text(payload, "terminal_code")
+    if terminal_code is not None and not _RUN_TERMINAL_CODE_PATTERN.fullmatch(terminal_code):
+        raise ValueError("Workshop attempt terminal_code must be a lowercase identifier")
+    if status not in allowed or lease_version != current_lease_version:
+        raise ValueError("Workshop attempt terminal transition is stale")
+    if occurred_at < (attempt_started_at or granted_at):
+        raise ValueError("Workshop attempt terminal transition cannot precede its current state")
+    if requires_expiry and occurred_at < lease_expires_at:
+        raise ValueError("Workshop attempt cannot expire before its lease")
+    if not requires_expiry and occurred_at >= lease_expires_at:
+        raise ValueError("Workshop attempt owner cannot settle an expired lease")
+    if terminal_status == "cancelled" and row[9] is None:
+        raise ValueError("Workshop attempt cannot confirm cancellation without durable human intent")
+    await connection.execute(
+        "UPDATE run_attempts SET status = ?, terminal_at = ?, terminal_code = ?, last_event_position = ? WHERE id = ?",
+        (terminal_status, occurred_text, terminal_code, event.position, envelope.aggregate_id),
+    )
+
+
 class CanonicalConversationProjection:
     """Rebuild the initial Workshop collaboration records from events."""
 
     name = "canonical_conversations"
-    # Artifact events were not emitted before artifact support existed, so
-    # adding their first handler does not change replay of any prior event.
-    # Keep the version stable to avoid an unnecessary production rebuild.
-    version = 5
+    # Run execution authority adds replayed attempt state and new run columns.
+    # Rebuild once so every installed projection shares the same v2 run rules.
+    version = 6
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -185,6 +509,7 @@ class CanonicalConversationProjection:
         for table in (
             "deliveries",
             "artifacts",
+            "run_attempts",
             "runs",
             "messages",
             "channel_agents",
@@ -207,12 +532,26 @@ class CanonicalConversationProjection:
 
         if envelope.event_type in {
             WorkshopEventType.RUN_ACCEPTED,
+            WorkshopEventType.RUN_CANCELLATION_REQUESTED,
             WorkshopEventType.RUN_STARTED,
             WorkshopEventType.RUN_COMPLETED,
             WorkshopEventType.RUN_FAILED,
             WorkshopEventType.RUN_CANCELLED,
         }:
             await _apply_run_event(connection, event)
+            return
+
+        if envelope.event_type in {
+            WorkshopEventType.RUN_ATTEMPT_GRANTED,
+            WorkshopEventType.RUN_ATTEMPT_STARTED,
+            WorkshopEventType.RUN_ATTEMPT_LEASE_RENEWED,
+            WorkshopEventType.RUN_ATTEMPT_EXPIRED,
+            WorkshopEventType.RUN_ATTEMPT_INTERRUPTED,
+            WorkshopEventType.RUN_ATTEMPT_COMPLETED,
+            WorkshopEventType.RUN_ATTEMPT_FAILED,
+            WorkshopEventType.RUN_ATTEMPT_CANCELLED,
+        }:
+            await _apply_run_attempt_event(connection, event)
             return
 
         if envelope.event_type == WorkshopEventType.WORKSHOP_CREATED:

--- a/src/kai/workshop/run_execution_authority.py
+++ b/src/kai/workshop/run_execution_authority.py
@@ -1,0 +1,817 @@
+"""Production-unused fenced execution authority for durable Workshop runs."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+
+from kai.workshop.domain import (
+    EventEnvelope,
+    EventId,
+    MessageId,
+    PrincipalId,
+    RunAttemptId,
+    RunExecutionOwnerId,
+    RunId,
+    WorkshopEventType,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_lifecycle import DurableRun, RunNotFoundError, RunStatus, _load_run
+from kai.workshop.store import StoredEvent, WorkshopEventStore
+
+_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
+_MODEL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_MAX_LEASE = timedelta(minutes=5)
+_EXECUTION_CONTRACT = "trusted_host_compatibility_v1"
+
+
+class RunAttemptStatus(StrEnum):
+    GRANTED = "granted"
+    STARTED = "started"
+    EXPIRED = "expired"
+    INTERRUPTED = "interrupted"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class RunExecutionAuthorityError(RuntimeError):
+    """Base error for a rejected run-execution authority operation."""
+
+
+class RunExecutionConflictError(RunExecutionAuthorityError):
+    """Current durable run state cannot accept the requested operation."""
+
+
+class StaleRunExecutionAuthorityError(RunExecutionAuthorityError):
+    """An owner tried to act through an expired or superseded fence."""
+
+
+@dataclass(frozen=True, slots=True)
+class RunExecutionSelection:
+    backend: str
+    model: str
+    provider: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_identifier(self.backend, field_name="backend")
+        if not isinstance(self.model, str) or not _MODEL_PATTERN.fullmatch(self.model):
+            raise ValueError("model must be a bounded model identifier")
+        if self.provider is not None:
+            _require_identifier(self.provider, field_name="provider")
+
+
+@dataclass(frozen=True, slots=True)
+class RunAttempt:
+    attempt_id: RunAttemptId
+    run_id: RunId
+    attempt_sequence: int
+    owner_id: RunExecutionOwnerId
+    fence_token: int
+    status: RunAttemptStatus
+    selection: RunExecutionSelection
+    execution_contract: str
+    lease_version: int
+    granted_at: datetime
+    lease_expires_at: datetime
+    started_at: datetime | None
+    terminal_at: datetime | None
+    terminal_code: str | None
+    last_event_position: int
+
+
+@dataclass(frozen=True, slots=True)
+class RunExecutionClaim:
+    attempt_id: RunAttemptId
+    run_id: RunId
+    owner_id: RunExecutionOwnerId
+    fence_token: int
+    lease_version: int
+
+    @classmethod
+    def from_attempt(cls, attempt: RunAttempt) -> RunExecutionClaim:
+        return cls(
+            attempt_id=attempt.attempt_id,
+            run_id=attempt.run_id,
+            owner_id=attempt.owner_id,
+            fence_token=attempt.fence_token,
+            lease_version=attempt.lease_version,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RunExecutionResult:
+    run: DurableRun
+    attempt: RunAttempt
+    events: tuple[StoredEvent, ...]
+    changed: bool
+
+    @property
+    def claim(self) -> RunExecutionClaim:
+        return RunExecutionClaim.from_attempt(self.attempt)
+
+
+@dataclass(frozen=True, slots=True)
+class RunRecoveryResult:
+    expired_before_dispatch: int
+    interrupted_after_dispatch: int
+
+
+def _timestamp(value: datetime, *, field_name: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    return value.astimezone(UTC)
+
+
+def _parse_timestamp(value: object) -> datetime:
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _optional_timestamp(value: object) -> datetime | None:
+    return None if value is None else _parse_timestamp(value)
+
+
+def _require_identifier(value: str, *, field_name: str) -> str:
+    if not isinstance(value, str) or not _IDENTIFIER_PATTERN.fullmatch(value):
+        raise ValueError(f"{field_name} must be a lowercase identifier")
+    return value
+
+
+def _require_code(value: str, *, field_name: str) -> str:
+    if not isinstance(value, str) or not _CODE_PATTERN.fullmatch(value):
+        raise ValueError(f"{field_name} must be a lowercase identifier of at most 64 characters")
+    return value
+
+
+def _attempt_key(attempt_id: RunAttemptId, operation: str, *, version: int | None = None) -> str:
+    suffix = f":{version}" if version is not None else ""
+    return f"workshop-run-attempt:v1:{attempt_id}:{operation}{suffix}"
+
+
+def _run_key(run_id: RunId, operation: str) -> str:
+    return f"workshop-run:v2:{run_id}:{operation}"
+
+
+async def _load_attempt(store: WorkshopEventStore, attempt_id: RunAttemptId) -> RunAttempt | None:
+    async with store.connection.execute(
+        "SELECT id, run_id, attempt_sequence, owner_id, fence_token, status, backend, provider, "
+        "model, execution_contract, lease_version, granted_at, lease_expires_at, started_at, "
+        "terminal_at, terminal_code, last_event_position FROM run_attempts WHERE id = ?",
+        (attempt_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        return None
+    return RunAttempt(
+        attempt_id=RunAttemptId(str(row[0])),
+        run_id=RunId(str(row[1])),
+        attempt_sequence=int(row[2]),
+        owner_id=RunExecutionOwnerId(str(row[3])),
+        fence_token=int(row[4]),
+        status=RunAttemptStatus(str(row[5])),
+        selection=RunExecutionSelection(
+            backend=str(row[6]),
+            provider=str(row[7]) if row[7] is not None else None,
+            model=str(row[8]),
+        ),
+        execution_contract=str(row[9]),
+        lease_version=int(row[10]),
+        granted_at=_parse_timestamp(row[11]),
+        lease_expires_at=_parse_timestamp(row[12]),
+        started_at=_optional_timestamp(row[13]),
+        terminal_at=_optional_timestamp(row[14]),
+        terminal_code=str(row[15]) if row[15] is not None else None,
+        last_event_position=int(row[16]),
+    )
+
+
+async def _agent_principal(store: WorkshopEventStore, run: DurableRun) -> PrincipalId:
+    async with store.connection.execute(
+        "SELECT principal_id FROM agents WHERE id = ? AND workshop_id = ?",
+        (run.agent_id, run.workshop_id),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        raise RunExecutionConflictError("Durable run no longer resolves its attached agent")
+    return PrincipalId(str(row[0]))
+
+
+def _attempt_payload(claim: RunExecutionClaim) -> dict[str, object]:
+    return {
+        "run_id": claim.run_id,
+        "owner_id": claim.owner_id,
+        "fence_token": claim.fence_token,
+        "lease_version": claim.lease_version,
+    }
+
+
+class WorkshopRunExecutionAuthority:
+    """Grant and fence execution without starting any backend process.
+
+    The injected resolver is the protected policy boundary: callers identify a
+    run and an execution owner, but cannot substitute a command, backend, or
+    model. No production object constructs this service yet.
+    """
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        *,
+        selection_resolver: Callable[[DurableRun], RunExecutionSelection],
+        registered_backend_ids: frozenset[str],
+    ) -> None:
+        if not registered_backend_ids:
+            raise ValueError("registered_backend_ids must not be empty")
+        for backend_id in registered_backend_ids:
+            _require_identifier(backend_id, field_name="registered backend ID")
+        self._store = store
+        self._selection_resolver = selection_resolver
+        self._registered_backend_ids = registered_backend_ids
+
+    async def attempt(self, attempt_id: RunAttemptId) -> RunAttempt:
+        if not isinstance(attempt_id, RunAttemptId):
+            raise ValueError("attempt_id must be a RunAttemptId")
+        attempt = await _load_attempt(self._store, attempt_id)
+        if attempt is None:
+            raise RunExecutionConflictError("Durable Workshop run attempt was not found")
+        return attempt
+
+    async def grant(
+        self,
+        run_id: RunId,
+        *,
+        owner_id: RunExecutionOwnerId,
+        occurred_at: datetime,
+        lease_expires_at: datetime,
+    ) -> RunExecutionResult:
+        if not isinstance(run_id, RunId) or not isinstance(owner_id, RunExecutionOwnerId):
+            raise ValueError("run_id and owner_id must be typed Workshop IDs")
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        lease_expires_at = _timestamp(lease_expires_at, field_name="lease_expires_at")
+        if lease_expires_at <= occurred_at or lease_expires_at - occurred_at > _MAX_LEASE:
+            raise ValueError("lease must be positive and no longer than five minutes")
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            run = await _load_run(self._store, run_id)
+            if run is None:
+                raise RunNotFoundError("Durable Workshop run was not found")
+            async with connection.execute(
+                "SELECT id FROM run_attempts WHERE run_id = ? AND status IN ('granted', 'started')",
+                (run_id,),
+            ) as cursor:
+                active_row = await cursor.fetchone()
+            if active_row is not None:
+                active = await self._require_attempt(RunAttemptId(str(active_row[0])))
+                if active.owner_id != owner_id:
+                    raise RunExecutionConflictError("Durable run already has an active execution owner")
+                await connection.commit()
+                return RunExecutionResult(run=run, attempt=active, events=(), changed=False)
+            if run.status != RunStatus.ACCEPTED or run.cancellation_requested_at is not None:
+                raise RunExecutionConflictError("Only an uncancelled accepted run can receive execution authority")
+
+            selection = self._selection_resolver(run)
+            if not isinstance(selection, RunExecutionSelection):
+                raise TypeError("selection_resolver must return RunExecutionSelection")
+            if selection.backend not in self._registered_backend_ids:
+                raise RunExecutionConflictError("Resolved backend is not present in the protected registry")
+            async with connection.execute(
+                "SELECT COALESCE(MAX(attempt_sequence), 0) FROM run_attempts WHERE run_id = ?",
+                (run_id,),
+            ) as cursor:
+                sequence_row = await cursor.fetchone()
+            if sequence_row is None:
+                raise RunExecutionConflictError("Run attempt sequence query returned no row")
+            sequence = int(sequence_row[0]) + 1
+            attempt_id = RunAttemptId.derived(run_id, f"attempt:{sequence}")
+            actor = await _agent_principal(self._store, run)
+            event = EventEnvelope.create(
+                event_id=EventId.derived(attempt_id, "granted"),
+                event_type=WorkshopEventType.RUN_ATTEMPT_GRANTED,
+                event_version=1,
+                workshop_id=run.workshop_id,
+                aggregate_type="run_attempt",
+                aggregate_id=attempt_id,
+                actor_principal_id=actor,
+                occurred_at=occurred_at,
+                idempotency_key=_attempt_key(attempt_id, "granted"),
+                payload={
+                    "run_id": run_id,
+                    "attempt_sequence": sequence,
+                    "owner_id": owner_id,
+                    "fence_token": sequence,
+                    "backend": selection.backend,
+                    "provider": selection.provider,
+                    "model": selection.model,
+                    "execution_contract": _EXECUTION_CONTRACT,
+                    "lease_version": 1,
+                    "lease_expires_at": lease_expires_at.isoformat(),
+                },
+                metadata={"source": "workshop_run_execution_authority"},
+            )
+            appended = await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(projection)
+            attempt = await self._require_attempt(attempt_id)
+            await connection.commit()
+            return RunExecutionResult(run=run, attempt=attempt, events=(appended.event,), changed=True)
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def start(self, claim: RunExecutionClaim, *, occurred_at: datetime) -> RunExecutionResult:
+        return await self._settle(
+            claim,
+            operation="started",
+            attempt_type=WorkshopEventType.RUN_ATTEMPT_STARTED,
+            run_type=WorkshopEventType.RUN_STARTED,
+            occurred_at=occurred_at,
+            terminal_code=None,
+        )
+
+    async def renew(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        occurred_at: datetime,
+        lease_expires_at: datetime,
+    ) -> RunExecutionResult:
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        lease_expires_at = _timestamp(lease_expires_at, field_name="lease_expires_at")
+        if lease_expires_at <= occurred_at or lease_expires_at - occurred_at > _MAX_LEASE:
+            raise ValueError("renewed lease must be positive and no longer than five minutes")
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            run, attempt = await self._current_claim(claim)
+            next_version = claim.lease_version + 1
+            key = _attempt_key(claim.attempt_id, "lease_renewed", version=next_version)
+            prior = await self._store.event_by_idempotency_key(key)
+            if prior is not None:
+                if prior.envelope.payload.get("lease_expires_at") != lease_expires_at.isoformat():
+                    raise RunExecutionConflictError("Lease renewal retry has conflicting expiry")
+                await connection.commit()
+                return RunExecutionResult(run=run, attempt=attempt, events=(prior,), changed=False)
+            if attempt.lease_version != claim.lease_version:
+                raise StaleRunExecutionAuthorityError("Execution claim has a stale lease version")
+            if (
+                attempt.status not in {RunAttemptStatus.GRANTED, RunAttemptStatus.STARTED}
+                or occurred_at >= attempt.lease_expires_at
+            ):
+                raise StaleRunExecutionAuthorityError("Execution claim no longer holds active authority")
+            actor = await _agent_principal(self._store, run)
+            payload = _attempt_payload(claim)
+            payload["lease_version"] = next_version
+            payload["lease_expires_at"] = lease_expires_at.isoformat()
+            event = EventEnvelope.create(
+                event_id=EventId.derived(claim.attempt_id, f"lease-renewed:{next_version}"),
+                event_type=WorkshopEventType.RUN_ATTEMPT_LEASE_RENEWED,
+                event_version=1,
+                workshop_id=run.workshop_id,
+                aggregate_type="run_attempt",
+                aggregate_id=claim.attempt_id,
+                actor_principal_id=actor,
+                occurred_at=occurred_at,
+                idempotency_key=key,
+                payload=payload,
+                metadata={"source": "workshop_run_execution_authority"},
+            )
+            appended = await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(projection)
+            updated = await self._require_attempt(claim.attempt_id)
+            await connection.commit()
+            return RunExecutionResult(run=run, attempt=updated, events=(appended.event,), changed=True)
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def request_cancellation(
+        self,
+        run_id: RunId,
+        *,
+        cancellation_code: str,
+        occurred_at: datetime,
+    ) -> tuple[DurableRun, StoredEvent, bool]:
+        if not isinstance(run_id, RunId):
+            raise ValueError("run_id must be a RunId")
+        cancellation_code = _require_code(cancellation_code, field_name="cancellation_code")
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            run = await _load_run(self._store, run_id)
+            if run is None:
+                raise RunNotFoundError("Durable Workshop run was not found")
+            key = _run_key(run_id, "cancellation_requested")
+            prior = await self._store.event_by_idempotency_key(key)
+            if prior is not None:
+                if prior.envelope.payload != {"cancellation_code": cancellation_code}:
+                    raise RunExecutionConflictError("Cancellation request retry has conflicting facts")
+                await connection.commit()
+                return run, prior, False
+            if run.status not in {RunStatus.ACCEPTED, RunStatus.STARTED}:
+                raise RunExecutionConflictError("Only a nonterminal run can request cancellation")
+            event = EventEnvelope.create(
+                event_id=EventId.derived(run_id, "cancellation-requested"),
+                event_type=WorkshopEventType.RUN_CANCELLATION_REQUESTED,
+                event_version=1,
+                workshop_id=run.workshop_id,
+                aggregate_type="run",
+                aggregate_id=run_id,
+                actor_principal_id=run.requested_by_principal_id,
+                occurred_at=occurred_at,
+                idempotency_key=key,
+                payload={"cancellation_code": cancellation_code},
+                metadata={"source": "workshop_run_execution_authority"},
+            )
+            appended = await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(projection)
+            updated = await self._require_run(run_id)
+            await connection.commit()
+            return updated, appended.event, True
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def complete(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        result_message_id: MessageId,
+        occurred_at: datetime,
+    ) -> RunExecutionResult:
+        if not isinstance(result_message_id, MessageId):
+            raise ValueError("result_message_id must be a MessageId")
+        return await self._settle(
+            claim,
+            operation="completed",
+            attempt_type=WorkshopEventType.RUN_ATTEMPT_COMPLETED,
+            run_type=WorkshopEventType.RUN_COMPLETED,
+            occurred_at=occurred_at,
+            terminal_code=None,
+            result_message_id=result_message_id,
+        )
+
+    async def fail(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        failure_code: str,
+        occurred_at: datetime,
+    ) -> RunExecutionResult:
+        return await self._settle(
+            claim,
+            operation="failed",
+            attempt_type=WorkshopEventType.RUN_ATTEMPT_FAILED,
+            run_type=WorkshopEventType.RUN_FAILED,
+            occurred_at=occurred_at,
+            terminal_code=_require_code(failure_code, field_name="failure_code"),
+        )
+
+    async def confirm_cancellation(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        occurred_at: datetime,
+    ) -> RunExecutionResult:
+        run = await self._require_run(claim.run_id)
+        if run.cancellation_code is None:
+            raise RunExecutionConflictError("Run has no durable cancellation request")
+        return await self._settle(
+            claim,
+            operation="cancelled",
+            attempt_type=WorkshopEventType.RUN_ATTEMPT_CANCELLED,
+            run_type=WorkshopEventType.RUN_CANCELLED,
+            occurred_at=occurred_at,
+            terminal_code=run.cancellation_code,
+        )
+
+    async def recover_expired(self, *, occurred_at: datetime) -> RunRecoveryResult:
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        connection = self._store.connection
+        expired = interrupted = 0
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            async with connection.execute(
+                "SELECT id FROM run_attempts WHERE status IN ('granted', 'started') "
+                "AND lease_expires_at <= ? ORDER BY lease_expires_at, id",
+                (occurred_at.isoformat(),),
+            ) as cursor:
+                attempt_ids = [RunAttemptId(str(row[0])) for row in await cursor.fetchall()]
+            for attempt_id in attempt_ids:
+                attempt = await self._require_attempt(attempt_id)
+                run = await self._require_run(attempt.run_id)
+                claim = RunExecutionClaim.from_attempt(attempt)
+                actor = await _agent_principal(self._store, run)
+                if attempt.status == RunAttemptStatus.GRANTED:
+                    event = self._attempt_terminal_envelope(
+                        run,
+                        claim,
+                        actor=actor,
+                        event_type=WorkshopEventType.RUN_ATTEMPT_EXPIRED,
+                        operation="expired",
+                        terminal_code="lease_expired",
+                        occurred_at=occurred_at,
+                    )
+                    await self._store.append_in_transaction(event)
+                    expired += 1
+                else:
+                    attempt_event = self._attempt_terminal_envelope(
+                        run,
+                        claim,
+                        actor=actor,
+                        event_type=WorkshopEventType.RUN_ATTEMPT_INTERRUPTED,
+                        operation="interrupted",
+                        terminal_code="execution_interrupted",
+                        occurred_at=occurred_at,
+                    )
+                    await self._store.append_in_transaction(attempt_event)
+                    await self._store.append_in_transaction(
+                        self._run_terminal_envelope(
+                            run,
+                            claim,
+                            actor=actor,
+                            event_type=WorkshopEventType.RUN_FAILED,
+                            operation="failed",
+                            terminal_code="execution_interrupted",
+                            occurred_at=occurred_at,
+                        )
+                    )
+                    interrupted += 1
+            await self._store.project_pending_in_transaction(projection)
+            await connection.commit()
+            return RunRecoveryResult(expired_before_dispatch=expired, interrupted_after_dispatch=interrupted)
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def _settle(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        operation: str,
+        attempt_type: WorkshopEventType,
+        run_type: WorkshopEventType,
+        occurred_at: datetime,
+        terminal_code: str | None,
+        result_message_id: MessageId | None = None,
+    ) -> RunExecutionResult:
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            run, attempt = await self._current_claim(claim)
+            attempt_key = _attempt_key(claim.attempt_id, operation)
+            prior_attempt = await self._store.event_by_idempotency_key(attempt_key)
+            run_key = _run_key(claim.run_id, operation)
+            prior_run = await self._store.event_by_idempotency_key(run_key)
+            actor = await _agent_principal(self._store, run)
+            if prior_attempt is not None or prior_run is not None:
+                if prior_attempt is None or prior_run is None:
+                    raise RunExecutionConflictError("Atomic run transition is missing one of its events")
+                expected_attempt_payload = _attempt_payload(claim)
+                if terminal_code is not None:
+                    expected_attempt_payload["terminal_code"] = terminal_code
+                expected_run_payload: dict[str, object] = {"attempt_id": claim.attempt_id}
+                if run_type == WorkshopEventType.RUN_COMPLETED:
+                    expected_run_payload["result_message_id"] = result_message_id
+                elif run_type == WorkshopEventType.RUN_FAILED:
+                    expected_run_payload["failure_code"] = terminal_code
+                elif run_type == WorkshopEventType.RUN_CANCELLED:
+                    expected_run_payload["cancellation_code"] = terminal_code
+                if (
+                    prior_attempt.envelope.event_type != attempt_type
+                    or prior_attempt.envelope.aggregate_id != claim.attempt_id
+                    or prior_attempt.envelope.actor_principal_id != actor
+                    or prior_attempt.envelope.payload != expected_attempt_payload
+                    or prior_run.envelope.event_type != run_type
+                    or prior_run.envelope.aggregate_id != claim.run_id
+                    or prior_run.envelope.actor_principal_id != actor
+                    or prior_run.envelope.payload != expected_run_payload
+                ):
+                    raise RunExecutionConflictError("Run transition retry has conflicting facts")
+                await connection.commit()
+                return RunExecutionResult(
+                    run=run,
+                    attempt=attempt,
+                    events=(prior_attempt, prior_run),
+                    changed=False,
+                )
+            if attempt.lease_version != claim.lease_version:
+                raise StaleRunExecutionAuthorityError("Execution claim has a stale lease version")
+            allowed_statuses = (
+                {RunAttemptStatus.GRANTED}
+                if operation == "started"
+                else {RunAttemptStatus.GRANTED, RunAttemptStatus.STARTED}
+                if operation == "cancelled"
+                else {RunAttemptStatus.STARTED}
+            )
+            if attempt.status not in allowed_statuses or occurred_at >= attempt.lease_expires_at:
+                raise StaleRunExecutionAuthorityError("Execution claim no longer holds active authority")
+            if operation == "started" and run.cancellation_requested_at is not None:
+                raise RunExecutionConflictError("Execution cannot start after cancellation was requested")
+            if operation == "started":
+                attempt_event = self._attempt_transition_envelope(
+                    run,
+                    claim,
+                    actor=actor,
+                    event_type=attempt_type,
+                    operation=operation,
+                    occurred_at=occurred_at,
+                )
+                run_event = self._run_transition_envelope(
+                    run,
+                    claim,
+                    actor=actor,
+                    event_type=run_type,
+                    operation=operation,
+                    occurred_at=occurred_at,
+                )
+            else:
+                attempt_event = self._attempt_terminal_envelope(
+                    run,
+                    claim,
+                    actor=actor,
+                    event_type=attempt_type,
+                    operation=operation,
+                    terminal_code=terminal_code,
+                    occurred_at=occurred_at,
+                )
+                run_event = self._run_terminal_envelope(
+                    run,
+                    claim,
+                    actor=actor,
+                    event_type=run_type,
+                    operation=operation,
+                    terminal_code=terminal_code,
+                    result_message_id=result_message_id,
+                    occurred_at=occurred_at,
+                )
+            first = await self._store.append_in_transaction(attempt_event)
+            second = await self._store.append_in_transaction(run_event)
+            await self._store.project_pending_in_transaction(projection)
+            updated_run = await self._require_run(claim.run_id)
+            updated_attempt = await self._require_attempt(claim.attempt_id)
+            await connection.commit()
+            return RunExecutionResult(
+                run=updated_run,
+                attempt=updated_attempt,
+                events=(first.event, second.event),
+                changed=True,
+            )
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def _current_claim(self, claim: RunExecutionClaim) -> tuple[DurableRun, RunAttempt]:
+        if not isinstance(claim, RunExecutionClaim):
+            raise ValueError("claim must be a RunExecutionClaim")
+        run = await self._require_run(claim.run_id)
+        attempt = await self._require_attempt(claim.attempt_id)
+        if (
+            attempt.run_id != claim.run_id
+            or attempt.owner_id != claim.owner_id
+            or attempt.fence_token != claim.fence_token
+        ):
+            raise StaleRunExecutionAuthorityError("Execution claim does not match its fenced owner")
+        return run, attempt
+
+    async def _require_run(self, run_id: RunId) -> DurableRun:
+        run = await _load_run(self._store, run_id)
+        if run is None:
+            raise RunNotFoundError("Durable Workshop run was not found")
+        return run
+
+    async def _require_attempt(self, attempt_id: RunAttemptId) -> RunAttempt:
+        attempt = await _load_attempt(self._store, attempt_id)
+        if attempt is None:
+            raise RunExecutionConflictError("Durable Workshop run attempt was not found")
+        return attempt
+
+    @staticmethod
+    def _attempt_transition_envelope(
+        run: DurableRun,
+        claim: RunExecutionClaim,
+        *,
+        actor: PrincipalId,
+        event_type: WorkshopEventType,
+        operation: str,
+        occurred_at: datetime,
+    ) -> EventEnvelope:
+        return EventEnvelope.create(
+            event_id=EventId.derived(claim.attempt_id, operation),
+            event_type=event_type,
+            event_version=1,
+            workshop_id=run.workshop_id,
+            aggregate_type="run_attempt",
+            aggregate_id=claim.attempt_id,
+            actor_principal_id=actor,
+            occurred_at=occurred_at,
+            idempotency_key=_attempt_key(claim.attempt_id, operation),
+            payload=_attempt_payload(claim),
+            metadata={"source": "workshop_run_execution_authority"},
+        )
+
+    @staticmethod
+    def _attempt_terminal_envelope(
+        run: DurableRun,
+        claim: RunExecutionClaim,
+        *,
+        actor: PrincipalId,
+        event_type: WorkshopEventType,
+        operation: str,
+        terminal_code: str | None,
+        occurred_at: datetime,
+    ) -> EventEnvelope:
+        payload = _attempt_payload(claim)
+        if terminal_code is not None:
+            payload["terminal_code"] = terminal_code
+        return EventEnvelope.create(
+            event_id=EventId.derived(claim.attempt_id, operation),
+            event_type=event_type,
+            event_version=1,
+            workshop_id=run.workshop_id,
+            aggregate_type="run_attempt",
+            aggregate_id=claim.attempt_id,
+            actor_principal_id=actor,
+            occurred_at=occurred_at,
+            idempotency_key=_attempt_key(claim.attempt_id, operation),
+            payload=payload,
+            metadata={"source": "workshop_run_execution_authority"},
+        )
+
+    @staticmethod
+    def _run_transition_envelope(
+        run: DurableRun,
+        claim: RunExecutionClaim,
+        *,
+        actor: PrincipalId,
+        event_type: WorkshopEventType,
+        operation: str,
+        occurred_at: datetime,
+    ) -> EventEnvelope:
+        return EventEnvelope.create(
+            event_id=EventId.derived(run.run_id, f"v2:{operation}"),
+            event_type=event_type,
+            event_version=2,
+            workshop_id=run.workshop_id,
+            aggregate_type="run",
+            aggregate_id=run.run_id,
+            actor_principal_id=actor,
+            occurred_at=occurred_at,
+            idempotency_key=_run_key(run.run_id, operation),
+            payload={"attempt_id": claim.attempt_id},
+            metadata={"source": "workshop_run_execution_authority"},
+        )
+
+    @staticmethod
+    def _run_terminal_envelope(
+        run: DurableRun,
+        claim: RunExecutionClaim,
+        *,
+        actor: PrincipalId,
+        event_type: WorkshopEventType,
+        operation: str,
+        terminal_code: str | None,
+        occurred_at: datetime,
+        result_message_id: MessageId | None = None,
+    ) -> EventEnvelope:
+        payload: dict[str, object] = {"attempt_id": claim.attempt_id}
+        if event_type == WorkshopEventType.RUN_COMPLETED:
+            if result_message_id is None:
+                raise ValueError("Completed run requires result_message_id")
+            payload["result_message_id"] = result_message_id
+        elif event_type == WorkshopEventType.RUN_FAILED:
+            if terminal_code is None:
+                raise ValueError("Failed run requires failure_code")
+            payload["failure_code"] = terminal_code
+        elif event_type == WorkshopEventType.RUN_CANCELLED:
+            if terminal_code is None:
+                raise ValueError("Cancelled run requires cancellation_code")
+            payload["cancellation_code"] = terminal_code
+        return EventEnvelope.create(
+            event_id=EventId.derived(run.run_id, f"v2:{operation}"),
+            event_type=event_type,
+            event_version=2,
+            workshop_id=run.workshop_id,
+            aggregate_type="run",
+            aggregate_id=run.run_id,
+            actor_principal_id=actor,
+            occurred_at=occurred_at,
+            idempotency_key=_run_key(run.run_id, operation),
+            payload=payload,
+            metadata={"source": "workshop_run_execution_authority"},
+        )

--- a/src/kai/workshop/run_lifecycle.py
+++ b/src/kai/workshop/run_lifecycle.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -22,8 +21,6 @@ from kai.workshop.domain import (
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.store import StoredEvent, WorkshopEventStore
 
-_TERMINAL_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
-
 
 class RunStatus(StrEnum):
     ACCEPTED = "accepted"
@@ -39,10 +36,6 @@ class RunLifecycleError(RuntimeError):
 
 class RunNotFoundError(RunLifecycleError, LookupError):
     """A typed run ID does not identify a durable run."""
-
-
-class InvalidRunTransitionError(RunLifecycleError):
-    """The requested lifecycle transition is not valid from current state."""
 
 
 class RunLifecycleConflictError(RunLifecycleError):
@@ -62,6 +55,9 @@ class DurableRun:
     started_at: datetime | None
     terminal_at: datetime | None
     terminal_code: str | None
+    cancellation_requested_at: datetime | None
+    cancellation_code: str | None
+    result_message_id: MessageId | None
     last_event_position: int
 
 
@@ -78,12 +74,6 @@ def _require_timestamp(value: datetime) -> datetime:
     return value.astimezone(UTC)
 
 
-def _require_terminal_code(value: str, *, field_name: str) -> str:
-    if not isinstance(value, str) or not _TERMINAL_CODE_PATTERN.fullmatch(value):
-        raise ValueError(f"{field_name} must be a lowercase identifier of at most 64 characters")
-    return value
-
-
 def _parse_timestamp(value: object) -> datetime:
     return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
 
@@ -96,6 +86,7 @@ async def _load_run(store: WorkshopEventStore, run_id: RunId) -> DurableRun | No
     async with store.connection.execute(
         "SELECT id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
         "inbound_message_id, status, accepted_at, started_at, terminal_at, terminal_code, "
+        "cancellation_requested_at, cancellation_code, result_message_id, "
         "last_event_position FROM runs WHERE id = ?",
         (run_id,),
     ) as cursor:
@@ -114,7 +105,10 @@ async def _load_run(store: WorkshopEventStore, run_id: RunId) -> DurableRun | No
         started_at=_optional_timestamp(row[8]),
         terminal_at=_optional_timestamp(row[9]),
         terminal_code=str(row[10]) if row[10] is not None else None,
-        last_event_position=int(row[11]),
+        cancellation_requested_at=_optional_timestamp(row[11]),
+        cancellation_code=str(row[12]) if row[12] is not None else None,
+        result_message_id=MessageId(str(row[13])) if row[13] is not None else None,
+        last_event_position=int(row[14]),
     )
 
 
@@ -128,17 +122,6 @@ async def _load_run_by_inbound_message(
     ) as cursor:
         row = await cursor.fetchone()
     return None if row is None else await _load_run(store, RunId(str(row[0])))
-
-
-async def _agent_principal_id(store: WorkshopEventStore, run: DurableRun) -> PrincipalId:
-    async with store.connection.execute(
-        "SELECT principal_id FROM agents WHERE id = ? AND workshop_id = ?",
-        (run.agent_id, run.workshop_id),
-    ) as cursor:
-        row = await cursor.fetchone()
-    if row is None:
-        raise RunLifecycleConflictError("Durable run no longer resolves its attached agent principal")
-    return PrincipalId(str(row[0]))
 
 
 def _event_key(run_id: RunId, status: RunStatus) -> str:
@@ -257,121 +240,6 @@ class WorkshopRunLifecycle:
                 raise RunLifecycleConflictError("Accepted run was not projected")
             await connection.commit()
             return RunLifecycleResult(run=run, event=appended.event, changed=appended.inserted)
-        except Exception:
-            await connection.rollback()
-            raise
-
-    async def start(self, run_id: RunId, *, occurred_at: datetime) -> RunLifecycleResult:
-        return await self._transition(run_id, RunStatus.STARTED, occurred_at=occurred_at, terminal_code=None)
-
-    async def complete(self, run_id: RunId, *, occurred_at: datetime) -> RunLifecycleResult:
-        return await self._transition(run_id, RunStatus.COMPLETED, occurred_at=occurred_at, terminal_code=None)
-
-    async def fail(
-        self,
-        run_id: RunId,
-        *,
-        failure_code: str,
-        occurred_at: datetime,
-    ) -> RunLifecycleResult:
-        return await self._transition(
-            run_id,
-            RunStatus.FAILED,
-            occurred_at=occurred_at,
-            terminal_code=_require_terminal_code(failure_code, field_name="failure_code"),
-        )
-
-    async def cancel(
-        self,
-        run_id: RunId,
-        *,
-        cancellation_code: str,
-        occurred_at: datetime,
-    ) -> RunLifecycleResult:
-        return await self._transition(
-            run_id,
-            RunStatus.CANCELLED,
-            occurred_at=occurred_at,
-            terminal_code=_require_terminal_code(cancellation_code, field_name="cancellation_code"),
-        )
-
-    async def _transition(
-        self,
-        run_id: RunId,
-        status: RunStatus,
-        *,
-        occurred_at: datetime,
-        terminal_code: str | None,
-    ) -> RunLifecycleResult:
-        if not isinstance(run_id, RunId):
-            raise ValueError("run_id must be a RunId")
-        occurred_at = _require_timestamp(occurred_at)
-        if status not in {RunStatus.STARTED, RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED}:
-            raise ValueError("Unsupported durable run transition")
-
-        connection = self._store.connection
-        try:
-            await connection.execute("BEGIN IMMEDIATE")
-            projection = CanonicalConversationProjection()
-            await self._store.project_pending_in_transaction(projection)
-            run = await _load_run(self._store, run_id)
-            if run is None:
-                raise RunNotFoundError("Durable Workshop run was not found")
-            actor = (
-                run.requested_by_principal_id
-                if status == RunStatus.CANCELLED
-                else await _agent_principal_id(self._store, run)
-            )
-            payload: dict[str, object]
-            if status == RunStatus.FAILED:
-                assert terminal_code is not None
-                payload = {"failure_code": terminal_code}
-            elif status == RunStatus.CANCELLED:
-                assert terminal_code is not None
-                payload = {"cancellation_code": terminal_code}
-            else:
-                payload = {}
-
-            existing_event = await _existing_event(
-                self._store,
-                run=run,
-                status=status,
-                actor_principal_id=actor,
-                payload=payload,
-            )
-            if existing_event is not None:
-                await connection.commit()
-                return RunLifecycleResult(run=run, event=existing_event, changed=False)
-
-            allowed_from = {
-                RunStatus.STARTED: {RunStatus.ACCEPTED},
-                RunStatus.COMPLETED: {RunStatus.STARTED},
-                RunStatus.FAILED: {RunStatus.STARTED},
-                RunStatus.CANCELLED: {RunStatus.ACCEPTED, RunStatus.STARTED},
-            }[status]
-            if run.status not in allowed_from:
-                raise InvalidRunTransitionError(f"Cannot transition durable run from {run.status} to {status}")
-
-            event = EventEnvelope.create(
-                event_id=EventId.derived(run.run_id, str(status)),
-                event_type=_event_type(status),
-                event_version=1,
-                workshop_id=run.workshop_id,
-                aggregate_type="run",
-                aggregate_id=run.run_id,
-                actor_principal_id=actor,
-                occurred_at=occurred_at,
-                idempotency_key=_event_key(run.run_id, status),
-                payload=payload,
-                metadata={"source": "workshop_run_lifecycle"},
-            )
-            appended = await self._store.append_in_transaction(event)
-            await self._store.project_pending_in_transaction(projection)
-            updated = await _load_run(self._store, run.run_id)
-            if updated is None:
-                raise RunLifecycleConflictError("Transitioned run was not projected")
-            await connection.commit()
-            return RunLifecycleResult(run=updated, event=appended.event, changed=appended.inserted)
         except Exception:
             await connection.rollback()
             raise

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 15
+WORKSHOP_SCHEMA_VERSION = 16
 
 
 @dataclass(frozen=True, slots=True)
@@ -571,6 +571,64 @@ _DURABLE_RUN_LIFECYCLE_SCHEMA = SchemaMigration(
     ),
 )
 
+_RUN_EXECUTION_AUTHORITY_SCHEMA = SchemaMigration(
+    version=16,
+    name="durable_run_execution_authority",
+    statements=(
+        "ALTER TABLE runs ADD COLUMN cancellation_requested_at TEXT",
+        "ALTER TABLE runs ADD COLUMN cancellation_code TEXT",
+        "ALTER TABLE runs ADD COLUMN result_message_id TEXT REFERENCES messages(id) ON DELETE RESTRICT",
+        """
+        CREATE TABLE run_attempts (
+            id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+            attempt_sequence INTEGER NOT NULL CHECK (attempt_sequence > 0),
+            owner_id TEXT NOT NULL,
+            fence_token INTEGER NOT NULL CHECK (fence_token > 0),
+            status TEXT NOT NULL CHECK (
+                status IN (
+                    'granted', 'started', 'expired', 'interrupted',
+                    'completed', 'failed', 'cancelled'
+                )
+            ),
+            backend TEXT NOT NULL,
+            provider TEXT,
+            model TEXT NOT NULL,
+            execution_contract TEXT NOT NULL,
+            lease_version INTEGER NOT NULL DEFAULT 1 CHECK (lease_version > 0),
+            granted_at TEXT NOT NULL,
+            lease_expires_at TEXT NOT NULL,
+            started_at TEXT,
+            terminal_at TEXT,
+            terminal_code TEXT,
+            last_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            UNIQUE (run_id, attempt_sequence),
+            UNIQUE (run_id, fence_token),
+            CHECK (
+                (status = 'granted' AND started_at IS NULL
+                    AND terminal_at IS NULL AND terminal_code IS NULL)
+                OR (status = 'started' AND started_at IS NOT NULL
+                    AND terminal_at IS NULL AND terminal_code IS NULL)
+                OR (status = 'expired' AND started_at IS NULL
+                    AND terminal_at IS NOT NULL AND terminal_code IS NOT NULL)
+                OR (status IN ('interrupted', 'failed') AND started_at IS NOT NULL
+                    AND terminal_at IS NOT NULL AND terminal_code IS NOT NULL)
+                OR (status = 'cancelled'
+                    AND terminal_at IS NOT NULL AND terminal_code IS NOT NULL)
+                OR (status = 'completed' AND started_at IS NOT NULL
+                    AND terminal_at IS NOT NULL
+                    AND terminal_code IS NULL)
+            )
+        )
+        """,
+        "CREATE UNIQUE INDEX run_attempts_active_run_idx ON run_attempts (run_id) "
+        "WHERE status IN ('granted', 'started')",
+        "CREATE INDEX run_attempts_lease_idx ON run_attempts (status, lease_expires_at)",
+        "CREATE INDEX run_attempts_owner_idx ON run_attempts (owner_id, fence_token, status)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -587,6 +645,7 @@ _MIGRATIONS = (
     _STREAMING_FINALIZATION_SCHEMA,
     _DELIVERY_AUTHORITY_EPOCH_SCHEMA,
     _DURABLE_RUN_LIFECYCLE_SCHEMA,
+    _RUN_EXECUTION_AUTHORITY_SCHEMA,
 )
 
 

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -267,7 +267,7 @@ class TestArtifactShadowRecording:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 5
+            assert checkpoint.version == 6
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -98,9 +98,18 @@ class TestEventEnvelope:
             "delivery.failed",
             "run.accepted",
             "run.started",
+            "run.cancellation_requested",
             "run.completed",
             "run.failed",
             "run.cancelled",
+            "run_attempt.granted",
+            "run_attempt.started",
+            "run_attempt.lease_renewed",
+            "run_attempt.expired",
+            "run_attempt.interrupted",
+            "run_attempt.completed",
+            "run_attempt.failed",
+            "run_attempt.cancelled",
         }
 
     def test_create_builds_a_versioned_transport_independent_envelope(self):
@@ -174,12 +183,13 @@ class TestWorkshopSchema:
             "delivery_fragments",
             "telegram_streaming_previews",
             "runs",
+            "run_attempts",
             "event_log",
             "projection_checkpoints",
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 15
+        assert await workshop_store.schema_version() == 16
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -192,7 +202,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 15
+        assert await second.schema_version() == 16
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -213,7 +223,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -244,6 +254,7 @@ class TestWorkshopSchema:
                     13,
                     14,
                     15,
+                    16,
                 ]
         finally:
             await upgraded.close()
@@ -266,7 +277,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -307,7 +318,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -360,7 +371,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -404,7 +415,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -448,7 +459,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -492,7 +503,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -596,7 +607,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -709,7 +720,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -1,0 +1,393 @@
+"""Contracts for production-unused fenced Workshop run execution authority."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.domain import MessageId, RunExecutionOwnerId
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.outbound import OutboundMessage, record_outbound_message
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_execution_authority import (
+    RunAttemptStatus,
+    RunExecutionAuthorityError,
+    RunExecutionClaim,
+    RunExecutionConflictError,
+    RunExecutionSelection,
+    StaleRunExecutionAuthorityError,
+    WorkshopRunExecutionAuthority,
+)
+from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 8, 12, 18, 0, tzinfo=UTC)
+
+
+async def _open_authority(
+    path: Path,
+) -> tuple[WorkshopEventStore, WorkshopRunExecutionAuthority, MessageId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="desktop",
+                external_subject="human-1",
+                external_channel_id="human-1",
+            ),
+        ),
+    )
+    inbound = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="desktop",
+            update_id="command-1",
+            message_id="message-1",
+            sender_subject="human-1",
+            channel_subject="human-1",
+            body="Perform one durable unit of work",
+            occurred_at=_NOW,
+        ),
+    )
+    inbound_id = MessageId(str(inbound.event.envelope.aggregate_id))
+    authority = WorkshopRunExecutionAuthority(
+        store,
+        selection_resolver=lambda _run: RunExecutionSelection(
+            backend="codex",
+            provider=None,
+            model="gpt-5.6-sol",
+        ),
+        registered_backend_ids=frozenset({"codex", "pi"}),
+    )
+    return store, authority, inbound_id
+
+
+async def _accepted(
+    store: WorkshopEventStore,
+    inbound_id: MessageId,
+    *,
+    offset: int = 1,
+):
+    return await WorkshopRunLifecycle(store).accept(inbound_id, occurred_at=_NOW + timedelta(seconds=offset))
+
+
+async def _grant(
+    authority: WorkshopRunExecutionAuthority,
+    run_id,
+    *,
+    owner_id: RunExecutionOwnerId | None = None,
+    offset: int = 2,
+):
+    return await authority.grant(
+        run_id,
+        owner_id=owner_id or RunExecutionOwnerId.new(),
+        occurred_at=_NOW + timedelta(seconds=offset),
+        lease_expires_at=_NOW + timedelta(seconds=offset + 60),
+    )
+
+
+class TestRunExecutionGrant:
+    @pytest.mark.parametrize("model", ["/usr/local/bin/codex", "model with prose", "../model"])
+    def test_selection_rejects_paths_and_non_identifiers(self, model: str):
+        with pytest.raises(ValueError, match="model identifier"):
+            RunExecutionSelection("codex", model)
+
+    async def test_grant_persists_protected_selection_and_fence(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            granted = await _grant(authority, accepted.run.run_id)
+
+            assert granted.changed is True
+            assert granted.run.status == RunStatus.ACCEPTED
+            assert granted.attempt.status == RunAttemptStatus.GRANTED
+            assert granted.attempt.attempt_sequence == 1
+            assert granted.attempt.fence_token == 1
+            assert granted.attempt.lease_version == 1
+            assert granted.attempt.selection == RunExecutionSelection("codex", "gpt-5.6-sol")
+            assert granted.attempt.execution_contract == "trusted_host_compatibility_v1"
+        finally:
+            await store.close()
+
+    async def test_same_owner_retries_but_second_owner_is_rejected(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            owner = RunExecutionOwnerId.new()
+            first = await _grant(authority, accepted.run.run_id, owner_id=owner)
+            retry = await _grant(authority, accepted.run.run_id, owner_id=owner, offset=3)
+
+            assert retry.changed is False
+            assert retry.attempt == first.attempt
+            with pytest.raises(RunExecutionConflictError, match="active execution owner"):
+                await _grant(authority, accepted.run.run_id, offset=4)
+        finally:
+            await store.close()
+
+    async def test_unregistered_resolved_backend_fails_closed(self, tmp_path: Path):
+        store, _, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            authority = WorkshopRunExecutionAuthority(
+                store,
+                selection_resolver=lambda _run: RunExecutionSelection("goose", "default"),
+                registered_backend_ids=frozenset({"codex"}),
+            )
+            with pytest.raises(RunExecutionConflictError, match="protected registry"):
+                await _grant(authority, accepted.run.run_id)
+        finally:
+            await store.close()
+
+
+class TestRunExecutionFence:
+    async def test_start_is_atomic_and_fenced(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            granted = await _grant(authority, accepted.run.run_id)
+            started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
+
+            assert started.run.status == RunStatus.STARTED
+            assert started.attempt.status == RunAttemptStatus.STARTED
+            assert [event.envelope.event_type for event in started.events] == [
+                "run_attempt.started",
+                "run.started",
+            ]
+            retry = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=30))
+            assert retry.changed is False
+
+            stale = RunExecutionClaim(
+                attempt_id=granted.claim.attempt_id,
+                run_id=granted.claim.run_id,
+                owner_id=RunExecutionOwnerId.new(),
+                fence_token=granted.claim.fence_token,
+                lease_version=granted.claim.lease_version,
+            )
+            with pytest.raises(StaleRunExecutionAuthorityError, match="fenced owner"):
+                await authority.fail(
+                    stale,
+                    failure_code="backend_unavailable",
+                    occurred_at=_NOW + timedelta(seconds=4),
+                )
+        finally:
+            await store.close()
+
+    async def test_renewal_advances_version_and_rejects_old_claim_for_new_work(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            granted = await _grant(authority, accepted.run.run_id)
+            new_expiry = _NOW + timedelta(seconds=100)
+            renewed = await authority.renew(
+                granted.claim,
+                occurred_at=_NOW + timedelta(seconds=3),
+                lease_expires_at=new_expiry,
+            )
+            retry = await authority.renew(
+                granted.claim,
+                occurred_at=_NOW + timedelta(seconds=4),
+                lease_expires_at=new_expiry,
+            )
+
+            assert renewed.attempt.lease_version == 2
+            assert retry.changed is False
+            with pytest.raises(StaleRunExecutionAuthorityError, match="stale lease version"):
+                await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=5))
+            started = await authority.start(renewed.claim, occurred_at=_NOW + timedelta(seconds=5))
+            assert started.run.status == RunStatus.STARTED
+        finally:
+            await store.close()
+
+
+class TestRunExecutionTerminalFacts:
+    async def test_completion_references_canonical_agent_result(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            granted = await _grant(authority, accepted.run.run_id)
+            started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
+            outbound = await record_outbound_message(
+                store,
+                OutboundMessage(
+                    in_reply_to_message_id=inbound_id,
+                    body="Canonical result",
+                    occurred_at=_NOW + timedelta(seconds=4),
+                ),
+            )
+            result_id = MessageId(str(outbound.event.envelope.aggregate_id))
+
+            completed = await authority.complete(
+                started.claim,
+                result_message_id=result_id,
+                occurred_at=_NOW + timedelta(seconds=5),
+            )
+
+            assert completed.run.status == RunStatus.COMPLETED
+            assert completed.run.result_message_id == result_id
+            assert completed.attempt.status == RunAttemptStatus.COMPLETED
+        finally:
+            await store.close()
+
+    async def test_cancellation_intent_is_separate_from_confirmation(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            granted = await _grant(authority, accepted.run.run_id)
+            requested, _, changed = await authority.request_cancellation(
+                accepted.run.run_id,
+                cancellation_code="requested_by_human",
+                occurred_at=_NOW + timedelta(seconds=3),
+            )
+
+            assert changed is True
+            assert requested.status == RunStatus.ACCEPTED
+            assert requested.cancellation_code == "requested_by_human"
+            with pytest.raises(RunExecutionConflictError, match="cancellation was requested"):
+                await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=4))
+
+            cancelled = await authority.confirm_cancellation(
+                granted.claim,
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+            assert cancelled.run.status == RunStatus.CANCELLED
+            assert cancelled.run.terminal_code == "requested_by_human"
+            assert cancelled.attempt.status == RunAttemptStatus.CANCELLED
+        finally:
+            await store.close()
+
+    async def test_one_terminal_transition_wins_cancellation_completion_race(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            granted = await _grant(authority, accepted.run.run_id)
+            started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
+            await authority.request_cancellation(
+                accepted.run.run_id,
+                cancellation_code="requested_by_human",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+            outbound = await record_outbound_message(
+                store,
+                OutboundMessage(inbound_id, "Already finished", _NOW + timedelta(seconds=5)),
+            )
+            completed = await authority.complete(
+                started.claim,
+                result_message_id=MessageId(str(outbound.event.envelope.aggregate_id)),
+                occurred_at=_NOW + timedelta(seconds=6),
+            )
+
+            with pytest.raises(StaleRunExecutionAuthorityError, match="active authority"):
+                await authority.confirm_cancellation(
+                    started.claim,
+                    occurred_at=_NOW + timedelta(seconds=7),
+                )
+            assert completed.run.status == RunStatus.COMPLETED
+            assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.COMPLETED
+        finally:
+            await store.close()
+
+    async def test_terminal_retry_with_different_code_fails_closed(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            granted = await _grant(authority, accepted.run.run_id)
+            started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
+            await authority.fail(
+                started.claim,
+                failure_code="backend_unavailable",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+
+            with pytest.raises(RunExecutionConflictError, match="conflicting facts"):
+                await authority.fail(
+                    started.claim,
+                    failure_code="authentication_required",
+                    occurred_at=_NOW + timedelta(seconds=5),
+                )
+        finally:
+            await store.close()
+
+
+class TestRunExecutionRecovery:
+    async def test_expired_grant_can_retry_but_interrupted_execution_cannot(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "pre.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            first = await _grant(authority, accepted.run.run_id)
+            recovery = await authority.recover_expired(occurred_at=_NOW + timedelta(seconds=63))
+            second = await _grant(authority, accepted.run.run_id, offset=64)
+
+            assert recovery.expired_before_dispatch == 1
+            assert recovery.interrupted_after_dispatch == 0
+            assert (await authority.attempt(first.claim.attempt_id)).status == RunAttemptStatus.EXPIRED
+            assert second.attempt.attempt_sequence == 2
+            assert second.attempt.fence_token == 2
+            with pytest.raises(StaleRunExecutionAuthorityError, match="active authority"):
+                await authority.fail(
+                    first.claim,
+                    failure_code="backend_unavailable",
+                    occurred_at=_NOW + timedelta(seconds=65),
+                )
+        finally:
+            await store.close()
+
+        store, authority, inbound_id = await _open_authority(tmp_path / "post.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            granted = await _grant(authority, accepted.run.run_id)
+            await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
+            recovery = await authority.recover_expired(occurred_at=_NOW + timedelta(seconds=63))
+
+            assert recovery.expired_before_dispatch == 0
+            assert recovery.interrupted_after_dispatch == 1
+            assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.FAILED
+            with pytest.raises(RunExecutionAuthorityError, match="accepted run"):
+                await _grant(authority, accepted.run.run_id, offset=64)
+        finally:
+            await store.close()
+
+    async def test_rebuild_restores_attempt_and_run_authority_state(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_authority(tmp_path / "kai.db")
+        try:
+            accepted = await _accepted(store, inbound_id)
+            granted = await _grant(authority, accepted.run.run_id)
+            started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
+            await store.connection.execute("DELETE FROM run_attempts")
+            await store.connection.execute("DELETE FROM runs")
+            await store.connection.commit()
+
+            checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
+
+            assert checkpoint.version == 6
+            assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
+            assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
+        finally:
+            await store.close()
+
+
+class TestRunExecutionMigration:
+    async def test_version_fifteen_database_adds_execution_authority_projection(self, tmp_path: Path, monkeypatch):
+        from kai.workshop import schema
+
+        path = tmp_path / "kai.db"
+        with monkeypatch.context() as migration_context:
+            migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 15)
+            migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:15])
+            version_fifteen = await WorkshopEventStore.open(path)
+            await version_fifteen.close()
+
+        upgraded = await WorkshopEventStore.open(path)
+        try:
+            assert await upgraded.schema_version() == 16
+            assert "run_attempts" in await upgraded.schema_tables()
+            async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
+                columns = {str(row[1]) for row in await cursor.fetchall()}
+            assert {"cancellation_requested_at", "cancellation_code", "result_message_id"} <= columns
+        finally:
+            await upgraded.close()

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -20,9 +20,6 @@ from kai.workshop.domain import (
 from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.run_lifecycle import (
-    InvalidRunTransitionError,
-    RunLifecycleConflictError,
-    RunNotFoundError,
     RunStatus,
     WorkshopRunLifecycle,
 )
@@ -112,13 +109,12 @@ class TestDurableRunAcceptance:
         try:
             lifecycle = WorkshopRunLifecycle(store)
             first = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
-            await lifecycle.start(first.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
 
             retry = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(hours=1))
 
             assert retry.changed is False
             assert retry.event.position == first.event.position
-            assert retry.run.status == RunStatus.STARTED
+            assert retry.run.status == RunStatus.ACCEPTED
             async with store.connection.execute(
                 "SELECT COUNT(*) FROM event_log WHERE event_type = 'run.accepted'"
             ) as cursor:
@@ -157,148 +153,19 @@ class TestDurableRunAcceptance:
             await store.close()
 
 
-class TestDurableRunTransitions:
-    async def test_rejects_transition_before_prior_lifecycle_fact(self, tmp_path: Path):
-        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
-        try:
-            lifecycle = WorkshopRunLifecycle(store)
-            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=2))
-
-            with pytest.raises(ValueError, match="start only once"):
-                await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=1))
-
-            assert (await lifecycle.state(accepted.run.run_id)).status == RunStatus.ACCEPTED
-            async with store.connection.execute(
-                "SELECT COUNT(*) FROM event_log WHERE event_type = 'run.started'"
-            ) as cursor:
-                assert (await cursor.fetchone())[0] == 0
-        finally:
-            await store.close()
-
-    async def test_completes_only_after_start_and_retries_prior_transition(self, tmp_path: Path):
-        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
-        try:
-            lifecycle = WorkshopRunLifecycle(store)
-            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
-            started = await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
-            completed = await lifecycle.complete(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=3))
-            start_retry = await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(hours=1))
-
-            assert started.run.status == RunStatus.STARTED
-            assert completed.run.status == RunStatus.COMPLETED
-            assert completed.run.started_at == _NOW + timedelta(seconds=2)
-            assert completed.run.terminal_at == _NOW + timedelta(seconds=3)
-            assert completed.run.terminal_code is None
-            assert start_retry.changed is False
-            assert start_retry.event.position == started.event.position
-            assert start_retry.run.status == RunStatus.COMPLETED
-        finally:
-            await store.close()
-
-    async def test_failure_records_only_stable_code(self, tmp_path: Path):
-        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
-        try:
-            lifecycle = WorkshopRunLifecycle(store)
-            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
-            await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
-
-            failed = await lifecycle.fail(
-                accepted.run.run_id,
-                failure_code="authentication_required",
-                occurred_at=_NOW + timedelta(seconds=3),
-            )
-
-            assert failed.run.status == RunStatus.FAILED
-            assert failed.run.terminal_code == "authentication_required"
-            assert failed.event.envelope.payload == {"failure_code": "authentication_required"}
-            assert "provider" not in failed.event.envelope.payload_json
-            assert "error" not in failed.event.envelope.payload_json
-        finally:
-            await store.close()
-
-    @pytest.mark.parametrize("start_first", [False, True])
-    async def test_requesting_human_can_cancel_nonterminal_run(self, tmp_path: Path, start_first: bool):
-        store, inbound_id = await _open_with_inbound(tmp_path / f"kai-{start_first}.db")
-        try:
-            lifecycle = WorkshopRunLifecycle(store)
-            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
-            if start_first:
-                await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
-
-            cancelled = await lifecycle.cancel(
-                accepted.run.run_id,
-                cancellation_code="requested_by_human",
-                occurred_at=_NOW + timedelta(seconds=3),
-            )
-
-            assert cancelled.run.status == RunStatus.CANCELLED
-            assert cancelled.run.terminal_code == "requested_by_human"
-            assert cancelled.event.envelope.actor_principal_id == accepted.run.requested_by_principal_id
-        finally:
-            await store.close()
-
-    async def test_invalid_and_conflicting_terminal_transitions_fail_closed(self, tmp_path: Path):
-        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
-        try:
-            lifecycle = WorkshopRunLifecycle(store)
-            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
-            with pytest.raises(InvalidRunTransitionError, match="accepted to completed"):
-                await lifecycle.complete(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
-
-            await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=3))
-            await lifecycle.fail(
-                accepted.run.run_id,
-                failure_code="backend_unavailable",
-                occurred_at=_NOW + timedelta(seconds=4),
-            )
-            with pytest.raises(RunLifecycleConflictError, match="conflicting facts"):
-                await lifecycle.fail(
-                    accepted.run.run_id,
-                    failure_code="authentication_required",
-                    occurred_at=_NOW + timedelta(seconds=5),
-                )
-            with pytest.raises(InvalidRunTransitionError, match="failed to cancelled"):
-                await lifecycle.cancel(
-                    accepted.run.run_id,
-                    cancellation_code="requested_by_human",
-                    occurred_at=_NOW + timedelta(seconds=6),
-                )
-        finally:
-            await store.close()
-
-    async def test_rejects_unknown_run_and_unbounded_terminal_code(self, tmp_path: Path):
-        store, _ = await _open_with_inbound(tmp_path / "kai.db")
-        try:
-            lifecycle = WorkshopRunLifecycle(store)
-            with pytest.raises(RunNotFoundError):
-                await lifecycle.start(RunId.new(), occurred_at=_NOW)
-            with pytest.raises(ValueError, match="lowercase identifier"):
-                await lifecycle.fail(RunId.new(), failure_code="Raw provider error!", occurred_at=_NOW)
-        finally:
-            await store.close()
-
-
 class TestDurableRunReplay:
     async def test_canonical_rebuild_restores_lifecycle_exactly(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:
             lifecycle = WorkshopRunLifecycle(store)
-            accepted = await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
-            await lifecycle.start(accepted.run.run_id, occurred_at=_NOW + timedelta(seconds=2))
-            before = (
-                await lifecycle.fail(
-                    accepted.run.run_id,
-                    failure_code="backend_unavailable",
-                    occurred_at=_NOW + timedelta(seconds=3),
-                )
-            ).run
+            before = (await lifecycle.accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))).run
             await store.connection.execute("DELETE FROM runs")
             await store.connection.commit()
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
-            after = await lifecycle.state(accepted.run.run_id)
+            after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 5
+            assert checkpoint.version == 6
             assert after == before
         finally:
             await store.close()
@@ -353,8 +220,9 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             assert "runs" in await upgraded.schema_tables()
+            assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:
                 assert (await cursor.fetchone())[0] == "Existing"
             async with upgraded.connection.execute("SELECT COUNT(*) FROM runs") as cursor:

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -466,7 +466,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -361,7 +361,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 15
+            assert await upgraded.schema_version() == 16
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"


### PR DESCRIPTION
## Summary

- add typed, replayable Workshop run attempts with one active execution owner, bounded leases, monotonic attempt sequences, and fencing tokens
- add a production-unused execution authority that resolves backend/provider/model selection through protected policy rather than caller input
- separate human cancellation intent from fenced terminal cancellation acknowledgement
- require completed v2 runs to reference a canonical agent result message
- remove the unfenced direct start/complete/fail/cancel helpers so future wiring has one transition authority
- update the Workshop implementation map with the completed foundation and the remaining activation blockers

## Authority and recovery contract

- a granted attempt is pre-dispatch and may expire back to an accepted run
- `run_attempt.started` and `run.started` commit together at the may-have-executed boundary
- an expired pre-dispatch grant may be retried through a higher fence
- an expired started attempt becomes `execution_interrupted` and atomically fails its run; Kai must not redispatch it automatically
- lease renewal advances a version, invalidating older claims
- completion, failure, and confirmed cancellation require the exact owner, fence, and lease version
- one transaction arbitrates completion/failure/cancellation so only one terminal outcome wins
- cancellation request remains nonterminal until the execution owner confirms shutdown

## Persisted data constraints

The attempt snapshot contains only:

- typed run/attempt/owner identities
- attempt sequence, fence token, lease version, and timestamps
- registered backend, optional provider, model, and execution-contract identifiers
- bounded terminal classification codes

It does not persist executable paths, commands, credentials, prompts, response text, or native backend errors. Model identifiers reject filesystem paths and prose.

## Schema and replay

- advance Workshop schema from 15 to 16
- add nullable cancellation intent and result-message references to `runs`
- add the replayed `run_attempts` projection with database checks and a partial unique index enforcing one active attempt per run
- advance the canonical projection from 5 to 6 so installed state rebuilds under the new v2 run rules
- retain version-1 lifecycle event replay compatibility; no production path emitted those events

## Production behavior

This change is intentionally production-unused:

- no production module imports or constructs `WorkshopRunExecutionAuthority`
- no worker, backend process, Telegram route, client endpoint, schedule, command, media path, memory path, history path, or delivery behavior is changed
- existing canonical conversations replay without synthesizing runs or attempts

Live activation remains blocked until a second review defines and verifies:

- atomic canonical inbound plus run acceptance
- atomic canonical result or bounded failure outcome plus exact-epoch delivery work and run settlement
- terminal replay suppression before backend invocation
- mapping the existing per-conversation lock to one active attempt
- live cancellation integration and user-visible failure/cancellation outcomes

## Verification

- `make check`
- `make typecheck`
- `make module-sizes`
- `.venv/bin/python -m pytest tests/ -q` — 5,437 passed, 1 skipped
- migration coverage from schema 15 to 16
- replay, protected selection, exact-owner fencing, renewal, stale claim, pre/post-dispatch expiry, canonical completion result, idempotency conflict, and cancellation/completion race coverage
