### PR TITLE
Decouple Workshop client enrollment from Telegram

### DIFF
--- a/src/kai/workshop/client_access.py
+++ b/src/kai/workshop/client_access.py
@@ -23,6 +23,13 @@ class IssuedClientEnrollment:
     channel_id: ChannelId
 
 
+@dataclass(frozen=True, slots=True)
+class EnrollableWorkshopHuman:
+    principal_id: PrincipalId
+    display_name: str
+    direct_channels: tuple[ChannelId, ...]
+
+
 def _telegram_subject(telegram_user_id: int) -> str:
     if (
         not isinstance(telegram_user_id, int)
@@ -40,6 +47,46 @@ class WorkshopClientAccess:
         self._store = store
         self._enrollment = WorkshopClientEnrollmentManager(store)
         self._sessions = WorkshopClientSessionManager(store)
+
+    async def list_humans(self) -> tuple[EnrollableWorkshopHuman, ...]:
+        """List canonical humans and their owned direct channels."""
+        async with self._store.connection.execute(
+            "SELECT p.id, p.display_name, c.id FROM principals p "
+            "JOIN workshop_memberships wm ON wm.principal_id = p.id "
+            "LEFT JOIN channel_memberships cm ON cm.principal_id = p.id AND cm.role = 'owner' "
+            "LEFT JOIN channels c ON c.id = cm.channel_id AND c.workshop_id = wm.workshop_id "
+            "AND c.kind = 'direct' WHERE p.kind = 'human' ORDER BY p.display_name, p.id, c.id"
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        humans: dict[PrincipalId, tuple[str, list[ChannelId]]] = {}
+        for row in rows:
+            principal_id = PrincipalId(str(row[0]))
+            entry = humans.setdefault(principal_id, (str(row[1]), []))
+            if row[2] is not None:
+                entry[1].append(ChannelId(str(row[2])))
+        return tuple(
+            EnrollableWorkshopHuman(principal_id, display_name, tuple(channels))
+            for principal_id, (display_name, channels) in humans.items()
+        )
+
+    async def _require_direct_human(
+        self,
+        principal_id: PrincipalId,
+        channel_id: ChannelId,
+    ) -> None:
+        if not isinstance(principal_id, PrincipalId) or not isinstance(channel_id, ChannelId):
+            raise WorkshopClientAccessError("Canonical principal and channel IDs are required")
+        async with self._store.connection.execute(
+            "SELECT 1 FROM principals p "
+            "JOIN workshop_memberships wm ON wm.principal_id = p.id "
+            "JOIN channels c ON c.workshop_id = wm.workshop_id AND c.id = ? AND c.kind = 'direct' "
+            "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.principal_id = p.id "
+            "AND cm.role = 'owner' WHERE p.id = ? AND p.kind = 'human' LIMIT 1",
+            (channel_id, principal_id),
+        ) as cursor:
+            available = await cursor.fetchone() is not None
+        if not available:
+            raise WorkshopClientAccessError("Canonical human does not own that direct channel in an active Workshop")
 
     async def _resolve_direct_human(self, telegram_user_id: int) -> tuple[PrincipalId, ChannelId]:
         subject = _telegram_subject(telegram_user_id)
@@ -62,17 +109,39 @@ class WorkshopClientAccess:
             )
         return PrincipalId(str(rows[0][0])), ChannelId(str(rows[0][1]))
 
-    async def issue_enrollment(self, telegram_user_id: int) -> IssuedClientEnrollment:
-        principal_id, channel_id = await self._resolve_direct_human(telegram_user_id)
+    async def issue_enrollment(
+        self,
+        principal_id: PrincipalId,
+        channel_id: ChannelId,
+    ) -> IssuedClientEnrollment:
+        await self._require_direct_human(principal_id, channel_id)
         grant = await self._enrollment.issue_grant(principal_id)
         return IssuedClientEnrollment(grant, channel_id)
 
-    async def revoke_device(self, telegram_user_id: int, device_id: DeviceId) -> None:
-        principal_id, _ = await self._resolve_direct_human(telegram_user_id)
+    async def issue_enrollment_for_telegram(self, telegram_user_id: int) -> IssuedClientEnrollment:
+        principal_id, channel_id = await self._resolve_direct_human(telegram_user_id)
+        return await self.issue_enrollment(principal_id, channel_id)
+
+    async def revoke_device(self, principal_id: PrincipalId, device_id: DeviceId) -> None:
         if not await self._sessions.revoke_device(principal_id, device_id):
             raise WorkshopClientAccessError("Client device is unavailable for that canonical human")
 
-    async def revoke_enrollment(self, telegram_user_id: int, grant_id: EnrollmentGrantId) -> None:
+    async def revoke_device_for_telegram(self, telegram_user_id: int, device_id: DeviceId) -> None:
         principal_id, _ = await self._resolve_direct_human(telegram_user_id)
+        await self.revoke_device(principal_id, device_id)
+
+    async def revoke_enrollment(
+        self,
+        principal_id: PrincipalId,
+        grant_id: EnrollmentGrantId,
+    ) -> None:
         if not await self._enrollment.revoke_grant(principal_id, grant_id):
             raise WorkshopClientAccessError("Enrollment grant is unavailable for that canonical human")
+
+    async def revoke_enrollment_for_telegram(
+        self,
+        telegram_user_id: int,
+        grant_id: EnrollmentGrantId,
+    ) -> None:
+        principal_id, _ = await self._resolve_direct_human(telegram_user_id)
+        await self.revoke_enrollment(principal_id, grant_id)

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -26,7 +26,7 @@ from kai.workshop.delivery_outbox import (
     WorkshopDeliveryOutbox,
 )
 from kai.workshop.delivery_qualification import DeliveryQualificationError, WorkshopDeliveryQualification
-from kai.workshop.domain import DeliveryId, DeviceId, EnrollmentGrantId
+from kai.workshop.domain import ChannelId, DeliveryId, DeviceId, EnrollmentGrantId, PrincipalId
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery import (
     TelegramWorkOutcome,
@@ -85,22 +85,33 @@ def _parser() -> argparse.ArgumentParser:
         help="issue or revoke human Workshop client credentials",
     )
     client_actions = client_access.add_subparsers(dest="action", required=True)
+    client_actions.add_parser(
+        "list-humans",
+        help="list canonical humans and their direct channels",
+    )
     issue = client_actions.add_parser(
         "issue-enrollment",
-        help="issue one short-lived enrollment token for a configured Telegram human",
+        help="issue one short-lived enrollment token for a canonical human",
     )
-    issue.add_argument("--telegram-user-id", required=True, type=int)
+    issue_identity = issue.add_mutually_exclusive_group(required=True)
+    issue_identity.add_argument("--principal-id")
+    issue_identity.add_argument("--telegram-user-id", type=int)
+    issue.add_argument("--channel-id")
     revoke_device = client_actions.add_parser(
         "revoke-device",
         help="revoke one client device and all of its sessions",
     )
-    revoke_device.add_argument("--telegram-user-id", required=True, type=int)
+    revoke_device_identity = revoke_device.add_mutually_exclusive_group(required=True)
+    revoke_device_identity.add_argument("--principal-id")
+    revoke_device_identity.add_argument("--telegram-user-id", type=int)
     revoke_device.add_argument("--device-id", required=True)
     revoke_enrollment = client_actions.add_parser(
         "revoke-enrollment",
         help="revoke one unredeemed enrollment grant",
     )
-    revoke_enrollment.add_argument("--telegram-user-id", required=True, type=int)
+    revoke_enrollment_identity = revoke_enrollment.add_mutually_exclusive_group(required=True)
+    revoke_enrollment_identity.add_argument("--principal-id")
+    revoke_enrollment_identity.add_argument("--telegram-user-id", type=int)
     revoke_enrollment.add_argument("--grant-id", required=True)
     return parser
 
@@ -124,6 +135,20 @@ def _enrollment_grant_id(value: str) -> EnrollmentGrantId:
         return EnrollmentGrantId(value)
     except (TypeError, ValueError) as exc:
         raise WorkshopClientAccessError("Invalid enrollment grant ID") from exc
+
+
+def _principal_id(value: str) -> PrincipalId:
+    try:
+        return PrincipalId(value)
+    except (TypeError, ValueError) as exc:
+        raise WorkshopClientAccessError("Invalid principal ID") from exc
+
+
+def _channel_id(value: str) -> ChannelId:
+    try:
+        return ChannelId(value)
+    except (TypeError, ValueError) as exc:
+        raise WorkshopClientAccessError("Invalid channel ID") from exc
 
 
 def _print_state(state: DeliveryState) -> None:
@@ -154,8 +179,32 @@ async def _run(args: argparse.Namespace) -> int:
     try:
         if args.command == "client-access":
             access = WorkshopClientAccess(store)
+            if args.action == "list-humans":
+                humans = await access.list_humans()
+                if not humans:
+                    print("No canonical Workshop humans are available.")
+                    return 0
+                for human in humans:
+                    print(f"Human: {human.display_name}")
+                    print(f"Principal: {human.principal_id}")
+                    if human.direct_channels:
+                        for channel_id in human.direct_channels:
+                            print(f"Direct channel: {channel_id}")
+                    else:
+                        print("Direct channel: unavailable")
+                return 0
             if args.action == "issue-enrollment":
-                issued = await access.issue_enrollment(args.telegram_user_id)
+                if args.principal_id is not None:
+                    if args.channel_id is None:
+                        raise WorkshopClientAccessError("--channel-id is required with --principal-id")
+                    issued = await access.issue_enrollment(
+                        _principal_id(args.principal_id),
+                        _channel_id(args.channel_id),
+                    )
+                else:
+                    if args.channel_id is not None:
+                        raise WorkshopClientAccessError("--channel-id cannot be used with --telegram-user-id")
+                    issued = await access.issue_enrollment_for_telegram(args.telegram_user_id)
                 print(f"Enrollment: {issued.grant.grant_id}")
                 print(f"Channel: {issued.channel_id}")
                 print(f"Expires: {issued.grant.expires_at.isoformat()}")
@@ -164,12 +213,18 @@ async def _run(args: argparse.Namespace) -> int:
                 return 0
             if args.action == "revoke-device":
                 device_id = _device_id(args.device_id)
-                await access.revoke_device(args.telegram_user_id, device_id)
+                if args.principal_id is not None:
+                    await access.revoke_device(_principal_id(args.principal_id), device_id)
+                else:
+                    await access.revoke_device_for_telegram(args.telegram_user_id, device_id)
                 print(f"Device: {device_id}")
                 print("Status: revoked (all device sessions revoked)")
                 return 0
             grant_id = _enrollment_grant_id(args.grant_id)
-            await access.revoke_enrollment(args.telegram_user_id, grant_id)
+            if args.principal_id is not None:
+                await access.revoke_enrollment(_principal_id(args.principal_id), grant_id)
+            else:
+                await access.revoke_enrollment_for_telegram(args.telegram_user_id, grant_id)
             print(f"Enrollment: {grant_id}")
             print("Status: revoked")
             return 0

--- a/tests/test_workshop_client_access.py
+++ b/tests/test_workshop_client_access.py
@@ -16,7 +16,7 @@ from kai.workshop.client_sessions import (
     WorkshopClientEnrollmentManager,
     WorkshopClientSessionManager,
 )
-from kai.workshop.domain import DeviceId, EnrollmentGrantId
+from kai.workshop.domain import ChannelId, DeviceId, EnrollmentGrantId, PrincipalId
 from kai.workshop.store import WorkshopEventStore
 
 
@@ -32,11 +32,28 @@ async def _store(path: Path) -> WorkshopEventStore:
     return store
 
 
+async def _canonical_access_ids(
+    store: WorkshopEventStore,
+    external_subject: str = "101",
+) -> tuple[PrincipalId, ChannelId]:
+    async with store.connection.execute(
+        "SELECT e.principal_id, c.id FROM external_identities e "
+        "JOIN channel_memberships cm ON cm.principal_id = e.principal_id AND cm.role = 'owner' "
+        "JOIN channels c ON c.id = cm.channel_id AND c.kind = 'direct' "
+        "WHERE e.provider = 'telegram' AND e.external_subject = ?",
+        (external_subject,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return PrincipalId(str(row[0])), ChannelId(str(row[1]))
+
+
 class TestWorkshopClientAccess:
     async def test_issue_resolves_server_selected_human_and_direct_channel(self, tmp_path: Path):
         store = await _store(tmp_path / "kai.db")
         try:
-            issued = await WorkshopClientAccess(store).issue_enrollment(101)
+            principal_id, channel_id = await _canonical_access_ids(store)
+            issued = await WorkshopClientAccess(store).issue_enrollment(principal_id, channel_id)
 
             assert issued.grant.token.startswith(f"kai_ws_enroll_v1.{issued.grant.grant_id}.")
             assert str(issued.channel_id).startswith("chn_")
@@ -51,11 +68,51 @@ class TestWorkshopClientAccess:
         finally:
             await store.close()
 
+    async def test_canonical_enrollment_needs_no_external_identity_or_transport_binding(
+        self,
+        tmp_path: Path,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            principal_id, channel_id = await _canonical_access_ids(store)
+            await store.connection.execute(
+                "DELETE FROM external_identities WHERE principal_id = ?",
+                (principal_id,),
+            )
+            await store.connection.execute(
+                "DELETE FROM channel_bindings WHERE channel_id = ?",
+                (channel_id,),
+            )
+            await store.connection.commit()
+
+            access = WorkshopClientAccess(store)
+            humans = await access.list_humans()
+            issued = await access.issue_enrollment(principal_id, channel_id)
+
+            assert any(human.principal_id == principal_id and channel_id in human.direct_channels for human in humans)
+            assert issued.grant.principal_id == principal_id
+            assert issued.channel_id == channel_id
+        finally:
+            await store.close()
+
+    async def test_canonical_enrollment_requires_owned_direct_channel(self, tmp_path: Path):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            alice_id, _ = await _canonical_access_ids(store, "101")
+            _, bob_channel_id = await _canonical_access_ids(store, "202")
+
+            with pytest.raises(WorkshopClientAccessError, match="does not own"):
+                await WorkshopClientAccess(store).issue_enrollment(alice_id, bob_channel_id)
+            async with store.connection.execute("SELECT COUNT(*) FROM workshop_client_enrollment_grants") as cursor:
+                assert (await cursor.fetchone())[0] == 0
+        finally:
+            await store.close()
+
     async def test_unknown_telegram_identity_cannot_receive_a_grant(self, tmp_path: Path):
         store = await _store(tmp_path / "kai.db")
         try:
             with pytest.raises(WorkshopClientAccessError, match="exactly one canonical human"):
-                await WorkshopClientAccess(store).issue_enrollment(999)
+                await WorkshopClientAccess(store).issue_enrollment_for_telegram(999)
             async with store.connection.execute("SELECT COUNT(*) FROM workshop_client_enrollment_grants") as cursor:
                 assert (await cursor.fetchone())[0] == 0
         finally:
@@ -66,7 +123,7 @@ class TestWorkshopClientAccess:
         store = await _store(tmp_path / "kai.db")
         try:
             with pytest.raises(WorkshopClientAccessError, match="positive signed 64-bit"):
-                await WorkshopClientAccess(store).issue_enrollment(telegram_user_id)
+                await WorkshopClientAccess(store).issue_enrollment_for_telegram(telegram_user_id)
         finally:
             await store.close()
 
@@ -74,17 +131,21 @@ class TestWorkshopClientAccess:
         database = tmp_path / "kai.db"
         store = await _store(database)
         access = WorkshopClientAccess(store)
-        issued = await access.issue_enrollment(101)
+        principal_id, channel_id = await _canonical_access_ids(store)
+        issued = await access.issue_enrollment(principal_id, channel_id)
         redeemed = await WorkshopClientEnrollmentManager(store).redeem_grant(issued.grant.token, "Alice laptop")
         token = redeemed.session.token
-        await access.revoke_device(101, redeemed.device.device_id)
+        await access.revoke_device(principal_id, redeemed.device.device_id)
         await store.close()
 
         restarted = await WorkshopEventStore.open(database)
         try:
             assert await WorkshopClientSessionManager(restarted).authenticate_token(token) is None
             with pytest.raises(WorkshopClientAccessError, match="unavailable"):
-                await WorkshopClientAccess(restarted).revoke_device(101, redeemed.device.device_id)
+                await WorkshopClientAccess(restarted).revoke_device(
+                    principal_id,
+                    redeemed.device.device_id,
+                )
         finally:
             await restarted.close()
 
@@ -92,8 +153,9 @@ class TestWorkshopClientAccess:
         database = tmp_path / "kai.db"
         store = await _store(database)
         access = WorkshopClientAccess(store)
-        issued = await access.issue_enrollment(101)
-        await access.revoke_enrollment(101, issued.grant.grant_id)
+        principal_id, channel_id = await _canonical_access_ids(store)
+        issued = await access.issue_enrollment(principal_id, channel_id)
+        await access.revoke_enrollment(principal_id, issued.grant.grant_id)
         await store.close()
 
         restarted = await WorkshopEventStore.open(database)
@@ -118,9 +180,31 @@ class TestWorkshopClientAccessCLI:
             workshop_cli._device_id("101")
         with pytest.raises(WorkshopClientAccessError, match="Invalid enrollment grant ID"):
             workshop_cli._enrollment_grant_id("101")
+        with pytest.raises(WorkshopClientAccessError, match="Invalid principal ID"):
+            workshop_cli._principal_id("101")
+        with pytest.raises(WorkshopClientAccessError, match="Invalid channel ID"):
+            workshop_cli._channel_id("101")
 
         assert workshop_cli._device_id("dev_" + "a" * 32) == DeviceId("dev_" + "a" * 32)
         assert workshop_cli._enrollment_grant_id("enr_" + "b" * 32) == EnrollmentGrantId("enr_" + "b" * 32)
+
+    async def test_list_humans_prints_canonical_enrollment_coordinates(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        capsys,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        principal_id, channel_id = await _canonical_access_ids(store)
+        await store.close()
+        monkeypatch.setattr(workshop_cli, "DATA_DIR", tmp_path)
+        args = workshop_cli._parser().parse_args(["client-access", "list-humans"])
+
+        assert await workshop_cli._run(args) == 0
+        output = capsys.readouterr().out
+        assert "Human: Alice" in output
+        assert f"Principal: {principal_id}" in output
+        assert f"Direct channel: {channel_id}" in output
 
     async def test_issue_command_prints_the_token_once_with_qualification_coordinates(
         self,
@@ -131,7 +215,19 @@ class TestWorkshopClientAccessCLI:
         store = await _store(tmp_path / "kai.db")
         await store.close()
         monkeypatch.setattr(workshop_cli, "DATA_DIR", tmp_path)
-        args = workshop_cli._parser().parse_args(["client-access", "issue-enrollment", "--telegram-user-id", "101"])
+        store = await WorkshopEventStore.open(tmp_path / "kai.db")
+        principal_id, channel_id = await _canonical_access_ids(store)
+        await store.close()
+        args = workshop_cli._parser().parse_args(
+            [
+                "client-access",
+                "issue-enrollment",
+                "--principal-id",
+                principal_id,
+                "--channel-id",
+                channel_id,
+            ]
+        )
 
         assert await workshop_cli._run(args) == 0
         output = capsys.readouterr().out
@@ -166,7 +262,11 @@ class TestWorkshopClientProductionRegistration:
 
             operator_store = await WorkshopEventStore.open(database)
             try:
-                issued = await WorkshopClientAccess(operator_store).issue_enrollment(101)
+                principal_id, channel_id = await _canonical_access_ids(operator_store)
+                issued = await WorkshopClientAccess(operator_store).issue_enrollment(
+                    principal_id,
+                    channel_id,
+                )
             finally:
                 await operator_store.close()
 


### PR DESCRIPTION
## Summary

- make canonical Workshop principal and direct-channel IDs the authority for client enrollment
- make device and enrollment revocation operate directly on canonical principal ownership
- retain `--telegram-user-id` as a compatibility resolver at the operator CLI boundary
- add `client-access list-humans` so operators can discover canonical enrollment coordinates without querying SQLite

## Security and architecture

The enrollment core no longer needs an external identity or transport binding. Before issuing a token, it requires that:

- the principal is a canonical human
- the human has an active membership in the channel's Workshop
- the channel is a canonical direct channel
- the human explicitly owns that channel

The compatibility Telegram path resolves a configured Telegram user to those canonical IDs, then calls the same canonical policy. It is no longer the enrollment authority.

## Compatibility

Existing operator commands using `--telegram-user-id` continue to work. The new canonical form is:

```text
python -m kai workshop client-access list-humans
python -m kai workshop client-access issue-enrollment \
  --principal-id <principal-id> \
  --channel-id <channel-id>
```

No production routing, browser API, token format, session lifetime, or Telegram delivery behavior changes.

## Validation

- 5,549 tests passed, 1 skipped
- focused client access/session/API suite: 84 passed
- Ruff lint and format checks passed
- Pyright passed with zero errors or warnings
- Workshop browser client typecheck, tests, build, and generated-asset verification passed
- module-size report passed

Tests specifically prove that canonical enrollment still works after deleting both the human's external identity and the direct channel's transport binding, and that one human cannot enroll against another human's direct channel.
