### PR TITLE
Decouple Workshop commands from Telegram delivery

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -60,6 +60,7 @@ def _workshop_bootstrap_humans(config) -> tuple[BootstrapHuman, ...]:
             transport="telegram",
             external_subject=str(user.telegram_id),
             external_channel_id=str(user.telegram_id),
+            runtime_subject=str(user.telegram_id),
         )
         for user in sorted(config.user_configs.values(), key=lambda user: user.telegram_id)
     )

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -37,6 +37,7 @@ class BootstrapHuman:
     transport: str
     external_subject: str
     external_channel_id: str
+    runtime_subject: str | None = None
 
     def __post_init__(self) -> None:
         if not self.display_name.strip():
@@ -49,6 +50,8 @@ class BootstrapHuman:
             raise ValueError("external_subject must be non-empty")
         if not self.external_channel_id.strip():
             raise ValueError("external_channel_id must be non-empty")
+        if self.runtime_subject is not None and not self.runtime_subject.strip():
+            raise ValueError("runtime_subject must be non-empty when provided")
 
 
 @dataclass(frozen=True, slots=True)
@@ -249,6 +252,22 @@ async def bootstrap_default_workshop(
                 "external_subject": human.external_subject,
             },
         )
+        if human.runtime_subject is not None:
+            runtime_token = _stable_token("kai", human.runtime_subject)
+            await ensure(
+                idempotency_key=_idempotency_key("external-identity", runtime_token),
+                event_type=WorkshopEventType.EXTERNAL_IDENTITY_BOUND,
+                aggregate_type="external_identity",
+                aggregate_id=ExternalIdentityId.derived(
+                    workshop_id,
+                    f"external-identity:{runtime_token}",
+                ),
+                payload={
+                    "principal_id": principal_id,
+                    "provider": "kai",
+                    "external_subject": human.runtime_subject,
+                },
+            )
         await ensure(
             idempotency_key=_idempotency_key("membership", token),
             event_type=WorkshopEventType.WORKSHOP_MEMBER_ADDED,

--- a/src/kai/workshop/client_commands.py
+++ b/src/kai/workshop/client_commands.py
@@ -39,12 +39,12 @@ class WorkshopClientCommandExecutor:
 
     async def submit(self, message: ClientInboundMessage) -> ClientCommandResult:
         accepted = await self._execution.accept_client(message)
-        chat_id = accepted.compatibility_chat_id
-        mapped_reader = reader_user(self._config, chat_id)
+        runtime_config_id = accepted.runtime_config_id
+        mapped_reader = reader_user(self._config, runtime_config_id)
         user_log = (
             log_message(
                 direction="user",
-                chat_id=chat_id,
+                chat_id=runtime_config_id,
                 text=message.body,
                 reader_user=mapped_reader,
             )
@@ -56,17 +56,17 @@ class WorkshopClientCommandExecutor:
         if result.terminal is not None:
             assistant_log = log_message(
                 direction="assistant",
-                chat_id=chat_id,
+                chat_id=runtime_config_id,
                 text=result.terminal.body,
                 reader_user=mapped_reader,
             )
             if result.session_id and result.selection is not None:
-                await sessions.save_session(chat_id, result.session_id, result.selection.model)
+                await sessions.save_session(runtime_config_id, result.session_id, result.selection.model)
             if result.disposition == CanonicalExecutionDisposition.COMPLETED and result.workspace is not None:
                 schedule_memory_ingestion(
                     prompt=message.body,
                     assistant_text=result.terminal.body,
-                    chat_id=chat_id,
+                    chat_id=runtime_config_id,
                     session_id=result.session_id,
                     config=self._config,
                     workspace=result.workspace,

--- a/src/kai/workshop/conversation_commands.py
+++ b/src/kai/workshop/conversation_commands.py
@@ -53,11 +53,11 @@ class ConversationCommandAcceptance:
 
 @dataclass(frozen=True, slots=True)
 class ClientConversationCommandAcceptance:
-    """Atomic client acceptance plus its durable Telegram bridge request."""
+    """Atomic client acceptance plus optional transport compatibility work."""
 
     command: ConversationCommandAcceptance
-    delivery: DeliveryRequestResult
-    compatibility_chat_id: int
+    delivery: DeliveryRequestResult | None
+    runtime_config_id: int
 
     @property
     def run(self) -> DurableRun:
@@ -111,7 +111,7 @@ class WorkshopConversationCommandService:
         self,
         message: ClientInboundMessage,
     ) -> ClientConversationCommandAcceptance:
-        """Accept one canonical browser command and Telegram echo atomically."""
+        """Accept one canonical browser command and optional Telegram echo."""
         if not isinstance(message, ClientInboundMessage):
             raise ValueError("message must be a ClientInboundMessage")
         connection = self._store.connection
@@ -125,21 +125,28 @@ class WorkshopConversationCommandService:
                 inbound_message_id,
                 occurred_at=inbound.event.envelope.occurred_at,
             )
-            binding_id, chat_id = await self._telegram_compatibility_target(
+            runtime_config_id = await self._runtime_config_id(message.principal_id)
+            binding_id = await self._optional_telegram_binding(
                 message.principal_id,
                 message.channel_id,
             )
-            delivery = await WorkshopDeliveryOutbox(self._store).request_delivery_in_transaction(
-                DeliveryRequest(
-                    message_id=inbound_message_id,
-                    channel_binding_id=binding_id,
-                    mode="workshop_client_text",
-                    purpose=CONVERSATION_REPLY_PURPOSE,
-                    occurred_at=inbound.event.envelope.occurred_at,
-                    max_attempts=5,
+            delivery = (
+                await WorkshopDeliveryOutbox(self._store).request_delivery_in_transaction(
+                    DeliveryRequest(
+                        message_id=inbound_message_id,
+                        channel_binding_id=binding_id,
+                        mode="workshop_client_text",
+                        purpose=CONVERSATION_REPLY_PURPOSE,
+                        occurred_at=inbound.event.envelope.occurred_at,
+                        max_attempts=5,
+                    )
                 )
+                if binding_id is not None
+                else None
             )
-            prior_states = {inbound.inserted, lifecycle.changed, delivery.inserted}
+            prior_states = {inbound.inserted, lifecycle.changed}
+            if delivery is not None:
+                prior_states.add(delivery.inserted)
             if len(prior_states) != 1:
                 raise ConversationCommandStateConflictError(
                     "Canonical inbound, run acceptance, and delivery request did not share one prior state"
@@ -153,37 +160,49 @@ class WorkshopConversationCommandService:
             return ClientConversationCommandAcceptance(
                 command=ConversationCommandAcceptance(inbound, lifecycle, disposition),
                 delivery=delivery,
-                compatibility_chat_id=chat_id,
+                runtime_config_id=runtime_config_id,
             )
         except Exception:
             await connection.rollback()
             raise
 
-    async def _telegram_compatibility_target(
+    async def _runtime_config_id(self, principal_id: PrincipalId) -> int:
+        async with self._store.connection.execute(
+            "SELECT external_subject FROM external_identities WHERE principal_id = ? AND provider = 'kai'",
+            (principal_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if len(rows) != 1:
+            raise ConversationCommandStateConflictError("Client principal requires one Kai runtime identity")
+        try:
+            runtime_config_id = int(str(rows[0][0]))
+        except ValueError as exc:
+            raise ConversationCommandStateConflictError("Kai runtime identity is not numeric") from exc
+        if runtime_config_id <= 0:
+            raise ConversationCommandStateConflictError("Kai runtime identity is not a positive configured-user ID")
+        return runtime_config_id
+
+    async def _optional_telegram_binding(
         self,
         principal_id: PrincipalId,
         channel_id: ChannelId,
-    ) -> tuple[ChannelBindingId, int]:
+    ) -> ChannelBindingId | None:
         async with self._store.connection.execute(
-            "SELECT cb.id, cb.external_channel_id, ei.external_subject "
+            "SELECT cb.id, EXISTS (SELECT 1 FROM external_identities ei "
+            "WHERE ei.principal_id = ? AND ei.provider = 'telegram' "
+            "AND ei.external_subject = cb.external_channel_id) "
             "FROM channel_bindings cb "
-            "JOIN external_identities ei ON ei.principal_id = ? "
-            "AND ei.provider = 'telegram' "
             "WHERE cb.channel_id = ? AND cb.transport = 'telegram'",
             (principal_id, channel_id),
         ) as cursor:
             rows = list(await cursor.fetchall())
-        if len(rows) != 1 or str(rows[0][1]) != str(rows[0][2]):
+        if not rows:
+            return None
+        if len(rows) != 1 or int(rows[0][1]) != 1:
             raise ConversationCommandStateConflictError(
-                "Client command requires one matching direct Telegram compatibility binding"
+                "Client command has an ambiguous or mismatched Telegram binding"
             )
-        try:
-            chat_id = int(str(rows[0][2]))
-        except ValueError as exc:
-            raise ConversationCommandStateConflictError("Telegram compatibility identity is not numeric") from exc
-        if chat_id <= 0:
-            raise ConversationCommandStateConflictError("Telegram compatibility identity is not a positive user ID")
-        return ChannelBindingId(str(rows[0][0])), chat_id
+        return ChannelBindingId(str(rows[0][0]))
 
     async def _replay_disposition(self, run: DurableRun) -> ConversationCommandDisposition:
         if run.status in {RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED}:

--- a/src/kai/workshop/conversation_runs.py
+++ b/src/kai/workshop/conversation_runs.py
@@ -13,7 +13,7 @@ from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, Work
 from kai.workshop.store import WorkshopEventStore
 
 type AgentPrompt = str | list[dict[str, str]]
-_TELEGRAM_USER_ID_PATTERN = re.compile(r"^[1-9][0-9]*$")
+_RUNTIME_SUBJECT_PATTERN = re.compile(r"^[1-9][0-9]*$")
 
 
 class ConversationRunUnavailableError(LookupError):
@@ -90,20 +90,21 @@ async def resolve_canonical_conversation_run(
     """Resolve a canonical target plus the current private pool adapter key.
 
     The public run request contains only a canonical message ID. During the
-    migration, the resolved human's Telegram identity supplies the existing
-    pool/config key internally. A caller cannot provide or override that key.
+    migration, the resolved human's protected Kai runtime identity supplies
+    the existing pool/config key internally. A caller cannot provide or
+    override that key, and transport identities are not execution authority.
     """
     target = await resolve_canonical_conversation_target(store, inbound_message_id)
     async with store.connection.execute(
-        "SELECT external_subject FROM external_identities WHERE principal_id = ? AND provider = 'telegram'",
+        "SELECT external_subject FROM external_identities WHERE principal_id = ? AND provider = 'kai'",
         (target.requested_by_principal_id,),
     ) as cursor:
         identity_rows = list(await cursor.fetchall())
     if len(identity_rows) != 1:
-        raise ConversationRunUnavailableError("Canonical human requires exactly one Telegram compatibility identity")
+        raise ConversationRunUnavailableError("Canonical human requires exactly one Kai runtime identity")
     external_subject = str(identity_rows[0][0])
-    if not _TELEGRAM_USER_ID_PATTERN.fullmatch(external_subject):
-        raise ConversationRunUnavailableError("Telegram compatibility identity is not a positive user ID")
+    if not _RUNTIME_SUBJECT_PATTERN.fullmatch(external_subject):
+        raise ConversationRunUnavailableError("Kai runtime identity is not a positive configured-user ID")
 
     return CompatibilityConversationRunResolution(
         target=target,

--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -107,8 +107,8 @@ class OutboundDeliveryResult:
 @dataclass(frozen=True, slots=True)
 class OutboundStreamingFinalizationResult:
     message: AppendResult
-    delivery: DeliveryRequestResult
-    plan: DeliveryFragmentPlanResult
+    delivery: DeliveryRequestResult | None
+    plan: DeliveryFragmentPlanResult | None
 
 
 async def _resolve_outbound(store: WorkshopEventStore, message_id: MessageId) -> _ResolvedOutbound:
@@ -339,7 +339,9 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
         store,
         message.in_reply_to_message_id,
     )
-    if streaming_target.workshop_id != binding.workshop_id or streaming_target.channel_id != binding.channel_id:
+    if streaming_target is not None and (
+        streaming_target.workshop_id != binding.workshop_id or streaming_target.channel_id != binding.channel_id
+    ):
         raise OutboundStreamingPreviewConflictError(
             "Telegram streaming target does not match the canonical agent reply target"
         )
@@ -351,15 +353,9 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
             channel_id=binding.channel_id,
             channel_binding_id=streaming_target.channel_binding_id,
         )
-        if streaming_target.preview_eligible
+        if streaming_target is not None and streaming_target.preview_eligible
         else None
     )
-    operations = _streaming_finalization_operations(
-        message.body,
-        preview_message_id=preview_message_id,
-    )
-    authority_epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch_in_transaction()
-    assert authority_epoch is not None
     message_result = await _existing_outbound(store, binding, message)
     if message_result is None:
         message_result = await store.append_in_transaction(_outbound_envelope(binding, message))
@@ -369,28 +365,37 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
     message_id = message_result.event.envelope.aggregate_id
     if not isinstance(message_id, MessageId):
         raise RuntimeError("Canonical outbound event did not identify a message")
-    delivery_result = await WorkshopDeliveryOutbox(store).request_delivery_in_transaction(
-        DeliveryRequest(
-            message_id=message_id,
-            channel_binding_id=streaming_target.channel_binding_id,
-            mode="text",
-            purpose=CONVERSATION_REPLY_PURPOSE,
-            occurred_at=message.occurred_at,
-            execution_contract=STREAMING_FINALIZATION_CONTRACT,
-            authority_epoch_id=authority_epoch.epoch_id,
-            max_attempts=5,
+    delivery_result = None
+    plan_result = None
+    if streaming_target is not None:
+        operations = _streaming_finalization_operations(
+            message.body,
+            preview_message_id=preview_message_id,
         )
-    )
-    plan_result = await WorkshopDeliveryFragments(store).prepare_operations_in_transaction(
-        delivery_result.delivery.delivery_id,
-        operations,
-        occurred_at=message.occurred_at,
-    )
-    prior_states = {
-        message_result.inserted,
-        delivery_result.inserted,
-        plan_result.inserted,
-    }
+        authority_epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch_in_transaction()
+        assert authority_epoch is not None
+        delivery_result = await WorkshopDeliveryOutbox(store).request_delivery_in_transaction(
+            DeliveryRequest(
+                message_id=message_id,
+                channel_binding_id=streaming_target.channel_binding_id,
+                mode="text",
+                purpose=CONVERSATION_REPLY_PURPOSE,
+                occurred_at=message.occurred_at,
+                execution_contract=STREAMING_FINALIZATION_CONTRACT,
+                authority_epoch_id=authority_epoch.epoch_id,
+                max_attempts=5,
+            )
+        )
+        plan_result = await WorkshopDeliveryFragments(store).prepare_operations_in_transaction(
+            delivery_result.delivery.delivery_id,
+            operations,
+            occurred_at=message.occurred_at,
+        )
+    prior_states = {message_result.inserted}
+    if delivery_result is not None:
+        prior_states.add(delivery_result.inserted)
+    if plan_result is not None:
+        prior_states.add(plan_result.inserted)
     if len(prior_states) != 1:
         raise OutboundDeliveryStateConflictError(
             "Canonical reply, delivery request, and operation plan did not share one prior state"

--- a/src/kai/workshop/streaming_preview.py
+++ b/src/kai/workshop/streaming_preview.py
@@ -92,7 +92,8 @@ async def _resolve_telegram_target(
     inbound_message_id: MessageId,
     *,
     allow_workshop_client: bool,
-) -> ResolvedTelegramFinalizationTarget:
+    require_binding: bool,
+) -> ResolvedTelegramFinalizationTarget | None:
     async with store.connection.execute(
         "SELECT c.workshop_id, m.channel_id, c.kind, p.kind, m.reply_to_message_id, "
         "json_extract(e.metadata_json, '$.source'), "
@@ -137,6 +138,8 @@ async def _resolve_telegram_target(
         (str(row[8]), channel_id),
     ) as cursor:
         bindings = list(await cursor.fetchall())
+    if not bindings and not require_binding:
+        return None
     if len(bindings) != 1 or int(bindings[0][1]) != 1:
         raise StreamingPreviewBindingError("Canonical direct channel must have exactly one Telegram binding")
     return ResolvedTelegramFinalizationTarget(
@@ -155,7 +158,9 @@ async def resolve_telegram_streaming_target(
         store,
         inbound_message_id,
         allow_workshop_client=False,
+        require_binding=True,
     )
+    assert target is not None
     return ResolvedTelegramStreamingTarget(
         workshop_id=target.workshop_id,
         channel_id=target.channel_id,
@@ -166,12 +171,13 @@ async def resolve_telegram_streaming_target(
 async def resolve_telegram_finalization_target(
     store: WorkshopEventStore,
     inbound_message_id: MessageId,
-) -> ResolvedTelegramFinalizationTarget:
-    """Resolve Telegram final delivery for Telegram or Workshop ingress."""
+) -> ResolvedTelegramFinalizationTarget | None:
+    """Resolve optional Telegram final delivery for supported ingress."""
     return await _resolve_telegram_target(
         store,
         inbound_message_id,
         allow_workshop_client=True,
+        require_binding=False,
     )
 
 

--- a/src/kai/workshop/terminal_transactions.py
+++ b/src/kai/workshop/terminal_transactions.py
@@ -250,10 +250,12 @@ class WorkshopRunTerminalTransactionCoordinator:
 
             prior_states = {
                 finalization.message.inserted,
-                finalization.delivery.inserted,
-                finalization.plan.inserted,
                 execution.changed,
             }
+            if finalization.delivery is not None:
+                prior_states.add(finalization.delivery.inserted)
+            if finalization.plan is not None:
+                prior_states.add(finalization.plan.inserted)
             if len(prior_states) != 1:
                 raise TerminalTransactionStateConflictError(
                     "Canonical outcome, delivery plan, and run settlement did not share one prior state"

--- a/tests/test_workshop_bootstrap.py
+++ b/tests/test_workshop_bootstrap.py
@@ -43,6 +43,7 @@ class TestBootstrapInput:
             ({"transport": "Telegram"}, "transport"),
             ({"external_subject": ""}, "external_subject"),
             ({"external_channel_id": ""}, "external_channel_id"),
+            ({"runtime_subject": ""}, "runtime_subject"),
         ],
     )
     def test_invalid_human_fails_before_database_changes(self, changes, match):
@@ -223,6 +224,37 @@ class TestDefaultWorkshopBootstrap:
         assert second.workshop_id == first.workshop_id
         assert second.agent_id == first.agent_id
         assert second_events == first_events
+
+    async def test_rerun_adds_one_protected_runtime_identity_without_replacing_transport_identity(
+        self,
+        store,
+    ):
+        original = _human(101, "Admin", role="admin")
+        first = await bootstrap_default_workshop(store, [original])
+        upgraded = await bootstrap_default_workshop(
+            store,
+            [
+                BootstrapHuman(
+                    display_name=original.display_name,
+                    role=original.role,
+                    transport=original.transport,
+                    external_subject=original.external_subject,
+                    external_channel_id=original.external_channel_id,
+                    runtime_subject="101",
+                )
+            ],
+        )
+
+        assert first.created_events == 12
+        assert upgraded.created_events == 1
+        assert upgraded.existing_events == 12
+        async with store.connection.execute(
+            "SELECT provider, external_subject FROM external_identities ORDER BY provider"
+        ) as cursor:
+            assert [tuple(row) for row in await cursor.fetchall()] == [
+                ("kai", "101"),
+                ("telegram", "101"),
+            ]
 
     async def test_input_order_does_not_change_event_or_projection_order(self, tmp_path: Path):
         first_store = await WorkshopEventStore.open(tmp_path / "first.db")

--- a/tests/test_workshop_client_commands.py
+++ b/tests/test_workshop_client_commands.py
@@ -32,7 +32,7 @@ async def test_completed_client_command_preserves_history_session_and_memory(
     message = _message()
     run_id = RunId.new()
     accepted = SimpleNamespace(
-        compatibility_chat_id=101,
+        runtime_config_id=101,
         command=SimpleNamespace(disposition=ConversationCommandDisposition.NEWLY_ACCEPTED),
         run=SimpleNamespace(run_id=run_id),
     )
@@ -97,7 +97,7 @@ async def test_terminal_replay_does_not_duplicate_compatibility_writes(monkeypat
     message = _message()
     run_id = RunId.new()
     accepted = SimpleNamespace(
-        compatibility_chat_id=101,
+        runtime_config_id=101,
         command=SimpleNamespace(disposition=ConversationCommandDisposition.TERMINAL_REPLAY),
         run=SimpleNamespace(run_id=run_id),
     )

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -70,6 +70,7 @@ async def _open_client_store(
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
+                runtime_subject="101",
             ),
         ),
     )
@@ -345,7 +346,8 @@ class TestAtomicClientConversationCommandAcceptance:
             assert accepted.command.message.inserted is True
             assert accepted.command.lifecycle.changed is True
             assert accepted.delivery.inserted is True
-            assert accepted.compatibility_chat_id == 101
+            assert accepted.runtime_config_id == 101
+            assert accepted.delivery is not None
             assert accepted.delivery.delivery.message_id == accepted.command.message.event.envelope.aggregate_id
             assert accepted.delivery.delivery.channel_id == channel_id
             assert accepted.delivery.delivery.mode == "workshop_client_text"
@@ -387,6 +389,8 @@ class TestAtomicClientConversationCommandAcceptance:
             assert retry.command.disposition == ConversationCommandDisposition.READY_REPLAY
             assert retry.command.message.inserted is False
             assert retry.command.lifecycle.changed is False
+            assert retry.delivery is not None
+            assert first.delivery is not None
             assert retry.delivery.inserted is False
             assert retry.command.message.event == first.command.message.event
             assert retry.command.lifecycle.event == first.command.lifecycle.event
@@ -399,5 +403,50 @@ class TestAtomicClientConversationCommandAcceptance:
                 "('message.created', 'run.accepted', 'delivery.requested')"
             ) as cursor:
                 assert int((await cursor.fetchone())[0]) == 3
+        finally:
+            await store.close()
+
+    async def test_workshop_only_channel_accepts_without_transport_delivery(
+        self,
+        tmp_path: Path,
+    ):
+        store = await WorkshopEventStore.open(tmp_path / "kai.db")
+        await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    display_name="Workshop Human",
+                    role="admin",
+                    transport="desktop",
+                    external_subject="desktop-human",
+                    external_channel_id="desktop-human",
+                    runtime_subject="101",
+                ),
+            ),
+        )
+        async with store.connection.execute(
+            "SELECT e.principal_id, c.id FROM external_identities e "
+            "JOIN channel_memberships cm ON cm.principal_id = e.principal_id "
+            "JOIN channels c ON c.id = cm.channel_id AND c.kind = 'direct' "
+            "WHERE e.provider = 'kai' AND e.external_subject = '101'"
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        try:
+            accepted = await WorkshopConversationCommandService(store).accept_client(
+                _client_message(PrincipalId(str(row[0])), ChannelId(str(row[1])))
+            )
+
+            assert accepted.command.disposition == ConversationCommandDisposition.NEWLY_ACCEPTED
+            assert accepted.runtime_config_id == 101
+            assert accepted.delivery is None
+            async with store.connection.execute(
+                "SELECT event_type FROM event_log WHERE position >= ? ORDER BY position",
+                (accepted.command.message.event.position,),
+            ) as cursor:
+                assert [str(item[0]) for item in await cursor.fetchall()] == [
+                    "message.created",
+                    "run.accepted",
+                ]
         finally:
             await store.close()

--- a/tests/test_workshop_conversation_runs.py
+++ b/tests/test_workshop_conversation_runs.py
@@ -35,6 +35,7 @@ async def _canonical_inbound(store: WorkshopEventStore, telegram_id: int = 101) 
                 transport="telegram",
                 external_subject=str(telegram_id),
                 external_channel_id=str(telegram_id),
+                runtime_subject=str(telegram_id),
             ),
         ),
     )
@@ -91,6 +92,53 @@ class TestCanonicalRunResolution:
         finally:
             await store.close()
 
+    async def test_runtime_resolution_does_not_require_telegram_identity_or_binding(
+        self,
+        tmp_path: Path,
+    ):
+        store = await WorkshopEventStore.open(tmp_path / "kai.db")
+        try:
+            await bootstrap_default_workshop(
+                store,
+                (
+                    BootstrapHuman(
+                        display_name="Workshop-only Human",
+                        role="admin",
+                        transport="desktop",
+                        external_subject="desktop-human",
+                        external_channel_id="desktop-human",
+                        runtime_subject="202",
+                    ),
+                ),
+            )
+            inbound = await record_inbound_message(
+                store,
+                InboundMessage(
+                    transport="desktop",
+                    update_id="desktop-command-1",
+                    message_id="desktop-message-1",
+                    sender_subject="desktop-human",
+                    channel_subject="desktop-human",
+                    body="Run without Telegram",
+                    occurred_at=_NOW,
+                ),
+            )
+            inbound_id = MessageId(str(inbound.event.envelope.aggregate_id))
+
+            resolution = await resolve_canonical_conversation_run(store, inbound_id)
+
+            assert resolution._legacy_pool_key == 202
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM external_identities WHERE provider = 'telegram'"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_bindings WHERE transport = 'telegram'"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+        finally:
+            await store.close()
+
     async def test_rejects_missing_compatibility_identity(self, tmp_path: Path):
         store = await WorkshopEventStore.open(tmp_path / "kai.db")
         try:
@@ -98,7 +146,7 @@ class TestCanonicalRunResolution:
             await store.connection.execute("DELETE FROM external_identities")
             await store.connection.commit()
 
-            with pytest.raises(ConversationRunUnavailableError, match="exactly one Telegram"):
+            with pytest.raises(ConversationRunUnavailableError, match="exactly one Kai runtime"):
                 await resolve_canonical_conversation_run(store, inbound_id)
         finally:
             await store.close()

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -64,6 +64,7 @@ async def _foundation(database: Path) -> None:
                     transport="telegram",
                     external_subject="101",
                     external_channel_id="101",
+                    runtime_subject="101",
                 ),
             ),
         )

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -34,6 +34,7 @@ async def _accepted_run(path: Path, home: Path):
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
+                runtime_subject="101",
             ),
         ),
     )

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -52,6 +52,7 @@ async def _started_run(
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
+                runtime_subject="101",
             ),
         ),
     )
