### PR TITLE
Add isolated Workshop LAN listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ make install-status
 
 `make install` invokes `sudo` internally and installs source, data, and secrets under separate protected system directories. It also generates the admin-owned `/etc/kai/backends.yaml` registry containing the discovered executable paths, allowed model surfaces, and selected default backend. Runtime configuration names backend identifiers; it cannot redirect a protected backend to an arbitrary executable. After a successful protected install, `install.conf` may be deleted because it can contain secrets; re-run `make config` before a later reconfiguration.
 
+Workshop remains loopback-only by default. To reach its browser client directly
+from a trusted private network, enter one private IPv4 interface address at the
+optional `Workshop LAN address` prompt. Kai then creates a second listener on
+the webhook port containing only the Workshop shell, enrollment, timeline, and
+event-stream routes; internal agent APIs and webhook ingress remain bound to
+loopback. This direct listener uses HTTP, so use a trusted LAN or put a trusted
+TLS terminator in front of it.
+
 Protected mode requires every Telegram user to have a unique `os_user` that differs from the Kai service account; this keeps persistent agents from inheriting the daemon's protected-config capabilities. Single-user mode runs the agent as the operator account.
 
 Kai-managed per-user identity has one editable source: `<DATA_DIR>/home/<chat_id>/AGENTS.md`. Codex, Goose, OpenCode, and Pi consume that file directly. Claude Code receives a generated `.claude/CLAUDE.md` adapter containing only `@../AGENTS.md`. On upgrade, `make install` migrates existing customized Claude identity content into `AGENTS.md`; if both files contain different customizations, installation stops without choosing or overwriting either one. Instruction files owned by individual project repositories remain independent.

--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1844,6 +1844,14 @@ assets that remain ordinary Python package data, so an installed Kai host does
 not need Node. CI type-checks and tests the source, rebuilds the client, and
 fails if the committed assets differ.
 
