### PR TITLE
Activate durable Workshop private-text execution

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -411,7 +411,7 @@ No entry may use an indefinite condition such as "keep for compatibility." A gen
 | JSONL transcript writes and reads | Canonical message projection, with an explicit export facility if still useful | Canonical reads serve complete context and transcript views; migration/parity diagnostics report no unexplained divergence | Stop JSONL writes; remove production reads and dual-write recovery code; retain only a documented importer/exporter if required | Planned |
 | Telegram `chat_id` used as internal identity, namespace, and routing key | Durable principal, channel, agent, and binding IDs | Private chats, notification-only groups, duplicate updates, and restart routing all resolve correctly through bindings | Confine Telegram IDs to external identity, transport binding, and idempotency records; remove chat-shaped domain keys | Active (authoritative private text now enters execution by canonical message ID, but the compatibility resolver still derives the current pool key from the human principal's protected Telegram identity; settings, locks, history, files, memory, and excluded routes remain chat-keyed) |
 | `SubprocessPool` keyed by Telegram chat ID | Durable channel/agent session plus run and attempt orchestration | All five harnesses pass continuity, restart, cancellation, and isolation tests through durable identities | Remove chat-key compatibility lookup and move lifecycle ownership behind the orchestrator/runtime contract | Active (a canonical conversation-run service hides the private-text pool lookup behind a temporary compatibility resolution; the pool and all five harness processes remain keyed by that resolved integer) |
-| Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Active (authoritative private text invokes through the canonical conversation-run service using only its inbound `MessageId`; a transport-neutral durable run lifecycle exists production-unused; the run-authority review holds live lifecycle activation until execution attempts, cancellation intent, atomic terminal results, and terminal replay suppression exist) |
+| Direct backend invocation from Telegram handlers | Transport-neutral command and run services | Telegram and the first Workshop client produce equivalent authorized runs and visible results | Remove handler-owned orchestration; leave authentication, parsing, and rendering in the Telegram adapter | Active (authenticated private-chat text with voice mode off now accepts and executes by canonical `RunId`, with fenced attempts, durable cancellation, atomic terminal settlement, and replay suppression; media, voice modes, groups, schedules, and integrations retain their compatibility orchestration) |
 | Direct Telegram delivery from handlers, schedules, and webhooks | Durable delivery outbox and Telegram delivery adapter | Delivery outcome events preserve binding identity; retry, crash recovery, ordering, private-chat and notification-group delivery tests pass; live delivery is verified | Migrate each remaining transport path separately; the private-text direct fallback is retired | Active (authenticated private-chat text with voice mode off uses atomic streaming finalization and a supervised exact-epoch worker and now fails closed rather than demoting to direct/shadow delivery; commands, media, voice, schedules, webhooks, files, and groups retain existing delivery) |
 | Operator-invoked Workshop delivery qualification CLI | Installed evidence followed by the production delivery worker | A configured direct-chat reply is prepared without sending, survives a service restart, recovers an intentionally abandoned lease, reaches Telegram once through the exact selected delivery, and records a terminal binding-aware outcome; a configured notification group resolves through its outbound-only canonical channel, receives one atomically prepared qualification message through the exact selected delivery, and does not become an inbound conversation | Remove the qualification command and its explicit-claim-only surface after the production worker has equivalent installed restart/recovery evidence and direct delivery is retired | Active (the installed direct-chat recovery and notification-group delivery gates passed on 2026-08-12; retain until equivalent production-worker evidence exists, while the command remains unregistered and incapable of draining unrelated work) |
 | Conversation-delivery authority epochs | A single durable delivery authority after direct-send rollback is retired | Activation/deactivation, restart, historical-row isolation, exact-epoch worker ownership, aggregate diagnostics, and installed rollback/reactivation evidence pass; no supported rollback crosses the direct-send/outbox boundary | Remove epoch stamping, activation/deactivation state, exact-epoch claim filters, transitional readiness output, schema columns/tables where safely migratable, and their compatibility tests | Active (production startup resumes or creates the exact epoch before ingress; installed private-text streaming, all-send, fragmentation, restart/no-replay, aggregate authority, and parity checks passed on 2026-08-12) |
@@ -1713,3 +1713,37 @@ Conduct the activation review, then route authenticated private Telegram text
 through this coordinator while retaining the current streaming presentation
 and delivery worker. That activation is the first slice in this sequence that
 will require `make install` and an operator-visible Telegram qualification.
+
+## 34. Authenticated private-text execution activation
+
+**Implementation date:** 2026-08-12
+
+Authenticated Telegram private-chat text with voice mode off now uses one
+production-owned Workshop execution service. The service atomically accepts
+the canonical command, resolves the protected runtime from the deployed
+backend registry, dispatches under the canonical `(channel_id, agent_id)`
+lane, renews its fenced lease, and commits exactly one terminal message,
+delivery plan, attempt outcome, and run outcome. The handler cannot fall back
+to direct backend invocation or direct final Telegram delivery if this service
+is unavailable.
+
+Telegram still renders stable non-final streaming prefixes. A confirmed
+preview is durably bound to the canonical inbound message; final presentation
+is left to the supervised Workshop outbox worker. Exact update replay does not
+invoke the backend or duplicate transitional JSONL user history. `/stop`
+resolves the active canonical private run and stops only its prepared runtime
+before cancellation is confirmed.
+
+Startup opens a dedicated event-store connection, completes expired-attempt
+recovery before polling or webhook ingress begins, and supervises the recovery
+loop alongside the delivery worker. Shutdown removes the handler-visible
+service and closes it before the delivery worker and shared session database.
+The old per-chat responding marker and Telegram-chat execution lock are not
+used by this route; durable run state and the canonical lane are authoritative.
+
+Photo, document, voice, voice-enabled text, groups, schedules, and webhook
+notifications remain on their established compatibility paths. This bounded
+activation therefore requires an installed private-text qualification after
+merge: one ordinary response, one duplicate/replay check, one `/stop` check,
+and a clean `make install-status` run with no pending, failed, or uncertain
+conversation deliveries.

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -83,10 +83,16 @@ from kai.telegram_utils import chunk_text
 from kai.transcribe import TranscriptionError, transcribe_voice
 from kai.tts import DEFAULT_VOICE, VOICES, TTSError, synthesize_speech
 from kai.workshop.artifacts import InboundArtifact
+from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.conversation_runs import PreparedConversationRun, WorkshopConversationRunService
-from kai.workshop.domain import MessageId
+from kai.workshop.domain import MessageId, RunId
+from kai.workshop.execution_coordinator import (
+    CanonicalCancellationDisposition,
+    CanonicalExecutionDisposition,
+)
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
+from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
 from kai.workspace_utils import is_workspace_allowed
 
@@ -1600,6 +1606,20 @@ async def handle_stop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     """
     assert update.message is not None
     chat_id = _chat_id(update)
+    execution: WorkshopPrivateTextExecutionService | None = context.bot_data.get("workshop_private_text_execution")
+    if execution is not None and chat_id == _user_id(update):
+        disposition = await execution.request_cancellation(
+            telegram_user_id=_user_id(update),
+            telegram_chat_id=chat_id,
+        )
+        if disposition == CanonicalCancellationDisposition.REQUESTED:
+            await update.message.reply_text("Stopping...")
+            return
+        if disposition == CanonicalCancellationDisposition.INTERRUPTED:
+            await update.message.reply_text(
+                "Kai could not confirm a clean stop. The interrupted request will not be retried automatically."
+            )
+            return
     pool = _get_pool(context)
     stop_event = get_stop_event(chat_id)
     stop_event.set()
@@ -4607,6 +4627,161 @@ async def _check_totp_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         return False
 
 
+def _schedule_memory_ingestion(
+    *,
+    prompt: str | list,
+    assistant_text: str,
+    chat_id: int,
+    session_id: str | None,
+    config: Config,
+    workspace: str,
+    user_log: LogEntry | None,
+    assistant_log: LogEntry | None,
+) -> None:
+    """Preserve the existing fire-and-forget semantic-memory write path."""
+    from kai.memory import is_enabled as memory_is_enabled
+
+    if memory_is_enabled():
+
+        async def _ingest_memory() -> None:
+            try:
+                from kai import memory_extraction
+
+                if isinstance(prompt, str):
+                    user_text = prompt
+                else:
+                    user_text = next(
+                        (block["text"] for block in prompt if block.get("type") == "text"),
+                        "",
+                    )
+                if not user_text:
+                    return
+                user_config = config.get_user_config(chat_id)
+                effective_backend = (
+                    user_config.backend if user_config and user_config.backend else config.default_backend
+                )
+                if config.memory_extraction_enabled and effective_backend in ONESHOT_REASONER_BACKENDS:
+                    prior_pairs: list[tuple[str, str]] = []
+                    if config.episode_classifier_context_turns > 0:
+                        from kai.history import get_recent_pairs
+
+                        fetched = get_recent_pairs(chat_id, config.episode_classifier_context_turns + 1)
+                        prior_pairs = fetched[:-1]
+                    await memory_extraction.extract_and_store(
+                        user_text=user_text,
+                        assistant_text=assistant_text,
+                        user_id=str(chat_id),
+                        session_id=session_id,
+                        config=config,
+                        prior_pairs=prior_pairs,
+                        workspace=workspace,
+                        user_log=user_log,
+                        assistant_log=assistant_log,
+                    )
+            except Exception:
+                log.warning("Memory ingestion failed", exc_info=True)
+
+        task = asyncio.create_task(_ingest_memory())
+        _pending_memory_tasks.add(task)
+        task.add_done_callback(_pending_memory_tasks.discard)
+
+
+async def _handle_workshop_private_text(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    *,
+    chat_id: int,
+    run_id: RunId,
+    inbound_message_id: MessageId,
+    prompt: str,
+    user_log: LogEntry | None,
+) -> None:
+    """Render streaming previews while Workshop owns execution and final delivery."""
+    assert update.message is not None
+    source_message = update.message
+    execution: WorkshopPrivateTextExecutionService = context.bot_data["workshop_private_text_execution"]
+    config: Config = context.bot_data["config"]
+    live_msg = None
+    last_edit_time = 0.0
+    last_edit_text = ""
+
+    async def observe(event) -> None:
+        nonlocal live_msg, last_edit_time, last_edit_text
+        if not event.text_so_far:
+            return
+        publishable = _stream_publishable_prefix(event.text_so_far)
+        if publishable is None or publishable == last_edit_text:
+            return
+        now = time.monotonic()
+        if live_msg is None:
+            live_msg = await _reply_safe(source_message, _truncate_for_telegram(publishable))
+            await sessions.record_workshop_streaming_preview(
+                ConfirmedTelegramStreamingPreview(
+                    inbound_message_id=inbound_message_id,
+                    external_message_id=live_msg.message_id,
+                    confirmed_at=datetime.now(UTC),
+                )
+            )
+            last_edit_time = now
+            last_edit_text = publishable
+        elif now - last_edit_time >= EDIT_INTERVAL:
+            await _edit_message_safe(live_msg, publishable)
+            last_edit_time = now
+            last_edit_text = publishable
+
+    typing_task = asyncio.create_task(_keep_private_text_typing(context, chat_id))
+    try:
+        result = await execution.execute(run_id, stream_observer=observe)
+    finally:
+        typing_task.cancel()
+        try:
+            await typing_task
+        except asyncio.CancelledError:
+            pass
+
+    if result.disposition == CanonicalExecutionDisposition.PREPARATION_DEFERRED:
+        await _reply_safe(update.message, "Kai could not safely prepare this request. Please try again.")
+        return
+    if result.disposition in {
+        CanonicalExecutionDisposition.ACTIVE_REPLAY,
+        CanonicalExecutionDisposition.CANCELLATION_PENDING_REPLAY,
+        CanonicalExecutionDisposition.TERMINAL_REPLAY,
+    }:
+        return
+    if result.terminal is None:
+        raise RuntimeError("Canonical execution settled without a terminal transaction")
+
+    final_text = result.terminal.body
+    if result.session_id and result.selection is not None:
+        await sessions.save_session(chat_id, result.session_id, result.selection.model)
+    assistant_log = log_message(
+        direction="assistant",
+        chat_id=chat_id,
+        text=final_text,
+        reader_user=_upload_reader_user(context, chat_id),
+    )
+    if result.disposition == CanonicalExecutionDisposition.COMPLETED and result.workspace is not None:
+        _schedule_memory_ingestion(
+            prompt=prompt,
+            assistant_text=final_text,
+            chat_id=chat_id,
+            session_id=result.session_id,
+            config=config,
+            workspace=result.workspace,
+            user_log=user_log,
+            assistant_log=assistant_log,
+        )
+
+
+async def _keep_private_text_typing(context: ContextTypes.DEFAULT_TYPE, chat_id: int) -> None:
+    while True:
+        try:
+            await context.bot.send_chat_action(chat_id=chat_id, action=ChatAction.TYPING)
+        except Exception:
+            pass
+        await asyncio.sleep(4)
+
+
 @_require_auth
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
@@ -4625,15 +4800,23 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     chat_id = _chat_id(update)
     prompt = update.message.text
     reader_user = _upload_reader_user(context, chat_id)
-    # Capture the user LogEntry so _handle_response can thread it to
-    # the provenance writer. None on JSONL write failure; the extraction
-    # path then skips provenance stamping for this exchange.
-    user_log = log_message(direction="user", chat_id=chat_id, text=prompt, reader_user=reader_user)
+    config: Config = context.bot_data["config"]
+    voice_mode = "off"
+    if config.tts_enabled:
+        voice_mode = await sessions.get_setting(f"voice_mode:{chat_id}") or "off"
+    private_text_activation = chat_id == _user_id(update) and voice_mode == "off"
+
     workshop_inbound_message_id: MessageId | None = None
-    recorder = context.bot_data.get("workshop_inbound_recorder")
-    if recorder is not None:
+    workshop_run_id: RunId | None = None
+    acceptance_disposition: ConversationCommandDisposition | None = None
+    if private_text_activation:
+        execution: WorkshopPrivateTextExecutionService | None = context.bot_data.get("workshop_private_text_execution")
+        if execution is None:
+            log.error("Workshop private-text execution service is unavailable; refusing legacy backend fallback")
+            await _reply_safe(update.message, "Kai's durable execution service is unavailable. Please try again.")
+            return
         try:
-            result = await recorder(
+            acceptance = await execution.accept(
                 InboundMessage(
                     transport="telegram",
                     update_id=str(update.update_id),
@@ -4644,22 +4827,73 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                     occurred_at=update.message.date,
                 )
             )
-            aggregate_id = result.event.envelope.aggregate_id
+            aggregate_id = acceptance.message.event.envelope.aggregate_id
             if not isinstance(aggregate_id, MessageId):
-                raise RuntimeError("Workshop inbound recorder returned a non-message aggregate")
+                raise RuntimeError("Workshop command acceptance returned a non-message aggregate")
             workshop_inbound_message_id = aggregate_id
+            workshop_run_id = acceptance.run.run_id
+            acceptance_disposition = acceptance.disposition
         except Exception:
             log.exception(
-                "Workshop inbound shadow write failed (update_id=%s, message_id=%s)",
+                "Workshop private-text acceptance failed; refusing legacy backend fallback "
+                "(update_id=%s, message_id=%s)",
                 update.update_id,
                 update.message.message_id,
             )
-    pool = _get_pool(context)
-    delivery_route = (
-        ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT if chat_id == _user_id(update) else ResponseDeliveryRoute.LEGACY
+            await _reply_safe(update.message, "Kai could not safely accept this request. Please try again.")
+            return
+    else:
+        recorder = context.bot_data.get("workshop_inbound_recorder")
+        if recorder is not None:
+            try:
+                result = await recorder(
+                    InboundMessage(
+                        transport="telegram",
+                        update_id=str(update.update_id),
+                        message_id=str(update.message.message_id),
+                        sender_subject=str(_user_id(update)),
+                        channel_subject=str(chat_id),
+                        body=prompt,
+                        occurred_at=update.message.date,
+                    )
+                )
+                aggregate_id = result.event.envelope.aggregate_id
+                if not isinstance(aggregate_id, MessageId):
+                    raise RuntimeError("Workshop inbound recorder returned a non-message aggregate")
+                workshop_inbound_message_id = aggregate_id
+            except Exception:
+                log.exception(
+                    "Workshop inbound shadow write failed (update_id=%s, message_id=%s)",
+                    update.update_id,
+                    update.message.message_id,
+                )
+
+    # Capture the user LogEntry so response processing can thread it to
+    # provenance. Exact durable replays must not duplicate JSONL history.
+    user_log = (
+        log_message(direction="user", chat_id=chat_id, text=prompt, reader_user=reader_user)
+        if acceptance_disposition in {None, ConversationCommandDisposition.NEWLY_ACCEPTED}
+        else None
     )
+    if private_text_activation:
+        if workshop_run_id is None or workshop_inbound_message_id is None:
+            raise RuntimeError("Accepted private text is missing canonical run authority")
+        await _handle_workshop_private_text(
+            update,
+            context,
+            chat_id=chat_id,
+            run_id=workshop_run_id,
+            inbound_message_id=workshop_inbound_message_id,
+            prompt=prompt,
+            user_log=user_log,
+        )
+        return
+
+    pool = _get_pool(context)
+    delivery_route = ResponseDeliveryRoute.LEGACY
     workshop_run: PreparedConversationRun | None = None
-    if delivery_route == ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT and workshop_inbound_message_id is not None:
+    if chat_id == _user_id(update) and workshop_inbound_message_id is not None:
+        delivery_route = ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT
         run_service: WorkshopConversationRunService | None = context.bot_data.get("workshop_conversation_run_service")
         if run_service is not None:
             try:
@@ -4848,6 +5082,7 @@ async def _handle_response(
                 last_edit_time = now
                 last_edit_text = publishable
                 if workshop_delivery_candidate:
+                    assert workshop_inbound_message_id is not None
                     preview_recorder = context.bot_data["workshop_streaming_preview_recorder"]
                     try:
                         await preview_recorder(
@@ -4962,6 +5197,7 @@ async def _handle_response(
     workshop_outbound_message_id: MessageId | None = None
     workshop_delivery_committed = False
     if workshop_delivery_candidate:
+        assert workshop_inbound_message_id is not None
         finalizer = context.bot_data["workshop_streaming_finalizer"]
         try:
             finalization_result = await finalizer(
@@ -5063,104 +5299,25 @@ async def _handle_response(
                 succeeded,
             )
 
-    # Fire-and-forget: embed this exchange in semantic memory.
-    # Runs in a background task so it does not delay response delivery.
-    # Failures are logged but never propagate to the user.
+    # Capture the workspace before scheduling ingestion so a later workspace
+    # switch cannot re-route facts from this exchange.
     from kai.memory import is_enabled as memory_is_enabled
 
-    if memory_is_enabled() and chat_id is not None:
-
-        async def _ingest_memory() -> None:
-            try:
-                from kai import memory_extraction
-
-                # Extract user text from prompt. For multimodal prompts
-                # (image + text), pull the first text block rather than
-                # storing the Python repr of the list.
-                if isinstance(prompt, str):
-                    user_text = prompt
-                else:
-                    user_text = next(
-                        (block["text"] for block in prompt if block.get("type") == "text"),
-                        "",
-                    )
-                # Skip image-only exchanges - no meaningful text to embed.
-                if not user_text:
-                    return
-
-                # Track 2: Haiku extraction. Runs only under the Claude
-                # backend and only when explicitly enabled. Fire-and-
-                # forget INSIDE the existing fire-and-forget task - the
-                # subprocess latency never blocks reply delivery.
-                #
-                # Spec 360 removed the previous Track 1 raw-user write
-                # that used to run alongside this call. The verbatim
-                # user storage was producing retrieval blocks dense
-                # with `User said:` lines that mimicked real user input
-                # and confused the inner agent on memory-adjacent
-                # topics. Extracted facts (Track 2) remain the only
-                # write path.
-                #
-                # Backend check uses the same per-user fall-through
-                # pattern as `_get_user_provider` (user override wins,
-                # else global). A global-only check would miss users
-                # with a per-user override, so the explicit fall-through
-                # is mandatory here.
-                user_config = config.get_user_config(chat_id)
-                effective_backend = (
-                    user_config.backend if user_config and user_config.backend else config.default_backend
-                )
-                if config.memory_extraction_enabled and effective_backend in ONESHOT_REASONER_BACKENDS:
-                    # Windowed PRIOR CONTEXT for the episode classifier
-                    # (issue #392). Fetch one extra pair beyond the
-                    # configured window and drop the most recent: the
-                    # current exchange has already been written to JSONL
-                    # by the log_message(direction="assistant", ...) call
-                    # above, so the newest pair returned by
-                    # `get_recent_pairs` IS the current exchange. The
-                    # `[:-1]` slice handles short-history cases
-                    # gracefully without a guard - on an empty `fetched`
-                    # list the slice is `[][:-1] == []`, on a single
-                    # element list it is `[]` (the only pair IS the
-                    # current exchange, nothing prior to drop into
-                    # `prior_pairs`), and on a multi-pair list it
-                    # drops only the most-recent entry. N=0 disables
-                    # windowing entirely; skip the disk read in that
-                    # case.
-                    prior_pairs: list[tuple[str, str]] = []
-                    if config.episode_classifier_context_turns > 0:
-                        from kai.history import get_recent_pairs
-
-                        fetched = get_recent_pairs(chat_id, config.episode_classifier_context_turns + 1)
-                        prior_pairs = fetched[:-1]
-                    await memory_extraction.extract_and_store(
-                        user_text=user_text,
-                        assistant_text=final_text,
-                        user_id=str(chat_id),
-                        session_id=final_response.session_id,
-                        config=config,
-                        prior_pairs=prior_pairs,
-                        workspace=ingest_workspace,
-                        user_log=user_log,
-                        assistant_log=assistant_log,
-                    )
-            except Exception:
-                log.warning("Memory ingestion failed", exc_info=True)
-
-        # Workspace for write-scope routing, captured BEFORE the
-        # fire-and-forget task is scheduled. The exchange being
-        # extracted happened in THIS workspace; reading
-        # pool.get_effective_workspace inside the task instead would
-        # let a /workspace switch that lands during the ingestion
-        # delay re-route the exchange's facts to a project the
-        # conversation never touched.
+    if memory_is_enabled():
         if workshop_delivery_candidate and workshop_run is not None:
             ingest_workspace = str(await workshop_run.effective_workspace())
         else:
             ingest_workspace = str(await pool.get_effective_workspace(chat_id))
-        task = asyncio.create_task(_ingest_memory())
-        _pending_memory_tasks.add(task)
-        task.add_done_callback(_pending_memory_tasks.discard)
+        _schedule_memory_ingestion(
+            prompt=prompt,
+            assistant_text=final_text,
+            chat_id=chat_id,
+            session_id=final_response.session_id,
+            config=config,
+            workspace=ingest_workspace,
+            user_log=user_log,
+            assistant_log=assistant_log,
+        )
 
     if workshop_delivery_committed:
         return

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -43,9 +43,11 @@ from telegram import BotCommand
 from telegram.error import NetworkError
 
 from kai import cron, services, sessions, webhook
+from kai.backend_registry import load_backend_registry
 from kai.bot import create_bot
 from kai.config import DATA_DIR, PROJECT_ROOT, _read_protected_file, load_config
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
+from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.telegram_delivery_runtime import WorkshopTelegramConversationDeliveryService
 
 
@@ -80,6 +82,16 @@ async def _workshop_bootstrap_notification_channels(config) -> tuple[BootstrapNo
         )
         for destination, members in sorted(members_by_group.items())
     )
+
+
+def _workshop_registered_backend_ids(config) -> frozenset[str]:
+    """Resolve the protected registry, with configured dev backends as fallback."""
+    registry = load_backend_registry()
+    if registry:
+        return frozenset(registry)
+    configured = {config.default_backend}
+    configured.update(user.backend for user in config.user_configs.values() if user.backend)
+    return frozenset(configured)
 
 
 def setup_logging() -> None:
@@ -309,6 +321,7 @@ def _start() -> None:
 
         app = create_bot(config, use_webhook=use_webhook)
         conversation_delivery: WorkshopTelegramConversationDeliveryService | None = None
+        private_text_execution: WorkshopPrivateTextExecutionService | None = None
 
         # Determine the default user (admin or first user) for per-user
         # data migrations and workspace restoration. users.yaml is
@@ -416,6 +429,14 @@ def _start() -> None:
             )
             logging.info("Workshop Telegram conversation delivery is ready")
 
+            private_text_execution = await WorkshopPrivateTextExecutionService.open_and_start(
+                config.session_db_path,
+                app.bot_data["pool"],
+                registered_backend_ids=_workshop_registered_backend_ids(config),
+            )
+            app.bot_data["workshop_private_text_execution"] = private_text_execution
+            logging.info("Workshop private-text execution is ready")
+
             # Start the HTTP server (always runs - serves scheduling API, GitHub
             # webhooks, file exchange, and health check regardless of transport mode).
             # In webhook mode, this also registers the Telegram webhook with the API.
@@ -488,7 +509,10 @@ def _start() -> None:
             # The delivery worker is part of service health. Unexpected worker
             # exit reaches the top-level crash path instead of leaving a loaded
             # Kai process that can accept replies it cannot deliver.
-            await conversation_delivery.wait()
+            await asyncio.gather(
+                conversation_delivery.wait(),
+                private_text_execution.wait(),
+            )
         finally:
             # Shutdown in reverse order of startup
             await webhook.stop()
@@ -496,6 +520,12 @@ def _start() -> None:
             # since the Updater was suppressed at build time)
             if not use_webhook and app.updater:
                 await app.updater.stop()
+            if private_text_execution is not None:
+                app.bot_data.pop("workshop_private_text_execution", None)
+                try:
+                    await private_text_execution.stop()
+                except Exception:
+                    logging.exception("Workshop private-text execution stopped with an error")
             if conversation_delivery is not None:
                 try:
                     await conversation_delivery.stop()

--- a/src/kai/workshop/conversation_commands.py
+++ b/src/kai/workshop/conversation_commands.py
@@ -1,4 +1,4 @@
-"""Production-unused atomic acceptance for canonical Workshop commands."""
+"""Atomic acceptance for canonical Workshop commands."""
 
 from __future__ import annotations
 
@@ -43,8 +43,8 @@ class ConversationCommandAcceptance:
 class WorkshopConversationCommandService:
     """Atomically append canonical inbound and run-acceptance facts.
 
-    This service starts no process and is not constructed by production code.
-    Its disposition is the durable input to a later execution coordinator.
+    This service starts no process. Its disposition is the durable input to
+    the execution coordinator owned by the production private-text runtime.
     """
 
     def __init__(self, store: WorkshopEventStore) -> None:

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -1,16 +1,16 @@
-"""Production-unused canonical coordination for durable Workshop execution."""
+"""Canonical coordination for durable Workshop execution."""
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Protocol
 
 from kai.agent_failure import AgentFailureKind
-from kai.backend import AgentResponse
+from kai.backend import AgentResponse, StreamEvent
 from kai.workshop.domain import AgentId, ChannelId, RunExecutionOwnerId, RunId
 from kai.workshop.protected_execution import PreparedWorkshopExecution
 from kai.workshop.run_execution_authority import (
@@ -31,6 +31,9 @@ from kai.workshop.terminal_transactions import (
 
 class ProtectedPreparation(Protocol):
     async def prepare(self, run_id: RunId) -> PreparedWorkshopExecution: ...
+
+
+type StreamObserver = Callable[[StreamEvent], Awaitable[None]]
 
 
 class CanonicalExecutionDisposition(StrEnum):
@@ -55,6 +58,9 @@ class CanonicalExecutionResult:
     disposition: CanonicalExecutionDisposition
     run: DurableRun
     terminal: TerminalTransactionResult | None = None
+    session_id: str | None = None
+    workspace: str | None = None
+    selection: RunExecutionSelection | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -73,7 +79,7 @@ class _ActiveExecution:
     cancel_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     claim_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     cancellation_requested: bool = False
-    cancellation_error: BaseException | None = None
+    cancellation_error: Exception | None = None
     prepared: PreparedWorkshopExecution | None = None
     authority: WorkshopRunExecutionAuthority | None = None
     claim: RunExecutionClaim | None = None
@@ -98,8 +104,7 @@ class WorkshopCanonicalExecutionCoordinator:
 
     The public execution input is only a canonical ``RunId``. Prompt, lane,
     compatibility runtime identity, backend selection, owner, and delivery
-    authority are all derived behind this boundary. Production does not yet
-    construct this coordinator.
+    authority are all derived behind this boundary.
     """
 
     def __init__(
@@ -110,6 +115,7 @@ class WorkshopCanonicalExecutionCoordinator:
         registered_backend_ids: frozenset[str],
         clock: Callable[[], datetime] | None = None,
         lease_duration: timedelta = timedelta(minutes=5),
+        database_lock: asyncio.Lock | None = None,
     ) -> None:
         if not registered_backend_ids:
             raise ValueError("registered_backend_ids must not be empty")
@@ -123,9 +129,14 @@ class WorkshopCanonicalExecutionCoordinator:
         self._lanes: dict[tuple[ChannelId, AgentId], asyncio.Lock] = {}
         self._active: dict[RunId, _ActiveExecution] = {}
         self._map_lock = asyncio.Lock()
-        self._database_lock = asyncio.Lock()
+        self._database_lock = database_lock or asyncio.Lock()
 
-    async def execute(self, run_id: RunId) -> CanonicalExecutionResult:
+    async def execute(
+        self,
+        run_id: RunId,
+        *,
+        stream_observer: StreamObserver | None = None,
+    ) -> CanonicalExecutionResult:
         if not isinstance(run_id, RunId):
             raise ValueError("run_id must be a RunId")
         run = await self._run(run_id)
@@ -140,7 +151,7 @@ class WorkshopCanonicalExecutionCoordinator:
             async with self._map_lock:
                 self._active[run_id] = active
             try:
-                return await self._execute_owned(active, run)
+                return await self._execute_owned(active, run, stream_observer=stream_observer)
             finally:
                 active.finished.set()
                 active.ready.set()
@@ -181,7 +192,7 @@ class WorkshopCanonicalExecutionCoordinator:
                     active.cancellation_error = None
                     active.cancellation_done.set()
                     return CanonicalCancellationDisposition.ALREADY_TERMINAL
-                except BaseException as exc:
+                except Exception as exc:
                     active.cancellation_error = exc
                 finally:
                     active.cancellation_done.set()
@@ -211,7 +222,13 @@ class WorkshopCanonicalExecutionCoordinator:
                     interrupted += 1
         return CanonicalRecoveryResult(expired, interrupted)
 
-    async def _execute_owned(self, active: _ActiveExecution, run: DurableRun) -> CanonicalExecutionResult:
+    async def _execute_owned(
+        self,
+        active: _ActiveExecution,
+        run: DurableRun,
+        *,
+        stream_observer: StreamObserver | None,
+    ) -> CanonicalExecutionResult:
         try:
             async with self._database_lock:
                 prepared = await self._preparation.prepare(run.run_id)
@@ -238,7 +255,7 @@ class WorkshopCanonicalExecutionCoordinator:
             active.claim = started.claim
             active.started = True
 
-            response = await self._consume_with_renewal(active, prepared)
+            response = await self._consume_with_renewal(active, prepared, stream_observer=stream_observer)
             if active.cancellation_requested:
                 return await self._settle_requested_cancellation(active)
             terminal = WorkshopRunTerminalTransactionCoordinator(authority)
@@ -268,13 +285,25 @@ class WorkshopCanonicalExecutionCoordinator:
                         occurred_at=self._now(),
                     )
                     disposition = CanonicalExecutionDisposition.FAILED