@@ -101,6 +102,7 @@ async def _started_client_run(
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
+                runtime_subject="101",
             ),
         ),
     )
@@ -134,6 +136,56 @@ async def _started_client_run(
     )
     started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
     await WorkshopConversationDeliveryAuthority(store).activate()
+    return store, authority, started.claim
+
+
+async def _started_workshop_only_client_run(
+    path: Path,
+) -> tuple[WorkshopEventStore, WorkshopRunExecutionAuthority, RunExecutionClaim]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="desktop",
+                external_subject="desktop-human",
+                external_channel_id="desktop-human",
+                runtime_subject="101",
+            ),
+        ),
+    )
+    async with store.connection.execute(
+        "SELECT e.principal_id, c.id FROM external_identities e "
+        "JOIN channel_memberships cm ON cm.principal_id = e.principal_id "
+        "JOIN channels c ON c.id = cm.channel_id AND c.kind = 'direct' "
+        "WHERE e.provider = 'kai' AND e.external_subject = '101'"
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    accepted = await WorkshopConversationCommandService(store).accept_client(
+        ClientInboundMessage(
+            principal_id=PrincipalId(str(row[0])),
+            channel_id=ChannelId(str(row[1])),
+            client_message_id="browser-command-1",
+            body="Perform one durable unit of work",
+            occurred_at=_NOW,
+        )
+    )
+    assert accepted.delivery is None
+    authority = WorkshopRunExecutionAuthority(
+        store,
+        selection_resolver=lambda _run: RunExecutionSelection("codex", "gpt-5.6-sol"),
+        registered_backend_ids=frozenset({"codex"}),
+    )
+    granted = await authority.grant(
+        accepted.run.run_id,
+        owner_id=RunExecutionOwnerId.new(),
+        occurred_at=_NOW + timedelta(seconds=2),
+        lease_expires_at=_NOW + timedelta(minutes=2),
+    )
+    started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
     return store, authority, started.claim
 
 
@@ -206,6 +258,34 @@ class TestAtomicTerminalTransactions:
             # The browser command's attributed echo precedes the assistant
             # finalization and both remain durable outbox work.
             assert await _terminal_rows(store) == (1, 2, 1)
+        finally:
+            await store.close()
+
+    async def test_workshop_only_success_commits_without_any_transport_work(
+        self,
+        tmp_path: Path,
+    ):
+        store, authority, claim = await _started_workshop_only_client_run(tmp_path / "kai.db")
+        try:
+            result = await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+                claim,
+                body="WORKSHOP-ONLY-OK",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+
+            assert result.outcome == TerminalOutcome.COMPLETED
+            assert result.execution.run.status == RunStatus.COMPLETED
+            assert result.finalization.delivery is None
+            assert result.finalization.plan is None
+            assert await _terminal_rows(store) == (1, 0, 0)
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_bindings WHERE transport = 'telegram'"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM external_identities WHERE provider = 'telegram'"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
         finally:
             await store.close()
 


### PR DESCRIPTION
## Summary

- make Telegram compatibility delivery optional for authenticated Workshop browser commands
- commit Workshop-only human messages, runs, and terminal agent results without creating transport outbox work
- preserve the existing attributed Telegram echo, streaming-finalization plan, and delivery behavior whenever a valid Telegram binding exists
- separate backend execution authority from Telegram by binding each configured human to a protected `kai` runtime identity during bootstrap

## Why

Workshop channels and messages are already canonical, but two required compatibility lookups still made Telegram part of the execution boundary:

1. browser command acceptance required a matching Telegram identity and channel binding so it could enqueue an attributed echo
2. terminal settlement required a Telegram binding so it could create a streaming-finalization delivery plan

That meant a canonical Workshop client could not complete a command in a channel with no Telegram transport. Backend selection also resolved through the human's Telegram external identity.

## Behavior

### Workshop-only channel

- the authenticated client message and accepted run commit atomically
- backend preparation resolves through the protected `kai` runtime identity, not a Telegram identity
- the terminal agent message and fenced run settlement commit atomically
- no `delivery_outbox` or `delivery_fragments` rows are created when no supported external binding exists
- timeline/SSE clients observe the canonical messages directly

### Telegram-backed channel

- browser ingress still enqueues the same attributed `workshop_client_text` echo
- Telegram ingress still uses confirmed streaming previews when available
- browser-originated results still use an immutable send-only finalization plan
- all existing delivery authority, idempotency, ordering, retry, and fail-closed binding checks remain in force

## Existing-install migration

Bootstrap now adds one deterministic `provider: kai` runtime identity for each configured human. It does not replace or mutate the existing Telegram identity or binding. The bootstrap rerun is idempotent; a deployed user missing this identity gains exactly one new event before private-text execution starts.

This remains a compatibility mapping to the current integer-keyed runtime configuration. Independent Workshop enrollment and an optional Telegram process are separate follow-up milestones.

## Tests

- Workshop-only browser acceptance with no Telegram identity or binding
- protected runtime resolution with no Telegram identity or binding
- Workshop-only terminal completion with canonical result and zero transport work
- existing Telegram-backed echo and finalization behavior
- bootstrap upgrade and idempotency contract for existing installs
- integrated private-text and protected-execution migration fixtures

Validation:

- `make check`
- `make typecheck`
- focused Workshop suite: 101 passed
- full suite: 5,546 passed, 1 skipped

## Rollout

After merge, run `make install`. Startup bootstrap will add the protected runtime identities before the Workshop execution service starts. Existing Telegram behavior should remain unchanged.
