### PR TITLE
Provision canonical Workshop humans

### DIFF
--- a/src/kai/workshop/human_provisioning.py
+++ b/src/kai/workshop/human_provisioning.py
@@ -1,0 +1,308 @@
+"""Canonical, transport-independent Workshop human provisioning."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from kai.workshop.domain import (
+    AgentId,
+    ChannelAgentId,
+    ChannelId,
+    ChannelMembershipId,
+    EventEnvelope,
+    PrincipalId,
+    WorkshopEventType,
+    WorkshopId,
+    WorkshopMembershipId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+
+
+class WorkshopHumanProvisioningError(RuntimeError):
+    """A canonical human could not be provisioned safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisionedWorkshopHuman:
+    workshop_id: WorkshopId
+    principal_id: PrincipalId
+    channel_id: ChannelId
+    display_name: str
+    role: str
+    provisioning_key: str
+    created: bool
+
+
+_PROVISIONING_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+
+
+def _normalize_display_name(value: object) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value.strip()) > 200:
+        raise WorkshopHumanProvisioningError("Display name must contain 1 through 200 characters")
+    return value.strip()
+
+
+def _normalize_role(value: object) -> str:
+    if value not in {"admin", "member"}:
+        raise WorkshopHumanProvisioningError("Role must be 'admin' or 'member'")
+    return str(value)
+
+
+def _normalize_provisioning_key(value: object) -> str:
+    if not isinstance(value, str) or not _PROVISIONING_KEY_PATTERN.fullmatch(value):
+        raise WorkshopHumanProvisioningError(
+            "Provisioning key must be a lowercase identifier of 1 through 64 characters"
+        )
+    return value
+
+
+class WorkshopHumanProvisioner:
+    """Create collaboration identity without granting transport or runtime authority."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def provision(
+        self,
+        provisioning_key: str,
+        display_name: str,
+        role: str,
+        *,
+        workshop_id: WorkshopId | None = None,
+    ) -> ProvisionedWorkshopHuman:
+        normalized_key = _normalize_provisioning_key(provisioning_key)
+        normalized_name = _normalize_display_name(display_name)
+        normalized_role = _normalize_role(role)
+        if workshop_id is not None and not isinstance(workshop_id, WorkshopId):
+            raise WorkshopHumanProvisioningError("workshop_id must be a WorkshopId when provided")
+
+        now = datetime.now(UTC)
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            resolved_workshop_id = await self._resolve_workshop(workshop_id)
+            agent_id, agent_principal_id = await self._resolve_kai_agent(resolved_workshop_id)
+            stable_prefix = f"operator-human:{normalized_key}"
+            principal_id = PrincipalId.derived(resolved_workshop_id, stable_prefix)
+            membership_id = WorkshopMembershipId.derived(
+                resolved_workshop_id,
+                f"{stable_prefix}:workshop-membership",
+            )
+            channel_id = ChannelId.derived(
+                resolved_workshop_id,
+                f"{stable_prefix}:direct-channel",
+            )
+            human_channel_membership_id = ChannelMembershipId.derived(
+                resolved_workshop_id,
+                f"{stable_prefix}:human-channel-membership",
+            )
+            agent_channel_membership_id = ChannelMembershipId.derived(
+                resolved_workshop_id,
+                f"{stable_prefix}:agent-channel-membership",
+            )
+            channel_agent_id = ChannelAgentId.derived(
+                resolved_workshop_id,
+                f"{stable_prefix}:channel-agent",
+            )
+            principal_event_key = f"operator:human-provisioning:{principal_id}:principal"
+            if await self._store.event_by_idempotency_key(principal_event_key) is not None:
+                if not await self._matches_existing_provisioning(
+                    resolved_workshop_id,
+                    principal_id,
+                    channel_id,
+                    agent_id,
+                    agent_principal_id,
+                    normalized_name,
+                    normalized_role,
+                ):
+                    raise WorkshopHumanProvisioningError(
+                        "Provisioning key already exists with different human or channel semantics"
+                    )
+                await connection.commit()
+                return ProvisionedWorkshopHuman(
+                    resolved_workshop_id,
+                    principal_id,
+                    channel_id,
+                    normalized_name,
+                    normalized_role,
+                    normalized_key,
+                    False,
+                )
+            events = (
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.PRINCIPAL_CREATED,
+                    event_version=1,
+                    workshop_id=resolved_workshop_id,
+                    aggregate_type="principal",
+                    aggregate_id=principal_id,
+                    occurred_at=now,
+                    idempotency_key=principal_event_key,
+                    payload={"kind": "human", "display_name": normalized_name},
+                    metadata={"source": "operator_cli"},
+                ),
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.WORKSHOP_MEMBER_ADDED,
+                    event_version=1,
+                    workshop_id=resolved_workshop_id,
+                    aggregate_type="workshop_membership",
+                    aggregate_id=membership_id,
+                    occurred_at=now,
+                    idempotency_key=f"operator:human-provisioning:{principal_id}:workshop-membership",
+                    payload={"principal_id": principal_id, "role": normalized_role},
+                    metadata={"source": "operator_cli"},
+                ),
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.CHANNEL_CREATED,
+                    event_version=1,
+                    workshop_id=resolved_workshop_id,
+                    aggregate_type="channel",
+                    aggregate_id=channel_id,
+                    occurred_at=now,
+                    idempotency_key=f"operator:human-provisioning:{principal_id}:direct-channel",
+                    payload={"kind": "direct", "name": "Direct"},
+                    metadata={"source": "operator_cli"},
+                ),
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                    event_version=1,
+                    workshop_id=resolved_workshop_id,
+                    aggregate_type="channel_membership",
+                    aggregate_id=human_channel_membership_id,
+                    occurred_at=now,
+                    idempotency_key=f"operator:human-provisioning:{principal_id}:human-channel-membership",
+                    payload={
+                        "channel_id": channel_id,
+                        "principal_id": principal_id,
+                        "role": "owner",
+                    },
+                    metadata={"source": "operator_cli"},
+                ),
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                    event_version=1,
+                    workshop_id=resolved_workshop_id,
+                    aggregate_type="channel_membership",
+                    aggregate_id=agent_channel_membership_id,
+                    occurred_at=now,
+                    idempotency_key=f"operator:human-provisioning:{principal_id}:agent-channel-membership",
+                    payload={
+                        "channel_id": channel_id,
+                        "principal_id": agent_principal_id,
+                        "role": "participant",
+                    },
+                    metadata={"source": "operator_cli"},
+                ),
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
+                    event_version=1,
+                    workshop_id=resolved_workshop_id,
+                    aggregate_type="channel_agent",
+                    aggregate_id=channel_agent_id,
+                    occurred_at=now,
+                    idempotency_key=f"operator:human-provisioning:{principal_id}:channel-agent",
+                    payload={"channel_id": channel_id, "agent_id": agent_id},
+                    metadata={"source": "operator_cli"},
+                ),
+            )
+            inserted_states: set[bool] = set()
+            for event in events:
+                result = await self._store.append_in_transaction(event)
+                inserted_states.add(result.inserted)
+            if len(inserted_states) != 1:
+                raise WorkshopHumanProvisioningError("Provisioning events do not share one prior state")
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            await connection.commit()
+        except IdempotencyConflictError as exc:
+            await connection.rollback()
+            raise WorkshopHumanProvisioningError(
+                "Provisioning key already exists with different human or channel semantics"
+            ) from exc
+        except Exception:
+            await connection.rollback()
+            raise
+        return ProvisionedWorkshopHuman(
+            resolved_workshop_id,
+            principal_id,
+            channel_id,
+            normalized_name,
+            normalized_role,
+            normalized_key,
+            inserted_states == {True},
+        )
+
+    async def _matches_existing_provisioning(
+        self,
+        workshop_id: WorkshopId,
+        principal_id: PrincipalId,
+        channel_id: ChannelId,
+        agent_id: AgentId,
+        agent_principal_id: PrincipalId,
+        display_name: str,
+        role: str,
+    ) -> bool:
+        async with self._store.connection.execute(
+            "SELECT 1 FROM principals p "
+            "JOIN workshop_memberships wm ON wm.principal_id = p.id "
+            "AND wm.workshop_id = ? AND wm.role = ? "
+            "JOIN channels c ON c.id = ? AND c.workshop_id = wm.workshop_id "
+            "AND c.kind = 'direct' "
+            "JOIN channel_memberships human_cm ON human_cm.channel_id = c.id "
+            "AND human_cm.principal_id = p.id AND human_cm.role = 'owner' "
+            "JOIN channel_agents ca ON ca.channel_id = c.id AND ca.agent_id = ? "
+            "JOIN channel_memberships agent_cm ON agent_cm.channel_id = c.id "
+            "AND agent_cm.principal_id = ? AND agent_cm.role = 'participant' "
+            "WHERE p.id = ? AND p.kind = 'human' AND p.display_name = ? LIMIT 1",
+            (
+                workshop_id,
+                role,
+                channel_id,
+                agent_id,
+                agent_principal_id,
+                principal_id,
+                display_name,
+            ),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return False
+        async with self._store.connection.execute(
+            "SELECT COUNT(*) FROM event_log WHERE idempotency_key LIKE ?",
+            (f"operator:human-provisioning:{principal_id}:%",),
+        ) as cursor:
+            count_row = await cursor.fetchone()
+        return count_row is not None and int(count_row[0]) == 6
+
+    async def _resolve_workshop(self, workshop_id: WorkshopId | None) -> WorkshopId:
+        if workshop_id is None:
+            async with self._store.connection.execute("SELECT id FROM workshops ORDER BY id") as cursor:
+                rows = list(await cursor.fetchall())
+            if len(rows) != 1:
+                raise WorkshopHumanProvisioningError(
+                    "Provisioning requires --workshop-id unless exactly one Workshop exists"
+                )
+            return WorkshopId(str(rows[0][0]))
+        async with self._store.connection.execute(
+            "SELECT 1 FROM workshops WHERE id = ?",
+            (workshop_id,),
+        ) as cursor:
+            exists = await cursor.fetchone() is not None
+        if not exists:
+            raise WorkshopHumanProvisioningError("Workshop is unavailable")
+        return workshop_id
+
+    async def _resolve_kai_agent(self, workshop_id: WorkshopId) -> tuple[AgentId, PrincipalId]:
+        async with self._store.connection.execute(
+            "SELECT a.id, a.principal_id FROM agents a "
+            "JOIN principals p ON p.id = a.principal_id AND p.kind = 'agent' "
+            "JOIN workshop_memberships wm ON wm.workshop_id = a.workshop_id "
+            "AND wm.principal_id = a.principal_id AND wm.role = 'agent' "
+            "WHERE a.workshop_id = ? AND a.name = 'Kai'",
+            (workshop_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if len(rows) != 1:
+            raise WorkshopHumanProvisioningError("Workshop does not contain exactly one canonical Kai agent")
+        return AgentId(str(rows[0][0])), PrincipalId(str(rows[0][1]))

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -26,7 +26,18 @@ from kai.workshop.delivery_outbox import (
     WorkshopDeliveryOutbox,
 )
 from kai.workshop.delivery_qualification import DeliveryQualificationError, WorkshopDeliveryQualification
-from kai.workshop.domain import ChannelId, DeliveryId, DeviceId, EnrollmentGrantId, PrincipalId
+from kai.workshop.domain import (
+    ChannelId,
+    DeliveryId,
+    DeviceId,
+    EnrollmentGrantId,
+    PrincipalId,
+    WorkshopId,
+)
+from kai.workshop.human_provisioning import (
+    WorkshopHumanProvisioner,
+    WorkshopHumanProvisioningError,
+)
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery import (
     TelegramWorkOutcome,
@@ -89,6 +100,14 @@ def _parser() -> argparse.ArgumentParser:
         "list-humans",
         help="list canonical humans and their direct channels",
     )
+    provision = client_actions.add_parser(
+        "provision-human",
+        help="create a canonical human and direct channel without transport or runtime access",
+    )
+    provision.add_argument("--provisioning-key", required=True)
+    provision.add_argument("--display-name", required=True)
+    provision.add_argument("--role", required=True, choices=("admin", "member"))
+    provision.add_argument("--workshop-id")
     issue = client_actions.add_parser(
         "issue-enrollment",
         help="issue one short-lived enrollment token for a canonical human",
@@ -151,6 +170,13 @@ def _channel_id(value: str) -> ChannelId:
         raise WorkshopClientAccessError("Invalid channel ID") from exc
 
 
+def _workshop_id(value: str) -> WorkshopId:
+    try:
+        return WorkshopId(value)
+    except (TypeError, ValueError) as exc:
+        raise WorkshopHumanProvisioningError("Invalid Workshop ID") from exc
+
+
 def _print_state(state: DeliveryState) -> None:
     print(f"Delivery: {state.delivery_id}")
     print(f"Status: {state.status}")
@@ -192,6 +218,23 @@ async def _run(args: argparse.Namespace) -> int:
                             print(f"Direct channel: {channel_id}")
                     else:
                         print("Direct channel: unavailable")
+                return 0
+            if args.action == "provision-human":
+                human = await WorkshopHumanProvisioner(store).provision(
+                    args.provisioning_key,
+                    args.display_name,
+                    args.role,
+                    workshop_id=(_workshop_id(args.workshop_id) if args.workshop_id is not None else None),
+                )
+                print(f"Human: {human.display_name}")
+                print(f"Principal: {human.principal_id}")
+                print(f"Workshop: {human.workshop_id}")
+                print(f"Direct channel: {human.channel_id}")
+                print(f"Role: {human.role}")
+                print(f"Provisioning key: {human.provisioning_key}")
+                print(f"Status: {'created' if human.created else 'already provisioned'}")
+                print("Transport access: not assigned")
+                print("Runtime access: not assigned")
                 return 0
             if args.action == "issue-enrollment":
                 if args.principal_id is not None:
@@ -317,6 +360,8 @@ def cli(args: list[str]) -> None:
         raise SystemExit(f"Workshop delivery authority failed: {exc}") from exc
     except WorkshopClientAccessError as exc:
         raise SystemExit(f"Workshop client access failed: {exc}") from exc
+    except WorkshopHumanProvisioningError as exc:
+        raise SystemExit(f"Workshop human provisioning failed: {exc}") from exc
     except (DeliveryQualificationError, DeliveryTargetNotFoundError) as exc:
         if parsed.command == "client-access":
             raise SystemExit(f"Workshop client access failed: {exc}") from exc

--- a/tests/test_workshop_client_access.py
+++ b/tests/test_workshop_client_access.py
@@ -17,6 +17,7 @@ from kai.workshop.client_sessions import (
     WorkshopClientSessionManager,
 )
 from kai.workshop.domain import ChannelId, DeviceId, EnrollmentGrantId, PrincipalId
+from kai.workshop.human_provisioning import WorkshopHumanProvisioningError
 from kai.workshop.store import WorkshopEventStore
 
 
@@ -184,6 +185,8 @@ class TestWorkshopClientAccessCLI:
             workshop_cli._principal_id("101")
         with pytest.raises(WorkshopClientAccessError, match="Invalid channel ID"):
             workshop_cli._channel_id("101")
+        with pytest.raises(WorkshopHumanProvisioningError, match="Invalid Workshop ID"):
+            workshop_cli._workshop_id("101")
 
         assert workshop_cli._device_id("dev_" + "a" * 32) == DeviceId("dev_" + "a" * 32)
         assert workshop_cli._enrollment_grant_id("enr_" + "b" * 32) == EnrollmentGrantId("enr_" + "b" * 32)
@@ -205,6 +208,40 @@ class TestWorkshopClientAccessCLI:
         assert "Human: Alice" in output
         assert f"Principal: {principal_id}" in output
         assert f"Direct channel: {channel_id}" in output
+
+    async def test_provision_command_reports_canonical_identity_without_implied_access(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        capsys,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        await store.close()
+        monkeypatch.setattr(workshop_cli, "DATA_DIR", tmp_path)
+        args = workshop_cli._parser().parse_args(
+            [
+                "client-access",
+                "provision-human",
+                "--provisioning-key",
+                "charlie",
+                "--display-name",
+                "Charlie",
+                "--role",
+                "member",
+            ]
+        )
+
+        assert await workshop_cli._run(args) == 0
+        output = capsys.readouterr().out
+        assert "Human: Charlie" in output
+        assert "Principal: prn_" in output
+        assert "Workshop: wsp_" in output
+        assert "Direct channel: chn_" in output
+        assert "Role: member" in output
+        assert "Provisioning key: charlie" in output
+        assert "Status: created" in output
+        assert "Transport access: not assigned" in output
+        assert "Runtime access: not assigned" in output
 
     async def test_issue_command_prints_the_token_once_with_qualification_coordinates(
         self,

--- a/tests/test_workshop_human_provisioning.py
+++ b/tests/test_workshop_human_provisioning.py
@@ -1,0 +1,232 @@
+"""Canonical Workshop human provisioning contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.authorization import CanonicalChannelAuthorizer
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.client_access import WorkshopClientAccess
+from kai.workshop.client_sessions import WorkshopClientEnrollmentManager
+from kai.workshop.conversation_commands import (
+    ConversationCommandStateConflictError,
+    WorkshopConversationCommandService,
+)
+from kai.workshop.human_provisioning import (
+    WorkshopHumanProvisioner,
+    WorkshopHumanProvisioningError,
+)
+from kai.workshop.inbound import ClientInboundMessage
+from kai.workshop.store import WorkshopEventStore
+
+
+async def _store(path: Path) -> WorkshopEventStore:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (BootstrapHuman("Alice", "admin", "telegram", "101", "101", "101"),),
+    )
+    return store
+
+
+class TestWorkshopHumanProvisioner:
+    async def test_provisions_complete_collaboration_identity_without_external_authority(
+        self,
+        tmp_path: Path,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            provisioned = await WorkshopHumanProvisioner(store).provision(
+                "charlie",
+                "  Charlie  ",
+                "member",
+            )
+
+            async with store.connection.execute(
+                "SELECT p.display_name, wm.role, c.kind, cm.role "
+                "FROM principals p "
+                "JOIN workshop_memberships wm ON wm.principal_id = p.id "
+                "JOIN channel_memberships cm ON cm.principal_id = p.id "
+                "JOIN channels c ON c.id = cm.channel_id AND c.workshop_id = wm.workshop_id "
+                "WHERE p.id = ? AND c.id = ?",
+                (provisioned.principal_id, provisioned.channel_id),
+            ) as cursor:
+                row = await cursor.fetchone()
+            assert row is not None
+            assert tuple(row) == ("Charlie", "member", "direct", "owner")
+
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM external_identities WHERE principal_id = ?",
+                (provisioned.principal_id,),
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_bindings WHERE channel_id = ?",
+                (provisioned.channel_id,),
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_agents ca "
+                "JOIN agents a ON a.id = ca.agent_id AND a.name = 'Kai' "
+                "JOIN channel_memberships cm ON cm.channel_id = ca.channel_id "
+                "AND cm.principal_id = a.principal_id AND cm.role = 'participant' "
+                "WHERE ca.channel_id = ?",
+                (provisioned.channel_id,),
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 1
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM event_log WHERE idempotency_key LIKE ? "
+                "AND json_extract(metadata_json, '$.source') = 'operator_cli'",
+                (f"operator:human-provisioning:{provisioned.principal_id}:%",),
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 6
+        finally:
+            await store.close()
+
+    async def test_provisioned_human_can_enroll_and_read_but_has_no_runtime_authority(
+        self,
+        tmp_path: Path,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            provisioned = await WorkshopHumanProvisioner(store).provision(
+                "charlie",
+                "Charlie",
+                "member",
+            )
+            access = WorkshopClientAccess(store)
+            issued = await access.issue_enrollment(
+                provisioned.principal_id,
+                provisioned.channel_id,
+            )
+            redeemed = await WorkshopClientEnrollmentManager(store).redeem_grant(
+                issued.grant.token,
+                "Charlie's laptop",
+            )
+
+            assert redeemed.device.principal_id == provisioned.principal_id
+            assert await CanonicalChannelAuthorizer(store).can_read_channel(
+                provisioned.principal_id,
+                provisioned.channel_id,
+            )
+            with pytest.raises(
+                ConversationCommandStateConflictError,
+                match="requires one Kai runtime identity",
+            ):
+                await WorkshopConversationCommandService(store).accept_client(
+                    ClientInboundMessage(
+                        principal_id=provisioned.principal_id,
+                        channel_id=provisioned.channel_id,
+                        client_message_id="provisioned-human-no-runtime",
+                        body="This must not inherit another user's runtime",
+                        occurred_at=datetime.now(UTC),
+                    )
+                )
+        finally:
+            await store.close()
+
+    async def test_same_provisioning_key_is_a_safe_semantic_retry(self, tmp_path: Path):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            provisioner = WorkshopHumanProvisioner(store)
+            first = await provisioner.provision("charlie", "Charlie", "member")
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                after_first = (await cursor.fetchone())[0]
+
+            retried = await provisioner.provision("charlie", "Charlie", "member")
+
+            assert first.created is True
+            assert retried.created is False
+            assert retried.principal_id == first.principal_id
+            assert retried.channel_id == first.channel_id
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                assert (await cursor.fetchone())[0] == after_first
+
+            with pytest.raises(WorkshopHumanProvisioningError, match="different human"):
+                await provisioner.provision("charlie", "Charles", "member")
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                assert (await cursor.fetchone())[0] == after_first
+        finally:
+            await store.close()
+
+    async def test_missing_canonical_kai_agent_rolls_back_without_partial_human(
+        self,
+        tmp_path: Path,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            await store.connection.execute("DELETE FROM channel_agents")
+            await store.connection.execute("DELETE FROM agents")
+            await store.connection.commit()
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                before_events = (await cursor.fetchone())[0]
+            async with store.connection.execute("SELECT COUNT(*) FROM principals") as cursor:
+                before_principals = (await cursor.fetchone())[0]
+
+            with pytest.raises(WorkshopHumanProvisioningError, match="canonical Kai agent"):
+                await WorkshopHumanProvisioner(store).provision(
+                    "charlie",
+                    "Charlie",
+                    "member",
+                )
+
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                assert (await cursor.fetchone())[0] == before_events
+            async with store.connection.execute("SELECT COUNT(*) FROM principals") as cursor:
+                assert (await cursor.fetchone())[0] == before_principals
+        finally:
+            await store.close()
+
+    @pytest.mark.parametrize(
+        ("display_name", "role", "match"),
+        [
+            ("", "member", "Display name"),
+            ("x" * 201, "member", "Display name"),
+            ("Charlie", "owner", "Role"),
+        ],
+    )
+    async def test_invalid_operator_input_creates_no_events(
+        self,
+        tmp_path: Path,
+        display_name: str,
+        role: str,
+        match: str,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                before = (await cursor.fetchone())[0]
+            with pytest.raises(WorkshopHumanProvisioningError, match=match):
+                await WorkshopHumanProvisioner(store).provision(
+                    "charlie",
+                    display_name,
+                    role,
+                )
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                assert (await cursor.fetchone())[0] == before
+        finally:
+            await store.close()
+
+    @pytest.mark.parametrize("provisioning_key", ["", "Charlie", "two words", "x" * 65])
+    async def test_invalid_provisioning_key_creates_no_events(
+        self,
+        tmp_path: Path,
+        provisioning_key: str,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                before = (await cursor.fetchone())[0]
+            with pytest.raises(WorkshopHumanProvisioningError, match="Provisioning key"):
+                await WorkshopHumanProvisioner(store).provision(
+                    provisioning_key,
+                    "Charlie",
+                    "member",
+                )
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                assert (await cursor.fetchone())[0] == before
+        finally:
+            await store.close()


### PR DESCRIPTION
## Summary

- add an atomic operator service for provisioning canonical Workshop humans
- create the human principal, Workshop membership, owned direct channel, Kai channel membership, and Kai agent attachment as one durable transaction
- add a safely retryable `client-access provision-human` command
- keep transport identities, transport bindings, runtime profiles, OS users, and backend authority out of identity provisioning

## Operator contract

Provisioning requires a stable lowercase key so an interrupted command can be retried without creating a duplicate human:

```text
python -m kai workshop client-access provision-human \
  --provisioning-key charlie \
  --display-name Charlie \
  --role member
```

The command returns the canonical Workshop, principal, and direct-channel IDs. Repeating the same command returns the same IDs with `Status: already provisioned`. Reusing the key with different human or channel semantics fails closed.

The existing canonical enrollment command can then issue a browser enrollment token for the returned principal/channel pair.

## Authority boundary

Provisioning grants collaboration membership only. It deliberately creates:

- no external identity
- no Telegram binding
- no runtime profile
- no OS-user association
- no backend execution authority

The provisioned human can enroll a browser and read their authorized direct channel. A command is rejected until a separate, explicit runtime policy is assigned, preventing accidental inheritance of another person's home directory, credentials, memory, sessions, or backend authentication.

## Durability

All six canonical events and their projection update share one SQLite transaction. Missing Workshop/Kai-agent prerequisites, invalid operator input, semantic key conflicts, or projection failures roll the operation back without leaving a partial principal or channel.

## Validation

- 5,561 tests passed, 1 skipped
- focused provisioning/client-access suite: 27 passed
- Ruff lint and format checks passed
- Pyright passed with zero errors or warnings
- Workshop browser client typecheck, tests, build, and generated-asset verification passed
- module-size report passed

Tests cover transport-free provisioning, canonical membership and agent attachment, browser enrollment/read access, absence of runtime authority, semantic retry, conflicting retry, invalid inputs, and atomic rollback.
