### PR TITLE
feat: add Workshop terminal transaction coordinator

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1643,3 +1643,40 @@ settles the fenced attempt/run together with the canonical result or bounded
 failure outcome, exact-epoch delivery request, and immutable delivery plan.
 Do not wire Telegram or register recovery until that coordinator and its
 commit-uncertain tests pass.
+
+## 32. Atomic terminal transaction coordinator
+
+**Implementation date:** 2026-08-12
+
+The production-unused terminal coordinator now commits one canonical visible
+outcome, its exact active-epoch delivery request, immutable edit/send plan,
+fenced attempt terminal fact, and run terminal fact in one `BEGIN IMMEDIATE`
+transaction. Successful completion records the canonical result `MessageId`.
+Failure accepts only typed backend-neutral codes and selects fixed bounded text
+internally; confirmed cancellation resolves its durable human-requested code
+and fixed visible text internally. Native backend errors cannot enter these
+facts.
+
+The existing outbound finalizer and execution authority now expose guarded
+transaction-local primitives while their public behavior remains unchanged.
+Exact retries require the message, delivery, plan, attempt, and run transition
+to share one prior state. A stale fence, plan failure, partial prior state, or
+losing terminal outcome rolls back without settling the run. If SQLite loses a
+commit result, the coordinator repeats the whole deterministic transaction;
+one unresolved retry becomes an explicit commit-uncertain error and never a
+direct-send or backend-replay instruction.
+
+Tests pin successful, failed, and cancelled settlement; exact replay; event
+ordering; stale-fence and injected-plan rollback; partial-state rejection;
+single-terminal arbitration; commit-result recovery; unresolved commit
+uncertainty; and absence from production construction. No worker, Telegram
+handler, recovery path, backend dispatch, schema migration, or installed
+behavior changed.
+
+### 32.1 Next bounded milestone
+
+Add production-unused canonical lane coordination around preparation, attempt
+grant, the conservative `started` boundary, and exact-runtime dispatch. Then
+integrate durable cancellation and interrupted-execution recovery with that
+lane. The lane identity must be canonical `(channel_id, agent_id)` and must not
+expose a Telegram chat ID as execution authority.

