### PR TITLE
Normalize source metadata created by pip

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -5925,6 +5925,12 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
     subprocess.run(pip_install_cmd, check=True)
     print("  Installed package into venv")
 
+    # Building from the installed source can create fresh packaging metadata
+    # (for example ``src/kai.egg-info``) after _apply_source normalized that
+    # tree. pip inherits the caller's umask, so normalize the source again
+    # before the service starts.
+    _set_static_install_tree_modes(src_dst)
+
     # Save checksums for future update detection. Both are written after a
     # successful install so that a partial failure (e.g., pip crash mid-install)
     # leaves stale checksums and triggers a retry on the next run.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4718,6 +4718,33 @@ class TestApplyVenv:
         assert not (install / "build").exists()
         assert "Installed package into venv" in output
 
+    def test_normalizes_source_metadata_created_by_pip(self, tmp_path, monkeypatch):
+        """Packaging metadata created after the source copy cannot retain 0700."""
+        install = tmp_path / "opt" / "kai"
+        (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").touch(mode=0o755)
+        (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        src = install / "src" / "kai"
+        src.mkdir(parents=True)
+        (src / "__init__.py").write_text("# init")
+
+        metadata = install / "src" / "kai.egg-info"
+        metadata_file = metadata / "PKG-INFO"
+
+        def fake_run(*args, **kwargs):
+            metadata.mkdir(mode=0o700)
+            metadata_file.write_text("Metadata-Version: 2.4\n")
+            metadata_file.chmod(0o600)
+            return subprocess.CompletedProcess(args=[], returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr("kai.install._set_ownership", lambda *a, **kw: None)
+
+        _apply_venv(install, is_update=True, dry_run=False)
+
+        assert stat.S_IMODE(metadata.stat().st_mode) == 0o755
+        assert stat.S_IMODE(metadata_file.stat().st_mode) == 0o644
+
     def test_reinstalls_on_source_change_dry_run(self, tmp_path, monkeypatch, capsys):
         """Dry run compares incoming source even though the copy is skipped."""
         install = tmp_path / "opt" / "kai"


### PR DESCRIPTION
## Summary

- normalize the installed source tree again after pip builds Kai
- prevent generated `src/kai.egg-info` metadata from retaining modes inherited from a restrictive caller umask
- add a regression test reproducing pip-created 0700 metadata and 0600 files

## Why this follow-up is needed

PR #884 correctly normalizes the deployed source before venv installation and normalizes the venv after pip. Installed qualification then exposed one ordering edge case: building the package creates `/opt/kai/src/kai.egg-info` after the initial source normalization. With `umask 077`, that new metadata directory was left at 0700.

Kai remains healthy because runtime imports come from the normalized venv, but root-owned static source metadata should still satisfy the same service-readable install contract as the rest of `/opt/kai/src`.

## Scope

The change adds one post-pip normalization call for `/opt/kai/src`. It does not affect secrets, mutable data, runtime behavior, backend configuration, or user directories.

## Verification

- localhost installed health check: HTTP 200
- installer suite: `558 passed`
- complete suite: `5513 passed, 1 skipped`
- Ruff formatting and lint pass
- Pyright reports zero errors and warnings
