### PR TITLE
feat: add atomic Workshop command acceptance

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1559,3 +1559,59 @@ Then, in separate bounded changes:
 
 Do not register a generic execution worker, emit live run facts, or change the
 installed Telegram path in the command-acceptance slice.
+
+## 30. Production-unused atomic conversation-command acceptance
+
+**Implementation date:** 2026-08-12
+
+The first bounded implementation from section 29 now provides one
+production-unused `WorkshopConversationCommandService`. It accepts a validated
+`InboundMessage` and owns a single `BEGIN IMMEDIATE` transaction spanning both
+the deterministic canonical `message.created` event and its deterministic
+`run.accepted` event. Both projections advance before commit, so no successful
+call can expose a canonical command without its run or an accepted run without
+its command.
+
+The existing inbound recorder and run lifecycle retain their public contracts.
+They now also expose transaction-local primitives that reject use without an
+active caller-owned transaction. The command service is the only coordinator
+of those primitives. If one event existed before the transaction and the other
+would be new, the service rolls back and reports a state conflict instead of
+silently repairing a half-authoritative command.
+
+Exact retries verify the stored message content and acceptance authority, then
+return a typed durable disposition:
+
+- `newly_accepted`: both facts committed by this call;
+- `ready_replay`: both facts already existed and no active attempt or
+  cancellation request blocks later preparation;
+- `active_replay`: a granted or started attempt already owns the run;
+- `cancellation_pending_replay`: durable human cancellation intent exists;
+- `terminal_replay`: the run is completed, failed, or cancelled.
+
+No disposition invokes a backend. A started run without an active attempt,
+multiple active attempts, changed content under the same transport identity,
+ambiguous canonical attachment, or any partial prior state fails closed.
+Concurrent duplicate commands on independent SQLite connections serialize to
+one new acceptance and one ready replay. Rollback, exact retry, conflicting
+content, partial-state rejection, active/cancellation/terminal classification,
+and projection-rebuild tests pin the contract.
+
+This foundation remains production-unused. `main.py`, `bot.py`, and
+`sessions.py` do not import or construct it. It changes no Telegram ingress,
+compatibility queue, backend process, lock, stop event, streaming preview,
+outbox, JSONL history, memory, media, command, schedule, integration, or
+installed behavior. No schema migration or generic worker was added.
+
+### 30.1 Next bounded milestone
+
+Add production-unused **protected asynchronous execution preparation**. It
+must resolve the hidden compatibility runtime and fully effective registered
+backend/provider/model selection as one object after pending persisted settings
+have been applied. The exact prepared runtime must later perform dispatch, so
+the attempt selection cannot differ from what executes. Callers continue to
+supply only canonical run identity and never a transport pool key, backend,
+provider, model, command, executable path, environment, or credential.
+
+Do not grant live attempts, call a backend, change the Telegram handler, or
+register a worker in that slice.

