### PR TITLE
feat: add protected Workshop execution preparation

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1615,3 +1615,31 @@ provider, model, command, executable path, environment, or credential.
 
 Do not grant live attempts, call a backend, change the Telegram handler, or
 register a worker in that slice.
+
+## 31. Protected execution preparation
+
+**Implementation date:** 2026-08-12
+
+The production-unused preparation service now resolves an accepted canonical
+run to its hidden compatibility identity, applies pending workspace and user
+settings, and snapshots the effective registered backend, provider, model, and
+workspace from the exact runtime object. A one-shot prepared handle dispatches
+only if that same pool object and its generic runtime fingerprint remain
+current; replacement, pending settings, or selection/workspace/timeout drift
+fails before the backend call. The transport pool key remains private.
+
+The ordinary pool send path uses the same preparation primitive, preserving
+existing behavior while eliminating the earlier difference between reported
+and executed selection. Tests cover per-user selection overriding a different
+global default, persisted setting application, exact-runtime dispatch,
+one-shot use, drift rejection, registry enforcement, and cancellation intent.
+No production module constructs the Workshop preparation service, so this
+change emits no live attempt and performs no live dispatch.
+
+### 31.1 Next bounded milestone
+
+Add one production-unused terminal transaction coordinator that atomically
+settles the fenced attempt/run together with the canonical result or bounded
+failure outcome, exact-epoch delivery request, and immutable delivery plan.
+Do not wire Telegram or register recovery until that coordinator and its
+commit-uncertain tests pass.

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -13,10 +13,13 @@ independent lifecycle, and OS-level enforcement via sudo -u when os_user is
 configured in users.yaml.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from pathlib import Path
 
 from kai import sessions
@@ -46,6 +49,62 @@ _EVICTION_CHECK_INTERVAL = 60
 # Maximum time to wait for shutdown() in force_kill before falling
 # back to raw SIGKILL (seconds).
 _FORCE_KILL_TIMEOUT = 5
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedBackendSelection:
+    """Effective backend-neutral selection bound to one prepared runtime."""
+
+    backend: str
+    provider: str
+    model: str
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedRuntimeFingerprint:
+    selection: PreparedBackendSelection
+    workspace: Path
+    timeout_seconds: int
+
+
+class PreparedBackendExecution:
+    """One-shot handle that can dispatch only through its exact prepared runtime."""
+
+    __slots__ = ("_chat_id", "_consumed", "_fingerprint", "_instance", "_pool")
+
+    def __init__(self, pool: SubprocessPool, chat_id: int, instance: AgentBackend) -> None:
+        self._pool = pool
+        self._chat_id = chat_id
+        self._instance = instance
+        self._fingerprint = _runtime_fingerprint(instance)
+        self._consumed = False
+
+    @property
+    def selection(self) -> PreparedBackendSelection:
+        return self._fingerprint.selection
+
+    @property
+    def workspace(self) -> Path:
+        return self._fingerprint.workspace
+
+    async def stream(self, prompt: str | list) -> AsyncGenerator[StreamEvent]:
+        if self._consumed:
+            raise RuntimeError("Prepared backend execution is one-shot")
+        self._consumed = True
+        async for event in self._pool._send_prepared(self, prompt):
+            yield event
+
+
+def _runtime_fingerprint(instance: AgentBackend) -> _PreparedRuntimeFingerprint:
+    return _PreparedRuntimeFingerprint(
+        selection=PreparedBackendSelection(
+            backend=require_backend_name(instance),
+            provider=instance.provider,
+            model=instance.model,
+        ),
+        workspace=instance.workspace,
+        timeout_seconds=instance.timeout_seconds,
+    )
 
 
 class SubprocessPool:
@@ -358,6 +417,20 @@ class SubprocessPool:
 
     # ── Prompt routing ──────────────────────────────────────────────
 
+    async def _prepare_instance(self, chat_id: int) -> AgentBackend:
+        """Apply every pending effective setting before returning one runtime."""
+        instance = self.get(chat_id)
+        if chat_id in self._pending_workspace_restore:
+            await self._attempt_workspace_restore(chat_id, instance)
+        if chat_id in self._pending_settings_restore:
+            await self._apply_user_db_settings(chat_id, instance)
+            self._pending_settings_restore.discard(chat_id)
+        return instance
+
+    async def prepare_execution(self, chat_id: int) -> PreparedBackendExecution:
+        """Bind the effective selection to the exact runtime that may dispatch later."""
+        return PreparedBackendExecution(self, chat_id, await self._prepare_instance(chat_id))
+
     async def send(self, prompt: str | list, *, chat_id: int) -> AsyncGenerator[StreamEvent]:
         """
         Route a prompt to the user's subprocess.
@@ -372,12 +445,30 @@ class SubprocessPool:
 
         Marks the user as in-flight to prevent eviction mid-stream.
         """