+Direct trusted-LAN access is opt-in through one explicit private IPv4
+interface. The existing mixed webhook/internal API application remains bound
+to loopback. A separate application on the selected address registers only the
+Workshop shell, enrollment redemption, authenticated timeline, and event
+stream, while sharing the same locks and process-wide rate limits. The direct
+listener is HTTP and is not a replacement for the documented trusted TLS
+terminator boundary on an untrusted network.
+
 ### 37.1 Installed qualification
 
 After merge, install the packaged client and prove: enrollment with a

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -12,6 +12,7 @@ All paths are resolved relative to PROJECT_ROOT (the repository root), which is
 derived from this file's location in the source tree: src/kai/config.py -> project root.
 """
 
+import ipaddress
 import logging
 import os
 import pwd
@@ -37,6 +38,32 @@ from kai.user_isolation import validate_protected_user_isolation
 
 log = logging.getLogger(__name__)
 _legacy_registry_model_warning_emitted: set[tuple[str, str]] = set()
+
+
+def normalize_workshop_lan_host(value: str) -> str:
+    """Return one canonical private IPv4 address, or disable with empty input.
+
+    Workshop's optional direct listener is intentionally narrower than a
+    general bind-address setting.  Wildcard, loopback, public, multicast, and
+    IPv6 addresses are rejected so an operator cannot accidentally expose it
+    beyond the private IPv4 interface they selected.
+    """
+    candidate = value.strip()
+    if not candidate:
+        return ""
+    try:
+        address = ipaddress.ip_address(candidate)
+    except ValueError:
+        raise ValueError("must be an empty value or a private IPv4 address") from None
+    if (
+        not isinstance(address, ipaddress.IPv4Address)
+        or not address.is_private
+        or address.is_loopback
+        or address.is_unspecified
+        or address.is_multicast
+    ):
+        raise ValueError("must be a non-loopback private IPv4 address")
+    return str(address)
 
 
 # ── Module-level paths and constants ─────────────────────────────────
@@ -1436,6 +1463,10 @@ class Config:
 
     # Webhook server
     webhook_port: int = 8080
+    # Optional second HTTP listener containing only the authenticated Workshop
+    # client surface. Empty keeps Workshop reachable through the loopback
+    # listener (and any trusted TLS terminator) only.
+    workshop_lan_host: str = ""
     github_webhook_secret: str = ""
     generic_webhook_secret: str = ""
     # True when load_config() populated secrets from the protected
@@ -3084,6 +3115,12 @@ def load_config() -> Config:
     except ValueError:
         raise SystemExit("WEBHOOK_PORT must be an integer") from None
     try:
+        workshop_lan_host = normalize_workshop_lan_host(
+            os.environ.get("WORKSHOP_LAN_HOST", ""),
+        )
+    except ValueError as exc:
+        raise SystemExit(f"WORKSHOP_LAN_HOST {exc}") from None
+    try:
         file_retention_days = int(os.environ.get("FILE_RETENTION_DAYS", "0"))
     except ValueError:
         raise SystemExit("FILE_RETENTION_DAYS must be an integer") from None
@@ -3642,6 +3679,7 @@ def load_config() -> Config:
         codex_auth_mode=codex_auth_mode,
         codex_effort_level=codex_effort_level,
         webhook_port=webhook_port,
+        workshop_lan_host=workshop_lan_host,
         github_webhook_secret=github_webhook_secret,
         generic_webhook_secret=generic_webhook_secret,
         protected_install=bool(protected_env),

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -60,6 +60,7 @@ from kai.config import (
     canonicalize_model_for_backend,
     get_default_model_for_backend,
     models_for_backend,
+    normalize_workshop_lan_host,
     validate_model_for_backend,
 )
 from kai.named_access import replace_named_read_access
@@ -1725,6 +1726,22 @@ def _cmd_config() -> None:
             break
         print("  Must be a valid port number (1-65535).")
 
+    while True:
+        workshop_lan_host_input = _prompt(
+            "Workshop LAN address (optional; client routes only)",
+            existing_env.get("WORKSHOP_LAN_HOST", ""),
+        )
+        try:
+            workshop_lan_host = normalize_workshop_lan_host(workshop_lan_host_input)
+            break
+        except ValueError as exc:
+            print(f"  Workshop LAN address {exc}.")
+    if workshop_lan_host:
+        print(
+            "  Warning: Workshop bearer sessions will use plain HTTP on this "
+            "trusted LAN address. Use a TLS terminator for untrusted networks."
+        )
+
     # Each external ingress has a dedicated credential. A legacy WEBHOOK_SECRET
     # from an older generated artifact is deliberately not carried forward.
     if had_legacy_webhook_secret:
@@ -2051,6 +2068,8 @@ def _cmd_config() -> None:
         "VOICE_ENABLED": str(voice_enabled).lower(),
         "TTS_ENABLED": str(tts_enabled).lower(),
     }
+    if workshop_lan_host:
+        env["WORKSHOP_LAN_HOST"] = workshop_lan_host
     # DEFAULT_BACKEND is the global default backend; users.yaml entries
     # can override it per user. The wizard writes the selected backend
     # explicitly; absence is not a backend-selection signal.
@@ -4976,6 +4995,8 @@ def _cmd_apply() -> None:
         print(f"  Data:    {data_dir}")
         print("  Secrets: /etc/kai/env")
         print(f"  User:    {service_user}")
+        if workshop_lan_host := env.get("WORKSHOP_LAN_HOST", "").strip():
+            print(f"  Workshop: http://{workshop_lan_host}:{env.get('WEBHOOK_PORT', '8080')}/workshop/")
         # Remind the user that install.conf contains secrets and can be
         # cleaned up. Don't auto-delete - the user may want to re-run
         # apply or adjust config.

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -54,6 +54,7 @@ import json
 import logging
 import re
 import time
+from collections.abc import Callable
 from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
@@ -69,6 +70,7 @@ from kai.job_types import CANONICAL_JOB_TYPES, normalize_job_type
 from kai.telegram_utils import chunk_text
 from kai.workshop.client_api import (
     WorkshopEnrollmentRateLimiter,
+    WorkshopEventStreamLimiter,
     register_workshop_enrollment_routes,
     register_workshop_read_routes,
 )
@@ -125,6 +127,7 @@ class UnauthorizedChatIdError(Exception):
 # Module-level server state, managed by start() and stop()
 _app: web.Application | None = None
 _runner: web.AppRunner | None = None
+_workshop_lan_runner: web.AppRunner | None = None
 _workshop_client_store: WorkshopEventStore | None = None
 # Tracks whether we registered a Telegram webhook with the API, so stop()
 # knows whether to call delete_webhook(). Only True in webhook mode.
@@ -2428,8 +2431,19 @@ def _register_routes(app: web.Application, config: Config) -> None:
     app.router.add_delete("/api/memory/all", _handle_memory_delete_all)
 
 
-async def _register_workshop_client_api(app: web.Application, database: Path) -> None:
-    """Open one protected client-state connection and register its HTTP boundary."""
+async def _register_workshop_client_api(
+    app: web.Application,
+    database: Path,
+) -> Callable[[web.Application], None]:
+    """Open one client-state connection and return its route registrar.
+
+    The returned registrar deliberately contains only the Workshop browser
+    shell and authenticated client API.  It can therefore be applied to the
+    loopback application and, when explicitly configured, to a second
+    LAN-bound application without exposing webhook or internal-agent routes.
+    Shared locks and rate limiters keep both listeners inside one security
+    boundary rather than giving each listener an independent allowance.
+    """
     global _workshop_client_store
     if _workshop_client_store is not None:
         raise RuntimeError("Workshop client API store is already open")
@@ -2438,23 +2452,33 @@ async def _register_workshop_client_api(app: web.Application, database: Path) ->
     try:
         request_lock = asyncio.Lock()
         sessions_manager = WorkshopClientSessionManager(store)
-        register_workshop_enrollment_routes(
-            app,
-            enrollment_manager=WorkshopClientEnrollmentManager(store),
-            rate_limiter=WorkshopEnrollmentRateLimiter(),
-            request_lock=request_lock,
-        )
-        register_workshop_read_routes(
-            app,
-            store=store,
-            authenticator=WorkshopBearerSessionAuthenticator(sessions_manager),
-            request_lock=request_lock,
-        )
-        register_workshop_shell_routes(app)
+        enrollment_manager = WorkshopClientEnrollmentManager(store)
+        authenticator = WorkshopBearerSessionAuthenticator(sessions_manager)
+        enrollment_rate_limiter = WorkshopEnrollmentRateLimiter()
+        event_stream_limiter = WorkshopEventStreamLimiter()
+
+        def register(target: web.Application) -> None:
+            register_workshop_enrollment_routes(
+                target,
+                enrollment_manager=enrollment_manager,
+                rate_limiter=enrollment_rate_limiter,
+                request_lock=request_lock,
+            )
+            register_workshop_read_routes(
+                target,
+                store=store,
+                authenticator=authenticator,
+                request_lock=request_lock,
+                event_stream_limiter=event_stream_limiter,
+            )
+            register_workshop_shell_routes(target)
+
+        register(app)
     except Exception:
         await store.close()
         raise
     _workshop_client_store = store
+    return register
 
 
 async def start(telegram_app, config) -> None:
@@ -2473,7 +2497,7 @@ async def start(telegram_app, config) -> None:
         telegram_app: The python-telegram-bot Application instance.
         config: The application Config instance.
     """