-            return CanonicalExecutionResult(disposition, settled.execution.run, settled)
+            return CanonicalExecutionResult(
+                disposition,
+                settled.execution.run,
+                settled,
+                session_id=response.session_id if response is not None and response.success else None,
+                workspace=str(prepared.workspace),
+                selection=prepared.selection,
+            )
         except Exception:
             if active.cancellation_requested and active.claim is not None:
                 return await self._settle_requested_cancellation(active)
             if active.settling:
                 raise
             if active.started and active.authority is not None and active.claim is not None:
+                if active.prepared is not None:
+                    try:
+                        await active.prepared.cancel()
+                    except Exception:
+                        pass
                 async with self._database_lock:
                     active.settling = True
                     settled = await WorkshopRunTerminalTransactionCoordinator(active.authority).fail(
@@ -282,7 +311,13 @@ class WorkshopCanonicalExecutionCoordinator:
                         failure_code=TerminalFailureCode.EXECUTION_INTERRUPTED,
                         occurred_at=self._now(),
                     )
-                return CanonicalExecutionResult(CanonicalExecutionDisposition.FAILED, settled.execution.run, settled)
+                return CanonicalExecutionResult(
+                    CanonicalExecutionDisposition.FAILED,
+                    settled.execution.run,
+                    settled,
+                    workspace=str(active.prepared.workspace) if active.prepared is not None else None,
+                    selection=active.prepared.selection if active.prepared is not None else None,
+                )
             return CanonicalExecutionResult(
                 CanonicalExecutionDisposition.PREPARATION_DEFERRED, await self._run(run.run_id)
             )