--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -317,73 +317,86 @@ async def record_outbound_message_with_streaming_finalization(
     connection = store.connection
     try:
         await connection.execute("BEGIN IMMEDIATE")
-        binding = await _resolve_outbound(store, message.in_reply_to_message_id)
-        streaming_target = await resolve_telegram_streaming_target(
-            store,
-            message.in_reply_to_message_id,
-        )
-        if streaming_target.workshop_id != binding.workshop_id or streaming_target.channel_id != binding.channel_id:
-            raise OutboundStreamingPreviewConflictError(
-                "Telegram streaming target does not match the canonical agent reply target"
-            )
-        preview_message_id = await _confirmed_preview_message_id(
-            store,
-            inbound_message_id=message.in_reply_to_message_id,
-            workshop_id=binding.workshop_id,
-            channel_id=binding.channel_id,
-            channel_binding_id=streaming_target.channel_binding_id,
-        )
-        operations = _streaming_finalization_operations(
-            message.body,
-            preview_message_id=preview_message_id,
-        )
-        authority_epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch_in_transaction()
-        assert authority_epoch is not None
-        message_result = await _existing_outbound(store, binding, message)
-        if message_result is None:
-            message_result = await store.append_in_transaction(_outbound_envelope(binding, message))
-
-        projection = CanonicalConversationProjection()
-        await store.project_pending_in_transaction(projection)
-        message_id = message_result.event.envelope.aggregate_id
-        if not isinstance(message_id, MessageId):
-            raise RuntimeError("Canonical outbound event did not identify a message")
-        delivery_result = await WorkshopDeliveryOutbox(store).request_delivery_in_transaction(
-            DeliveryRequest(
-                message_id=message_id,
-                channel_binding_id=streaming_target.channel_binding_id,
-                mode="text",
-                purpose=CONVERSATION_REPLY_PURPOSE,
-                occurred_at=message.occurred_at,
-                execution_contract=STREAMING_FINALIZATION_CONTRACT,
-                authority_epoch_id=authority_epoch.epoch_id,
-                max_attempts=5,
-            )
-        )
-        plan_result = await WorkshopDeliveryFragments(store).prepare_operations_in_transaction(
-            delivery_result.delivery.delivery_id,
-            operations,
-            occurred_at=message.occurred_at,
-        )
-        prior_states = {
-            message_result.inserted,
-            delivery_result.inserted,
-            plan_result.inserted,
-        }
-        if len(prior_states) != 1:
-            raise OutboundDeliveryStateConflictError(
-                "Canonical reply, delivery request, and operation plan did not share one prior state"
-            )
-        await store.project_pending_in_transaction(projection)
+        result = await record_outbound_message_with_streaming_finalization_in_transaction(store, message)
         await connection.commit()
-        return OutboundStreamingFinalizationResult(
-            message=message_result,
-            delivery=delivery_result,
-            plan=plan_result,
-        )
+        return result
     except Exception:
         await connection.rollback()
         raise
+
+
+async def record_outbound_message_with_streaming_finalization_in_transaction(
+    store: WorkshopEventStore,
+    message: OutboundMessage,
+) -> OutboundStreamingFinalizationResult:
+    """Persist a reply and immutable delivery plan in a caller-owned transaction."""
+    if not store.connection.in_transaction:
+        raise RuntimeError(
+            "record_outbound_message_with_streaming_finalization_in_transaction requires an active transaction"
+        )
+    binding = await _resolve_outbound(store, message.in_reply_to_message_id)
+    streaming_target = await resolve_telegram_streaming_target(
+        store,
+        message.in_reply_to_message_id,
+    )
+    if streaming_target.workshop_id != binding.workshop_id or streaming_target.channel_id != binding.channel_id:
+        raise OutboundStreamingPreviewConflictError(
+            "Telegram streaming target does not match the canonical agent reply target"
+        )
+    preview_message_id = await _confirmed_preview_message_id(
+        store,
+        inbound_message_id=message.in_reply_to_message_id,
+        workshop_id=binding.workshop_id,
+        channel_id=binding.channel_id,
+        channel_binding_id=streaming_target.channel_binding_id,
+    )
+    operations = _streaming_finalization_operations(
+        message.body,
+        preview_message_id=preview_message_id,
+    )
+    authority_epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch_in_transaction()
+    assert authority_epoch is not None
+    message_result = await _existing_outbound(store, binding, message)
+    if message_result is None:
+        message_result = await store.append_in_transaction(_outbound_envelope(binding, message))
+
+    projection = CanonicalConversationProjection()
+    await store.project_pending_in_transaction(projection)
+    message_id = message_result.event.envelope.aggregate_id
+    if not isinstance(message_id, MessageId):
+        raise RuntimeError("Canonical outbound event did not identify a message")
+    delivery_result = await WorkshopDeliveryOutbox(store).request_delivery_in_transaction(
+        DeliveryRequest(
+            message_id=message_id,
+            channel_binding_id=streaming_target.channel_binding_id,
+            mode="text",
+            purpose=CONVERSATION_REPLY_PURPOSE,
+            occurred_at=message.occurred_at,
+            execution_contract=STREAMING_FINALIZATION_CONTRACT,
+            authority_epoch_id=authority_epoch.epoch_id,
+            max_attempts=5,
+        )
+    )
+    plan_result = await WorkshopDeliveryFragments(store).prepare_operations_in_transaction(
+        delivery_result.delivery.delivery_id,
+        operations,
+        occurred_at=message.occurred_at,
+    )
+    prior_states = {
+        message_result.inserted,
+        delivery_result.inserted,
+        plan_result.inserted,
+    }
+    if len(prior_states) != 1:
+        raise OutboundDeliveryStateConflictError(
+            "Canonical reply, delivery request, and operation plan did not share one prior state"
+        )
+    await store.project_pending_in_transaction(projection)
+    return OutboundStreamingFinalizationResult(
+        message=message_result,
+        delivery=delivery_result,
+        plan=plan_result,
+    )
 
 
 async def _resolve_delivery(store: WorkshopEventStore, message_id: MessageId) -> tuple[WorkshopId, ChannelId]:

--- a/src/kai/workshop/run_execution_authority.py
+++ b/src/kai/workshop/run_execution_authority.py
@@ -232,6 +232,11 @@ class WorkshopRunExecutionAuthority:
         self._selection_resolver = selection_resolver
         self._registered_backend_ids = registered_backend_ids
 
+    @property
+    def event_store(self) -> WorkshopEventStore:
+        """Return the store used by transaction coordinators in this package."""
+        return self._store
+
     async def attempt(self, attempt_id: RunAttemptId) -> RunAttempt:
         if not isinstance(attempt_id, RunAttemptId):
             raise ValueError("attempt_id must be a RunAttemptId")
@@ -461,6 +466,26 @@ class WorkshopRunExecutionAuthority:
             result_message_id=result_message_id,
         )
 
+    async def complete_in_transaction(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        result_message_id: MessageId,
+        occurred_at: datetime,
+    ) -> RunExecutionResult:
+        """Complete a claim inside a caller-owned terminal transaction."""
+        if not isinstance(result_message_id, MessageId):
+            raise ValueError("result_message_id must be a MessageId")
+        return await self._settle_in_transaction(
+            claim,
+            operation="completed",
+            attempt_type=WorkshopEventType.RUN_ATTEMPT_COMPLETED,
+            run_type=WorkshopEventType.RUN_COMPLETED,
+            occurred_at=occurred_at,
+            terminal_code=None,
+            result_message_id=result_message_id,
+        )
+
     async def fail(
         self,
         claim: RunExecutionClaim,
@@ -477,22 +502,52 @@ class WorkshopRunExecutionAuthority:
             terminal_code=_require_code(failure_code, field_name="failure_code"),
         )
 
+    async def fail_in_transaction(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        failure_code: str,
+        occurred_at: datetime,
+    ) -> RunExecutionResult:
+        """Fail a claim inside a caller-owned terminal transaction."""
+        return await self._settle_in_transaction(
+            claim,
+            operation="failed",
+            attempt_type=WorkshopEventType.RUN_ATTEMPT_FAILED,
+            run_type=WorkshopEventType.RUN_FAILED,
+            occurred_at=occurred_at,
+            terminal_code=_require_code(failure_code, field_name="failure_code"),
+        )
+
     async def confirm_cancellation(
         self,
         claim: RunExecutionClaim,
         *,
         occurred_at: datetime,
     ) -> RunExecutionResult:
-        run = await self._require_run(claim.run_id)
-        if run.cancellation_code is None:
-            raise RunExecutionConflictError("Run has no durable cancellation request")
         return await self._settle(
             claim,
             operation="cancelled",
             attempt_type=WorkshopEventType.RUN_ATTEMPT_CANCELLED,
             run_type=WorkshopEventType.RUN_CANCELLED,
             occurred_at=occurred_at,
-            terminal_code=run.cancellation_code,
+            terminal_code=None,
+        )
+
+    async def confirm_cancellation_in_transaction(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        occurred_at: datetime,
+    ) -> RunExecutionResult:
+        """Confirm cancellation inside a caller-owned terminal transaction."""
+        return await self._settle_in_transaction(
+            claim,
+            operation="cancelled",
+            attempt_type=WorkshopEventType.RUN_ATTEMPT_CANCELLED,
+            run_type=WorkshopEventType.RUN_CANCELLED,
+            occurred_at=occurred_at,
+            terminal_code=None,
         )
 
     async def recover_expired(self, *, occurred_at: datetime) -> RunRecoveryResult:
@@ -571,110 +626,138 @@ class WorkshopRunExecutionAuthority:
         connection = self._store.connection
         try:
             await connection.execute("BEGIN IMMEDIATE")
-            projection = CanonicalConversationProjection()
-            await self._store.project_pending_in_transaction(projection)
-            run, attempt = await self._current_claim(claim)
-            attempt_key = _attempt_key(claim.attempt_id, operation)
-            prior_attempt = await self._store.event_by_idempotency_key(attempt_key)
-            run_key = _run_key(claim.run_id, operation)
-            prior_run = await self._store.event_by_idempotency_key(run_key)
-            actor = await _agent_principal(self._store, run)
-            if prior_attempt is not None or prior_run is not None:
-                if prior_attempt is None or prior_run is None:
-                    raise RunExecutionConflictError("Atomic run transition is missing one of its events")
-                expected_attempt_payload = _attempt_payload(claim)
-                if terminal_code is not None:
-                    expected_attempt_payload["terminal_code"] = terminal_code
-                expected_run_payload: dict[str, object] = {"attempt_id": claim.attempt_id}
-                if run_type == WorkshopEventType.RUN_COMPLETED:
-                    expected_run_payload["result_message_id"] = result_message_id
-                elif run_type == WorkshopEventType.RUN_FAILED:
-                    expected_run_payload["failure_code"] = terminal_code
-                elif run_type == WorkshopEventType.RUN_CANCELLED:
-                    expected_run_payload["cancellation_code"] = terminal_code
-                if (
-                    prior_attempt.envelope.event_type != attempt_type
-                    or prior_attempt.envelope.aggregate_id != claim.attempt_id
-                    or prior_attempt.envelope.actor_principal_id != actor
-                    or prior_attempt.envelope.payload != expected_attempt_payload
-                    or prior_run.envelope.event_type != run_type
-                    or prior_run.envelope.aggregate_id != claim.run_id
-                    or prior_run.envelope.actor_principal_id != actor
-                    or prior_run.envelope.payload != expected_run_payload
-                ):
-                    raise RunExecutionConflictError("Run transition retry has conflicting facts")
-                await connection.commit()
-                return RunExecutionResult(
-                    run=run,
-                    attempt=attempt,
-                    events=(prior_attempt, prior_run),
-                    changed=False,
-                )
-            if attempt.lease_version != claim.lease_version:
-                raise StaleRunExecutionAuthorityError("Execution claim has a stale lease version")
-            allowed_statuses = (
-                {RunAttemptStatus.GRANTED}
-                if operation == "started"
-                else {RunAttemptStatus.GRANTED, RunAttemptStatus.STARTED}
-                if operation == "cancelled"
-                else {RunAttemptStatus.STARTED}
+            result = await self._settle_in_transaction(
+                claim,
+                operation=operation,
+                attempt_type=attempt_type,
+                run_type=run_type,
+                occurred_at=occurred_at,
+                terminal_code=terminal_code,
+                result_message_id=result_message_id,
             )
-            if attempt.status not in allowed_statuses or occurred_at >= attempt.lease_expires_at:
-                raise StaleRunExecutionAuthorityError("Execution claim no longer holds active authority")
-            if operation == "started" and run.cancellation_requested_at is not None:
-                raise RunExecutionConflictError("Execution cannot start after cancellation was requested")
-            if operation == "started":
-                attempt_event = self._attempt_transition_envelope(
-                    run,
-                    claim,
-                    actor=actor,
-                    event_type=attempt_type,
-                    operation=operation,
-                    occurred_at=occurred_at,
-                )
-                run_event = self._run_transition_envelope(
-                    run,
-                    claim,
-                    actor=actor,
-                    event_type=run_type,
-                    operation=operation,
-                    occurred_at=occurred_at,
-                )
-            else:
-                attempt_event = self._attempt_terminal_envelope(
-                    run,
-                    claim,
-                    actor=actor,
-                    event_type=attempt_type,
-                    operation=operation,
-                    terminal_code=terminal_code,
-                    occurred_at=occurred_at,
-                )
-                run_event = self._run_terminal_envelope(
-                    run,
-                    claim,
-                    actor=actor,
-                    event_type=run_type,
-                    operation=operation,
-                    terminal_code=terminal_code,
-                    result_message_id=result_message_id,
-                    occurred_at=occurred_at,
-                )
-            first = await self._store.append_in_transaction(attempt_event)
-            second = await self._store.append_in_transaction(run_event)
-            await self._store.project_pending_in_transaction(projection)
-            updated_run = await self._require_run(claim.run_id)
-            updated_attempt = await self._require_attempt(claim.attempt_id)
             await connection.commit()
-            return RunExecutionResult(
-                run=updated_run,
-                attempt=updated_attempt,
-                events=(first.event, second.event),
-                changed=True,
-            )
+            return result
         except Exception:
             await connection.rollback()
             raise
+
+    async def _settle_in_transaction(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        operation: str,
+        attempt_type: WorkshopEventType,
+        run_type: WorkshopEventType,
+        occurred_at: datetime,
+        terminal_code: str | None,
+        result_message_id: MessageId | None = None,
+    ) -> RunExecutionResult:
+        if not self._store.connection.in_transaction:
+            raise RuntimeError("run settlement in transaction requires an active transaction")
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        projection = CanonicalConversationProjection()
+        await self._store.project_pending_in_transaction(projection)
+        run, attempt = await self._current_claim(claim)
+        if operation == "cancelled":
+            if run.cancellation_code is None:
+                raise RunExecutionConflictError("Run has no durable cancellation request")
+            terminal_code = run.cancellation_code
+        attempt_key = _attempt_key(claim.attempt_id, operation)
+        prior_attempt = await self._store.event_by_idempotency_key(attempt_key)
+        run_key = _run_key(claim.run_id, operation)
+        prior_run = await self._store.event_by_idempotency_key(run_key)
+        actor = await _agent_principal(self._store, run)
+        if prior_attempt is not None or prior_run is not None:
+            if prior_attempt is None or prior_run is None:
+                raise RunExecutionConflictError("Atomic run transition is missing one of its events")
+            expected_attempt_payload = _attempt_payload(claim)
+            if terminal_code is not None:
+                expected_attempt_payload["terminal_code"] = terminal_code
+            expected_run_payload: dict[str, object] = {"attempt_id": claim.attempt_id}
+            if run_type == WorkshopEventType.RUN_COMPLETED:
+                expected_run_payload["result_message_id"] = result_message_id
+            elif run_type == WorkshopEventType.RUN_FAILED:
+                expected_run_payload["failure_code"] = terminal_code
+            elif run_type == WorkshopEventType.RUN_CANCELLED:
+                expected_run_payload["cancellation_code"] = terminal_code
+            if (
+                prior_attempt.envelope.event_type != attempt_type
+                or prior_attempt.envelope.aggregate_id != claim.attempt_id
+                or prior_attempt.envelope.actor_principal_id != actor
+                or prior_attempt.envelope.payload != expected_attempt_payload
+                or prior_run.envelope.event_type != run_type
+                or prior_run.envelope.aggregate_id != claim.run_id
+                or prior_run.envelope.actor_principal_id != actor
+                or prior_run.envelope.payload != expected_run_payload
+            ):
+                raise RunExecutionConflictError("Run transition retry has conflicting facts")
+            return RunExecutionResult(
+                run=run,
+                attempt=attempt,
+                events=(prior_attempt, prior_run),
+                changed=False,
+            )
+        if attempt.lease_version != claim.lease_version:
+            raise StaleRunExecutionAuthorityError("Execution claim has a stale lease version")
+        allowed_statuses = (
+            {RunAttemptStatus.GRANTED}
+            if operation == "started"
+            else {RunAttemptStatus.GRANTED, RunAttemptStatus.STARTED}
+            if operation == "cancelled"
+            else {RunAttemptStatus.STARTED}
+        )
+        if attempt.status not in allowed_statuses or occurred_at >= attempt.lease_expires_at:
+            raise StaleRunExecutionAuthorityError("Execution claim no longer holds active authority")
+        if operation == "started" and run.cancellation_requested_at is not None:
+            raise RunExecutionConflictError("Execution cannot start after cancellation was requested")
+        if operation == "started":
+            attempt_event = self._attempt_transition_envelope(
+                run,
+                claim,
+                actor=actor,
+                event_type=attempt_type,
+                operation=operation,
+                occurred_at=occurred_at,
+            )
+            run_event = self._run_transition_envelope(
+                run,
+                claim,
+                actor=actor,
+                event_type=run_type,
+                operation=operation,
+                occurred_at=occurred_at,
+            )
+        else:
+            attempt_event = self._attempt_terminal_envelope(
+                run,
+                claim,
+                actor=actor,
+                event_type=attempt_type,
+                operation=operation,
+                terminal_code=terminal_code,
+                occurred_at=occurred_at,
+            )
+            run_event = self._run_terminal_envelope(
+                run,
+                claim,
+                actor=actor,
+                event_type=run_type,
+                operation=operation,
+                terminal_code=terminal_code,
+                result_message_id=result_message_id,
+                occurred_at=occurred_at,
+            )
+        first = await self._store.append_in_transaction(attempt_event)
+        second = await self._store.append_in_transaction(run_event)
+        await self._store.project_pending_in_transaction(projection)
+        updated_run = await self._require_run(claim.run_id)
+        updated_attempt = await self._require_attempt(claim.attempt_id)
+        return RunExecutionResult(
+            run=updated_run,
+            attempt=updated_attempt,
+            events=(first.event, second.event),
+            changed=True,
+        )
 
     async def _current_claim(self, claim: RunExecutionClaim) -> tuple[DurableRun, RunAttempt]:
         if not isinstance(claim, RunExecutionClaim):

--- a/src/kai/workshop/terminal_transactions.py
+++ b/src/kai/workshop/terminal_transactions.py
@@ -1,0 +1,244 @@
+"""Atomic, production-unused terminal transactions for Workshop runs."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+import aiosqlite
+
+from kai.workshop.domain import MessageId
+from kai.workshop.outbound import (
+    OutboundMessage,
+    OutboundStreamingFinalizationResult,
+    record_outbound_message_with_streaming_finalization_in_transaction,
+)
+from kai.workshop.run_execution_authority import (
+    RunExecutionClaim,
+    RunExecutionResult,
+    WorkshopRunExecutionAuthority,
+)
+from kai.workshop.run_lifecycle import WorkshopRunLifecycle
+
+
+class TerminalTransactionError(RuntimeError):
+    """Base error for atomic Workshop terminal settlement."""
+
+
+class TerminalTransactionStateConflictError(TerminalTransactionError):
+    """Visible outcome and run settlement do not share one prior state."""
+
+
+class TerminalTransactionCommitUncertainError(TerminalTransactionError):
+    """A deterministic retry could not resolve a possible committed outcome."""
+
+
+class _PossibleCommitError(RuntimeError):
+    """SQLite could not confirm whether the transaction commit completed."""
+
+
+class TerminalOutcome(StrEnum):
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class TerminalFailureCode(StrEnum):
+    """Bounded backend-neutral failure facts allowed into Workshop history."""
+
+    AUTHENTICATION_EXPIRED = "authentication_expired"
+    AUTHENTICATION_REQUIRED = "authentication_required"
+    QUOTA_EXHAUSTED = "quota_exhausted"
+    MODEL_UNAVAILABLE = "model_unavailable"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+    TRANSIENT = "transient"
+    BACKEND_CRASHED = "backend_crashed"
+    NO_RESPONSE = "no_response"
+    UNKNOWN = "unknown"
+
+
+_FAILURE_MESSAGES = {
+    TerminalFailureCode.AUTHENTICATION_EXPIRED: (
+        "Authentication for the configured agent has expired. Kai did not complete this request."
+    ),
+    TerminalFailureCode.AUTHENTICATION_REQUIRED: (
+        "Authentication for the configured agent is required. Kai did not complete this request."
+    ),
+    TerminalFailureCode.QUOTA_EXHAUSTED: (
+        "The configured agent reported that its usage allowance is exhausted. Kai did not complete this request."
+    ),
+    TerminalFailureCode.MODEL_UNAVAILABLE: ("The configured model is unavailable. Kai did not complete this request."),
+    TerminalFailureCode.PROVIDER_UNAVAILABLE: (
+        "The configured agent provider is unavailable. Kai did not complete this request."
+    ),
+    TerminalFailureCode.TRANSIENT: (
+        "The configured agent reported a temporary failure. Kai did not complete this request."
+    ),
+    TerminalFailureCode.BACKEND_CRASHED: (
+        "The configured agent stopped unexpectedly. Kai did not complete this request."
+    ),
+    TerminalFailureCode.NO_RESPONSE: "The configured agent returned no response. Kai did not complete this request.",
+    TerminalFailureCode.UNKNOWN: "The configured agent could not complete this request.",
+}
+
+_CANCELLATION_MESSAGE = "This request was cancelled."
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalTransactionResult:
+    outcome: TerminalOutcome
+    finalization: OutboundStreamingFinalizationResult
+    execution: RunExecutionResult
+    changed: bool
+
+
+class WorkshopRunTerminalTransactionCoordinator:
+    """Commit a visible terminal outcome and fenced settlement together.
+
+    The caller supplies a fenced execution claim and, for successful work,
+    only the assistant's final text. Routing, delivery authority, operation
+    plan, cancellation code, and terminal failure text are protected inputs.
+    This service is not constructed by production code.
+    """
+
+    def __init__(self, authority: WorkshopRunExecutionAuthority) -> None:
+        if not isinstance(authority, WorkshopRunExecutionAuthority):
+            raise TypeError("authority must be a WorkshopRunExecutionAuthority")
+        self._authority = authority
+        self._store = authority.event_store
+
+    async def complete(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        body: str,
+        occurred_at: datetime,
+    ) -> TerminalTransactionResult:
+        return await self._resolve_possible_commit(
+            lambda: self._settle_once(
+                claim,
+                outcome=TerminalOutcome.COMPLETED,
+                body=body,
+                occurred_at=occurred_at,
+            )
+        )
+
+    async def fail(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        failure_code: TerminalFailureCode,
+        occurred_at: datetime,
+    ) -> TerminalTransactionResult:
+        if not isinstance(failure_code, TerminalFailureCode):
+            raise ValueError("failure_code must be a TerminalFailureCode")
+        return await self._resolve_possible_commit(
+            lambda: self._settle_once(
+                claim,
+                outcome=TerminalOutcome.FAILED,
+                body=_FAILURE_MESSAGES[failure_code],
+                occurred_at=occurred_at,
+                failure_code=failure_code,
+            )
+        )
+
+    async def confirm_cancellation(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        occurred_at: datetime,
+    ) -> TerminalTransactionResult:
+        return await self._resolve_possible_commit(
+            lambda: self._settle_once(
+                claim,
+                outcome=TerminalOutcome.CANCELLED,
+                body=_CANCELLATION_MESSAGE,
+                occurred_at=occurred_at,
+            )
+        )
+
+    async def _resolve_possible_commit(
+        self,
+        operation: Callable[[], Awaitable[TerminalTransactionResult]],
+    ) -> TerminalTransactionResult:
+        try:
+            return await operation()
+        except _PossibleCommitError:
+            try:
+                return await operation()
+            except Exception as resolution_error:
+                raise TerminalTransactionCommitUncertainError(
+                    "Could not determine whether the Workshop terminal transaction committed"
+                ) from resolution_error
+
+    async def _settle_once(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        outcome: TerminalOutcome,
+        body: str,
+        occurred_at: datetime,
+        failure_code: TerminalFailureCode | None = None,
+    ) -> TerminalTransactionResult:
+        if not isinstance(claim, RunExecutionClaim):
+            raise ValueError("claim must be a RunExecutionClaim")
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            run = await WorkshopRunLifecycle(self._store).state(claim.run_id)
+            finalization = await record_outbound_message_with_streaming_finalization_in_transaction(
+                self._store,
+                OutboundMessage(
+                    in_reply_to_message_id=run.inbound_message_id,
+                    body=body,
+                    occurred_at=occurred_at,
+                ),
+            )
+            message_id = finalization.message.event.envelope.aggregate_id
+            if not isinstance(message_id, MessageId):
+                raise TerminalTransactionStateConflictError("Canonical terminal outcome did not identify a message")
+            if outcome == TerminalOutcome.COMPLETED:
+                execution = await self._authority.complete_in_transaction(
+                    claim,
+                    result_message_id=message_id,
+                    occurred_at=occurred_at,
+                )
+            elif outcome == TerminalOutcome.FAILED:
+                assert failure_code is not None
+                execution = await self._authority.fail_in_transaction(
+                    claim,
+                    failure_code=failure_code.value,
+                    occurred_at=occurred_at,
+                )
+            else:
+                execution = await self._authority.confirm_cancellation_in_transaction(
+                    claim,
+                    occurred_at=occurred_at,
+                )
+
+            prior_states = {
+                finalization.message.inserted,
+                finalization.delivery.inserted,
+                finalization.plan.inserted,
+                execution.changed,
+            }
+            if len(prior_states) != 1:
+                raise TerminalTransactionStateConflictError(
+                    "Canonical outcome, delivery plan, and run settlement did not share one prior state"
+                )
+            changed = execution.changed
+            try:
+                await connection.commit()
+            except aiosqlite.Error as commit_error:
+                raise _PossibleCommitError("Workshop terminal commit result was unavailable") from commit_error
+            return TerminalTransactionResult(
+                outcome=outcome,
+                finalization=finalization,
+                execution=execution,
+                changed=changed,
+            )
+        except Exception:
+            await connection.rollback()
+            raise

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -1,0 +1,333 @@
+"""Atomic terminal transaction contracts for production-unused Workshop runs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.domain import MessageId, RunExecutionOwnerId
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.outbound import (
+    OutboundMessage,
+    record_outbound_message_with_streaming_finalization,
+)
+from kai.workshop.run_execution_authority import (
+    RunAttemptStatus,
+    RunExecutionClaim,
+    RunExecutionSelection,
+    StaleRunExecutionAuthorityError,
+    WorkshopRunExecutionAuthority,
+)
+from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
+from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+from kai.workshop.terminal_transactions import (
+    TerminalFailureCode,
+    TerminalOutcome,
+    TerminalTransactionCommitUncertainError,
+    TerminalTransactionStateConflictError,
+    WorkshopRunTerminalTransactionCoordinator,
+)
+
+_NOW = datetime(2026, 8, 12, 21, 0, tzinfo=UTC)
+
+
+async def _started_run(
+    path: Path,
+) -> tuple[WorkshopEventStore, WorkshopRunExecutionAuthority, RunExecutionClaim]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="telegram",
+                external_subject="101",
+                external_channel_id="101",
+            ),
+        ),
+    )
+    inbound = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="telegram",
+            update_id="command-1",
+            message_id="message-1",
+            sender_subject="101",
+            channel_subject="101",
+            body="Perform one durable unit of work",
+            occurred_at=_NOW,
+        ),
+    )
+    inbound_id = MessageId(str(inbound.event.envelope.aggregate_id))
+    accepted = await WorkshopRunLifecycle(store).accept(
+        inbound_id,
+        occurred_at=_NOW + timedelta(seconds=1),
+    )
+    authority = WorkshopRunExecutionAuthority(
+        store,
+        selection_resolver=lambda _run: RunExecutionSelection("codex", "gpt-5.6-sol"),
+        registered_backend_ids=frozenset({"codex"}),
+    )
+    granted = await authority.grant(
+        accepted.run.run_id,
+        owner_id=RunExecutionOwnerId.new(),
+        occurred_at=_NOW + timedelta(seconds=2),
+        lease_expires_at=_NOW + timedelta(minutes=2),
+    )
+    started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
+    await WorkshopConversationDeliveryAuthority(store).activate()
+    return store, authority, started.claim
+
+
+async def _terminal_rows(store: WorkshopEventStore) -> tuple[int, int, int]:
+    counts = []
+    for table in ("messages", "delivery_outbox", "delivery_fragments"):
+        async with store.connection.execute(f"SELECT COUNT(*) FROM {table}") as cursor:
+            counts.append(int((await cursor.fetchone())[0]))
+    # One inbound message already exists.
+    return counts[0] - 1, counts[1], counts[2]
+
+
+class TestAtomicTerminalTransactions:
+    async def test_success_commits_result_delivery_plan_and_fenced_settlement(self, tmp_path: Path):
+        store, authority, claim = await _started_run(tmp_path / "kai.db")
+        coordinator = WorkshopRunTerminalTransactionCoordinator(authority)
+        try:
+            result = await coordinator.complete(
+                claim,
+                body="Canonical result",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+            retry = await coordinator.complete(
+                claim,
+                body="Canonical result",
+                occurred_at=_NOW + timedelta(seconds=30),
+            )
+
+            assert result.outcome == TerminalOutcome.COMPLETED
+            assert result.changed is True
+            assert result.execution.run.status == RunStatus.COMPLETED
+            assert result.execution.attempt.status == RunAttemptStatus.COMPLETED
+            assert result.execution.run.result_message_id == result.finalization.message.event.envelope.aggregate_id
+            assert result.finalization.delivery.delivery.authority_epoch_id is not None
+            assert [fragment.body for fragment in result.finalization.plan.fragments] == ["Canonical result"]
+            assert retry.changed is False
+            assert retry.finalization.message.event == result.finalization.message.event
+            assert retry.finalization.delivery.delivery == result.finalization.delivery.delivery
+            assert retry.finalization.plan.fragments == result.finalization.plan.fragments
+            assert await _terminal_rows(store) == (1, 1, 1)
+            async with store.connection.execute(
+                "SELECT event_type FROM event_log WHERE position >= ? ORDER BY position",
+                (result.finalization.message.event.position,),
+            ) as cursor:
+                assert [str(row[0]) for row in await cursor.fetchall()] == [
+                    "message.created",
+                    "delivery.requested",
+                    "run_attempt.completed",
+                    "run.completed",
+                ]
+        finally:
+            await store.close()
+
+    async def test_failure_commits_only_typed_sanitized_visible_outcome(self, tmp_path: Path):
+        store, authority, claim = await _started_run(tmp_path / "kai.db")
+        try:
+            result = await WorkshopRunTerminalTransactionCoordinator(authority).fail(
+                claim,
+                failure_code=TerminalFailureCode.AUTHENTICATION_EXPIRED,
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+
+            assert result.outcome == TerminalOutcome.FAILED
+            assert result.execution.run.status == RunStatus.FAILED
+            assert result.execution.run.terminal_code == "authentication_expired"
+            assert result.execution.attempt.status == RunAttemptStatus.FAILED
+            assert [fragment.body for fragment in result.finalization.plan.fragments] == [
+                "Authentication for the configured agent has expired. Kai did not complete this request."
+            ]
+            with pytest.raises(ValueError, match="TerminalFailureCode"):
+                await WorkshopRunTerminalTransactionCoordinator(authority).fail(
+                    claim,
+                    failure_code="native provider payload",  # type: ignore[arg-type]
+                    occurred_at=_NOW + timedelta(seconds=5),
+                )
+        finally:
+            await store.close()
+
+    async def test_confirmed_cancellation_commits_request_code_and_fixed_outcome(self, tmp_path: Path):
+        store, authority, claim = await _started_run(tmp_path / "kai.db")
+        try:
+            await authority.request_cancellation(
+                claim.run_id,
+                cancellation_code="requested_by_human",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+            result = await WorkshopRunTerminalTransactionCoordinator(authority).confirm_cancellation(
+                claim,
+                occurred_at=_NOW + timedelta(seconds=5),
+            )
+
+            assert result.outcome == TerminalOutcome.CANCELLED
+            assert result.execution.run.status == RunStatus.CANCELLED
+            assert result.execution.run.terminal_code == "requested_by_human"
+            assert result.execution.attempt.status == RunAttemptStatus.CANCELLED
+            assert [fragment.body for fragment in result.finalization.plan.fragments] == ["This request was cancelled."]
+        finally:
+            await store.close()
+
+    async def test_stale_fence_rolls_back_every_visible_outcome_row(self, tmp_path: Path):
+        store, authority, stale_claim = await _started_run(tmp_path / "kai.db")
+        try:
+            renewed = await authority.renew(
+                stale_claim,
+                occurred_at=_NOW + timedelta(seconds=4),
+                lease_expires_at=_NOW + timedelta(minutes=3),
+            )
+            with pytest.raises(StaleRunExecutionAuthorityError, match="stale lease version"):
+                await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+                    stale_claim,
+                    body="Must roll back",
+                    occurred_at=_NOW + timedelta(seconds=5),
+                )
+
+            assert await _terminal_rows(store) == (0, 0, 0)
+            assert (await WorkshopRunLifecycle(store).state(stale_claim.run_id)).status == RunStatus.STARTED
+            assert (await authority.attempt(renewed.claim.attempt_id)).status == RunAttemptStatus.STARTED
+        finally:
+            await store.close()
+
+    async def test_plan_failure_rolls_back_message_delivery_and_run_settlement(self, tmp_path: Path):
+        store, authority, claim = await _started_run(tmp_path / "kai.db")
+        try:
+            await store.connection.execute(
+                "CREATE TRIGGER reject_terminal_plan BEFORE INSERT ON delivery_fragments "
+                "BEGIN SELECT RAISE(ABORT, 'terminal plan rejected'); END"
+            )
+            await store.connection.commit()
+
+            with pytest.raises(aiosqlite.IntegrityError, match="terminal plan rejected"):
+                await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+                    claim,
+                    body="Must roll back",
+                    occurred_at=_NOW + timedelta(seconds=4),
+                )
+
+            assert await _terminal_rows(store) == (0, 0, 0)
+            assert (await WorkshopRunLifecycle(store).state(claim.run_id)).status == RunStatus.STARTED
+            assert (await authority.attempt(claim.attempt_id)).status == RunAttemptStatus.STARTED
+        finally:
+            await store.close()
+
+    async def test_preexisting_visible_outcome_without_settlement_is_rejected(self, tmp_path: Path):
+        store, authority, claim = await _started_run(tmp_path / "kai.db")
+        try:
+            run = await WorkshopRunLifecycle(store).state(claim.run_id)
+            await record_outbound_message_with_streaming_finalization(
+                store,
+                OutboundMessage(
+                    in_reply_to_message_id=run.inbound_message_id,
+                    body="Half state",
+                    occurred_at=_NOW + timedelta(seconds=4),
+                ),
+            )
+
+            with pytest.raises(TerminalTransactionStateConflictError, match="share one prior state"):
+                await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+                    claim,
+                    body="Half state",
+                    occurred_at=_NOW + timedelta(seconds=5),
+                )
+
+            assert (await WorkshopRunLifecycle(store).state(claim.run_id)).status == RunStatus.STARTED
+            assert (await authority.attempt(claim.attempt_id)).status == RunAttemptStatus.STARTED
+            assert await _terminal_rows(store) == (1, 1, 1)
+        finally:
+            await store.close()
+
+    async def test_first_terminal_outcome_wins_without_persisting_loser(self, tmp_path: Path):
+        store, authority, claim = await _started_run(tmp_path / "kai.db")
+        coordinator = WorkshopRunTerminalTransactionCoordinator(authority)
+        try:
+            completed = await coordinator.complete(
+                claim,
+                body="Winning result",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+
+            with pytest.raises(IdempotencyConflictError):
+                await coordinator.fail(
+                    claim,
+                    failure_code=TerminalFailureCode.TRANSIENT,
+                    occurred_at=_NOW + timedelta(seconds=5),
+                )
+
+            run = await WorkshopRunLifecycle(store).state(claim.run_id)
+            assert run.status == RunStatus.COMPLETED
+            assert run.result_message_id == completed.finalization.message.event.envelope.aggregate_id
+            assert await _terminal_rows(store) == (1, 1, 1)
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM event_log WHERE event_type IN ('run.failed', 'run_attempt.failed')"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+        finally:
+            await store.close()
+
+    async def test_commit_result_loss_is_resolved_by_deterministic_retry(self, tmp_path: Path, monkeypatch):
+        store, authority, claim = await _started_run(tmp_path / "kai.db")
+        coordinator = WorkshopRunTerminalTransactionCoordinator(authority)
+        original_commit = aiosqlite.Connection.commit
+        commit_calls = 0
+
+        async def commit_then_lose_result(connection: aiosqlite.Connection) -> None:
+            nonlocal commit_calls
+            await original_commit(connection)
+            commit_calls += 1
+            if connection is store.connection and commit_calls == 1:
+                raise aiosqlite.OperationalError("commit result lost")
+
+        try:
+            monkeypatch.setattr(aiosqlite.Connection, "commit", commit_then_lose_result)
+            result = await coordinator.complete(
+                claim,
+                body="Committed exactly once",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+
+            assert result.changed is False
+            assert commit_calls == 2
+            assert await _terminal_rows(store) == (1, 1, 1)
+            assert result.execution.run.status == RunStatus.COMPLETED
+        finally:
+            await store.close()
+
+    async def test_second_commit_resolution_failure_is_explicitly_uncertain(self, tmp_path: Path, monkeypatch):
+        store, authority, claim = await _started_run(tmp_path / "kai.db")
+        coordinator = WorkshopRunTerminalTransactionCoordinator(authority)
+
+        async def unavailable_commit(_connection: aiosqlite.Connection) -> None:
+            raise aiosqlite.OperationalError("commit unavailable")
+
+        try:
+            monkeypatch.setattr(aiosqlite.Connection, "commit", unavailable_commit)
+            with pytest.raises(TerminalTransactionCommitUncertainError):
+                await coordinator.complete(
+                    claim,
+                    body="Never committed",
+                    occurred_at=_NOW + timedelta(seconds=4),
+                )
+
+            assert await _terminal_rows(store) == (0, 0, 0)
+        finally:
+            await store.close()
+
+    def test_coordinator_remains_unregistered(self):
+        source_root = Path(__file__).parents[1] / "src" / "kai"
+        for relative_path in ("main.py", "bot.py", "sessions.py"):
+            source = (source_root / relative_path).read_text(encoding="utf-8")
+            assert "WorkshopRunTerminalTransactionCoordinator" not in source


### PR DESCRIPTION
## Summary

- atomically commit canonical terminal text, exact-epoch delivery work, immutable operation plan, fenced attempt settlement, and run settlement
- support success, typed backend-neutral failure, and confirmed cancellation without persisting native backend errors
- reject stale fences, partial prior state, losing terminal outcomes, and delivery-plan failures without partial settlement
- resolve a lost commit result through one deterministic retry and report unresolved outcomes explicitly

## Production impact

The coordinator is not constructed by production code. Existing outbound finalization and run-authority APIs retain their behavior through guarded transaction-local primitives. No worker, Telegram route, backend dispatch, recovery registration, schema migration, or installed behavior changes.

## Validation

- `5463 passed, 1 skipped`
- `make check`
- `make typecheck`
- `make module-sizes`
- `git diff --check`