-    global _app, _runner, _webhook_registered, _health_monitor_task
+    global _app, _runner, _workshop_lan_runner, _webhook_registered, _health_monitor_task
 
     _app = web.Application()
     _app[TELEGRAM_APP_KEY] = telegram_app
@@ -2550,15 +2574,36 @@ async def start(telegram_app, config) -> None:
                     val,
                 )
     _register_routes(_app, config)
-    await _register_workshop_client_api(_app, Path(config.session_db_path))
+    register_workshop_routes = await _register_workshop_client_api(
+        _app,
+        Path(config.session_db_path),
+    )
 
     _runner = web.AppRunner(_app, access_log=None)
     await _runner.setup()
-    # Bind to localhost only - all external access routes through Cloudflare Tunnel,
-    # so there's no reason to expose the server on the LAN.
+    # The mixed webhook/internal API application remains loopback-only.  A
+    # separately configured LAN listener below receives only Workshop client
+    # routes, so opting into browser access cannot expose /api or /webhook.
     site = web.TCPSite(_runner, "127.0.0.1", config.webhook_port)
     await site.start()
-    log.info("Webhook server listening on port %d", config.webhook_port)
+    log.info("Webhook server listening on 127.0.0.1:%d", config.webhook_port)
+
+    if config.workshop_lan_host:
+        workshop_lan_app = web.Application()
+        register_workshop_routes(workshop_lan_app)
+        _workshop_lan_runner = web.AppRunner(workshop_lan_app, access_log=None)
+        await _workshop_lan_runner.setup()
+        workshop_lan_site = web.TCPSite(
+            _workshop_lan_runner,
+            config.workshop_lan_host,
+            config.webhook_port,
+        )
+        await workshop_lan_site.start()
+        log.warning(
+            "Workshop client listening on trusted-LAN HTTP at http://%s:%d/workshop/",
+            config.workshop_lan_host,
+            config.webhook_port,
+        )
 
     # Register the webhook URL with Telegram's API if in webhook mode. This must
     # come after the server is listening so the endpoint is ready before Telegram
