### PR TITLE
Coordinate durable Workshop execution

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1680,3 +1680,36 @@ grant, the conservative `started` boundary, and exact-runtime dispatch. Then
 integrate durable cancellation and interrupted-execution recovery with that
 lane. The lane identity must be canonical `(channel_id, agent_id)` and must not
 expose a Telegram chat ID as execution authority.
+
+## 33. Canonical execution coordinator
+
+**Implementation date:** 2026-08-12
+
+The production-unused coordinator now owns one canonical
+`(channel_id, agent_id)` lane from an accepted `RunId` through protected
+preparation, internal owner/fence grant, exact-runtime validation, the durable
+started boundary, dispatch, lease renewal, and atomic terminal settlement. It
+loads the prompt from the canonical inbound message; callers cannot supply a
+transport identity, prompt override, backend, provider, model, command, path,
+environment, or credential. Concurrent replay cannot invoke a second backend.
+
+Cancellation records durable human intent, stops only the exact prepared
+runtime, and confirms cancellation only after shutdown completes. A failed
+shutdown becomes a bounded interruption rather than a false cancellation.
+Pre-dispatch drift leaves an expirable grant and never calls the backend.
+Expired started work now commits a fixed visible interruption, exact-epoch
+delivery work, interrupted attempt, and failed run atomically; the obsolete
+invisible-recovery path no longer exists. Native backend errors never enter
+canonical history.
+
+Focused tests cover success ordering, stored-prompt authority, duplicate
+dispatch suppression, bounded failures, exact-runtime cancellation, drift and
+grant recovery, post-start interruption, terminal replay, and absence from
+production construction. No installed behavior changes.
+
+### 33.1 Next bounded milestone
+
+Conduct the activation review, then route authenticated private Telegram text
+through this coordinator while retaining the current streaming presentation
+and delivery worker. That activation is the first slice in this sequence that
+will require `make install` and an operator-visible Telegram qualification.

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -87,6 +87,14 @@ class PreparedBackendExecution:
     def workspace(self) -> Path:
         return self._fingerprint.workspace
 
+    def validate_current(self) -> None:
+        """Fail before dispatch if the protected runtime selection drifted."""
+        self._pool._validate_prepared(self)
+
+    async def cancel(self) -> None:
+        """Stop only the exact runtime bound to this protected handle."""
+        await self._pool._cancel_prepared(self)
+
     async def stream(self, prompt: str | list) -> AsyncGenerator[StreamEvent]:
         if self._consumed:
             raise RuntimeError("Prepared backend execution is one-shot")
@@ -461,14 +469,9 @@ class SubprocessPool:
         prompt: str | list,
     ) -> AsyncGenerator[StreamEvent]:
         """Dispatch through a prepared handle only while its runtime remains exact."""
+        self._validate_prepared(prepared)
         chat_id = prepared._chat_id
-        instance = self.get_if_exists(chat_id)
-        if instance is not prepared._instance:
-            raise RuntimeError("Prepared backend runtime is no longer current")
-        if chat_id in self._pending_workspace_restore or chat_id in self._pending_settings_restore:
-            raise RuntimeError("Prepared backend runtime has pending effective settings")
-        if _runtime_fingerprint(instance) != prepared._fingerprint:
-            raise RuntimeError("Prepared backend runtime changed before dispatch")
+        instance = prepared._instance
         self._last_activity[chat_id] = time.monotonic()
         self._in_flight.add(chat_id)
         try:
@@ -477,6 +480,32 @@ class SubprocessPool:
         finally:
             self._in_flight.discard(chat_id)
             self._last_activity[chat_id] = time.monotonic()
