### PR TITLE
Fix installed code modes under restrictive umask

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2449,6 +2449,55 @@ def _set_private_user_tree_modes(path: Path) -> None:
         os.chmod(path, _PRIVATE_USER_FILE_MODE)
 
 
+def _set_static_install_tree_modes(path: Path) -> bool:
+    """Make root-owned installed code traversable and readable by the service.
+
+    Installer callers may have a restrictive umask (for example ``077``).
+    Directory creation performed by ``mkdir``, ``venv``, and ``pip`` inherits
+    that umask, which can otherwise leave root-owned installed code at 0700 and
+    prevent the unprivileged Kai service from importing it.  Static install
+    trees contain no secrets: directories are normalized to 0755 and regular
+    files to 0644, while files that already carry an executable bit retain an
+    executable mode of 0755.  Symlinks are skipped so chmod never follows an
+    operator-created link outside the tree.
+
+    Returns True when at least one mode was changed.
+    """
+    if path.is_symlink() or not path.exists():
+        return False
+
+    changed = False
+
+    def normalize(candidate: Path, expected_mode: int) -> None:
+        nonlocal changed
+        current_mode = stat.S_IMODE(candidate.stat().st_mode)
+        if current_mode != expected_mode:
+            os.chmod(candidate, expected_mode)
+            changed = True
+
+    if path.is_dir():
+        normalize(path, 0o755)
+        for root, dirs, files in os.walk(path, followlinks=False):
+            root_path = Path(root)
+            if not root_path.is_symlink():
+                normalize(root_path, 0o755)
+            for dirname in dirs:
+                child = root_path / dirname
+                if not child.is_symlink():
+                    normalize(child, 0o755)
+            for filename in files:
+                child = root_path / filename
+                if child.is_symlink():
+                    continue
+                current_mode = stat.S_IMODE(child.stat().st_mode)
+                normalize(child, 0o755 if current_mode & 0o111 else 0o644)
+    else:
+        current_mode = stat.S_IMODE(path.stat().st_mode)
+        normalize(path, 0o755 if current_mode & 0o111 else 0o644)
+
+    return changed
+
+
 def _copy_tree(
     src: Path,
     dst: Path,
@@ -5649,6 +5698,7 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
     # included by the subsequent non-editable pip install.
     _copy_tree(src_src, src_dst, _SOURCE_EXCLUDES, replace=True)
     _set_ownership(src_dst, 0, 0, recursive=True)
+    _set_static_install_tree_modes(src_dst)
     print(f"  Copied source to {src_dst}")
 
     shutil.copy2(pyproject_src, pyproject_dst)
@@ -5675,6 +5725,7 @@ def _apply_source(install_path: Path, svc_uid: int, svc_gid: int, dry_run: bool)
         # no parent-creation step is needed here).
         _copy_tree(config_src, config_dst)
         _set_ownership(config_dst, 0, 0, recursive=True)
+        _set_static_install_tree_modes(config_dst)
         print(f"  Copied config templates to {config_dst}")
 
     # Retire the now-vestigial `<install>/home/` directory. On a clean
@@ -5744,6 +5795,13 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
     build_path = install_path / "build"
 
     if is_update and venv_path.exists():
+        # A prior install (or pip update) may have run beneath a restrictive
+        # caller umask. Repair the entire root-owned static venv before the
+        # checksum fast path so a no-change install also restores service
+        # access. Dry-run must remain side-effect free.
+        if not dry_run and _set_static_install_tree_modes(venv_path):
+            print("  Restored service-readable venv modes")
+
         # Homebrew removes the old Cellar path when Python is upgraded. A venv
         # created with symlinks can therefore remain on disk while its Python
         # interpreter becomes a dangling symlink. Detect that before the
@@ -5876,6 +5934,10 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
 
     # Set venv ownership to root (read-only for service user)
     _set_ownership(venv_path, 0, 0, recursive=True)
+    # pip creates package directories using the caller's umask. Normalize
+    # after every install so newly written package metadata and modules stay
+    # importable by the unprivileged service.
+    _set_static_install_tree_modes(venv_path)
 
 
 def _apply_models(install_path: Path, dry_run: bool) -> None:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -60,6 +60,7 @@ from kai.install import (
     _secure_history_directories,
     _secure_upload_directories,
     _set_ownership,
+    _set_static_install_tree_modes,
     _src_checksum,
     _start_service,
     _stop_service,
@@ -4643,6 +4644,42 @@ class TestApplyVenv:
         assert "Venv unchanged" in output
         assert "checksums match" in output
 
+    def test_matching_checksums_repair_restrictive_venv_modes(self, tmp_path, capsys):
+        """The no-change fast path repairs modes inherited from umask 077."""
+        install = tmp_path / "opt" / "kai"
+        venv = install / "venv"
+        venv_bin = venv / "bin"
+        venv_bin.mkdir(parents=True)
+        venv_python = venv_bin / "python"
+        venv_python.touch(mode=0o755)
+        package = venv / "lib" / "python3.13" / "site-packages" / "kai"
+        package.mkdir(parents=True)
+        module = package / "__init__.py"
+        module.write_text("# init")
+
+        (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        src = install / "src" / "kai"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("# init")
+        (install / ".pyproject.sha256").write_text(
+            _file_checksum(install / "pyproject.toml") + "\n"
+        )
+        (install / ".src.sha256").write_text(_src_checksum(install / "src") + "\n")
+
+        for directory in (venv, venv_bin, package.parent, package):
+            directory.chmod(0o700)
+        module.chmod(0o600)
+
+        _apply_venv(install, is_update=True, dry_run=False)
+
+        output = capsys.readouterr().out
+        assert "Restored service-readable venv modes" in output
+        assert "Venv unchanged" in output
+        assert stat.S_IMODE(venv.stat().st_mode) == 0o755
+        assert stat.S_IMODE(package.stat().st_mode) == 0o755
+        assert stat.S_IMODE(module.stat().st_mode) == 0o644
+        assert stat.S_IMODE(venv_python.stat().st_mode) == 0o755
+
     def test_reinstalls_on_source_change(self, tmp_path, monkeypatch, capsys):
         """Triggers reinstall when source files change but pyproject.toml does not."""
         install = tmp_path / "opt" / "kai"
@@ -6967,6 +7004,59 @@ class TestApplySource:
         # <install>/config/ should be root-owned (static template, not runtime data)
         own_calls = [c for c in mock_own.call_args_list if c[0] == (config_dst, 0, 0) and c[1].get("recursive") is True]
         assert len(own_calls) == 1
+
+    def test_normalizes_static_tree_modes_under_restrictive_umask(self, tmp_path):
+        """Copied code remains readable when the installer caller uses umask 077."""
+        project = tmp_path / "source"
+        package = project / "src" / "kai" / "nested"
+        package.mkdir(parents=True)
+        (package / "module.py").write_text("value = 1\n")
+        (project / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        config = project / "templates" / "config"
+        config.mkdir(parents=True)
+        (config / "goose-config.yaml").write_text("extensions: []\n")
+        install = tmp_path / "install"
+        install.mkdir()
+
+        previous_umask = os.umask(0o077)
+        try:
+            with (
+                patch("kai.install.PROJECT_ROOT", project),
+                patch("kai.install._set_ownership"),
+                patch("os.chown"),
+            ):
+                _apply_source(install, svc_uid=1000, svc_gid=1000, dry_run=False)
+        finally:
+            os.umask(previous_umask)
+
+        assert stat.S_IMODE((install / "src").stat().st_mode) == 0o755
+        assert stat.S_IMODE((install / "src" / "kai" / "nested").stat().st_mode) == 0o755
+        assert stat.S_IMODE((install / "src" / "kai" / "nested" / "module.py").stat().st_mode) == 0o644
+        assert stat.S_IMODE((install / "config").stat().st_mode) == 0o755
+        assert stat.S_IMODE((install / "config" / "goose-config.yaml").stat().st_mode) == 0o644
+
+
+    def test_preserves_executable_intent_and_skips_symlinks(self, tmp_path):
+        tree = tmp_path / "tree"
+        tree.mkdir(mode=0o700)
+        executable = tree / "tool"
+        executable.write_text("#!/bin/sh\n")
+        executable.chmod(0o700)
+        regular = tree / "data"
+        regular.write_text("data\n")
+        regular.chmod(0o600)
+        target = tmp_path / "outside"
+        target.write_text("outside\n")
+        target.chmod(0o600)
+        (tree / "link").symlink_to(target)
+
+        assert _set_static_install_tree_modes(tree) is True
+
+        assert stat.S_IMODE(tree.stat().st_mode) == 0o755
+        assert stat.S_IMODE(executable.stat().st_mode) == 0o755
+        assert stat.S_IMODE(regular.stat().st_mode) == 0o644
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+        assert _set_static_install_tree_modes(tree) is False
 
     def test_dry_run_includes_templates_config(self, tmp_path, capsys):
         """Dry run names templates/config/ when it exists."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4661,9 +4661,7 @@ class TestApplyVenv:
         src = install / "src" / "kai"
         src.mkdir(parents=True)
         (src / "__init__.py").write_text("# init")
-        (install / ".pyproject.sha256").write_text(
-            _file_checksum(install / "pyproject.toml") + "\n"
-        )
+        (install / ".pyproject.sha256").write_text(_file_checksum(install / "pyproject.toml") + "\n")
         (install / ".src.sha256").write_text(_src_checksum(install / "src") + "\n")
 
         for directory in (venv, venv_bin, package.parent, package):
@@ -7034,7 +7032,6 @@ class TestApplySource:
         assert stat.S_IMODE((install / "src" / "kai" / "nested" / "module.py").stat().st_mode) == 0o644
         assert stat.S_IMODE((install / "config").stat().st_mode) == 0o755
         assert stat.S_IMODE((install / "config" / "goose-config.yaml").stat().st_mode) == 0o644
-
 
     def test_preserves_executable_intent_and_skips_symlinks(self, tmp_path):
         tree = tmp_path / "tree"


### PR DESCRIPTION
## Summary

- normalize deployed source and configuration trees independently of the installer's caller umask
- normalize the root-owned virtual environment before the checksum fast path and after pip installation
- preserve executable files while keeping symlinks untouched

## Incident

Running `make install` from a shell with `umask 077` left newly created root-owned directories at mode 0700. The `kai` service user could not traverse `/opt/kai/src` or the newly installed Kai package in the venv, so launchd repeatedly failed with `No module named kai.__main__`.

The deployed system was recovered by restoring service-readable modes and restarting the service. Its localhost health endpoint now returns HTTP 200.

## Security boundary

This changes modes only in static, root-owned installation trees:

- `/opt/kai/src`
- `/opt/kai/config`
- `/opt/kai/venv`

Directories become 0755. Regular files become 0644 unless they already carry an executable bit, in which case they become 0755. Symlinks are not followed or changed.

Secrets and mutable user data are unaffected. The fix does not change `/etc/kai`, the database, uploads, memory, preferences, per-user homes, or credentials.

## Verification

- `557 passed` in `tests/test_install.py`
- `5512 passed, 1 skipped` in the complete test suite
- Ruff passes for the changed files
- Pyright reports zero errors and warnings
- dedicated coverage reproduces `umask 077`, repairs a no-change venv, preserves executable intent, and verifies symlink targets remain untouched