@@ -2625,7 +2670,8 @@ async def stop() -> None:
     if the network is down at shutdown time, Telegram will just overwrite the
     stale webhook on the next set_webhook call at startup.
     """
-    global _app, _runner, _webhook_registered, _health_monitor_task, _workshop_client_store
+    global _app, _runner, _workshop_lan_runner, _webhook_registered, _health_monitor_task
+    global _workshop_client_store
     # Cancel the webhook health monitor before tearing down the server
     if _health_monitor_task is not None:
         _health_monitor_task.cancel()
@@ -2647,10 +2693,14 @@ async def stop() -> None:
         _webhook_registered = False
     await _drain_background_tasks(_BACKGROUND_TASK_DRAIN_TIMEOUT)
     try:
+        if _workshop_lan_runner:
+            await _workshop_lan_runner.cleanup()
+            log.info("Workshop LAN client server stopped")
         if _runner:
             await _runner.cleanup()
             log.info("Webhook server stopped")
     finally:
+        _workshop_lan_runner = None
         _runner = None
         _app = None
         if _workshop_client_store is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,7 @@ _CONFIG_ENV_VARS = [
     "AGENT_IDLE_TIMEOUT",
     "CLAUDE_IDLE_TIMEOUT",  # backward compat (renamed to AGENT_IDLE_TIMEOUT)
     "WEBHOOK_PORT",
+    "WORKSHOP_LAN_HOST",
     "WEBHOOK_SECRET",
     "VOICE_ENABLED",
     "TTS_ENABLED",
@@ -223,6 +224,7 @@ class TestLoadConfigDefaults:
         assert config.default_timeout == 120
         assert config.agent_max_session_hours == 0
         assert config.webhook_port == 8080
+        assert config.workshop_lan_host == ""
         # Without TELEGRAM_WEBHOOK_URL, defaults to polling mode
         assert config.telegram_webhook_url is None
         assert config.telegram_webhook_secret is None
@@ -240,6 +242,11 @@ class TestLoadConfigDefaults:
         config = load_config()
         assert config.claude_autocompact_pct == 80
 
+    def test_private_workshop_lan_host_from_env(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("WORKSHOP_LAN_HOST", "10.0.0.36")
+        assert load_config().workshop_lan_host == "10.0.0.36"
+
     def test_retired_context_window_env_warns_but_loads(self, monkeypatch, caplog):
         """A lingering CLAUDE_MAX_CONTEXT_WINDOW (the setting was
         removed) does not block startup; load_config warns that the
@@ -256,6 +263,16 @@ class TestLoadConfigDefaults:
 
 
 class TestLoadConfigErrors:
+    @pytest.mark.parametrize(
+        "value",
+        ["0.0.0.0", "127.0.0.1", "8.8.8.8", "::", "not-an-address"],
+    )
+    def test_rejects_unsafe_workshop_lan_host(self, monkeypatch, value):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("WORKSHOP_LAN_HOST", value)
+        with pytest.raises(SystemExit, match="WORKSHOP_LAN_HOST"):
+            load_config()
+
     def test_missing_token(self):
         with pytest.raises(SystemExit, match="TELEGRAM_BOT_TOKEN"):
             load_config()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1440,6 +1440,7 @@ class TestCmdConfig:
                 "80",  # autocompact pct
                 "",  # claude effort level (take default "high")
                 "8080",  # port
+                "10.0.0.36",  # Workshop LAN address
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
@@ -1467,6 +1468,7 @@ class TestCmdConfig:
         assert conf["env"]["TELEGRAM_BOT_TOKEN"] == "fake-token"
         assert conf["env"]["GITHUB_WEBHOOK_SECRET"] == "test-secret"
         assert conf["env"]["GENERIC_WEBHOOK_SECRET"] != "test-secret"