@@ -299,7 +334,13 @@ class WorkshopCanonicalExecutionCoordinator:
                         failure_code=TerminalFailureCode.EXECUTION_INTERRUPTED,
                         occurred_at=self._now(),
                     )
-                return CanonicalExecutionResult(CanonicalExecutionDisposition.FAILED, result.execution.run, result)
+                return CanonicalExecutionResult(
+                    CanonicalExecutionDisposition.FAILED,
+                    result.execution.run,
+                    result,
+                    workspace=str(active.prepared.workspace) if active.prepared is not None else None,
+                    selection=active.prepared.selection if active.prepared is not None else None,
+                )
             return CanonicalExecutionResult(
                 CanonicalExecutionDisposition.PREPARATION_DEFERRED,
                 await self._run(active.run_id),
@@ -310,25 +351,40 @@ class WorkshopCanonicalExecutionCoordinator:
                 active.claim,
                 occurred_at=self._now(),
             )
-        return CanonicalExecutionResult(CanonicalExecutionDisposition.CANCELLED, result.execution.run, result)
+        return CanonicalExecutionResult(
+            CanonicalExecutionDisposition.CANCELLED,
+            result.execution.run,
+            result,
+            workspace=str(active.prepared.workspace) if active.prepared is not None else None,
+            selection=active.prepared.selection if active.prepared is not None else None,
+        )
 
