### PR TITLE
Fix durable webhook stop interruption

### DIFF
--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -584,6 +584,33 @@ async def claim_next_telegram_update() -> TelegramUpdateQueueRow | None:
         raise
 
 
+async def claim_telegram_update(row_id: int) -> TelegramUpdateQueueRow | None:
+    """
+    Atomically claim one pending Telegram update by durable queue row ID.
+
+    This is used for control updates that must be able to interrupt the update
+    currently being processed by the ordinary FIFO worker.  Returning None
+    means another worker already claimed or completed the row.
+    """
+    async with _get_db().execute(
+        """
+        UPDATE telegram_update_queue
+        SET status = 'processing',
+            attempt_count = attempt_count + 1,
+            locked_at = CURRENT_TIMESTAMP,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = ? AND status = 'pending'
+        RETURNING *
+        """,
+        (row_id,),
+    ) as cursor:
+        claimed = await cursor.fetchone()
+    await _get_db().commit()
+    if claimed is None:
+        return None
+    return _telegram_update_queue_row(claimed)
+
+
 async def complete_telegram_update(row_id: int) -> bool:
     """Mark a claimed Telegram update as done."""
     cursor = await _get_db().execute(

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -120,6 +120,7 @@ _webhook_registered: bool = False
 _background_tasks: set[asyncio.Task] = set()
 _BACKGROUND_TASK_DRAIN_TIMEOUT = 30.0
 _telegram_queue_worker_task: asyncio.Task | None = None
+_telegram_queue_worker_active_row_id: int | None = None
 _TELEGRAM_UPDATE_MAX_ATTEMPTS = 5
 
 # Webhook health monitor task, started in start() and cancelled in stop().
@@ -212,12 +213,17 @@ async def _process_queued_telegram_update(
 
 
 async def _telegram_update_queue_worker(telegram_app: Application, bot: Bot) -> None:
+    global _telegram_queue_worker_active_row_id
     try:
         while True:
             row = await sessions.claim_next_telegram_update()
             if row is None:
                 return
-            await _process_queued_telegram_update(row, telegram_app, bot)
+            _telegram_queue_worker_active_row_id = row["id"]
+            try:
+                await _process_queued_telegram_update(row, telegram_app, bot)
+            finally:
+                _telegram_queue_worker_active_row_id = None
     except asyncio.CancelledError:
         raise
     except Exception:
@@ -239,6 +245,49 @@ def _ensure_telegram_update_queue_worker(telegram_app: Application, bot: Bot) ->
     _telegram_queue_worker_task = task
     _background_tasks.add(task)
     task.add_done_callback(_telegram_worker_done)
+
+
+def _is_telegram_stop_update(data: object) -> bool:
+    """Return whether a raw Telegram update contains a /stop command message."""
+    if not isinstance(data, dict):
+        return False
+    message = data.get("message")
+    if not isinstance(message, dict):
+        return False
+    text = message.get("text")
+    if not isinstance(text, str):
+        return False
+    return re.match(r"^/stop(?:@[A-Za-z0-9_]+)?(?:\s|$)", text) is not None
+
+
+async def _process_priority_telegram_update(
+    row_id: int,
+    telegram_app: Application,
+    bot: Bot,
+) -> None:
+    """Claim and process one persisted control update outside the FIFO worker."""
+    try:
+        row = await sessions.claim_telegram_update(row_id)
+        if row is not None:
+            await _process_queued_telegram_update(row, telegram_app, bot)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        log.exception("Priority Telegram update queue task crashed for row %s", row_id)
+
+
+def _dispatch_priority_telegram_stop(
+    row_id: int,
+    data: object,
+    telegram_app: Application,
+    bot: Bot,
+) -> None:
+    """Dispatch a persisted /stop concurrently when the FIFO worker is busy."""
+    if _telegram_queue_worker_active_row_id is None or not _is_telegram_stop_update(data):
+        return
+    task = asyncio.create_task(_process_priority_telegram_update(row_id, telegram_app, bot))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
 
 
 # If Telegram reports an error within this window, re-register the webhook.
@@ -631,7 +680,10 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
 
     Validates the X-Telegram-Bot-Api-Secret-Token header against the configured
     secret, persists the raw update to the durable inbound queue, and starts a
-    background worker that dispatches queued updates to process_update().
+    background worker that dispatches queued updates to process_update().  A
+    persisted /stop command may use a separately tracked task while that FIFO
+    worker is busy so it can interrupt the active request; other updates remain
+    serialized.
 
     IMPORTANT: queued updates are processed by a background task, not awaited.
     Claude responses can take 30+ seconds, and Telegram's webhook client times
@@ -666,7 +718,7 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
         return web.Response(status=200)
 
     try:
-        await sessions.enqueue_telegram_update(update_id, json.dumps(data))
+        row_id, _inserted = await sessions.enqueue_telegram_update(update_id, json.dumps(data))
     except Exception:
         log.exception("Failed to persist Telegram update %s", update_id)
         return web.Response(status=500, text="Failed to enqueue update")
@@ -675,6 +727,11 @@ async def _handle_telegram_update(request: web.Request) -> web.Response:
         _ensure_telegram_update_queue_worker(telegram_app, bot)
     except Exception:
         log.exception("Failed to start Telegram update queue worker")
+    else:
+        try:
+            _dispatch_priority_telegram_stop(row_id, data, telegram_app, bot)
+        except Exception:
+            log.exception("Failed to dispatch priority Telegram /stop row %s", row_id)
 
     return web.Response(status=200)
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -126,6 +126,20 @@ class TestTelegramUpdateQueue:
         assert await sessions.complete_telegram_update(row_id) is False
         assert await sessions.claim_next_telegram_update() is None
 
+    async def test_claim_specific_pending_update(self, db):
+        first_id, _ = await sessions.enqueue_telegram_update(1006, '{"update_id":1006}')
+        second_id, _ = await sessions.enqueue_telegram_update(1007, '{"update_id":1007}')
+
+        claimed = await sessions.claim_telegram_update(second_id)
+
+        assert claimed is not None
+        assert claimed["id"] == second_id
+        assert claimed["attempt_count"] == 1
+        assert await sessions.claim_telegram_update(second_id) is None
+        next_claim = await sessions.claim_next_telegram_update()
+        assert next_claim is not None
+        assert next_claim["id"] == first_id
+
     async def test_retry_returns_processing_update_to_pending(self, db):
         row_id, _ = await sessions.enqueue_telegram_update(1003, '{"update_id":1003}')
         first_claim = await sessions.claim_next_telegram_update()

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -733,6 +733,13 @@ def telegram_request():
 
 
 class TestTelegramUpdate:
+    def test_priority_classifier_matches_only_stop_commands(self):
+        assert webhook_mod._is_telegram_stop_update({"message": {"text": "/stop"}}) is True
+        assert webhook_mod._is_telegram_stop_update({"message": {"text": "/stop@kai_bot"}}) is True
+        assert webhook_mod._is_telegram_stop_update({"message": {"text": "/stop now"}}) is True
+        assert webhook_mod._is_telegram_stop_update({"message": {"text": "/stopping"}}) is False
+        assert webhook_mod._is_telegram_stop_update({"message": {"caption": "/stop"}}) is False
+
     async def test_valid_secret_dispatches_update(self, db, telegram_request, monkeypatch):
         """Valid secret and JSON body dispatches to process_update."""
         fake_update = MagicMock()
@@ -782,6 +789,81 @@ class TestTelegramUpdate:
 
         assert resp.status == 200
         telegram_request.app[TELEGRAM_APP_KEY].process_update.assert_not_called()
+
+    async def test_persisted_stop_interrupts_busy_fifo_worker(self, db, telegram_request, monkeypatch):
+        """A queued /stop dispatches while an earlier webhook update is still running."""
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        stop_processed = asyncio.Event()
+
+        def deserialize(data, _bot):
+            return MagicMock(update_id=data["update_id"])
+
+        async def process(update):
+            if update.update_id == 2001:
+                first_started.set()
+                await release_first.wait()
+            elif update.update_id == 2002:
+                stop_processed.set()
+
+        monkeypatch.setattr("kai.webhook.Update.de_json", deserialize)
+        telegram_request.app[TELEGRAM_APP_KEY].process_update = AsyncMock(side_effect=process)
+
+        telegram_request.json = AsyncMock(return_value={"update_id": 2001, "message": {"text": "work"}})
+        assert (await _handle_telegram_update(telegram_request)).status == 200
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+
+        telegram_request.json = AsyncMock(return_value={"update_id": 2002, "message": {"text": "/stop"}})
+        assert (await _handle_telegram_update(telegram_request)).status == 200
+        await asyncio.wait_for(stop_processed.wait(), timeout=1)
+
+        assert release_first.is_set() is False
+        release_first.set()
+        assert webhook_mod._telegram_queue_worker_task is not None
+        await webhook_mod._telegram_queue_worker_task
+        await asyncio.gather(*webhook_mod._background_tasks)
+
+        async with sessions._get_db().execute(
+            "SELECT status, attempt_count FROM telegram_update_queue ORDER BY id"
+        ) as cursor:
+            rows = await cursor.fetchall()
+        assert [(row["status"], row["attempt_count"]) for row in rows] == [
+            ("done", 1),
+            ("done", 1),
+        ]
+
+    async def test_ordinary_update_remains_fifo_while_worker_is_busy(self, db, telegram_request, monkeypatch):
+        """The interrupt path does not broadly parallelize Telegram updates."""
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        second_processed = asyncio.Event()
+
+        def deserialize(data, _bot):
+            return MagicMock(update_id=data["update_id"])
+
+        async def process(update):
+            if update.update_id == 2011:
+                first_started.set()
+                await release_first.wait()
+            elif update.update_id == 2012:
+                second_processed.set()
+
+        monkeypatch.setattr("kai.webhook.Update.de_json", deserialize)
+        telegram_request.app[TELEGRAM_APP_KEY].process_update = AsyncMock(side_effect=process)
+
+        telegram_request.json = AsyncMock(return_value={"update_id": 2011, "message": {"text": "one"}})
+        assert (await _handle_telegram_update(telegram_request)).status == 200
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+
+        telegram_request.json = AsyncMock(return_value={"update_id": 2012, "message": {"text": "two"}})
+        assert (await _handle_telegram_update(telegram_request)).status == 200
+        await asyncio.sleep(0)
+        assert second_processed.is_set() is False
+
+        release_first.set()
+        assert webhook_mod._telegram_queue_worker_task is not None
+        await webhook_mod._telegram_queue_worker_task
+        assert second_processed.is_set() is True
 
     async def test_persistence_failure_returns_500(self, telegram_request, monkeypatch):
         """If the durable queue write fails, do not acknowledge the update as accepted."""


### PR DESCRIPTION
## Summary

- let a durably persisted Telegram `/stop` command run while the FIFO webhook worker is occupied by the request it needs to cancel
- keep every ordinary Telegram update on the existing serialized queue path
- add an atomic claim-by-row primitive so the priority task and FIFO worker cannot process the same update
- keep priority tasks in the existing shutdown-drained background-task registry

## Root cause

Telegram webhook updates were persisted correctly, but the queue worker awaited each `process_update()` call before claiming the next row. A `/stop` sent during a long response therefore remained pending until that response had already completed. The bot then displayed `Stopping...`, but too late to request durable cancellation of the active Workshop run.

## Behavior after this change

When the FIFO worker is actively processing an update, an exact `/stop` command is still authenticated and written to `telegram_update_queue` first. Kai then claims that specific durable row and dispatches it through the normal Telegram application concurrently. Duplicate webhook deliveries cannot duplicate processing because only a pending row can be claimed.

Messages other than `/stop` remain serialized behind the active update, preserving the established ordering contract.

## Verification

- `make check`
- `make typecheck`
- focused queue/webhook tests: 17 passed
- full suite: 5,481 passed, 1 skipped

The new tests prove that persisted `/stop` is processed before the active update is released, that both queue rows complete exactly once, and that an ordinary second message cannot overtake the first.