+        assert conf["env"]["WORKSHOP_LAN_HOST"] == "10.0.0.36"
         assert "WEBHOOK_SECRET" not in conf["env"]
         # The context window setting was removed; the wizard never
         # emits the retired key.
@@ -1537,6 +1539,7 @@ class TestCmdConfig:
                 "80",  # autocompact pct
                 "",  # claude effort level (take default "high")
                 "8080",  # port
+                "",  # Workshop LAN address (disabled)
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
@@ -1618,6 +1621,7 @@ class TestCmdConfig:
                 "80",  # autocompact pct
                 "",  # claude effort level (take default "high")
                 "8080",  # port
+                "",  # Workshop LAN address (disabled)
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces
@@ -1687,6 +1691,7 @@ class TestCmdConfig:
                 "80",
                 "",  # claude effort level (take default "high")
                 "8080",
+                "",  # Workshop LAN address (disabled)
                 "test-secret",
                 "~/Projects",
                 "",
@@ -1747,6 +1752,7 @@ class TestCmdConfig:
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "8080",  # port
+                "",  # Workshop LAN address (disabled)
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
@@ -1880,6 +1886,7 @@ class TestCmdConfig:
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "8080",  # port
+                "",  # Workshop LAN address (disabled)
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces (empty)
@@ -2097,6 +2104,7 @@ class TestCmdConfig:
             "1800",  # idle eviction timeout seconds
             *claude_only_pre_webhook,  # autocompact + effort (claude only)
             "8080",  # port
+            "",  # Workshop LAN address (disabled)
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base
             "",  # allowed workspaces
@@ -2534,6 +2542,7 @@ class TestCmdConfig:
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "8080",  # port
+                "",  # Workshop LAN address (disabled)
                 "test-secret",  # webhook secret
                 "~/Projects",  # workspace base
                 "",  # allowed workspaces
@@ -2874,6 +2883,7 @@ class TestCmdConfig:
                 # autocompact + claude effort skipped on non-claude backend
                 "",  # codex reasoning effort (empty = codex default)
                 "8080",  # webhook port
+                "",  # Workshop LAN address (disabled)
                 "test-secret",  # webhook secret
                 "",  # workspace base
                 "",  # allowed workspaces
@@ -3399,6 +3409,7 @@ class TestCmdConfigDefaultModelDispatch:
             "80",  # autocompact pct
             "",  # effort level (default)
             "8080",  # webhook port
+            "",  # Workshop LAN address (disabled)
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base (global default)
             "",  # allowed workspaces (global default, empty)
@@ -3440,6 +3451,7 @@ class TestCmdConfigDefaultModelDispatch:
             # No autocompact_pct / claude effort prompts (claude-only)
             "",  # codex reasoning effort (empty = codex default)
             "8080",  # webhook port
+            "",  # Workshop LAN address (disabled)
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base (global default)
             "",  # allowed workspaces (global default, empty)
@@ -3474,6 +3486,7 @@ class TestCmdConfigDefaultModelDispatch:
             # (claude tunables and the codex effort prompt all skip
             # on goose)
             "8080",  # webhook port
+            "",  # Workshop LAN address (disabled)
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base (global default)
             "",  # allowed workspaces (global default, empty)
@@ -8542,6 +8555,7 @@ class TestCmdConfigCanonicalUsersYaml:
             "80",
             "",  # effort level (default)
             "8080",
+            "",  # Workshop LAN address (disabled)
             "test-secret",
             "~/Projects",
             "",
@@ -9005,6 +9019,7 @@ class TestCmdConfigSingleUserMode:
             "80",  # autocompact
             "",  # effort level
             "8080",  # webhook port
+            "",  # Workshop LAN address (disabled)
             "test-secret",  # webhook secret
             "~/Projects",  # workspace_base
             "",  # allowed_workspaces
@@ -10499,6 +10514,7 @@ class TestOpenCodeConfigWizard:
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
             "8080",  # webhook port
+            "",  # Workshop LAN address (disabled)
             "test-secret",  # webhook secret
             "",  # workspace base
             "",  # allowed workspaces

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2369,6 +2369,7 @@ class TestNotificationChatIdMutations:
         config.pr_review_cooldown = 0
         config.pr_review_timeout_s = 0
         config.webhook_port = 0
+        config.workshop_lan_host = ""
         config.workspace_base = None
         config.allowed_workspaces = []
         config.spec_dir = "specs"