-    async def _consume(self, prepared: PreparedWorkshopExecution) -> AgentResponse | None:
+    async def _consume(
+        self,
+        prepared: PreparedWorkshopExecution,
+        *,
+        stream_observer: StreamObserver | None,
+    ) -> AgentResponse | None:
         prompt = await self._prompt(prepared.run)
         response: AgentResponse | None = None
         async for event in prepared.stream(prompt):
             if event.done:
                 response = event.response
                 break
+            if stream_observer is not None:
+                await stream_observer(event)
         return response
 
     async def _consume_with_renewal(
         self,
         active: _ActiveExecution,
         prepared: PreparedWorkshopExecution,
+        *,
+        stream_observer: StreamObserver | None,
     ) -> AgentResponse | None:
         renewal = asyncio.create_task(self._renew_while_running(active))
         try:
-            return await self._consume(prepared)
+            return await self._consume(prepared, stream_observer=stream_observer)
         finally:
             active.renewal_stop.set()
             await renewal

--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -1,0 +1,149 @@
+"""Production owner for authenticated private-text Workshop execution."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from kai.pool import SubprocessPool
+from kai.workshop.conversation_commands import ConversationCommandAcceptance, WorkshopConversationCommandService
+from kai.workshop.domain import RunId
+from kai.workshop.execution_coordinator import (
+    CanonicalCancellationDisposition,
+    CanonicalExecutionResult,
+    StreamObserver,
+    WorkshopCanonicalExecutionCoordinator,
+)
+from kai.workshop.inbound import InboundMessage
+from kai.workshop.protected_execution import WorkshopProtectedExecutionPreparationService
+from kai.workshop.store import WorkshopEventStore
+
+_RECOVERY_INTERVAL_SECONDS = 5.0
+
+
+class WorkshopPrivateTextExecutionService:
+    """Own one store, coordinator, and recovery loop for private text."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        coordinator: WorkshopCanonicalExecutionCoordinator,
+        command_service: WorkshopConversationCommandService,
+        database_lock: asyncio.Lock,
+    ) -> None:
+        self._store = store
+        self._coordinator = coordinator
+        self._command_service = command_service
+        self._database_lock = database_lock
+        self._stop_event = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    @classmethod
+    async def open_and_start(
+        cls,
+        database_path: Path,
+        pool: SubprocessPool,
+        *,
+        registered_backend_ids: frozenset[str],
+    ) -> WorkshopPrivateTextExecutionService:
+        store = await WorkshopEventStore.open(database_path)
+        database_lock = asyncio.Lock()
+        coordinator = WorkshopCanonicalExecutionCoordinator(
+            store,
+            WorkshopProtectedExecutionPreparationService(
+                store,
+                pool,
+                registered_backend_ids=registered_backend_ids,
+            ),
+            registered_backend_ids=registered_backend_ids,
+            database_lock=database_lock,
+        )
+        service = cls(store, coordinator, WorkshopConversationCommandService(store), database_lock)
+        try:
+            await coordinator.recover_expired()
+            service._task = asyncio.create_task(
+                service._recovery_loop(),
+                name="kai-workshop-private-text-recovery",
+            )
+        except BaseException:
+            await store.close()
+            raise
+        return service
+
+    @property
+    def ready(self) -> bool:
+        return not self._closed and self._task is not None and not self._task.done()
+
+    async def accept(self, message: InboundMessage) -> ConversationCommandAcceptance:
+        if self._closed:
+            raise RuntimeError("Workshop private-text execution service is closed")
+        async with self._database_lock:
+            return await self._command_service.accept(message)
+
+    async def execute(
+        self,
+        run_id: RunId,
+        *,
+        stream_observer: StreamObserver | None = None,
+    ) -> CanonicalExecutionResult:
+        if self._closed:
+            raise RuntimeError("Workshop private-text execution service is closed")
+        return await self._coordinator.execute(run_id, stream_observer=stream_observer)
+
+    async def request_cancellation(
+        self,
+        *,
+        telegram_user_id: int,
+        telegram_chat_id: int,
+    ) -> CanonicalCancellationDisposition:
+        """Resolve transport identity to a canonical run before cancellation."""
+        if telegram_user_id <= 0 or telegram_chat_id <= 0 or telegram_user_id != telegram_chat_id:
+            return CanonicalCancellationDisposition.NOT_ACTIVE
+        async with (
+            self._database_lock,
+            self._store.connection.execute(
+                "SELECT r.id FROM runs r "
+                "JOIN channels c ON c.id = r.channel_id AND c.kind = 'direct' "
+                "JOIN external_identities ei ON ei.principal_id = r.requested_by_principal_id "
+                "AND ei.provider = 'telegram' AND ei.external_subject = ? "
+                "JOIN channel_bindings cb ON cb.channel_id = r.channel_id "
+                "AND cb.transport = 'telegram' AND cb.external_channel_id = ? "
+                "WHERE r.status IN ('accepted', 'started') "
+                "ORDER BY r.accepted_at DESC, r.id",
+                (str(telegram_user_id), str(telegram_chat_id)),
+            ) as cursor,
+        ):
+            rows = list(await cursor.fetchall())
+        if not rows:
+            return CanonicalCancellationDisposition.NOT_ACTIVE
+        if len(rows) > 1:
+            raise RuntimeError("Canonical private channel has multiple nonterminal runs")
+        return await self._coordinator.request_cancellation(RunId(str(rows[0][0])))
+
+    async def wait(self) -> None:
+        task = self._task
+        if task is None:
+            raise RuntimeError("Workshop private-text recovery loop was not started")
+        await asyncio.shield(task)
+
+    async def stop(self) -> None:
+        if self._closed:
+            return
+        self._stop_event.set()
+        task = self._task
+        try:
+            if task is not None:
+                await asyncio.shield(task)
+        finally:
+            self._closed = True
+            self._task = None
+            await self._store.close()
+
+    async def _recovery_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=_RECOVERY_INTERVAL_SECONDS)
+                return
+            except TimeoutError:
+                await self._coordinator.recover_expired()

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -1,4 +1,4 @@
-"""Production-unused protected preparation for Workshop execution."""
+"""Protected preparation for Workshop execution."""
 
 from __future__ import annotations
 

