### PR TITLE
Finalize Workshop client results without a Telegram preview

### DIFF
--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -35,7 +35,7 @@ from kai.workshop.domain import (
 )
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.store import AppendResult, IdempotencyConflictError, WorkshopEventStore
-from kai.workshop.streaming_preview import resolve_telegram_streaming_target
+from kai.workshop.streaming_preview import resolve_telegram_finalization_target
 
 _IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 
@@ -335,7 +335,7 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
             "record_outbound_message_with_streaming_finalization_in_transaction requires an active transaction"
         )
     binding = await _resolve_outbound(store, message.in_reply_to_message_id)
-    streaming_target = await resolve_telegram_streaming_target(
+    streaming_target = await resolve_telegram_finalization_target(
         store,
         message.in_reply_to_message_id,
     )
@@ -343,12 +343,16 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
         raise OutboundStreamingPreviewConflictError(
             "Telegram streaming target does not match the canonical agent reply target"
         )
-    preview_message_id = await _confirmed_preview_message_id(
-        store,
-        inbound_message_id=message.in_reply_to_message_id,
-        workshop_id=binding.workshop_id,
-        channel_id=binding.channel_id,
-        channel_binding_id=streaming_target.channel_binding_id,
+    preview_message_id = (
+        await _confirmed_preview_message_id(
+            store,
+            inbound_message_id=message.in_reply_to_message_id,
+            workshop_id=binding.workshop_id,
+            channel_id=binding.channel_id,
+            channel_binding_id=streaming_target.channel_binding_id,
+        )
+        if streaming_target.preview_eligible
+        else None
     )
     operations = _streaming_finalization_operations(
         message.body,

--- a/src/kai/workshop/streaming_preview.py
+++ b/src/kai/workshop/streaming_preview.py
@@ -69,6 +69,16 @@ class ResolvedTelegramStreamingTarget:
     channel_binding_id: ChannelBindingId
 
 
+@dataclass(frozen=True, slots=True)
+class ResolvedTelegramFinalizationTarget:
+    """A direct Telegram delivery target plus preview eligibility."""
+
+    workshop_id: WorkshopId
+    channel_id: ChannelId
+    channel_binding_id: ChannelBindingId
+    preview_eligible: bool
+
+
 def _format_timestamp(value: datetime) -> str:
     return value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
@@ -77,14 +87,17 @@ def _parse_timestamp(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
 
 
-async def resolve_telegram_streaming_target(
+async def _resolve_telegram_target(
     store: WorkshopEventStore,
     inbound_message_id: MessageId,
-) -> ResolvedTelegramStreamingTarget:
+    *,
+    allow_workshop_client: bool,
+) -> ResolvedTelegramFinalizationTarget:
     async with store.connection.execute(
         "SELECT c.workshop_id, m.channel_id, c.kind, p.kind, m.reply_to_message_id, "
         "json_extract(e.metadata_json, '$.source'), "
-        "json_extract(e.metadata_json, '$.transport_message_id'), p.id "
+        "json_extract(e.metadata_json, '$.transport_message_id'), "
+        "json_extract(e.metadata_json, '$.client_message_id'), p.id "
         "FROM messages m "
         "JOIN channels c ON c.id = m.channel_id "
         "JOIN principals p ON p.id = m.author_principal_id "
@@ -93,17 +106,25 @@ async def resolve_telegram_streaming_target(
         (inbound_message_id,),
     ) as cursor:
         row = await cursor.fetchone()
+    valid_telegram = row is not None and row[5] == "telegram" and isinstance(row[6], str) and bool(row[6])
+    valid_workshop_client = (
+        allow_workshop_client
+        and row is not None
+        and row[5] == "workshop_client"
+        and row[6] is None
+        and isinstance(row[7], str)
+        and bool(row[7])
+    )
     if (
         row is None
         or row[2] != "direct"
         or row[3] != "human"
         or row[4] is not None
-        or row[5] != "telegram"
-        or not isinstance(row[6], str)
-        or not row[6]
+        or not (valid_telegram or valid_workshop_client)
     ):
+        expected = "Telegram or Workshop client" if allow_workshop_client else "Telegram inbound"
         raise StreamingPreviewTargetError(
-            "Preview target must be an existing Telegram inbound message from a human in a direct channel"
+            f"Target must be an existing {expected} message from a human in a direct channel"
         )
 
     channel_id = ChannelId(str(row[1]))
@@ -113,15 +134,44 @@ async def resolve_telegram_streaming_target(
         "AND e.external_subject = b.external_channel_id) "
         "FROM channel_bindings b WHERE b.channel_id = ? "
         "AND b.transport = 'telegram' ORDER BY b.id",
-        (str(row[7]), channel_id),
+        (str(row[8]), channel_id),
     ) as cursor:
         bindings = list(await cursor.fetchall())
     if len(bindings) != 1 or int(bindings[0][1]) != 1:
         raise StreamingPreviewBindingError("Canonical direct channel must have exactly one Telegram binding")
-    return ResolvedTelegramStreamingTarget(
+    return ResolvedTelegramFinalizationTarget(
         workshop_id=WorkshopId(str(row[0])),
         channel_id=channel_id,
         channel_binding_id=ChannelBindingId(str(bindings[0][0])),
+        preview_eligible=valid_telegram,
+    )
+
+
+async def resolve_telegram_streaming_target(
+    store: WorkshopEventStore,
+    inbound_message_id: MessageId,
+) -> ResolvedTelegramStreamingTarget:
+    target = await _resolve_telegram_target(
+        store,
+        inbound_message_id,
+        allow_workshop_client=False,
+    )
+    return ResolvedTelegramStreamingTarget(
+        workshop_id=target.workshop_id,
+        channel_id=target.channel_id,
+        channel_binding_id=target.channel_binding_id,
+    )
+
+
+async def resolve_telegram_finalization_target(
+    store: WorkshopEventStore,
+    inbound_message_id: MessageId,
+) -> ResolvedTelegramFinalizationTarget:
+    """Resolve Telegram final delivery for Telegram or Workshop ingress."""
+    return await _resolve_telegram_target(
+        store,
+        inbound_message_id,
+        allow_workshop_client=True,
     )
 
 

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -17,6 +17,7 @@ from kai.workshop.bootstrap import (
 )
 from kai.workshop.domain import (
     ChannelBindingId,
+    ChannelId,
     EventEnvelope,
     MessageId,
     PrincipalId,
@@ -33,6 +34,7 @@ from kai.workshop.streaming_preview import (
     StreamingPreviewConflictError,
     StreamingPreviewTargetError,
     bind_confirmed_telegram_streaming_preview,
+    resolve_telegram_finalization_target,
 )
 
 _NOW = datetime(2026, 8, 12, 12, 0, tzinfo=UTC)
@@ -202,7 +204,7 @@ class TestTelegramStreamingPreviewBinding:
         finally:
             await store.close()
 
-    async def test_non_telegram_direct_message_is_not_a_preview_target(self, tmp_path: Path):
+    async def test_workshop_client_message_is_finalizable_but_not_a_preview_target(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:
             async with store.connection.execute(
@@ -227,13 +229,20 @@ class TestTelegramStreamingPreviewBinding:
                         "author_principal_id": str(row[2]),
                         "body": "Canonical, but not Telegram inbound",
                     },
-                    metadata={"source": "workshop_client"},
+                    metadata={
+                        "source": "workshop_client",
+                        "client_message_id": "browser-command-1",
+                    },
                 )
             )
             await store.project_pending(CanonicalConversationProjection())
 
             with pytest.raises(StreamingPreviewTargetError, match="Telegram inbound"):
                 await bind_confirmed_telegram_streaming_preview(store, _preview(message_id))
+
+            target = await resolve_telegram_finalization_target(store, message_id)
+            assert target.channel_id == ChannelId(str(row[1]))
+            assert target.preview_eligible is False
         finally:
             await store.close()
 

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -9,9 +9,12 @@ import aiosqlite
 import pytest
 
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
-from kai.workshop.domain import MessageId, RunExecutionOwnerId
-from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.delivery_fragments import SEND_OPERATION
+from kai.workshop.delivery_outbox import STREAMING_FINALIZATION_CONTRACT
+from kai.workshop.domain import ChannelId, MessageId, PrincipalId, RunExecutionOwnerId
+from kai.workshop.inbound import ClientInboundMessage, InboundMessage, record_inbound_message
 from kai.workshop.outbound import (
     OutboundMessage,
     record_outbound_message_with_streaming_finalization,
@@ -85,6 +88,55 @@ async def _started_run(
     return store, authority, started.claim
 
 
+async def _started_client_run(
+    path: Path,
+) -> tuple[WorkshopEventStore, WorkshopRunExecutionAuthority, RunExecutionClaim]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="telegram",
+                external_subject="101",
+                external_channel_id="101",
+            ),
+        ),
+    )
+    async with store.connection.execute(
+        "SELECT e.principal_id, cb.channel_id FROM external_identities e "
+        "JOIN channel_bindings cb ON cb.transport = e.provider "
+        "AND cb.external_channel_id = e.external_subject "
+        "WHERE e.provider = 'telegram' AND e.external_subject = '101'"
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    accepted = await WorkshopConversationCommandService(store).accept_client(
+        ClientInboundMessage(
+            principal_id=PrincipalId(str(row[0])),
+            channel_id=ChannelId(str(row[1])),
+            client_message_id="browser-command-1",
+            body="Perform one durable unit of work",
+            occurred_at=_NOW,
+        )
+    )
+    authority = WorkshopRunExecutionAuthority(
+        store,
+        selection_resolver=lambda _run: RunExecutionSelection("codex", "gpt-5.6-sol"),
+        registered_backend_ids=frozenset({"codex"}),
+    )
+    granted = await authority.grant(
+        accepted.run.run_id,
+        owner_id=RunExecutionOwnerId.new(),
+        occurred_at=_NOW + timedelta(seconds=2),
+        lease_expires_at=_NOW + timedelta(minutes=2),
+    )
+    started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
+    await WorkshopConversationDeliveryAuthority(store).activate()
+    return store, authority, started.claim
+
+
 async def _terminal_rows(store: WorkshopEventStore) -> tuple[int, int, int]:
     counts = []
     for table in ("messages", "delivery_outbox", "delivery_fragments"):
@@ -132,6 +184,28 @@ class TestAtomicTerminalTransactions:
                     "run_attempt.completed",
                     "run.completed",
                 ]
+        finally:
+            await store.close()
+
+    async def test_workshop_client_success_sends_without_telegram_preview(self, tmp_path: Path):
+        store, authority, claim = await _started_client_run(tmp_path / "kai.db")
+        try:
+            result = await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+                claim,
+                body="WORKSHOP-COMMAND-OK",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+
+            assert result.outcome == TerminalOutcome.COMPLETED
+            assert result.execution.run.status == RunStatus.COMPLETED
+            assert result.finalization.delivery.delivery.execution_contract == STREAMING_FINALIZATION_CONTRACT
+            assert [
+                (fragment.operation, fragment.target_external_message_id, fragment.body)
+                for fragment in result.finalization.plan.fragments
+            ] == [(SEND_OPERATION, None, "WORKSHOP-COMMAND-OK")]
+            # The browser command's attributed echo precedes the assistant
+            # finalization and both remain durable outbox work.
+            assert await _terminal_rows(store) == (1, 2, 1)
         finally:
             await store.close()
 


### PR DESCRIPTION
## Summary

- allow a canonical Workshop-client message to resolve the existing direct Telegram binding for assistant final delivery
- preserve strict Telegram-only eligibility for binding or editing an existing streaming-preview message
- use a normal SEND fragment plan when Workshop ingress has no Telegram preview
- retain the existing durable ordering that places the attributed Workshop echo before the assistant result

## Incident

The installed browser command crossed the authenticated boundary successfully: Kai committed the canonical human message, accepted the durable run, and delivered the attributed Telegram echo. Backend execution also completed. Atomic terminal settlement then failed because it required the inbound message to be an original Telegram message before resolving any final delivery target:

`StreamingPreviewTargetError: Preview target must be an existing Telegram inbound message from a human in a direct channel`

A Workshop-originated command has no inbound Telegram message by design. It needs a fresh Telegram SEND for the assistant result, not a preview edit.

## Security boundary

- finalization still requires an existing canonical human message in a direct channel
- only server-authored `telegram` and `workshop_client` event sources are eligible
- Workshop-client events must carry their server-validated opaque client identity and cannot carry a Telegram transport message identity
- the target must resolve to exactly one Telegram channel binding matching the human's Telegram external identity
- Workshop-client messages remain ineligible for `bind_confirmed_telegram_streaming_preview`, so this change cannot select an existing Telegram message for editing

## Durability

Terminal settlement still commits the canonical assistant message, immutable delivery plan, and fenced run outcome in one transaction. Workshop-client results use the existing streaming-finalization worker with a SEND-only plan; the earlier attributed echo remains durable predecessor work and must settle first.

## Tests

- a Workshop-client message resolves final delivery but is rejected as a preview-binding target
- a started Workshop-client run completes atomically with a SEND-only result plan
- the attributed echo and assistant result remain two durable deliveries
- focused Workshop delivery and terminal suite: 88 passed
- full suite: 5,541 passed, 1 skipped
- formatting and type checking pass

## Installed qualification

After merge and installation, allow startup recovery to settle the command affected by this incident. Do not paste that same command as a new request. Once recovery is visible, send a fresh command with distinct text and verify one attributed human echo plus one assistant result in Telegram and one copy of each in Workshop.