--- a/src/kai/workshop/conversation_commands.py
+++ b/src/kai/workshop/conversation_commands.py
@@ -1,0 +1,107 @@
+"""Production-unused atomic acceptance for canonical Workshop commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from kai.workshop.domain import MessageId
+from kai.workshop.inbound import InboundMessage, record_inbound_message_in_transaction
+from kai.workshop.run_lifecycle import DurableRun, RunLifecycleResult, RunStatus, WorkshopRunLifecycle
+from kai.workshop.store import AppendResult, WorkshopEventStore
+
+
+class ConversationCommandAcceptanceError(RuntimeError):
+    """Base error for an invalid atomic conversation-command acceptance."""
+
+
+class ConversationCommandStateConflictError(ConversationCommandAcceptanceError):
+    """Canonical message and run acceptance do not share one prior state."""
+
+
+class ConversationCommandDisposition(StrEnum):
+    """Durable replay decision returned before any backend preparation."""
+
+    NEWLY_ACCEPTED = "newly_accepted"
+    READY_REPLAY = "ready_replay"
+    ACTIVE_REPLAY = "active_replay"
+    CANCELLATION_PENDING_REPLAY = "cancellation_pending_replay"
+    TERMINAL_REPLAY = "terminal_replay"
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationCommandAcceptance:
+    message: AppendResult
+    lifecycle: RunLifecycleResult
+    disposition: ConversationCommandDisposition
+
+    @property
+    def run(self) -> DurableRun:
+        return self.lifecycle.run
+
+
+class WorkshopConversationCommandService:
+    """Atomically append canonical inbound and run-acceptance facts.
+
+    This service starts no process and is not constructed by production code.
+    Its disposition is the durable input to a later execution coordinator.
+    """
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def accept(self, message: InboundMessage) -> ConversationCommandAcceptance:
+        if not isinstance(message, InboundMessage):
+            raise ValueError("message must be an InboundMessage")
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            inbound = await record_inbound_message_in_transaction(self._store, message)
+            inbound_message_id = inbound.event.envelope.aggregate_id
+            if not isinstance(inbound_message_id, MessageId):
+                raise ConversationCommandStateConflictError("Canonical inbound event did not identify a message")
+            lifecycle = await WorkshopRunLifecycle(self._store).accept_in_transaction(
+                inbound_message_id,
+                occurred_at=message.occurred_at,
+            )
+            if inbound.inserted != lifecycle.changed:
+                raise ConversationCommandStateConflictError(
+                    "Canonical inbound and run acceptance did not share one prior state"
+                )
+            disposition = (
+                ConversationCommandDisposition.NEWLY_ACCEPTED
+                if inbound.inserted
+                else await self._replay_disposition(lifecycle.run)
+            )
+            await connection.commit()
+            return ConversationCommandAcceptance(
+                message=inbound,
+                lifecycle=lifecycle,
+                disposition=disposition,
+            )
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def _replay_disposition(self, run: DurableRun) -> ConversationCommandDisposition:
+        if run.status in {RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED}:
+            return ConversationCommandDisposition.TERMINAL_REPLAY
+        if run.cancellation_requested_at is not None:
+            return ConversationCommandDisposition.CANCELLATION_PENDING_REPLAY
+        async with self._store.connection.execute(
+            "SELECT COUNT(*) FROM run_attempts WHERE run_id = ? AND status IN ('granted', 'started')",
+            (run.run_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise ConversationCommandStateConflictError("Active-attempt query returned no row")
+        active_attempts = int(row[0])
+        if active_attempts > 1:
+            raise ConversationCommandStateConflictError("Durable run has multiple active execution attempts")
+        if active_attempts == 1:
+            return ConversationCommandDisposition.ACTIVE_REPLAY
+        if run.status == RunStatus.STARTED:
+            raise ConversationCommandStateConflictError("Started run has no active execution attempt")
+        if run.status != RunStatus.ACCEPTED:
+            raise ConversationCommandStateConflictError("Nonterminal run has an unsupported durable state")
+        return ConversationCommandDisposition.READY_REPLAY

--- a/src/kai/workshop/inbound.py
+++ b/src/kai/workshop/inbound.py
@@ -100,32 +100,47 @@ async def _resolve_binding(store: WorkshopEventStore, message: InboundMessage) -
     )
 
 
+def _inbound_envelope(binding: _ResolvedInboundBinding, message: InboundMessage) -> EventEnvelope:
+    token = _stable_token(message)
+    return EventEnvelope.create(
+        event_id=EventId.derived(binding.workshop_id, f"inbound-message-event:{token}"),
+        event_type=WorkshopEventType.MESSAGE_CREATED,
+        event_version=1,
+        workshop_id=binding.workshop_id,
+        aggregate_type="message",
+        aggregate_id=MessageId.derived(binding.workshop_id, f"inbound-message:{token}"),
+        actor_principal_id=binding.principal_id,
+        occurred_at=message.occurred_at,
+        idempotency_key=f"workshop-inbound:v1:{message.transport}:{token}",
+        payload={
+            "channel_id": binding.channel_id,
+            "author_principal_id": binding.principal_id,
+            "body": message.body,
+        },
+        metadata={
+            "source": message.transport,
+            "transport_update_id": message.update_id,
+            "transport_message_id": message.message_id,
+        },
+    )
+
+
+async def record_inbound_message_in_transaction(
+    store: WorkshopEventStore,
+    message: InboundMessage,
+) -> AppendResult:
+    """Append and project one inbound message inside a caller-owned transaction."""
+    if not store.connection.in_transaction:
+        raise RuntimeError("record_inbound_message_in_transaction requires an active transaction")
+    binding = await _resolve_binding(store, message)
+    result = await store.append_in_transaction(_inbound_envelope(binding, message))
+    await store.project_pending_in_transaction(CanonicalConversationProjection())
+    return result
+
+
 async def record_inbound_message(store: WorkshopEventStore, message: InboundMessage) -> AppendResult:
     """Append and project one authenticated inbound transport message."""
     binding = await _resolve_binding(store, message)
-    token = _stable_token(message)
-    result = await store.append(
-        EventEnvelope.create(
-            event_id=EventId.derived(binding.workshop_id, f"inbound-message-event:{token}"),
-            event_type=WorkshopEventType.MESSAGE_CREATED,
-            event_version=1,
-            workshop_id=binding.workshop_id,
-            aggregate_type="message",
-            aggregate_id=MessageId.derived(binding.workshop_id, f"inbound-message:{token}"),
-            actor_principal_id=binding.principal_id,
-            occurred_at=message.occurred_at,
-            idempotency_key=f"workshop-inbound:v1:{message.transport}:{token}",
-            payload={
-                "channel_id": binding.channel_id,
-                "author_principal_id": binding.principal_id,
-                "body": message.body,
-            },
-            metadata={
-                "source": message.transport,
-                "transport_update_id": message.update_id,
-                "transport_message_id": message.message_id,
-            },
-        )
-    )
+    result = await store.append(_inbound_envelope(binding, message))
     await store.project_pending(CanonicalConversationProjection())
     return result

--- a/src/kai/workshop/run_lifecycle.py
+++ b/src/kai/workshop/run_lifecycle.py
@@ -190,56 +190,71 @@ class WorkshopRunLifecycle:
         connection = self._store.connection
         try:
             await connection.execute("BEGIN IMMEDIATE")
-            projection = CanonicalConversationProjection()
-            await self._store.project_pending_in_transaction(projection)
-            existing_run = await _load_run_by_inbound_message(self._store, inbound_message_id)
-            if existing_run is not None:
-                existing_payload: dict[str, object] = {
-                    "inbound_message_id": existing_run.inbound_message_id,
-                    "channel_id": existing_run.channel_id,
-                    "requested_by_principal_id": existing_run.requested_by_principal_id,
-                    "agent_id": existing_run.agent_id,
-                }
-                existing_event = await _existing_event(
-                    self._store,
-                    run=existing_run,
-                    status=RunStatus.ACCEPTED,
-                    actor_principal_id=existing_run.requested_by_principal_id,
-                    payload=existing_payload,
-                )
-                if existing_event is None:
-                    raise RunLifecycleConflictError("Durable run is missing its acceptance event")
-                await connection.commit()
-                return RunLifecycleResult(run=existing_run, event=existing_event, changed=False)
-
-            target = await resolve_canonical_conversation_target(self._store, inbound_message_id)
-            run_id = RunId.derived(target.workshop_id, f"conversation:{inbound_message_id}")
-            payload: dict[str, object] = {
-                "inbound_message_id": target.inbound_message_id,
-                "channel_id": target.channel_id,
-                "requested_by_principal_id": target.requested_by_principal_id,
-                "agent_id": target.agent_id,
-            }
-            event = EventEnvelope.create(
-                event_id=EventId.derived(run_id, "accepted"),
-                event_type=WorkshopEventType.RUN_ACCEPTED,
-                event_version=1,
-                workshop_id=target.workshop_id,
-                aggregate_type="run",
-                aggregate_id=run_id,
-                actor_principal_id=target.requested_by_principal_id,
-                occurred_at=occurred_at,
-                idempotency_key=_event_key(run_id, RunStatus.ACCEPTED),
-                payload=payload,
-                metadata={"source": "workshop_run_lifecycle"},
-            )
-            appended = await self._store.append_in_transaction(event)
-            await self._store.project_pending_in_transaction(projection)
-            run = await _load_run(self._store, run_id)
-            if run is None:
-                raise RunLifecycleConflictError("Accepted run was not projected")
+            result = await self.accept_in_transaction(inbound_message_id, occurred_at=occurred_at)
             await connection.commit()
-            return RunLifecycleResult(run=run, event=appended.event, changed=appended.inserted)
+            return result
         except Exception:
             await connection.rollback()
             raise
+
+    async def accept_in_transaction(
+        self,
+        inbound_message_id: MessageId,
+        *,
+        occurred_at: datetime,
+    ) -> RunLifecycleResult:
+        """Accept one run inside a caller-owned transaction."""
+        if not isinstance(inbound_message_id, MessageId):
+            raise ValueError("inbound_message_id must be a MessageId")
+        occurred_at = _require_timestamp(occurred_at)
+        if not self._store.connection.in_transaction:
+            raise RuntimeError("accept_in_transaction requires an active transaction")
+
+        projection = CanonicalConversationProjection()
+        await self._store.project_pending_in_transaction(projection)
+        existing_run = await _load_run_by_inbound_message(self._store, inbound_message_id)
+        if existing_run is not None:
+            existing_payload: dict[str, object] = {
+                "inbound_message_id": existing_run.inbound_message_id,
+                "channel_id": existing_run.channel_id,
+                "requested_by_principal_id": existing_run.requested_by_principal_id,
+                "agent_id": existing_run.agent_id,
+            }
+            existing_event = await _existing_event(
+                self._store,
+                run=existing_run,
+                status=RunStatus.ACCEPTED,
+                actor_principal_id=existing_run.requested_by_principal_id,
+                payload=existing_payload,
+            )
+            if existing_event is None:
+                raise RunLifecycleConflictError("Durable run is missing its acceptance event")
+            return RunLifecycleResult(run=existing_run, event=existing_event, changed=False)
+
+        target = await resolve_canonical_conversation_target(self._store, inbound_message_id)
+        run_id = RunId.derived(target.workshop_id, f"conversation:{inbound_message_id}")
+        payload: dict[str, object] = {
+            "inbound_message_id": target.inbound_message_id,
+            "channel_id": target.channel_id,
+            "requested_by_principal_id": target.requested_by_principal_id,
+            "agent_id": target.agent_id,
+        }
+        event = EventEnvelope.create(
+            event_id=EventId.derived(run_id, "accepted"),
+            event_type=WorkshopEventType.RUN_ACCEPTED,
+            event_version=1,
+            workshop_id=target.workshop_id,
+            aggregate_type="run",
+            aggregate_id=run_id,
+            actor_principal_id=target.requested_by_principal_id,
+            occurred_at=occurred_at,
+            idempotency_key=_event_key(run_id, RunStatus.ACCEPTED),
+            payload=payload,
+            metadata={"source": "workshop_run_lifecycle"},
+        )
+        appended = await self._store.append_in_transaction(event)
+        await self._store.project_pending_in_transaction(projection)
+        run = await _load_run(self._store, run_id)
+        if run is None:
+            raise RunLifecycleConflictError("Accepted run was not projected")
+        return RunLifecycleResult(run=run, event=appended.event, changed=appended.inserted)

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -1,0 +1,290 @@
+"""Contracts for production-unused atomic Workshop command acceptance."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.conversation_commands import (
+    ConversationCommandDisposition,
+    ConversationCommandStateConflictError,
+    WorkshopConversationCommandService,
+)
+from kai.workshop.domain import AgentId, ChannelAgentId, PrincipalId, RunExecutionOwnerId
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_execution_authority import (
+    RunExecutionSelection,
+    WorkshopRunExecutionAuthority,
+)
+from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
+from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+
+_NOW = datetime(2026, 8, 12, 20, 0, tzinfo=UTC)
+
+
+def _message(*, body: str = "Perform one atomic unit of work") -> InboundMessage:
+    return InboundMessage(
+        transport="desktop",
+        update_id="command-1",
+        message_id="message-1",
+        sender_subject="human-1",
+        channel_subject="human-1",
+        body=body,
+        occurred_at=_NOW,
+    )
+
+
+async def _open_store(path: Path) -> WorkshopEventStore:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="desktop",
+                external_subject="human-1",
+                external_channel_id="human-1",
+            ),
+        ),
+    )
+    return store
+
+
+def _authority(store: WorkshopEventStore) -> WorkshopRunExecutionAuthority:
+    return WorkshopRunExecutionAuthority(
+        store,
+        selection_resolver=lambda _run: RunExecutionSelection(
+            backend="codex",
+            provider=None,
+            model="gpt-5.6-sol",
+        ),
+        registered_backend_ids=frozenset({"codex"}),
+    )
+
+
+class TestAtomicConversationCommandAcceptance:
+    async def test_accepts_message_and_run_in_one_transaction(self, tmp_path: Path):
+        store = await _open_store(tmp_path / "kai.db")
+        try:
+            accepted = await WorkshopConversationCommandService(store).accept(_message())
+
+            assert accepted.message.inserted is True
+            assert accepted.lifecycle.changed is True
+            assert accepted.disposition == ConversationCommandDisposition.NEWLY_ACCEPTED
+            assert accepted.run.status == RunStatus.ACCEPTED
+            assert accepted.run.inbound_message_id == accepted.message.event.envelope.aggregate_id
+            assert accepted.message.event.position + 1 == accepted.lifecycle.event.position
+            async with store.connection.execute(
+                "SELECT event_type FROM event_log WHERE position IN (?, ?) ORDER BY position",
+                (accepted.message.event.position, accepted.lifecycle.event.position),
+            ) as cursor:
+                assert [str(row[0]) for row in await cursor.fetchall()] == [
+                    "message.created",
+                    "run.accepted",
+                ]
+        finally:
+            await store.close()
+
+    async def test_exact_retry_returns_ready_without_new_facts(self, tmp_path: Path):
+        store = await _open_store(tmp_path / "kai.db")
+        try:
+            service = WorkshopConversationCommandService(store)
+            first = await service.accept(_message())
+            retry = await service.accept(_message())
+
+            assert retry.message.inserted is False
+            assert retry.lifecycle.changed is False
+            assert retry.disposition == ConversationCommandDisposition.READY_REPLAY
+            assert retry.message.event == first.message.event
+            assert retry.lifecycle.event == first.lifecycle.event
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM event_log WHERE event_type IN ('message.created', 'run.accepted')"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 2
+        finally:
+            await store.close()
+
+    async def test_concurrent_duplicate_commands_serialize_to_one_acceptance(self, tmp_path: Path):
+        path = tmp_path / "kai.db"
+        first_store = await _open_store(path)
+        second_store = await WorkshopEventStore.open(path)
+        try:
+            first, second = await asyncio.gather(
+                WorkshopConversationCommandService(first_store).accept(_message()),
+                WorkshopConversationCommandService(second_store).accept(_message()),
+            )
+
+            assert {first.disposition, second.disposition} == {
+                ConversationCommandDisposition.NEWLY_ACCEPTED,
+                ConversationCommandDisposition.READY_REPLAY,
+            }
+            async with first_store.connection.execute(
+                "SELECT COUNT(*) FROM event_log WHERE event_type IN ('message.created', 'run.accepted')"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 2
+        finally:
+            await second_store.close()
+            await first_store.close()
+
+    async def test_changed_content_under_same_transport_identity_fails_closed(self, tmp_path: Path):
+        store = await _open_store(tmp_path / "kai.db")
+        try:
+            service = WorkshopConversationCommandService(store)
+            first = await service.accept(_message(body="Original command"))
+
+            with pytest.raises(IdempotencyConflictError):
+                await service.accept(_message(body="Changed command"))
+
+            assert (await WorkshopRunLifecycle(store).state(first.run.run_id)).status == RunStatus.ACCEPTED
+            async with store.connection.execute("SELECT body FROM messages") as cursor:
+                assert str((await cursor.fetchone())[0]) == "Original command"
+        finally:
+            await store.close()
+
+    async def test_ambiguous_agent_rolls_back_message_and_acceptance(self, tmp_path: Path):
+        store = await _open_store(tmp_path / "kai.db")
+        try:
+            async with store.connection.execute("SELECT id FROM workshops") as cursor:
+                workshop_id = str((await cursor.fetchone())[0])
+            async with store.connection.execute("SELECT id FROM channels WHERE kind = 'direct'") as cursor:
+                channel_id = str((await cursor.fetchone())[0])
+            principal_id = PrincipalId.new()
+            agent_id = AgentId.new()
+            await store.connection.execute(
+                "INSERT INTO principals (id, kind, display_name, created_at) VALUES (?, 'agent', 'Second agent', ?)",
+                (principal_id, _NOW.isoformat()),
+            )
+            await store.connection.execute(
+                "INSERT INTO agents (id, workshop_id, principal_id, name, created_at) "
+                "VALUES (?, ?, ?, 'Second agent', ?)",
+                (agent_id, workshop_id, principal_id, _NOW.isoformat()),
+            )
+            await store.connection.execute(
+                "INSERT INTO channel_agents (id, channel_id, agent_id, created_at) VALUES (?, ?, ?, ?)",
+                (ChannelAgentId.new(), channel_id, agent_id, _NOW.isoformat()),
+            )
+            await store.connection.commit()
+
+            with pytest.raises(LookupError, match="one human channel member and one attached agent"):
+                await WorkshopConversationCommandService(store).accept(_message())
+
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM event_log WHERE event_type IN ('message.created', 'run.accepted')"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute("SELECT COUNT(*) FROM messages") as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute("SELECT COUNT(*) FROM runs") as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+        finally:
+            await store.close()
+
+    async def test_preexisting_message_without_run_is_rejected_and_not_repaired(self, tmp_path: Path):
+        store = await _open_store(tmp_path / "kai.db")
+        try:
+            await record_inbound_message(store, _message())
+
+            with pytest.raises(ConversationCommandStateConflictError, match="did not share one prior state"):
+                await WorkshopConversationCommandService(store).accept(_message())
+
+            async with store.connection.execute("SELECT COUNT(*) FROM runs") as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM event_log WHERE event_type = 'run.accepted'"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+        finally:
+            await store.close()
+
+
+class TestConversationCommandReplayDisposition:
+    async def test_active_and_cancellation_pending_replays_never_look_ready(self, tmp_path: Path):
+        store = await _open_store(tmp_path / "kai.db")
+        try:
+            service = WorkshopConversationCommandService(store)
+            accepted = await service.accept(_message())
+            authority = _authority(store)
+            grant = await authority.grant(
+                accepted.run.run_id,
+                owner_id=RunExecutionOwnerId.new(),
+                occurred_at=_NOW + timedelta(seconds=1),
+                lease_expires_at=_NOW + timedelta(seconds=61),
+            )
+
+            active = await service.accept(_message())
+            assert active.disposition == ConversationCommandDisposition.ACTIVE_REPLAY
+
+            await authority.request_cancellation(
+                accepted.run.run_id,
+                cancellation_code="requested_by_human",
+                occurred_at=_NOW + timedelta(seconds=2),
+            )
+            cancelling = await service.accept(_message())
+            assert cancelling.disposition == ConversationCommandDisposition.CANCELLATION_PENDING_REPLAY
+            assert cancelling.run.cancellation_requested_at is not None
+            assert grant.attempt.run_id == cancelling.run.run_id
+        finally:
+            await store.close()
+
+    async def test_terminal_replay_suppresses_ready_disposition(self, tmp_path: Path):
+        store = await _open_store(tmp_path / "kai.db")
+        try:
+            service = WorkshopConversationCommandService(store)
+            accepted = await service.accept(_message())
+            authority = _authority(store)
+            grant = await authority.grant(
+                accepted.run.run_id,
+                owner_id=RunExecutionOwnerId.new(),
+                occurred_at=_NOW + timedelta(seconds=1),
+                lease_expires_at=_NOW + timedelta(seconds=61),
+            )
+            started = await authority.start(grant.claim, occurred_at=_NOW + timedelta(seconds=2))
+            await authority.fail(
+                started.claim,
+                failure_code="backend_unavailable",
+                occurred_at=_NOW + timedelta(seconds=3),
+            )
+
+            replay = await service.accept(_message())
+
+            assert replay.disposition == ConversationCommandDisposition.TERMINAL_REPLAY
+            assert replay.run.status == RunStatus.FAILED
+        finally:
+            await store.close()
+
+
+class TestConversationCommandReplay:
+    async def test_projection_rebuild_restores_atomic_command_exactly(self, tmp_path: Path):
+        store = await _open_store(tmp_path / "kai.db")
+        try:
+            service = WorkshopConversationCommandService(store)
+            before = await service.accept(_message())
+            await store.connection.execute("DELETE FROM runs")
+            await store.connection.execute("DELETE FROM messages")
+            await store.connection.commit()
+
+            checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
+            after = await WorkshopRunLifecycle(store).state(before.run.run_id)
+
+            assert checkpoint.version == 6
+            assert after == before.run
+            async with store.connection.execute("SELECT body FROM messages") as cursor:
+                assert str((await cursor.fetchone())[0]) == _message().body
+        finally:
+            await store.close()
+
+    def test_service_remains_unregistered_in_production(self):
+        source_root = Path(__file__).parents[1] / "src" / "kai"
+        service_path = source_root / "workshop" / "conversation_commands.py"
+        for path in source_root.rglob("*.py"):
+            if path == service_path:
+                continue
+            source = path.read_text(encoding="utf-8")
+            assert "conversation_commands" not in source
+            assert "WorkshopConversationCommandService" not in source


### PR DESCRIPTION
## Summary

- add a production-unused Workshop conversation-command service that commits canonical inbound and `run.accepted` facts in one SQLite transaction
- extract transaction-local inbound recording and lifecycle acceptance primitives while preserving their existing public behavior
- return typed replay dispositions for newly accepted, ready, active, cancellation-pending, and terminal commands
- reject half-existing message/run state, conflicting duplicate content, ambiguous authority, and inconsistent active-run state before any future backend preparation
- record the completed milestone and next protected-execution-preparation boundary in the Workshop implementation map

## Safety properties

- one `BEGIN IMMEDIATE` transaction spans message append, message projection, run acceptance, run projection, and replay classification
- exact concurrent duplicates serialize to one new acceptance and one replay
- a pre-existing message without its run is not silently repaired; the attempted acceptance rolls back and fails closed
- transitional JSONL history is not an authority input
- no backend, executable, command, credential, pool key, or client-supplied execution selection enters this service

## Production impact

None. The service is not imported or constructed by any production module. This PR:

- emits no live run or attempt facts
- starts no backend process or worker
- changes no Telegram ingress, locking, streaming, delivery, history, memory, media, command, schedule, or integration behavior
- adds no schema migration

## Tests

- new acceptance and exact retry
- concurrent duplicates through independent SQLite connections
- changed-content conflict
- atomic rollback on ambiguous agent attachment
- half-existing message/run rejection
- active, cancellation-pending, and terminal replay dispositions
- canonical projection rebuild
- production non-registration contract

## Validation

- `5447 passed, 1 skipped`
- `make check`
- `make typecheck`
- `make module-sizes`
- `git diff --check`