--- a/src/kai/workshop/run_execution_authority.py
+++ b/src/kai/workshop/run_execution_authority.py
@@ -214,7 +214,7 @@ class WorkshopRunExecutionAuthority:
 
     The injected resolver is the protected policy boundary: callers identify a
     run and an execution owner, but cannot substitute a command, backend, or
-    model. No production object constructs this service yet.
+    model.
     """
 
     def __init__(

--- a/src/kai/workshop/terminal_transactions.py
+++ b/src/kai/workshop/terminal_transactions.py
@@ -93,6 +93,7 @@ _CANCELLATION_MESSAGE = "This request was cancelled."
 @dataclass(frozen=True, slots=True)
 class TerminalTransactionResult:
     outcome: TerminalOutcome
+    body: str
     finalization: OutboundStreamingFinalizationResult
     execution: RunExecutionResult
     changed: bool
@@ -264,6 +265,7 @@ class WorkshopRunTerminalTransactionCoordinator:
                 raise _PossibleCommitError("Workshop terminal commit result was unavailable") from commit_error
             return TerminalTransactionResult(
                 outcome=outcome,
+                body=body,
                 finalization=finalization,
                 execution=execution,
                 changed=changed,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -82,12 +82,14 @@ from kai.config import PROVIDER_MODELS, Config, UserConfig, get_default_model_fo
 from kai.review import CollectionWarning, PRReviewResult
 from kai.tts import DEFAULT_VOICE, VOICES
 from kai.workshop.artifacts import InboundArtifact
+from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.conversation_runs import (
     CanonicalConversationRunTarget,
     PreparedConversationRun,
     WorkshopConversationRunService,
 )
-from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, WorkshopId
+from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, RunId, WorkshopId
+from kai.workshop.execution_coordinator import CanonicalCancellationDisposition
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
 from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
@@ -1188,6 +1190,21 @@ class TestHandleStop:
         claude.force_kill.assert_called_once()
         reply = update.message.reply_text.call_args[0][0]
         assert "stopping" in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_private_text_stop_uses_canonical_cancellation_without_pool_kill(self):
+        pool = _make_mock_claude()
+        update = _make_update(chat_id=1, user_id=1)
+        ctx = _make_context(claude=pool, config=_make_config(allowed_user_ids={1}))
+        execution = MagicMock()
+        execution.request_cancellation = AsyncMock(return_value=CanonicalCancellationDisposition.REQUESTED)
+        ctx.bot_data["workshop_private_text_execution"] = execution
+
+        await handle_stop(update, ctx)
+
+        execution.request_cancellation.assert_awaited_once_with(telegram_user_id=1, telegram_chat_id=1)
+        pool.force_kill.assert_not_called()
+        assert update.message.reply_text.await_args.args[0] == "Stopping..."
 
 
 # ── handle_stats ─────────────────────────────────────────────────────
@@ -2784,24 +2801,25 @@ class TestHandleMessage:
         ctx = _make_context(config=_make_config(allowed_user_ids={1}))
         recorder = AsyncMock()
         inbound_id = MessageId("msg_00000000000000000000000000000001")
-        recorder.return_value.event.envelope.aggregate_id = inbound_id
         ctx.bot_data["workshop_inbound_recorder"] = recorder
-        prepared_run = MagicMock(spec=PreparedConversationRun)
-        prepared_run.model = "gpt-5.6-sol"
-        run_service = MagicMock(spec=WorkshopConversationRunService)
-        run_service.prepare = AsyncMock(return_value=prepared_run)
-        ctx.bot_data["workshop_conversation_run_service"] = run_service
+        run_id = RunId("run_00000000000000000000000000000001")
+        execution = MagicMock()
+        execution.accept = AsyncMock()
+        execution.accept.return_value.message.event.envelope.aggregate_id = inbound_id
+        execution.accept.return_value.run.run_id = run_id
+        execution.accept.return_value.disposition = ConversationCommandDisposition.NEWLY_ACCEPTED
+        ctx.bot_data["workshop_private_text_execution"] = execution
         with (
             patch("kai.bot.is_totp_configured", return_value=False),
-            patch("kai.bot._handle_response", new_callable=AsyncMock) as response,
+            patch("kai.bot._handle_workshop_private_text", new_callable=AsyncMock) as response,
             patch("kai.bot.log_message"),
-            patch("kai.bot._set_responding"),
-            patch("kai.bot._clear_responding"),
-            patch("kai.bot.get_lock", return_value=_fake_lock()),
+            patch("kai.bot._set_responding") as set_responding,
+            patch("kai.bot._clear_responding") as clear_responding,
+            patch("kai.bot.get_lock", return_value=_fake_lock()) as get_lock,
         ):
             await handle_message(update, ctx)
 
-        recorder.assert_awaited_once_with(
+        execution.accept.assert_awaited_once_with(
             InboundMessage(
                 transport="telegram",
                 update_id="9001",
@@ -2812,10 +2830,48 @@ class TestHandleMessage:
                 occurred_at=datetime(2026, 8, 11, 12, 0, tzinfo=UTC),
             )
         )
-        assert response.await_args.kwargs["workshop_inbound_message_id"] == inbound_id
-        assert response.await_args.kwargs["delivery_route"] == ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT
-        run_service.prepare.assert_awaited_once_with(inbound_id)
-        assert response.await_args.kwargs["workshop_run"] is prepared_run
+        recorder.assert_not_awaited()
+        assert response.await_args.kwargs["inbound_message_id"] == inbound_id
+        assert response.await_args.kwargs["run_id"] == run_id
+        get_lock.assert_not_called()
+        set_responding.assert_not_called()
+        clear_responding.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_private_text_without_durable_service_fails_closed(self):
+        update = _make_update(text="do not dispatch", chat_id=1, user_id=1)
+        pool = _make_mock_claude()
+        ctx = _make_context(claude=pool, config=_make_config(allowed_user_ids={1}))
+
+        with patch("kai.bot.is_totp_configured", return_value=False):
+            await handle_message(update, ctx)
+
+        pool.send.assert_not_called()
+        assert "durable execution service is unavailable" in update.message.reply_text.await_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_private_text_terminal_replay_does_not_duplicate_jsonl_user_history(self):
+        update = _make_update(text="same durable update", chat_id=1, user_id=1)
+        ctx = _make_context(config=_make_config(allowed_user_ids={1}))
+        execution = MagicMock()
+        execution.accept = AsyncMock()
+        execution.accept.return_value.message.event.envelope.aggregate_id = MessageId(
+            "msg_00000000000000000000000000000001"
+        )
+        execution.accept.return_value.run.run_id = RunId("run_00000000000000000000000000000001")
+        execution.accept.return_value.disposition = ConversationCommandDisposition.TERMINAL_REPLAY
+        ctx.bot_data["workshop_private_text_execution"] = execution
+
+        with (
+            patch("kai.bot.is_totp_configured", return_value=False),
+            patch("kai.bot._handle_workshop_private_text", new_callable=AsyncMock) as execute,
+            patch("kai.bot.log_message") as history,
+        ):
+            await handle_message(update, ctx)
+
+        execute.assert_awaited_once()
+        assert execute.await_args.kwargs["user_log"] is None
+        history.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_does_not_record_when_totp_denies_message(self):
@@ -2840,8 +2896,8 @@ class TestHandleMessage:
         recorder.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_shadow_failure_does_not_change_existing_response_path(self, caplog):
-        update = _make_update(chat_id=1, user_id=1)
+    async def test_group_shadow_failure_does_not_change_existing_response_path(self, caplog):
+        update = _make_update(chat_id=-100, user_id=1)
         ctx = _make_context(config=_make_config(allowed_user_ids={1}))
         ctx.bot_data["workshop_inbound_recorder"] = AsyncMock(side_effect=RuntimeError("shadow failed"))
         with (

--- a/tests/test_bot_totp.py
+++ b/tests/test_bot_totp.py
@@ -59,6 +59,7 @@ def _make_context(user_data: dict | None = None) -> MagicMock:
     cfg.totp_challenge_seconds = 120
     cfg.totp_lockout_attempts = 3
     cfg.totp_lockout_minutes = 15
+    cfg.tts_enabled = False
     return ctx
 
 

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -279,12 +279,8 @@ class TestConversationCommandReplay:
         finally:
             await store.close()
 
-    def test_service_remains_unregistered_in_production(self):
+    def test_service_is_registered_only_through_private_text_runtime_owner(self):
         source_root = Path(__file__).parents[1] / "src" / "kai"
-        service_path = source_root / "workshop" / "conversation_commands.py"
-        for path in source_root.rglob("*.py"):
-            if path == service_path:
-                continue
-            source = path.read_text(encoding="utf-8")
-            assert "conversation_commands" not in source
-            assert "WorkshopConversationCommandService" not in source
+        owner_source = (source_root / "workshop" / "private_text_execution.py").read_text(encoding="utf-8")
+        assert "WorkshopConversationCommandService" in owner_source
+        assert "WorkshopConversationCommandService" not in (source_root / "main.py").read_text(encoding="utf-8")

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -41,6 +41,7 @@ class _Prepared:
     ) -> None:
         self.run = run
         self.selection = RunExecutionSelection("codex", "gpt-5.6-sol")
+        self.workspace = Path("/private/tmp/kai-workshop-test-workspace")
         self.response = response or AgentResponse(success=True, text="Canonical answer")
         self.wait = wait
         self.on_stream = on_stream
@@ -142,6 +143,33 @@ class TestCanonicalExecutionCoordinator:
             assert prepared.validated is True
             assert prepared.prompts == ["Canonical prompt 1"]
             assert await _terminal_bodies(store) == ["Canonical prompt 1", "Canonical answer"]
+        finally:
+            await store.close()
+
+    async def test_stream_observer_sees_only_nonterminal_events(self, tmp_path: Path):
+        store, run = await _accepted(tmp_path / "kai.db")
+        prepared = _Prepared(run)
+        observed: list[StreamEvent] = []
+
+        async def observe(event: StreamEvent) -> None:
+            observed.append(event)
+
+        original_stream = prepared.stream
+
+        async def stream_with_preview(prompt: str) -> AsyncIterator[StreamEvent]:
+            yield StreamEvent(text_so_far="Stable preview.", done=False)
+            async for event in original_stream(prompt):
+                yield event
+
+        prepared.stream = stream_with_preview  # type: ignore[method-assign]
+        try:
+            result = await _coordinator(store, _Preparation(prepared)).execute(
+                run.run_id,
+                stream_observer=observe,
+            )
+
+            assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+            assert [event.text_so_far for event in observed] == ["Stable preview."]
         finally:
             await store.close()
 

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -1,0 +1,153 @@
+"""Integrated contracts for the production private-text execution owner."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from kai.backend import AgentResponse, StreamEvent
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.execution_coordinator import (
+    CanonicalCancellationDisposition,
+    CanonicalExecutionDisposition,
+)
+from kai.workshop.inbound import InboundMessage
+from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
+from kai.workshop.run_lifecycle import RunStatus
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 1, 1, 23, 0, tzinfo=UTC)
+
+
+class _Runtime:
+    def __init__(self, workspace: Path, *, wait: asyncio.Event | None = None) -> None:
+        self.selection = SimpleNamespace(backend="codex", provider="openai", model="gpt-5.6-sol")
+        self.workspace = workspace
+        self.wait = wait
+        self.validated = False
+        self.cancelled = False
+
+    def validate_current(self) -> None:
+        self.validated = True
+
+    async def cancel(self) -> None:
+        self.cancelled = True
+        if self.wait is not None:
+            self.wait.set()
+
+    async def stream(self, prompt: str):
+        yield StreamEvent(text_so_far="Stable preview.", done=False)
+        if self.wait is not None:
+            await self.wait.wait()
+            if self.cancelled:
+                raise RuntimeError("runtime stopped")
+        yield StreamEvent(
+            text_so_far="Durable answer",
+            done=True,
+            response=AgentResponse(success=True, text="Durable answer", session_id="session-1"),
+        )
+
+
+async def _foundation(database: Path) -> None:
+    store = await WorkshopEventStore.open(database)
+    try:
+        await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    display_name="Workshop Human",
+                    role="admin",
+                    transport="telegram",
+                    external_subject="101",
+                    external_channel_id="101",
+                ),
+            ),
+        )
+        await WorkshopConversationDeliveryAuthority(store).activate()
+    finally:
+        await store.close()
+
+
+def _message(*, suffix: str = "1") -> InboundMessage:
+    return InboundMessage(
+        transport="telegram",
+        update_id=f"update-{suffix}",
+        message_id=f"message-{suffix}",
+        sender_subject="101",
+        channel_subject="101",
+        body=f"Canonical prompt {suffix}",
+        occurred_at=_NOW,
+    )
+
+
+async def test_owner_accepts_executes_and_atomically_enqueues_terminal_reply(tmp_path: Path):
+    database = tmp_path / "kai.db"
+    await _foundation(database)
+    runtime = _Runtime(tmp_path)
+    pool = SimpleNamespace(prepare_execution=AsyncMock(return_value=runtime))
+    service = await WorkshopPrivateTextExecutionService.open_and_start(
+        database,
+        pool,  # type: ignore[arg-type]
+        registered_backend_ids=frozenset({"codex"}),
+    )
+    observed: list[str] = []
+    try:
+        accepted = await service.accept(_message())
+
+        async def observe(event: StreamEvent) -> None:
+            observed.append(event.text_so_far)
+
+        result = await service.execute(accepted.run.run_id, stream_observer=observe)
+
+        assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+        assert result.run.status == RunStatus.COMPLETED
+        assert result.session_id == "session-1"
+        assert result.workspace == str(tmp_path)
+        assert observed == ["Stable preview."]
+        assert runtime.validated is True
+        pool.prepare_execution.assert_awaited_once_with(101)
+    finally:
+        await service.stop()
+
+    inspection = await WorkshopEventStore.open(database)
+    try:
+        async with inspection.connection.execute(
+            "SELECT m.body, d.status FROM messages m "
+            "JOIN delivery_outbox d ON d.message_id = m.id "
+            "WHERE m.reply_to_message_id IS NOT NULL"
+        ) as cursor:
+            assert tuple(await cursor.fetchone()) == ("Durable answer", "pending")
+    finally:
+        await inspection.close()
+
+
+async def test_owner_routes_stop_to_exact_active_runtime_and_terminal_cancellation(tmp_path: Path):
+    database = tmp_path / "kai.db"
+    await _foundation(database)
+    release = asyncio.Event()
+    runtime = _Runtime(tmp_path, wait=release)
+    pool = SimpleNamespace(prepare_execution=AsyncMock(return_value=runtime))
+    service = await WorkshopPrivateTextExecutionService.open_and_start(
+        database,
+        pool,  # type: ignore[arg-type]
+        registered_backend_ids=frozenset({"codex"}),
+    )
+    try:
+        accepted = await service.accept(_message())
+        execution = asyncio.create_task(service.execute(accepted.run.run_id))
+        while not runtime.validated:
+            await asyncio.sleep(0)
+
+        cancellation = await service.request_cancellation(telegram_user_id=101, telegram_chat_id=101)
+        result = await execution
+
+        assert cancellation == CanonicalCancellationDisposition.REQUESTED
+        assert runtime.cancelled is True
+        assert result.disposition == CanonicalExecutionDisposition.CANCELLED
+        assert result.run.status == RunStatus.CANCELLED
+    finally:
+        await service.stop()

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -1,4 +1,4 @@
-"""Contracts for production-unused protected Workshop execution preparation."""
+"""Contracts for protected Workshop execution preparation."""
 
 from __future__ import annotations
 