-        instance = self.get(chat_id)
-        if chat_id in self._pending_workspace_restore:
-            await self._attempt_workspace_restore(chat_id, instance)
-        if chat_id in self._pending_settings_restore:
-            await self._apply_user_db_settings(chat_id, instance)
-            self._pending_settings_restore.discard(chat_id)
+        instance = await self._prepare_instance(chat_id)
+        self._last_activity[chat_id] = time.monotonic()
+        self._in_flight.add(chat_id)
+        try:
+            async for event in instance.send(prompt, chat_id=chat_id):
+                yield event
+        finally:
+            self._in_flight.discard(chat_id)
+            self._last_activity[chat_id] = time.monotonic()
+
+    async def _send_prepared(
+        self,
+        prepared: PreparedBackendExecution,
+        prompt: str | list,
+    ) -> AsyncGenerator[StreamEvent]:
+        """Dispatch through a prepared handle only while its runtime remains exact."""
+        chat_id = prepared._chat_id
+        instance = self.get_if_exists(chat_id)
+        if instance is not prepared._instance:
+            raise RuntimeError("Prepared backend runtime is no longer current")
+        if chat_id in self._pending_workspace_restore or chat_id in self._pending_settings_restore:
+            raise RuntimeError("Prepared backend runtime has pending effective settings")
+        if _runtime_fingerprint(instance) != prepared._fingerprint:
+            raise RuntimeError("Prepared backend runtime changed before dispatch")
         self._last_activity[chat_id] = time.monotonic()
         self._in_flight.add(chat_id)
         try:

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -1,0 +1,90 @@
+"""Production-unused protected preparation for Workshop execution."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from kai.backend import StreamEvent
+from kai.config import VALID_BACKENDS, validate_model_for_backend
+from kai.pool import PreparedBackendExecution, SubprocessPool
+from kai.workshop.conversation_runs import resolve_canonical_conversation_run
+from kai.workshop.domain import RunId
+from kai.workshop.run_execution_authority import RunExecutionSelection
+from kai.workshop.run_lifecycle import DurableRun, RunStatus, WorkshopRunLifecycle
+from kai.workshop.store import WorkshopEventStore
+
+type AgentPrompt = str | list[dict[str, str]]
+
+
+class ProtectedExecutionPreparationError(RuntimeError):
+    """The canonical run cannot safely bind one effective runtime."""
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedWorkshopExecution:
+    run: DurableRun
+    selection: RunExecutionSelection
+    workspace: Path
+    _runtime: PreparedBackendExecution = field(repr=False, compare=False)
+
+    async def stream(self, prompt: AgentPrompt) -> AsyncIterator[StreamEvent]:
+        """Dispatch once through the exact runtime bound during preparation."""
+        async for event in self._runtime.stream(prompt):
+            yield event
+
+
+class WorkshopProtectedExecutionPreparationService:
+    """Resolve canonical run authority into one protected compatibility runtime."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        pool: SubprocessPool,
+        *,
+        registered_backend_ids: frozenset[str],
+    ) -> None:
+        if not registered_backend_ids:
+            raise ValueError("registered_backend_ids must not be empty")
+        unknown = registered_backend_ids - VALID_BACKENDS
+        if unknown:
+            raise ValueError(f"registered_backend_ids contains unsupported backends: {', '.join(sorted(unknown))}")
+        self._store = store
+        self._pool = pool
+        self._registered_backend_ids = registered_backend_ids
+
+    async def prepare(self, run_id: RunId) -> PreparedWorkshopExecution:
+        if not isinstance(run_id, RunId):
+            raise ValueError("run_id must be a RunId")
+        run = await WorkshopRunLifecycle(self._store).state(run_id)
+        if run.status != RunStatus.ACCEPTED or run.cancellation_requested_at is not None:
+            raise ProtectedExecutionPreparationError("Only an uncancelled accepted run can prepare execution")
+
+        resolution = await resolve_canonical_conversation_run(self._store, run.inbound_message_id)
+        target = resolution.target
+        if (
+            target.workshop_id != run.workshop_id
+            or target.channel_id != run.channel_id
+            or target.requested_by_principal_id != run.requested_by_principal_id
+            or target.agent_id != run.agent_id
+        ):
+            raise ProtectedExecutionPreparationError("Canonical run authority changed after acceptance")
+
+        runtime = await self._pool.prepare_execution(resolution._legacy_pool_key)
+        prepared = runtime.selection
+        if prepared.backend not in self._registered_backend_ids:
+            raise ProtectedExecutionPreparationError("Effective backend is not present in the protected registry")
+        if not validate_model_for_backend(prepared.model, prepared.backend, prepared.provider):
+            raise ProtectedExecutionPreparationError("Effective model is not valid for the protected backend selection")
+        selection = RunExecutionSelection(
+            backend=prepared.backend,
+            provider=prepared.provider or None,
+            model=prepared.model,
+        )
+        return PreparedWorkshopExecution(
+            run=run,
+            selection=selection,
+            workspace=runtime.workspace,
+            _runtime=runtime,
+        )

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -744,6 +744,64 @@ class TestWorkspaceRestoration:
                     pass
             mock_change.assert_called_once()
 