@@ -2398,6 +2399,81 @@ class TestNotificationChatIdMutations:
         finally:
             wh._app = old_app
             wh._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_start_lan_listener_exposes_only_workshop_client_routes(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Opt-in LAN access must not publish webhook or internal API routes."""
+        import kai.webhook as wh
+
+        admin = UserConfig(telegram_id=111, name="alice", role="admin")
+        config = MagicMock()
+        config.user_configs = {111: admin}
+        config.allowed_user_ids = {111}
+        config.get_admins.return_value = [admin]
+        config.telegram_webhook_url = None
+        config.telegram_webhook_secret = None
+        config.github_webhook_secret = None
+        config.generic_webhook_secret = None
+        config.pr_review_cooldown = 0
+        config.pr_review_timeout_s = 0
+        config.webhook_port = 8080
+        config.workshop_lan_host = "10.0.0.36"
+        config.workspace_base = None
+        config.allowed_workspaces = []
+        config.spec_dir = "specs"
+        config.session_db_path = tmp_path / "kai.db"
+
+        telegram_app = MagicMock()
+        telegram_app.bot = AsyncMock()
+        telegram_app.bot_data = {"pool": MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"}))}
+
+        apps: list[web.Application] = []
+        runners: list[MagicMock] = []
+        sites: list[tuple[MagicMock, str, int]] = []
+
+        def fake_runner(app, *, access_log=None):
+            apps.append(app)
+            runner = MagicMock()
+            runner.setup = AsyncMock()
+            runner.cleanup = AsyncMock()
+            runners.append(runner)
+            return runner
+
+        def fake_site(runner, host, port):
+            sites.append((runner, host, port))
+            site = MagicMock()
+            site.start = AsyncMock()
+            return site
+
+        monkeypatch.setattr("kai.webhook.web.AppRunner", fake_runner)
+        monkeypatch.setattr("kai.webhook.web.TCPSite", fake_site)
+        monkeypatch.setattr("kai.webhook.sessions.get_setting", AsyncMock(return_value=None))
+
+        await wh.start(telegram_app, config)
+        try:
+            assert [(host, port) for _, host, port in sites] == [
+                ("127.0.0.1", 8080),
+                ("10.0.0.36", 8080),
+            ]
+            assert len(apps) == 2
+            lan_paths = {resource.canonical for resource in apps[1].router.resources()}
+            assert lan_paths == {
+                "/v1/client/enrollment/redeem",
+                "/v1/channels/{channel_id}/timeline",
+                "/v1/channels/{channel_id}/events",
+                "/workshop",
+                "/workshop/",
+                "/workshop/app.css",
+                "/workshop/app.js",
+            }
+            assert not any(path.startswith("/api/") for path in lan_paths)
+            assert not any(path.startswith("/webhook") for path in lan_paths)
+        finally:
+            await wh.stop()
 
     def test_add_notification_chat_id(self):
         """add_notification_chat_id adds a chat_id to the outbound registry."""


### PR DESCRIPTION
## Summary

- add an opt-in Workshop-only listener on one explicit private IPv4 interface
- keep Kai's mixed webhook and internal-agent HTTP application bound to loopback
- preserve one shared Workshop database lock, enrollment limiter, and event-stream limiter across both listeners
- add a `Workshop LAN address` configuration prompt and print the resulting URL after install

## Security boundary

The LAN application registers only:

- `/workshop` and its packaged assets
- `/v1/client/enrollment/redeem`
- authenticated channel timeline reads
- authenticated resumable channel event streams

It does not register `/api/*`, `/webhook*`, or `/health`. The address validator rejects wildcard, loopback, public, multicast, malformed, and IPv6 values. Direct LAN access remains plain HTTP and is explicitly documented for trusted networks only; untrusted networks still require a trusted TLS terminator.

## Operator flow

Run `make config`, enter the Mac mini's private interface address at the optional Workshop LAN prompt (`10.0.0.36` on the current host), and then run `make install`. An empty answer retains the existing loopback-only behavior.

Because browser session storage is origin-scoped, the LAN URL requires a fresh one-time Workshop enrollment; it does not copy or expose the existing localhost session.

## Verification

- full Python suite: `5524 passed, 1 skipped`
- final installer/config/webhook suite: `988 passed`
- Ruff lint and formatting checks pass
- route-contract test proves the LAN application contains exactly the Workshop routes and no internal API or webhook routes