@@ -146,8 +146,12 @@ class TestProtectedExecutionPreparation:
             await pool.shutdown()
             await store.close()
 
-    def test_service_remains_unregistered(self):
+    def test_service_is_registered_only_through_private_text_runtime_owner(self):
         source_root = Path(__file__).parents[1] / "src" / "kai"
-        for relative_path in ("main.py", "bot.py", "sessions.py"):
-            source = (source_root / relative_path).read_text(encoding="utf-8")
-            assert "WorkshopProtectedExecutionPreparationService" not in source
+        main_source = (source_root / "main.py").read_text(encoding="utf-8")
+        owner_source = (source_root / "workshop" / "private_text_execution.py").read_text(encoding="utf-8")
+        assert "WorkshopPrivateTextExecutionService.open_and_start" in main_source
+        assert "WorkshopProtectedExecutionPreparationService" in owner_source
+        assert "WorkshopProtectedExecutionPreparationService" not in (source_root / "bot.py").read_text(
+            encoding="utf-8"
+        )


### PR DESCRIPTION
## Summary

- activate the durable Workshop run lifecycle for authenticated Telegram private-chat text when voice mode is off
- make canonical `RunId` execution, fenced attempt ownership, terminal settlement, and the Workshop outbox authoritative for that route
- preserve stable-prefix Telegram streaming previews while leaving final delivery to the supervised outbox worker
- integrate canonical `/stop`, expired-attempt recovery, startup readiness, health supervision, and shutdown ownership
- keep photo, document, voice, voice-enabled text, groups, schedules, GitHub/generic webhooks, and notification delivery on their existing paths