+
+class TestPreparedExecution:
+    @pytest.mark.asyncio
+    async def test_preparation_applies_pending_settings_and_binds_exact_runtime(self):
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        instance = pool.get(111)
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch(
+                "kai.pool.sessions.get_user_settings",
+                new_callable=AsyncMock,
+                return_value={"model": "opus", "timeout": "120"},
+            ),
+            patch.object(instance, "restart", new_callable=AsyncMock) as restart,
+            patch.object(instance, "send", new_callable=MagicMock) as send,
+        ):
+
+            async def empty_send(*args, **kwargs):
+                return
+                yield
+
+            send.side_effect = empty_send
+            prepared = await pool.prepare_execution(111)
+
+            assert prepared.selection.backend == "claude"
+            assert prepared.selection.provider == "anthropic"
+            assert prepared.selection.model == "opus"
+            assert prepared.workspace == instance.workspace
+            assert instance.timeout_seconds == 120
+            assert 111 not in pool._pending_workspace_restore
+            assert 111 not in pool._pending_settings_restore
+            restart.assert_awaited_once()
+
+            async for _ in prepared.stream("hello"):
+                pass
+            send.assert_called_once_with("hello", chat_id=111)
+            with pytest.raises(RuntimeError, match="one-shot"):
+                async for _ in prepared.stream("again"):
+                    pass
+
+    @pytest.mark.asyncio
+    async def test_prepared_execution_rejects_runtime_drift_before_dispatch(self):
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
+        ):
+            prepared = await pool.prepare_execution(111)
+        instance = pool.get(111)
+        instance.model = "opus"
+        with (
+            patch.object(instance, "send", new_callable=MagicMock) as send,
+            pytest.raises(RuntimeError, match="changed before dispatch"),
+        ):
+            async for _ in prepared.stream("must not run"):
+                pass
+        send.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_restore_applies_db_user_settings(self, tmp_path):
         """DB per-user settings override users.yaml baseline on restore."""

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -1,0 +1,153 @@
+"""Contracts for production-unused protected Workshop execution preparation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from kai.config import Config, UserConfig
+from kai.pool import SubprocessPool
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.conversation_commands import WorkshopConversationCommandService
+from kai.workshop.inbound import InboundMessage
+from kai.workshop.protected_execution import (
+    ProtectedExecutionPreparationError,
+    WorkshopProtectedExecutionPreparationService,
+)
+from kai.workshop.run_execution_authority import RunExecutionSelection, WorkshopRunExecutionAuthority
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 8, 12, 21, 0, tzinfo=UTC)
+
+
+async def _accepted_run(path: Path, home: Path):
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="telegram",
+                external_subject="101",
+                external_channel_id="101",
+            ),
+        ),
+    )
+    accepted = await WorkshopConversationCommandService(store).accept(
+        InboundMessage(
+            transport="telegram",
+            update_id="command-1",
+            message_id="message-1",
+            sender_subject="101",
+            channel_subject="101",
+            body="Prepare one protected execution",
+            occurred_at=_NOW,
+        )
+    )
+    config = Config(
+        telegram_bot_token="test",
+        allowed_user_ids={101},
+        default_backend="codex",
+        default_provider="openai",
+        default_model="gpt-5.5",
+        default_timeout=30,
+        agent_max_session_hours=0,
+        agent_idle_timeout=1800,
+        webhook_port=8080,
+        user_configs={
+            101: UserConfig(
+                telegram_id=101,
+                name="human",
+                backend="claude",
+                model="sonnet",
+                home_workspace=home,
+            )
+        },
+    )
+    return store, accepted.run, SubprocessPool(config=config, services_info=[])
+
+
+class TestProtectedExecutionPreparation:
+    async def test_resolves_effective_registered_selection_and_hides_transport_key(self, tmp_path: Path):
+        home = tmp_path / "home"
+        home.mkdir()
+        store, run, pool = await _accepted_run(tmp_path / "kai.db", home)
+        try:
+            with (
+                patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+                patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
+            ):
+                prepared = await WorkshopProtectedExecutionPreparationService(
+                    store,
+                    pool,
+                    registered_backend_ids=frozenset({"claude"}),
+                ).prepare(run.run_id)
+
+            assert prepared.run == run
+            assert prepared.selection.backend == "claude"
+            assert prepared.selection.provider == "anthropic"
+            assert prepared.selection.model == "sonnet"
+            assert prepared.workspace == home
+            assert "101" not in repr(prepared)
+            assert not hasattr(prepared, "chat_id")
+        finally:
+            await pool.shutdown()
+            await store.close()
+
+    async def test_unregistered_effective_backend_fails_closed(self, tmp_path: Path):
+        home = tmp_path / "home"
+        home.mkdir()
+        store, run, pool = await _accepted_run(tmp_path / "kai.db", home)
+        try:
+            with (
+                patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+                patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
+                pytest.raises(ProtectedExecutionPreparationError, match="protected registry"),
+            ):
+                await WorkshopProtectedExecutionPreparationService(
+                    store,
+                    pool,
+                    registered_backend_ids=frozenset({"codex"}),
+                ).prepare(run.run_id)
+        finally:
+            await pool.shutdown()
+            await store.close()
+
+    async def test_cancellation_pending_run_never_prepares_a_runtime(self, tmp_path: Path):
+        home = tmp_path / "home"
+        home.mkdir()
+        store, run, pool = await _accepted_run(tmp_path / "kai.db", home)
+        try:
+            authority = WorkshopRunExecutionAuthority(
+                store,
+                selection_resolver=lambda _run: RunExecutionSelection("claude", "sonnet", "anthropic"),
+                registered_backend_ids=frozenset({"claude"}),
+            )
+            await authority.request_cancellation(
+                run.run_id,
+                cancellation_code="requested_by_human",
+                occurred_at=_NOW,
+            )
+            with (
+                patch.object(pool, "prepare_execution", new_callable=AsyncMock) as prepare,
+                pytest.raises(ProtectedExecutionPreparationError, match="uncancelled accepted"),
+            ):
+                await WorkshopProtectedExecutionPreparationService(
+                    store,
+                    pool,
+                    registered_backend_ids=frozenset({"claude"}),
+                ).prepare(run.run_id)
+            prepare.assert_not_awaited()
+        finally:
+            await pool.shutdown()
+            await store.close()
+
+    def test_service_remains_unregistered(self):
+        source_root = Path(__file__).parents[1] / "src" / "kai"
+        for relative_path in ("main.py", "bot.py", "sessions.py"):
+            source = (source_root / relative_path).read_text(encoding="utf-8")
+            assert "WorkshopProtectedExecutionPreparationService" not in source


### PR DESCRIPTION
## Summary

- apply pending workspace and user settings before snapshotting execution selection
- bind backend, provider, model, and workspace to the exact one-shot runtime
- resolve accepted canonical Workshop runs without exposing Telegram pool keys
- fail closed on cancellation, registry mismatch, runtime replacement, or selection drift

## Production impact

The Workshop preparation service is not registered in production. Existing pool dispatch uses the factored preparation helper with unchanged behavior. This PR does not create run attempts, launch a Workshop worker, dispatch canonical runs, or change the database schema.

## Validation

- `5453 passed, 1 skipped`
- `make check`
- `make typecheck`
- `make module-sizes`
- `git diff --check`
