### PR TITLE
Refresh packaged assets during installation

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -36,6 +36,7 @@ import tempfile
 import textwrap
 import time
 from collections.abc import Iterable
+from fnmatch import fnmatch
 from pathlib import Path
 
 import yaml
@@ -2395,21 +2396,27 @@ def _file_checksum(path: Path) -> str:
 
 def _src_checksum(src_dir: Path) -> str:
     """
-    Return a SHA-256 digest representing the contents of all .py files under src_dir.
+    Return a SHA-256 digest representing installable source under src_dir.
 
     Walks the directory tree in sorted order (for determinism), feeding each
-    file's relative path and content into a rolling hash. Returns an empty
-    string if the directory doesn't exist. Used alongside _file_checksum() on
-    pyproject.toml to detect source-only changes that require a pip reinstall.
+    non-generated file's relative path and content into a rolling hash. This
+    includes package data such as the Workshop HTML, CSS, and JavaScript;
+    excluding it would let the copied source advance while the non-editable
+    venv continued serving stale package resources. Returns an empty string if
+    the directory doesn't exist. Used alongside _file_checksum() on
+    pyproject.toml to detect source changes that require a pip reinstall.
     """
     if not src_dir.is_dir():
         return ""
     h = hashlib.sha256()
     # Sort for deterministic ordering across platforms and filesystems
-    for py_file in sorted(src_dir.rglob("*.py")):
+    for source_file in sorted(path for path in src_dir.rglob("*") if path.is_file()):
+        relative_path = source_file.relative_to(src_dir)
+        if any(fnmatch(part, pattern) for part in relative_path.parts for pattern in _SOURCE_EXCLUDES):
+            continue
         # Include the relative path so renames/moves change the hash
-        h.update(str(py_file.relative_to(src_dir)).encode())
-        h.update(py_file.read_bytes())
+        h.update(str(relative_path).encode())
+        h.update(source_file.read_bytes())
     return h.hexdigest()
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4731,6 +4731,33 @@ class TestApplyVenv:
         assert not (install / "build").exists()
         assert "Installed package into venv" in output
 
+    def test_reinstalls_on_packaged_static_asset_change(self, tmp_path, monkeypatch, capsys):
+        """A Workshop bundle change refreshes its copied site-packages resource."""
+        install = tmp_path / "opt" / "kai"
+        (install / "venv" / "bin").mkdir(parents=True)
+        (install / "venv" / "bin" / "python").touch(mode=0o755)
+        (install / "pyproject.toml").write_text("[project]\nname = 'kai'\n")
+        static = install / "src" / "kai" / "workshop" / "static"
+        static.mkdir(parents=True)
+        bundle = static / "app.js"
+        bundle.write_text("const version = 1;")
+        (install / ".pyproject.sha256").write_text(_file_checksum(install / "pyproject.toml") + "\n")
+        (install / ".src.sha256").write_text(_src_checksum(install / "src") + "\n")
+
+        bundle.write_text("const version = 2;")
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: subprocess.CompletedProcess(args=[], returncode=0),
+        )
+        monkeypatch.setattr("kai.install._set_ownership", lambda *a, **kw: None)
+
+        _apply_venv(install, is_update=True, dry_run=False)
+
+        output = capsys.readouterr().out
+        assert "source changed" in output
+        assert "Installed package into venv" in output
+
     def test_normalizes_source_metadata_created_by_pip(self, tmp_path, monkeypatch):
         """Packaging metadata created after the source copy cannot retain 0700."""
         install = tmp_path / "opt" / "kai"
@@ -5001,7 +5028,7 @@ class TestSrcChecksum:
     """Tests for _src_checksum(), the directory content hasher."""
 
     def test_empty_dir(self, tmp_path):
-        """Empty directory (no .py files) returns a hash (of zero inputs)."""
+        """Empty source directory returns a hash of zero inputs."""
         d = tmp_path / "src"
         d.mkdir()
         result = _src_checksum(d)
@@ -5045,19 +5072,36 @@ class TestSrcChecksum:
 
         assert h1 != h2
 
-    def test_ignores_non_py_files(self, tmp_path):
-        """Non-.py files do not affect the hash."""
+    def test_package_data_change_changes_hash(self, tmp_path):
+        """Changing packaged static data invalidates the non-editable venv."""
         d = tmp_path / "src"
         d.mkdir()
         (d / "a.py").write_text("hello")
         h1 = _src_checksum(d)
 
-        # Add non-Python files - hash should not change
-        (d / "readme.md").write_text("docs")
-        (d / "data.json").write_text("{}")
+        static = d / "kai" / "workshop" / "static"
+        static.mkdir(parents=True)
+        (static / "app.js").write_text("console.log('new client')")
         h2 = _src_checksum(d)
 
-        assert h1 == h2
+        assert h1 != h2
+
+    def test_ignores_generated_source_artifacts(self, tmp_path):
+        """Bytecode and packaging metadata cannot cause reinstall loops."""
+        d = tmp_path / "src"
+        package = d / "kai"
+        package.mkdir(parents=True)
+        (package / "a.py").write_text("hello")
+        h1 = _src_checksum(d)
+
+        cache = package / "__pycache__"
+        cache.mkdir()
+        (cache / "a.cpython-313.pyc").write_bytes(b"bytecode")
+        metadata = d / "kai.egg-info"
+        metadata.mkdir()
+        (metadata / "PKG-INFO").write_text("generated metadata")
+
+        assert _src_checksum(d) == h1
 
     def test_rename_changes_hash(self, tmp_path):
         """Renaming a file changes the hash (path is included in the digest)."""


### PR DESCRIPTION
## Summary

- include packaged non-Python resources in the installer's source checksum
- force the non-editable virtual environment to refresh when Workshop HTML, CSS, JavaScript, or future package data changes
- continue excluding bytecode, caches, and packaging metadata so generated files cannot cause reinstall loops

## Incident

After #891 was merged, `make install` copied the corrected Workshop bundle to `/opt/kai/src`, but reported the virtual environment unchanged. The running service loads packaged resources from `/opt/kai/venv`, whose `app.js` remained the pre-fix version. The browser therefore reproduced the same silent Send failure even though the repository and copied source were correct.

The installer checksum covered only `*.py`. That assumption was valid before Kai shipped a browser client as package data, but it is no longer correct.

## Migration behavior

The checksum algorithm intentionally changes. On the first `make install` after this PR, the saved Python-only digest cannot match the new full-source digest, so Kai will reinstall the package into the venv and replace the stale Workshop bundle. Subsequent unchanged installs return to the checksum fast path.

## Tests

- package-data changes alter `_src_checksum`
- generated bytecode and `egg-info` do not alter `_src_checksum`
- changing `static/app.js` causes `_apply_venv` to invoke package installation
- 560 installer tests pass
- full suite: 5,540 passed, 1 skipped
- formatting and type checking pass

## Installed qualification

After merge, run `make install` and confirm that the output includes `Updating venv (source changed)` and `Installed package into venv`. Reload Workshop and submit the retained command; it should clear after acceptance and appear once in Workshop and Telegram.