## Execution boundary

The Telegram handler now atomically accepts each eligible message through `WorkshopConversationCommandService` and passes only its canonical `RunId` to `WorkshopCanonicalExecutionCoordinator`. The coordinator derives the prompt, channel/agent lane, effective protected runtime, registered backend/provider/model selection, workspace, owner, fence, and lease internally. The handler cannot supply or override those values.

Eligible private text no longer uses the Telegram-chat execution lock or the old responding crash marker. The canonical `(channel_id, agent_id)` lane is its sole dispatch lock, and exact update replay cannot call the backend again or duplicate transitional JSONL user history.

## Terminal and delivery behavior

Successful, failed, cancelled, no-response, and interrupted runs settle through the existing atomic terminal transaction. Each settlement commits the bounded canonical assistant message, immutable streaming-finalization plan, exact-epoch delivery request, attempt outcome, and terminal run state together.

Non-final stable streaming prefixes may still be shown immediately. Once Telegram confirms the preview message, its ID is bound to the canonical inbound message. The handler performs no direct final send or edit; the already-supervised Workshop outbox worker owns final presentation.

Native provider failures remain outside canonical history. The terminal result exposes only its bounded canonical body to compatibility JSONL and memory ingestion.

## Lifecycle and cancellation

`WorkshopPrivateTextExecutionService` owns a dedicated event-store connection, shared database serialization for command acceptance and coordination, the protected preparation service, and a five-second expired-attempt recovery loop. Startup completes initial recovery before polling or webhook ingress begins. Main service health now supervises both execution recovery and Telegram delivery, and shutdown closes them in reverse startup order.