+
+    def _validate_prepared(self, prepared: PreparedBackendExecution) -> None:
+        chat_id = prepared._chat_id
+        instance = self.get_if_exists(chat_id)
+        if instance is not prepared._instance:
+            raise RuntimeError("Prepared backend runtime is no longer current")
+        if chat_id in self._pending_workspace_restore or chat_id in self._pending_settings_restore:
+            raise RuntimeError("Prepared backend runtime has pending effective settings")
+        if _runtime_fingerprint(instance) != prepared._fingerprint:
+            raise RuntimeError("Prepared backend runtime changed before dispatch")
+
+    async def _cancel_prepared(self, prepared: PreparedBackendExecution) -> None:
+        self._validate_prepared(prepared)
+        chat_id = prepared._chat_id
+        instance = prepared._instance
+        try:
+            await asyncio.wait_for(instance.shutdown(), timeout=_FORCE_KILL_TIMEOUT)
+        except Exception:
+            instance.force_kill()
+            log.warning("prepared cancellation: shutdown failed for user %d, sent SIGKILL", chat_id)
+        finally:
+            # Never remove or stop a replacement installed while the exact
+            # prepared runtime was shutting down.
+            if self._pool.get(chat_id) is instance:
+                self._pool.pop(chat_id, None)
+                self._last_activity.pop(chat_id, None)
 
     async def _attempt_workspace_restore(self, chat_id: int, instance: AgentBackend) -> Path:
         """Restore the saved workspace into a live instance.

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -1,0 +1,406 @@
+"""Production-unused canonical coordination for durable Workshop execution."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Protocol
+
+from kai.agent_failure import AgentFailureKind
+from kai.backend import AgentResponse
+from kai.workshop.domain import AgentId, ChannelId, RunExecutionOwnerId, RunId
+from kai.workshop.protected_execution import PreparedWorkshopExecution
+from kai.workshop.run_execution_authority import (
+    RunAttemptStatus,
+    RunExecutionClaim,
+    RunExecutionConflictError,
+    RunExecutionSelection,
+    WorkshopRunExecutionAuthority,
+)
+from kai.workshop.run_lifecycle import DurableRun, RunStatus, WorkshopRunLifecycle
+from kai.workshop.store import WorkshopEventStore
+from kai.workshop.terminal_transactions import (
+    TerminalFailureCode,
+    TerminalTransactionResult,
+    WorkshopRunTerminalTransactionCoordinator,
+)
+
+
+class ProtectedPreparation(Protocol):
+    async def prepare(self, run_id: RunId) -> PreparedWorkshopExecution: ...
+
+
+class CanonicalExecutionDisposition(StrEnum):
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    TERMINAL_REPLAY = "terminal_replay"
+    ACTIVE_REPLAY = "active_replay"
+    CANCELLATION_PENDING_REPLAY = "cancellation_pending_replay"
+    PREPARATION_DEFERRED = "preparation_deferred"
+
+
+class CanonicalCancellationDisposition(StrEnum):
+    REQUESTED = "requested"
+    NOT_ACTIVE = "not_active"
+    ALREADY_TERMINAL = "already_terminal"
+    INTERRUPTED = "interrupted"
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalExecutionResult:
+    disposition: CanonicalExecutionDisposition
+    run: DurableRun
+    terminal: TerminalTransactionResult | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalRecoveryResult:
+    expired_before_dispatch: int
+    interrupted_after_dispatch: int
+
+
+@dataclass(slots=True)
+class _ActiveExecution:
+    run_id: RunId
+    ready: asyncio.Event = field(default_factory=asyncio.Event)
+    finished: asyncio.Event = field(default_factory=asyncio.Event)
+    cancellation_done: asyncio.Event = field(default_factory=asyncio.Event)
+    renewal_stop: asyncio.Event = field(default_factory=asyncio.Event)
+    cancel_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    claim_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    cancellation_requested: bool = False
+    cancellation_error: BaseException | None = None
+    prepared: PreparedWorkshopExecution | None = None
+    authority: WorkshopRunExecutionAuthority | None = None
+    claim: RunExecutionClaim | None = None
+    started: bool = False
+    settling: bool = False
+
+
+_FAILURE_CODE_BY_KIND = {
+    AgentFailureKind.AUTHENTICATION_EXPIRED: TerminalFailureCode.AUTHENTICATION_EXPIRED,
+    AgentFailureKind.AUTHENTICATION_REQUIRED: TerminalFailureCode.AUTHENTICATION_REQUIRED,
+    AgentFailureKind.QUOTA_EXHAUSTED: TerminalFailureCode.QUOTA_EXHAUSTED,
+    AgentFailureKind.MODEL_UNAVAILABLE: TerminalFailureCode.MODEL_UNAVAILABLE,
+    AgentFailureKind.PROVIDER_UNAVAILABLE: TerminalFailureCode.PROVIDER_UNAVAILABLE,
+    AgentFailureKind.TRANSIENT: TerminalFailureCode.TRANSIENT,
+    AgentFailureKind.BACKEND_CRASHED: TerminalFailureCode.BACKEND_CRASHED,
+    AgentFailureKind.UNKNOWN: TerminalFailureCode.UNKNOWN,
+}
+
+
+class WorkshopCanonicalExecutionCoordinator:
+    """Own one canonical lane from accepted run through terminal settlement.
+
+    The public execution input is only a canonical ``RunId``. Prompt, lane,
+    compatibility runtime identity, backend selection, owner, and delivery
+    authority are all derived behind this boundary. Production does not yet
+    construct this coordinator.
+    """
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        preparation: ProtectedPreparation,
+        *,
+        registered_backend_ids: frozenset[str],
+        clock: Callable[[], datetime] | None = None,
+        lease_duration: timedelta = timedelta(minutes=5),
+    ) -> None:
+        if not registered_backend_ids:
+            raise ValueError("registered_backend_ids must not be empty")
+        if lease_duration <= timedelta(0) or lease_duration > timedelta(minutes=5):
+            raise ValueError("lease_duration must be positive and no longer than five minutes")
+        self._store = store
+        self._preparation = preparation
+        self._registered_backend_ids = registered_backend_ids
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self._lease_duration = lease_duration
+        self._lanes: dict[tuple[ChannelId, AgentId], asyncio.Lock] = {}
+        self._active: dict[RunId, _ActiveExecution] = {}
+        self._map_lock = asyncio.Lock()
+        self._database_lock = asyncio.Lock()
+
+    async def execute(self, run_id: RunId) -> CanonicalExecutionResult:
+        if not isinstance(run_id, RunId):
+            raise ValueError("run_id must be a RunId")
+        run = await self._run(run_id)
+        lane = await self._lane(run.channel_id, run.agent_id)
+        async with lane:
+            run = await self._run(run_id)
+            replay = await self._replay_disposition(run)
+            if replay is not None:
+                return CanonicalExecutionResult(replay, run)
+
+            active = _ActiveExecution(run_id)
+            async with self._map_lock:
+                self._active[run_id] = active
+            try:
+                return await self._execute_owned(active, run)
+            finally:
+                active.finished.set()
+                active.ready.set()
+                active.cancellation_done.set()
+                async with self._map_lock:
+                    if self._active.get(run_id) is active:
+                        del self._active[run_id]
+
+    async def request_cancellation(self, run_id: RunId) -> CanonicalCancellationDisposition:
+        if not isinstance(run_id, RunId):
+            raise ValueError("run_id must be a RunId")
+        async with self._map_lock:
+            active = self._active.get(run_id)
+            if active is not None:
+                active.cancellation_requested = True
+        if active is None:
+            run = await self._run(run_id)
+            return (
+                CanonicalCancellationDisposition.ALREADY_TERMINAL
+                if run.status in {RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED}
+                else CanonicalCancellationDisposition.NOT_ACTIVE
+            )
+
+        await active.ready.wait()
+        async with active.cancel_lock:
+            if active.finished.is_set() or active.claim is None or active.authority is None or active.prepared is None:
+                return CanonicalCancellationDisposition.NOT_ACTIVE
+            if not active.cancellation_done.is_set():
+                try:
+                    async with self._database_lock:
+                        await active.authority.request_cancellation(
+                            run_id,
+                            cancellation_code="requested_by_human",
+                            occurred_at=self._now(),
+                        )
+                    await active.prepared.cancel()
+                except RunExecutionConflictError:
+                    active.cancellation_error = None
+                    active.cancellation_done.set()
+                    return CanonicalCancellationDisposition.ALREADY_TERMINAL
+                except BaseException as exc:
+                    active.cancellation_error = exc
+                finally:
+                    active.cancellation_done.set()
+        return (
+            CanonicalCancellationDisposition.REQUESTED
+            if active.cancellation_error is None
+            else CanonicalCancellationDisposition.INTERRUPTED
+        )
+
+    async def recover_expired(self, *, occurred_at: datetime | None = None) -> CanonicalRecoveryResult:
+        now = self._timestamp(occurred_at or self._now())
+        expired = interrupted = 0
+        async with self._database_lock:
+            probe = self._probe_authority()
+            attempts = await probe.expired_attempts(occurred_at=now)
+            for attempt in attempts:
+                authority = self._authority(attempt.selection)
+                claim = RunExecutionClaim.from_attempt(attempt)
+                if attempt.status == RunAttemptStatus.GRANTED:
+                    await authority.expire_grant(claim, occurred_at=now)
+                    expired += 1
+                else:
+                    await WorkshopRunTerminalTransactionCoordinator(authority).interrupt_expired(
+                        claim,
+                        occurred_at=now,
+                    )
+                    interrupted += 1
+        return CanonicalRecoveryResult(expired, interrupted)
+
+    async def _execute_owned(self, active: _ActiveExecution, run: DurableRun) -> CanonicalExecutionResult:
+        try:
+            async with self._database_lock:
+                prepared = await self._preparation.prepare(run.run_id)
+            authority = self._authority(prepared.selection)
+            now = self._now()
+            async with self._database_lock:
+                granted = await authority.grant(
+                    run.run_id,
+                    owner_id=RunExecutionOwnerId.new(),
+                    occurred_at=now,
+                    lease_expires_at=now + self._lease_duration,
+                )
+            active.prepared = prepared
+            active.authority = authority
+            active.claim = granted.claim
+            active.ready.set()
+
+            if active.cancellation_requested:
+                return await self._settle_requested_cancellation(active)
+
+            prepared.validate_current()
+            async with self._database_lock:
+                started = await authority.start(granted.claim, occurred_at=self._now())
+            active.claim = started.claim
+            active.started = True
+
+            response = await self._consume_with_renewal(active, prepared)
+            if active.cancellation_requested:
+                return await self._settle_requested_cancellation(active)
+            terminal = WorkshopRunTerminalTransactionCoordinator(authority)
+            async with self._database_lock:
+                active.settling = True
+                if response is None or (response.success and not response.text.strip()):
+                    settled = await terminal.fail(
+                        active.claim,
+                        failure_code=TerminalFailureCode.NO_RESPONSE,
+                        occurred_at=self._now(),
+                    )
+                    disposition = CanonicalExecutionDisposition.FAILED
+                elif response.success:
+                    settled = await terminal.complete(
+                        active.claim,
+                        body=response.text,
+                        occurred_at=self._now(),
+                    )
+                    disposition = CanonicalExecutionDisposition.COMPLETED
+                else:
+                    settled = await terminal.fail(
+                        active.claim,
+                        failure_code=_FAILURE_CODE_BY_KIND.get(
+                            response.failure_kind or AgentFailureKind.UNKNOWN,
+                            TerminalFailureCode.UNKNOWN,
+                        ),
+                        occurred_at=self._now(),
+                    )
+                    disposition = CanonicalExecutionDisposition.FAILED
+            return CanonicalExecutionResult(disposition, settled.execution.run, settled)
+        except Exception:
+            if active.cancellation_requested and active.claim is not None:
+                return await self._settle_requested_cancellation(active)
+            if active.settling:
+                raise
+            if active.started and active.authority is not None and active.claim is not None:
+                async with self._database_lock:
+                    active.settling = True
+                    settled = await WorkshopRunTerminalTransactionCoordinator(active.authority).fail(
+                        active.claim,
+                        failure_code=TerminalFailureCode.EXECUTION_INTERRUPTED,
+                        occurred_at=self._now(),
+                    )
+                return CanonicalExecutionResult(CanonicalExecutionDisposition.FAILED, settled.execution.run, settled)
+            return CanonicalExecutionResult(
+                CanonicalExecutionDisposition.PREPARATION_DEFERRED, await self._run(run.run_id)
+            )
+
+    async def _settle_requested_cancellation(self, active: _ActiveExecution) -> CanonicalExecutionResult:
+        await active.cancellation_done.wait()
+        assert active.authority is not None and active.claim is not None
+        if active.cancellation_error is not None:
+            if active.started:
+                async with self._database_lock:
+                    active.settling = True
+                    result = await WorkshopRunTerminalTransactionCoordinator(active.authority).fail(
+                        active.claim,
+                        failure_code=TerminalFailureCode.EXECUTION_INTERRUPTED,
+                        occurred_at=self._now(),
+                    )
+                return CanonicalExecutionResult(CanonicalExecutionDisposition.FAILED, result.execution.run, result)
+            return CanonicalExecutionResult(
+                CanonicalExecutionDisposition.PREPARATION_DEFERRED,
+                await self._run(active.run_id),
+            )
+        async with self._database_lock:
+            active.settling = True
+            result = await WorkshopRunTerminalTransactionCoordinator(active.authority).confirm_cancellation(
+                active.claim,
+                occurred_at=self._now(),
+            )
+        return CanonicalExecutionResult(CanonicalExecutionDisposition.CANCELLED, result.execution.run, result)
+
+    async def _consume(self, prepared: PreparedWorkshopExecution) -> AgentResponse | None:
+        prompt = await self._prompt(prepared.run)
+        response: AgentResponse | None = None
+        async for event in prepared.stream(prompt):
+            if event.done:
+                response = event.response
+                break
+        return response
+
+    async def _consume_with_renewal(
+        self,
+        active: _ActiveExecution,
+        prepared: PreparedWorkshopExecution,
+    ) -> AgentResponse | None:
+        renewal = asyncio.create_task(self._renew_while_running(active))
+        try:
+            return await self._consume(prepared)
+        finally:
+            active.renewal_stop.set()
+            await renewal
+
+    async def _renew_while_running(self, active: _ActiveExecution) -> None:
+        interval = self._lease_duration.total_seconds() / 2
+        while True:
+            try:
+                await asyncio.wait_for(active.renewal_stop.wait(), timeout=interval)
+                return
+            except TimeoutError:
+                pass
+            async with active.claim_lock:
+                if active.settling or active.claim is None or active.authority is None:
+                    return
+                now = self._now()
+                async with self._database_lock:
+                    renewed = await active.authority.renew(
+                        active.claim,
+                        occurred_at=now,
+                        lease_expires_at=now + self._lease_duration,
+                    )
+                active.claim = renewed.claim
+
+    async def _prompt(self, run: DurableRun) -> str:
+        async with (
+            self._database_lock,
+            self._store.connection.execute(
+                "SELECT body FROM messages WHERE id = ? AND channel_id = ? AND author_principal_id = ?",
+                (run.inbound_message_id, run.channel_id, run.requested_by_principal_id),
+            ) as cursor,
+        ):
+            row = await cursor.fetchone()
+        if row is None:
+            raise RunExecutionConflictError("Durable run no longer resolves its canonical prompt")
+        return str(row[0])
+
+    async def _run(self, run_id: RunId) -> DurableRun:
+        async with self._database_lock:
+            return await WorkshopRunLifecycle(self._store).state(run_id)
+
+    async def _replay_disposition(self, run: DurableRun) -> CanonicalExecutionDisposition | None:
+        if run.status in {RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED}:
+            return CanonicalExecutionDisposition.TERMINAL_REPLAY
+        if run.cancellation_requested_at is not None:
+            return CanonicalExecutionDisposition.CANCELLATION_PENDING_REPLAY
+        authority = self._probe_authority()
+        async with self._database_lock:
+            attempt = await authority.active_attempt(run.run_id)
+        return CanonicalExecutionDisposition.ACTIVE_REPLAY if attempt is not None else None
+
+    async def _lane(self, channel_id: ChannelId, agent_id: AgentId) -> asyncio.Lock:
+        key = (channel_id, agent_id)
+        async with self._map_lock:
+            return self._lanes.setdefault(key, asyncio.Lock())
+
+    def _authority(self, selection: RunExecutionSelection) -> WorkshopRunExecutionAuthority:
+        return WorkshopRunExecutionAuthority(
+            self._store,
+            selection_resolver=lambda _run: selection,
+            registered_backend_ids=self._registered_backend_ids,
+        )
+
+    def _probe_authority(self) -> WorkshopRunExecutionAuthority:
+        backend = min(self._registered_backend_ids)
+        return self._authority(RunExecutionSelection(backend, "coordinator-probe"))
+
+    def _now(self) -> datetime:
+        return self._timestamp(self._clock())
+
+    @staticmethod
+    def _timestamp(value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("clock must return a timezone-aware datetime")
+        return value.astimezone(UTC)

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -34,6 +34,14 @@ class PreparedWorkshopExecution:
         async for event in self._runtime.stream(prompt):
             yield event
 
+    def validate_current(self) -> None:
+        """Verify the exact runtime immediately before the started boundary."""
+        self._runtime.validate_current()
+
+    async def cancel(self) -> None:
+        """Stop only this prepared compatibility runtime."""
+        await self._runtime.cancel()
+
 
 class WorkshopProtectedExecutionPreparationService:
     """Resolve canonical run authority into one protected compatibility runtime."""

--- a/src/kai/workshop/run_execution_authority.py
+++ b/src/kai/workshop/run_execution_authority.py
@@ -245,6 +245,33 @@ class WorkshopRunExecutionAuthority:
             raise RunExecutionConflictError("Durable Workshop run attempt was not found")
         return attempt
 
+    async def active_attempt(self, run_id: RunId) -> RunAttempt | None:
+        """Return the sole nonterminal attempt for a run, failing on corruption."""
+        if not isinstance(run_id, RunId):
+            raise ValueError("run_id must be a RunId")
+        async with self._store.connection.execute(
+            "SELECT id FROM run_attempts WHERE run_id = ? AND status IN ('granted', 'started') ORDER BY id",
+            (run_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if len(rows) > 1:
+            raise RunExecutionConflictError("Durable run has multiple active attempts")
+        return None if not rows else await self._require_attempt(RunAttemptId(str(rows[0][0])))
+
+    async def expired_attempts(self, *, occurred_at: datetime) -> tuple[RunAttempt, ...]:
+        """Return expired active claims in deterministic recovery order."""
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        async with self._store.connection.execute(
+            "SELECT id FROM run_attempts WHERE status IN ('granted', 'started') "
+            "AND lease_expires_at <= ? ORDER BY lease_expires_at, id",
+            (occurred_at.isoformat(),),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        attempts = []
+        for row in rows:
+            attempts.append(await self._require_attempt(RunAttemptId(str(row[0]))))
+        return tuple(attempts)
+
     async def grant(
         self,
         run_id: RunId,
@@ -550,66 +577,171 @@ class WorkshopRunExecutionAuthority:
             terminal_code=None,
         )
 
-    async def recover_expired(self, *, occurred_at: datetime) -> RunRecoveryResult:
+    async def expire_grant(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        occurred_at: datetime,
+    ) -> RunExecutionResult:
+        """Expire authority that never crossed the backend-dispatch boundary."""
         occurred_at = _timestamp(occurred_at, field_name="occurred_at")
         connection = self._store.connection
-        expired = interrupted = 0
         try:
             await connection.execute("BEGIN IMMEDIATE")
-            projection = CanonicalConversationProjection()
-            await self._store.project_pending_in_transaction(projection)
-            async with connection.execute(
-                "SELECT id FROM run_attempts WHERE status IN ('granted', 'started') "
-                "AND lease_expires_at <= ? ORDER BY lease_expires_at, id",
-                (occurred_at.isoformat(),),
-            ) as cursor:
-                attempt_ids = [RunAttemptId(str(row[0])) for row in await cursor.fetchall()]
-            for attempt_id in attempt_ids:
-                attempt = await self._require_attempt(attempt_id)
-                run = await self._require_run(attempt.run_id)
-                claim = RunExecutionClaim.from_attempt(attempt)
-                actor = await _agent_principal(self._store, run)
-                if attempt.status == RunAttemptStatus.GRANTED:
-                    event = self._attempt_terminal_envelope(
-                        run,
-                        claim,
-                        actor=actor,
-                        event_type=WorkshopEventType.RUN_ATTEMPT_EXPIRED,
-                        operation="expired",
-                        terminal_code="lease_expired",
-                        occurred_at=occurred_at,
-                    )
-                    await self._store.append_in_transaction(event)
-                    expired += 1
-                else:
-                    attempt_event = self._attempt_terminal_envelope(
-                        run,
-                        claim,
-                        actor=actor,
-                        event_type=WorkshopEventType.RUN_ATTEMPT_INTERRUPTED,
-                        operation="interrupted",
-                        terminal_code="execution_interrupted",
-                        occurred_at=occurred_at,
-                    )
-                    await self._store.append_in_transaction(attempt_event)
-                    await self._store.append_in_transaction(
-                        self._run_terminal_envelope(
-                            run,
-                            claim,
-                            actor=actor,
-                            event_type=WorkshopEventType.RUN_FAILED,
-                            operation="failed",
-                            terminal_code="execution_interrupted",
-                            occurred_at=occurred_at,
-                        )
-                    )
-                    interrupted += 1
-            await self._store.project_pending_in_transaction(projection)
+            result = await self.expire_grant_in_transaction(claim, occurred_at=occurred_at)
             await connection.commit()
-            return RunRecoveryResult(expired_before_dispatch=expired, interrupted_after_dispatch=interrupted)
+            return result
         except Exception:
             await connection.rollback()
             raise
+
+    async def expire_grant_in_transaction(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        occurred_at: datetime,
+    ) -> RunExecutionResult:
+        """Expire one granted claim inside a caller-owned recovery transaction."""
+        if not self._store.connection.in_transaction:
+            raise RuntimeError("grant expiry in transaction requires an active transaction")
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        projection = CanonicalConversationProjection()
+        await self._store.project_pending_in_transaction(projection)
+        run, attempt = await self._current_claim(claim)
+        key = _attempt_key(claim.attempt_id, "expired")
+        prior = await self._store.event_by_idempotency_key(key)
+        if prior is not None:
+            expected = _attempt_payload(claim)
+            expected["terminal_code"] = "lease_expired"
+            if (
+                prior.envelope.event_type != WorkshopEventType.RUN_ATTEMPT_EXPIRED
+                or prior.envelope.aggregate_id != claim.attempt_id
+                or prior.envelope.payload != expected
+            ):
+                raise RunExecutionConflictError("Grant expiry retry has conflicting facts")
+            return RunExecutionResult(run=run, attempt=attempt, events=(prior,), changed=False)
+        if (
+            attempt.status != RunAttemptStatus.GRANTED
+            or attempt.lease_version != claim.lease_version
+            or occurred_at < attempt.lease_expires_at
+        ):
+            raise StaleRunExecutionAuthorityError("Execution grant is not eligible for expiry")
+        actor = await _agent_principal(self._store, run)
+        appended = await self._store.append_in_transaction(
+            self._attempt_terminal_envelope(
+                run,
+                claim,
+                actor=actor,
+                event_type=WorkshopEventType.RUN_ATTEMPT_EXPIRED,
+                operation="expired",
+                terminal_code="lease_expired",
+                occurred_at=occurred_at,
+            )
+        )
+        await self._store.project_pending_in_transaction(projection)
+        return RunExecutionResult(
+            run=await self._require_run(claim.run_id),
+            attempt=await self._require_attempt(claim.attempt_id),
+            events=(appended.event,),
+            changed=True,
+        )
+
+    async def interrupt_expired_in_transaction(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        occurred_at: datetime,
+    ) -> RunExecutionResult:
+        """Settle an expired started claim inside an atomic visible transaction."""
+        if not self._store.connection.in_transaction:
+            raise RuntimeError("interruption in transaction requires an active transaction")
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        projection = CanonicalConversationProjection()
+        await self._store.project_pending_in_transaction(projection)
+        run, attempt = await self._current_claim(claim)
+        attempt_key = _attempt_key(claim.attempt_id, "interrupted")
+        run_key = _run_key(claim.run_id, "failed")
+        prior_attempt = await self._store.event_by_idempotency_key(attempt_key)
+        prior_run = await self._store.event_by_idempotency_key(run_key)
+        actor = await _agent_principal(self._store, run)
+        expected_attempt = _attempt_payload(claim)
+        expected_attempt["terminal_code"] = "execution_interrupted"
+        expected_run = {
+            "attempt_id": claim.attempt_id,
+            "failure_code": "execution_interrupted",
+        }
+        if prior_attempt is not None or prior_run is not None:
+            if (
+                prior_attempt is None
+                or prior_run is None
+                or prior_attempt.envelope.event_type != WorkshopEventType.RUN_ATTEMPT_INTERRUPTED
+                or prior_attempt.envelope.payload != expected_attempt
+                or prior_run.envelope.event_type != WorkshopEventType.RUN_FAILED
+                or prior_run.envelope.payload != expected_run
+            ):
+                raise RunExecutionConflictError("Interrupted recovery retry has conflicting facts")
+            return RunExecutionResult(
+                run=run,
+                attempt=attempt,
+                events=(prior_attempt, prior_run),
+                changed=False,
+            )
+        if (
+            attempt.status != RunAttemptStatus.STARTED
+            or attempt.lease_version != claim.lease_version
+            or occurred_at < attempt.lease_expires_at
+        ):
+            raise StaleRunExecutionAuthorityError("Started execution is not eligible for interruption recovery")
+        first = await self._store.append_in_transaction(
+            self._attempt_terminal_envelope(
+                run,
+                claim,
+                actor=actor,
+                event_type=WorkshopEventType.RUN_ATTEMPT_INTERRUPTED,
+                operation="interrupted",
+                terminal_code="execution_interrupted",
+                occurred_at=occurred_at,
+            )
+        )
+        second = await self._store.append_in_transaction(
+            self._run_terminal_envelope(
+                run,
+                claim,
+                actor=actor,
+                event_type=WorkshopEventType.RUN_FAILED,
+                operation="failed",
+                terminal_code="execution_interrupted",
+                occurred_at=occurred_at,
+            )
+        )
+        await self._store.project_pending_in_transaction(projection)
+        return RunExecutionResult(
+            run=await self._require_run(claim.run_id),
+            attempt=await self._require_attempt(claim.attempt_id),
+            events=(first.event, second.event),
+            changed=True,
+        )
+
+    async def recover_expired(self, *, occurred_at: datetime) -> RunRecoveryResult:
+        """Recover expired authority through the canonical terminal contract."""
+        occurred_at = _timestamp(occurred_at, field_name="occurred_at")
+        expired = interrupted = 0
+        for attempt in await self.expired_attempts(occurred_at=occurred_at):
+            claim = RunExecutionClaim.from_attempt(attempt)
+            if attempt.status == RunAttemptStatus.GRANTED:
+                await self.expire_grant(claim, occurred_at=occurred_at)
+                expired += 1
+            else:
+                # Local import avoids making terminal transaction definitions
+                # part of the authority module's construction dependency.
+                from kai.workshop.terminal_transactions import WorkshopRunTerminalTransactionCoordinator
+
+                await WorkshopRunTerminalTransactionCoordinator(self).interrupt_expired(
+                    claim,
+                    occurred_at=occurred_at,
+                )
+                interrupted += 1
+        return RunRecoveryResult(expired_before_dispatch=expired, interrupted_after_dispatch=interrupted)
 
     async def _settle(
         self,

--- a/src/kai/workshop/terminal_transactions.py
+++ b/src/kai/workshop/terminal_transactions.py
@@ -56,6 +56,7 @@ class TerminalFailureCode(StrEnum):
     TRANSIENT = "transient"
     BACKEND_CRASHED = "backend_crashed"
     NO_RESPONSE = "no_response"
+    EXECUTION_INTERRUPTED = "execution_interrupted"
     UNKNOWN = "unknown"
 
 
@@ -80,6 +81,9 @@ _FAILURE_MESSAGES = {
         "The configured agent stopped unexpectedly. Kai did not complete this request."
     ),
     TerminalFailureCode.NO_RESPONSE: "The configured agent returned no response. Kai did not complete this request.",
+    TerminalFailureCode.EXECUTION_INTERRUPTED: (
+        "Kai was interrupted while the configured agent was working. This request was not retried."
+    ),
     TerminalFailureCode.UNKNOWN: "The configured agent could not complete this request.",
 }
 
@@ -159,6 +163,24 @@ class WorkshopRunTerminalTransactionCoordinator:
             )
         )
 
+    async def interrupt_expired(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        occurred_at: datetime,
+    ) -> TerminalTransactionResult:
+        """Atomically expose and settle an expired post-dispatch interruption."""
+        return await self._resolve_possible_commit(
+            lambda: self._settle_once(
+                claim,
+                outcome=TerminalOutcome.FAILED,
+                body=_FAILURE_MESSAGES[TerminalFailureCode.EXECUTION_INTERRUPTED],
+                occurred_at=occurred_at,
+                failure_code=TerminalFailureCode.EXECUTION_INTERRUPTED,
+                expired_interruption=True,
+            )
+        )
+
     async def _resolve_possible_commit(
         self,
         operation: Callable[[], Awaitable[TerminalTransactionResult]],
@@ -181,6 +203,7 @@ class WorkshopRunTerminalTransactionCoordinator:
         body: str,
         occurred_at: datetime,
         failure_code: TerminalFailureCode | None = None,
+        expired_interruption: bool = False,
     ) -> TerminalTransactionResult:
         if not isinstance(claim, RunExecutionClaim):
             raise ValueError("claim must be a RunExecutionClaim")
@@ -207,11 +230,17 @@ class WorkshopRunTerminalTransactionCoordinator:
                 )
             elif outcome == TerminalOutcome.FAILED:
                 assert failure_code is not None
-                execution = await self._authority.fail_in_transaction(
-                    claim,
-                    failure_code=failure_code.value,
-                    occurred_at=occurred_at,
-                )
+                if expired_interruption:
+                    execution = await self._authority.interrupt_expired_in_transaction(
+                        claim,
+                        occurred_at=occurred_at,
+                    )
+                else:
+                    execution = await self._authority.fail_in_transaction(
+                        claim,
+                        failure_code=failure_code.value,
+                        occurred_at=occurred_at,
+                    )
             else:
                 execution = await self._authority.confirm_cancellation_in_transaction(
                     claim,

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -803,6 +803,44 @@ class TestPreparedExecution:
         send.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_prepared_cancellation_stops_only_the_exact_current_runtime(self):
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
+        ):
+            prepared = await pool.prepare_execution(111)
+        instance = pool.get(111)
+        with patch.object(instance, "shutdown", new_callable=AsyncMock) as shutdown:
+            await prepared.cancel()
+        shutdown.assert_awaited_once_with()
+        assert pool.get_if_exists(111) is None
+
+        pool._pool[111] = MagicMock()
+        with (
+            pytest.raises(RuntimeError, match="no longer current"),
+        ):
+            await prepared.cancel()
+
+    @pytest.mark.asyncio
+    async def test_prepared_cancellation_preserves_replacement_created_during_shutdown(self):
+        pool = SubprocessPool(config=_make_config(), services_info=[])
+        with (
+            patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
+            patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
+        ):
+            prepared = await pool.prepare_execution(111)
+        instance = pool.get(111)
+        replacement = MagicMock()
+
+        async def replace_during_shutdown():
+            pool._pool[111] = replacement
+
+        with patch.object(instance, "shutdown", side_effect=replace_during_shutdown):
+            await prepared.cancel()
+        assert pool.get_if_exists(111) is replacement
+
+    @pytest.mark.asyncio
     async def test_restore_applies_db_user_settings(self, tmp_path):
         """DB per-user settings override users.yaml baseline on restore."""
         ws = tmp_path / "saved_ws"

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -1,0 +1,269 @@
+"""End-to-end contracts for the production-unused Workshop coordinator."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from kai.agent_failure import AgentFailureKind
+from kai.backend import AgentResponse, StreamEvent
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.conversation_commands import WorkshopConversationCommandService
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.domain import RunExecutionOwnerId
+from kai.workshop.execution_coordinator import (
+    CanonicalCancellationDisposition,
+    CanonicalExecutionDisposition,
+    WorkshopCanonicalExecutionCoordinator,
+)
+from kai.workshop.inbound import InboundMessage
+from kai.workshop.run_execution_authority import (
+    RunAttemptStatus,
+    RunExecutionSelection,
+    WorkshopRunExecutionAuthority,
+)
+from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 8, 12, 22, 0, tzinfo=UTC)
+
+
+class _Prepared:
+    def __init__(
+        self,
+        run,
+        *,
+        response: AgentResponse | None = None,
+        wait: asyncio.Event | None = None,
+        on_stream: Callable[[], Awaitable[None]] | None = None,
+    ) -> None:
+        self.run = run
+        self.selection = RunExecutionSelection("codex", "gpt-5.6-sol")
+        self.response = response or AgentResponse(success=True, text="Canonical answer")
+        self.wait = wait
+        self.on_stream = on_stream
+        self.prompts: list[str] = []
+        self.validated = False
+        self.cancelled = False
+        self.reject_validation = False
+
+    def validate_current(self) -> None:
+        self.validated = True
+        if self.reject_validation:
+            raise RuntimeError("runtime drift")
+
+    async def cancel(self) -> None:
+        self.cancelled = True
+        if self.wait is not None:
+            self.wait.set()
+
+    async def stream(self, prompt: str) -> AsyncIterator[StreamEvent]:
+        self.prompts.append(prompt)
+        if self.on_stream is not None:
+            await self.on_stream()
+        if self.wait is not None:
+            await self.wait.wait()
+            if self.cancelled:
+                raise RuntimeError("runtime stopped")
+        yield StreamEvent(text_so_far=self.response.text, done=True, response=self.response)
+
+
+class _Preparation:
+    def __init__(self, prepared: _Prepared) -> None:
+        self.prepared = prepared
+        self.calls = 0
+
+    async def prepare(self, run_id):
+        assert run_id == self.prepared.run.run_id
+        self.calls += 1
+        return self.prepared
+
+
+async def _accepted(path: Path, *, suffix: str = "1"):
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="telegram",
+                external_subject="101",
+                external_channel_id="101",
+            ),
+        ),
+    )
+    result = await WorkshopConversationCommandService(store).accept(
+        InboundMessage(
+            transport="telegram",
+            update_id=f"command-{suffix}",
+            message_id=f"message-{suffix}",
+            sender_subject="101",
+            channel_subject="101",
+            body=f"Canonical prompt {suffix}",
+            occurred_at=_NOW,
+        )
+    )
+    await WorkshopConversationDeliveryAuthority(store).activate()
+    return store, result.run
+
+
+def _coordinator(store, preparation, *, lease_seconds: int = 60):
+    return WorkshopCanonicalExecutionCoordinator(
+        store,
+        preparation,
+        registered_backend_ids=frozenset({"codex"}),
+        clock=lambda: _NOW + timedelta(seconds=10),
+        lease_duration=timedelta(seconds=lease_seconds),
+    )
+
+
+async def _terminal_bodies(store: WorkshopEventStore) -> list[str]:
+    async with store.connection.execute("SELECT body FROM messages ORDER BY created_event_position") as cursor:
+        return [str(row[0]) for row in await cursor.fetchall()]
+
+
+class TestCanonicalExecutionCoordinator:
+    async def test_success_uses_stored_prompt_and_starts_before_exact_dispatch(self, tmp_path: Path):
+        store, run = await _accepted(tmp_path / "kai.db")
+
+        async def assert_started() -> None:
+            assert (await WorkshopRunLifecycle(store).state(run.run_id)).status == RunStatus.STARTED
+
+        prepared = _Prepared(run, on_stream=assert_started)
+        coordinator = _coordinator(store, _Preparation(prepared))
+        try:
+            result = await coordinator.execute(run.run_id)
+
+            assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+            assert result.run.status == RunStatus.COMPLETED
+            assert prepared.validated is True
+            assert prepared.prompts == ["Canonical prompt 1"]
+            assert await _terminal_bodies(store) == ["Canonical prompt 1", "Canonical answer"]
+        finally:
+            await store.close()
+
+    async def test_concurrent_duplicate_dispatches_backend_once(self, tmp_path: Path):
+        store, run = await _accepted(tmp_path / "kai.db")
+        release = asyncio.Event()
+        prepared = _Prepared(run, wait=release)
+        preparation = _Preparation(prepared)
+        coordinator = _coordinator(store, preparation)
+        try:
+            first = asyncio.create_task(coordinator.execute(run.run_id))
+            while not prepared.prompts:
+                await asyncio.sleep(0)
+            second = asyncio.create_task(coordinator.execute(run.run_id))
+            release.set()
+            first_result, second_result = await asyncio.gather(first, second)
+
+            assert first_result.disposition == CanonicalExecutionDisposition.COMPLETED
+            assert second_result.disposition == CanonicalExecutionDisposition.TERMINAL_REPLAY
+            assert preparation.calls == 1
+            assert prepared.prompts == ["Canonical prompt 1"]
+        finally:
+            await store.close()
+
+    async def test_native_failure_is_replaced_by_bounded_canonical_text(self, tmp_path: Path):
+        store, run = await _accepted(tmp_path / "kai.db")
+        prepared = _Prepared(
+            run,
+            response=AgentResponse(
+                success=False,
+                text="",
+                error="native secret-bearing payload",
+                failure_kind=AgentFailureKind.AUTHENTICATION_REQUIRED,
+            ),
+        )
+        try:
+            result = await _coordinator(store, _Preparation(prepared)).execute(run.run_id)
+
+            assert result.disposition == CanonicalExecutionDisposition.FAILED
+            bodies = await _terminal_bodies(store)
+            assert (
+                bodies[-1] == "Authentication for the configured agent is required. Kai did not complete this request."
+            )
+            assert "native" not in bodies[-1]
+        finally:
+            await store.close()
+
+    async def test_runtime_drift_leaves_retryable_grant_until_expiry(self, tmp_path: Path):
+        store, run = await _accepted(tmp_path / "kai.db")
+        prepared = _Prepared(run)
+        prepared.reject_validation = True
+        preparation = _Preparation(prepared)
+        coordinator = _coordinator(store, preparation, lease_seconds=5)
+        try:
+            deferred = await coordinator.execute(run.run_id)
+            assert deferred.disposition == CanonicalExecutionDisposition.PREPARATION_DEFERRED
+            assert (await WorkshopRunLifecycle(store).state(run.run_id)).status == RunStatus.ACCEPTED
+
+            recovered = await coordinator.recover_expired(occurred_at=_NOW + timedelta(seconds=16))
+            assert recovered.expired_before_dispatch == 1
+            prepared.reject_validation = False
+            completed = await coordinator.execute(run.run_id)
+            assert completed.disposition == CanonicalExecutionDisposition.COMPLETED
+            assert preparation.calls == 2
+        finally:
+            await store.close()
+
+    async def test_cancellation_is_confirmed_only_after_exact_runtime_stops(self, tmp_path: Path):
+        store, run = await _accepted(tmp_path / "kai.db")
+        release = asyncio.Event()
+        prepared = _Prepared(run, wait=release)
+        coordinator = _coordinator(store, _Preparation(prepared))
+        try:
+            execution = asyncio.create_task(coordinator.execute(run.run_id))
+            while not prepared.prompts:
+                await asyncio.sleep(0)
+            cancellation = await coordinator.request_cancellation(run.run_id)
+            result = await execution
+
+            assert cancellation == CanonicalCancellationDisposition.REQUESTED
+            assert prepared.cancelled is True
+            assert result.disposition == CanonicalExecutionDisposition.CANCELLED
+            assert result.run.status == RunStatus.CANCELLED
+            assert (await _terminal_bodies(store))[-1] == "This request was cancelled."
+        finally:
+            await store.close()
+
+    async def test_expired_started_attempt_gets_visible_interruption_without_redispatch(self, tmp_path: Path):
+        store, run = await _accepted(tmp_path / "kai.db")
+        selection = RunExecutionSelection("codex", "gpt-5.6-sol")
+        authority = WorkshopRunExecutionAuthority(
+            store,
+            selection_resolver=lambda _run: selection,
+            registered_backend_ids=frozenset({"codex"}),
+        )
+        granted = await authority.grant(
+            run.run_id,
+            owner_id=RunExecutionOwnerId.new(),
+            occurred_at=_NOW + timedelta(seconds=1),
+            lease_expires_at=_NOW + timedelta(seconds=2),
+        )
+        await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=1, milliseconds=500))
+        prepared = _Prepared(run)
+        preparation = _Preparation(prepared)
+        coordinator = _coordinator(store, preparation)
+        try:
+            recovered = await coordinator.recover_expired(occurred_at=_NOW + timedelta(seconds=3))
+
+            assert recovered.interrupted_after_dispatch == 1
+            assert (await authority.attempt(granted.claim.attempt_id)).status == RunAttemptStatus.INTERRUPTED
+            assert (await WorkshopRunLifecycle(store).state(run.run_id)).status == RunStatus.FAILED
+            assert (await _terminal_bodies(store))[-1] == (
+                "Kai was interrupted while the configured agent was working. This request was not retried."
+            )
+            replay = await coordinator.execute(run.run_id)
+            assert replay.disposition == CanonicalExecutionDisposition.TERMINAL_REPLAY
+            assert preparation.calls == 0
+        finally:
+            await store.close()
+
+    async def test_coordinator_remains_absent_from_production_construction(self):
+        source_root = Path(__file__).parents[1] / "src" / "kai"
+        for relative_path in ("main.py", "bot.py", "sessions.py"):
+            source = (source_root / relative_path).read_text(encoding="utf-8")
+            assert "WorkshopCanonicalExecutionCoordinator" not in source

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -92,7 +92,7 @@ class TestProtectedExecutionPreparation:
             assert prepared.selection.provider == "anthropic"
             assert prepared.selection.model == "sonnet"
             assert prepared.workspace == home
-            assert "101" not in repr(prepared)
+            assert "_runtime" not in repr(prepared)
             assert not hasattr(prepared, "chat_id")
         finally:
             await pool.shutdown()

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.domain import MessageId, RunExecutionOwnerId
 from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.outbound import OutboundMessage, record_outbound_message
@@ -37,20 +38,20 @@ async def _open_authority(
             BootstrapHuman(
                 display_name="Workshop Human",
                 role="admin",
-                transport="desktop",
-                external_subject="human-1",
-                external_channel_id="human-1",
+                transport="telegram",
+                external_subject="101",
+                external_channel_id="101",
             ),
         ),
     )
     inbound = await record_inbound_message(
         store,
         InboundMessage(
-            transport="desktop",
+            transport="telegram",
             update_id="command-1",
             message_id="message-1",
-            sender_subject="human-1",
-            channel_subject="human-1",
+            sender_subject="101",
+            channel_subject="101",
             body="Perform one durable unit of work",
             occurred_at=_NOW,
         ),
@@ -65,6 +66,7 @@ async def _open_authority(
         ),
         registered_backend_ids=frozenset({"codex", "pi"}),
     )
+    await WorkshopConversationDeliveryAuthority(store).activate()
     return store, authority, inbound_id
 
 


### PR DESCRIPTION
## Summary

- add a production-unused canonical Workshop execution coordinator keyed by `(channel_id, agent_id)`
- derive prompt, protected runtime selection, execution owner, fence, and delivery authority from a canonical `RunId`
- bind validation, started state, dispatch, lease renewal, and atomic terminal settlement into one lifecycle
- suppress duplicate backend dispatch and return typed active, cancellation-pending, and terminal replay dispositions
- record durable cancellation intent, stop only the exact prepared runtime, and confirm cancellation only after shutdown
- replace the old invisible started-attempt recovery with an atomic visible `execution_interrupted` outcome and outbox plan

## Execution boundary

The coordinator accepts only a typed canonical run identity. It does not accept a Telegram ID, prompt override, backend, provider, model, command, executable path, environment, or credential. It loads the stored inbound message body and resolves the compatibility runtime behind the protected preparation boundary.

Immediately before the durable `started` transition, the coordinator verifies that the prepared pool object, effective selection, workspace, timeout, and pending settings remain unchanged. Dispatch then uses that exact one-shot runtime. Long-running work renews the fenced lease; terminal settlement uses the latest claim.

## Cancellation and recovery

- `/stop` integration is not activated in this PR, but the coordinator contract records `run.cancellation_requested`, shuts down the exact runtime, and only then commits the fixed cancellation result with attempt/run settlement.
- replacement runtimes are neither killed nor removed if one appears while the prepared runtime is shutting down.
- pre-dispatch runtime drift leaves the grant unstarted; lease expiry returns the run to accepted so a higher fence may retry.
- expired started work commits the fixed visible interruption message, exact-epoch delivery request and immutable plan, `run_attempt.interrupted`, and `run.failed` in one transaction. It is never automatically redispatched.
- native provider errors are mapped to bounded backend-neutral failure codes and cannot enter canonical history.

## Tests

- `make check`
- `make typecheck`
- `make module-sizes`
- focused coordinator/authority/terminal/protected-runtime/pool suite: `113 passed`
- full suite: `5472 passed, 1 skipped`

Focused coverage includes stored-prompt authority, started-before-dispatch ordering, concurrent duplicate suppression, bounded failure rendering, pre-dispatch drift and retry, exact-runtime cancellation, replacement-runtime preservation, expired-start interruption, terminal replay, and absence from production construction.

## Operational impact

None yet. `main.py`, `bot.py`, and `sessions.py` do not construct this coordinator. No schema, configuration, installed service, Telegram behavior, streaming UI, or backend selection changes in this PR, so `make install` is not required after merge.

The next bounded PR is the activation review and production wiring for authenticated private Telegram text. That will be the first slice in this sequence requiring install and Telegram qualification.