For an active eligible private run, `/stop` records durable cancellation intent and stops only the exact prepared runtime. Cancellation is confirmed only after shutdown succeeds; an unconfirmed stop becomes a bounded interrupted outcome.

## Compatibility and failure policy

- missing or failed durable command acceptance is fail-closed and cannot fall back to direct backend execution
- duplicate active or terminal updates do not redispatch
- pre-dispatch preparation deferral never invokes a second runtime
- excluded routes retain their current behavior
- TOTP remains the authentication gate before canonical command acceptance
- memory extraction retains its existing enabled/disabled gate and workspace capture semantics

## Tests

- `make check`
- `make typecheck`
- `make module-sizes`
- `.venv/bin/python -m pytest tests/ -q`
  - `5478 passed, 1 skipped`

New integrated tests exercise real canonical acceptance and database state with a protected fake runtime, including preview observation, exact compatibility pool-key resolution, atomic terminal reply/outbox enqueue, session/workspace metadata, and exact-runtime cancellation. Bot contracts additionally pin fail-closed service absence, replay history suppression, canonical lock ownership, and `/stop` routing.

## Required installed qualification after merge

This PR changes live execution and requires `make install` after merge. Then verify:

1. one ordinary authenticated private text produces one response;
2. one longer response streams a stable preview and finalizes without a duplicate;
3. `/stop` cancels one in-flight private-text run;
4. a follow-up `PING` returns one `PONG`;
5. `make install-status` reports clean Workshop parity and no pending, leased, retrying, failed, uncertain, or unacknowledged delivery authority state.
