### PR TITLE
Workshop: assign explicit runtime profiles

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -60,7 +60,7 @@ def _workshop_bootstrap_humans(config) -> tuple[BootstrapHuman, ...]:
             transport="telegram",
             external_subject=str(user.telegram_id),
             external_channel_id=str(user.telegram_id),
-            runtime_subject=str(user.telegram_id),
+            runtime_profile_id=str(user.telegram_id),
         )
         for user in sorted(config.user_configs.values(), key=lambda user: user.telegram_id)
     )

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -19,6 +19,7 @@ from kai.workshop.domain import (
     ExternalIdentityId,
     OpaqueId,
     PrincipalId,
+    RuntimeAssignmentId,
     WorkshopEventType,
     WorkshopId,
     WorkshopMembershipId,
@@ -37,7 +38,7 @@ class BootstrapHuman:
     transport: str
     external_subject: str
     external_channel_id: str
-    runtime_subject: str | None = None
+    runtime_profile_id: str | None = None
 
     def __post_init__(self) -> None:
         if not self.display_name.strip():
@@ -50,8 +51,14 @@ class BootstrapHuman:
             raise ValueError("external_subject must be non-empty")
         if not self.external_channel_id.strip():
             raise ValueError("external_channel_id must be non-empty")
-        if self.runtime_subject is not None and not self.runtime_subject.strip():
-            raise ValueError("runtime_subject must be non-empty when provided")
+        if self.runtime_profile_id is not None and not self.runtime_profile_id.strip():
+            raise ValueError("runtime_profile_id must be non-empty when provided")
+        if self.runtime_profile_id is not None and (
+            not self.runtime_profile_id.isascii()
+            or not self.runtime_profile_id.isdigit()
+            or self.runtime_profile_id.startswith("0")
+        ):
+            raise ValueError("runtime_profile_id must identify a positive integer-keyed configured runtime")
 
 
 @dataclass(frozen=True, slots=True)
@@ -252,22 +259,6 @@ async def bootstrap_default_workshop(
                 "external_subject": human.external_subject,
             },
         )
-        if human.runtime_subject is not None:
-            runtime_token = _stable_token("kai", human.runtime_subject)
-            await ensure(
-                idempotency_key=_idempotency_key("external-identity", runtime_token),
-                event_type=WorkshopEventType.EXTERNAL_IDENTITY_BOUND,
-                aggregate_type="external_identity",
-                aggregate_id=ExternalIdentityId.derived(
-                    workshop_id,
-                    f"external-identity:{runtime_token}",
-                ),
-                payload={
-                    "principal_id": principal_id,
-                    "provider": "kai",
-                    "external_subject": human.runtime_subject,
-                },
-            )
         await ensure(
             idempotency_key=_idempotency_key("membership", token),
             event_type=WorkshopEventType.WORKSHOP_MEMBER_ADDED,
@@ -322,6 +313,21 @@ async def bootstrap_default_workshop(
             aggregate_id=channel_agent_id,
             payload={"channel_id": channel_id, "agent_id": agent_id},
         )
+        if human.runtime_profile_id is not None:
+            await ensure(
+                idempotency_key=_idempotency_key("runtime-assignment", channel_token),
+                event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
+                aggregate_type="runtime_assignment",
+                aggregate_id=RuntimeAssignmentId.derived(
+                    channel_id,
+                    f"runtime-profile:{agent_id}",
+                ),
+                payload={
+                    "channel_id": channel_id,
+                    "agent_id": agent_id,
+                    "runtime_profile_id": human.runtime_profile_id,
+                },
+            )
 
     for notification in ordered_notifications:
         channel_token = _stable_token(notification.transport, notification.external_channel_id)

--- a/src/kai/workshop/client_commands.py
+++ b/src/kai/workshop/client_commands.py
@@ -18,6 +18,7 @@ from kai.workshop.execution_coordinator import (
 )
 from kai.workshop.inbound import ClientInboundMessage
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
+from kai.workshop.runtime_assignments import compatibility_user_id
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,7 +40,7 @@ class WorkshopClientCommandExecutor:
 
     async def submit(self, message: ClientInboundMessage) -> ClientCommandResult:
         accepted = await self._execution.accept_client(message)
-        runtime_config_id = accepted.runtime_config_id
+        runtime_config_id = compatibility_user_id(accepted.runtime_profile_id)
         mapped_reader = reader_user(self._config, runtime_config_id)
         user_log = (
             log_message(

--- a/src/kai/workshop/conversation_commands.py
+++ b/src/kai/workshop/conversation_commands.py
@@ -19,6 +19,10 @@ from kai.workshop.inbound import (
     record_inbound_message_in_transaction,
 )
 from kai.workshop.run_lifecycle import DurableRun, RunLifecycleResult, RunStatus, WorkshopRunLifecycle
+from kai.workshop.runtime_assignments import (
+    WorkshopRuntimeAssignmentError,
+    resolve_channel_runtime_profile,
+)
 from kai.workshop.store import AppendResult, WorkshopEventStore
 
 
@@ -57,7 +61,7 @@ class ClientConversationCommandAcceptance:
 
     command: ConversationCommandAcceptance
     delivery: DeliveryRequestResult | None
-    runtime_config_id: int
+    runtime_profile_id: str
 
     @property
     def run(self) -> DurableRun:
@@ -125,7 +129,13 @@ class WorkshopConversationCommandService:
                 inbound_message_id,
                 occurred_at=inbound.event.envelope.occurred_at,
             )
-            runtime_config_id = await self._runtime_config_id(message.principal_id)
+            try:
+                _, runtime_profile_id = await resolve_channel_runtime_profile(
+                    self._store,
+                    message.channel_id,
+                )
+            except WorkshopRuntimeAssignmentError as exc:
+                raise ConversationCommandStateConflictError(str(exc)) from exc
             binding_id = await self._optional_telegram_binding(
                 message.principal_id,
                 message.channel_id,
@@ -160,27 +170,11 @@ class WorkshopConversationCommandService:
             return ClientConversationCommandAcceptance(
                 command=ConversationCommandAcceptance(inbound, lifecycle, disposition),
                 delivery=delivery,
-                runtime_config_id=runtime_config_id,
+                runtime_profile_id=runtime_profile_id,
             )
         except Exception:
             await connection.rollback()
             raise
-
-    async def _runtime_config_id(self, principal_id: PrincipalId) -> int:
-        async with self._store.connection.execute(
-            "SELECT external_subject FROM external_identities WHERE principal_id = ? AND provider = 'kai'",
-            (principal_id,),
-        ) as cursor:
-            rows = list(await cursor.fetchall())
-        if len(rows) != 1:
-            raise ConversationCommandStateConflictError("Client principal requires one Kai runtime identity")
-        try:
-            runtime_config_id = int(str(rows[0][0]))
-        except ValueError as exc:
-            raise ConversationCommandStateConflictError("Kai runtime identity is not numeric") from exc
-        if runtime_config_id <= 0:
-            raise ConversationCommandStateConflictError("Kai runtime identity is not a positive configured-user ID")
-        return runtime_config_id
 
     async def _optional_telegram_binding(
         self,

--- a/src/kai/workshop/conversation_runs.py
+++ b/src/kai/workshop/conversation_runs.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -10,10 +9,14 @@ from typing import Protocol
 
 from kai.backend import StreamEvent
 from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, WorkshopId
+from kai.workshop.runtime_assignments import (
+    WorkshopRuntimeAssignmentError,
+    compatibility_user_id,
+    resolve_channel_runtime_profile,
+)
 from kai.workshop.store import WorkshopEventStore
 
 type AgentPrompt = str | list[dict[str, str]]
-_RUNTIME_SUBJECT_PATTERN = re.compile(r"^[1-9][0-9]*$")
 
 
 class ConversationRunUnavailableError(LookupError):
@@ -90,25 +93,25 @@ async def resolve_canonical_conversation_run(
     """Resolve a canonical target plus the current private pool adapter key.
 
     The public run request contains only a canonical message ID. During the
-    migration, the resolved human's protected Kai runtime identity supplies
-    the existing pool/config key internally. A caller cannot provide or
-    override that key, and transport identities are not execution authority.
+    migration, the channel-agent's protected runtime-profile assignment
+    supplies the existing pool/config key internally. A caller cannot provide
+    or override that key, and human or transport identities are not execution
+    authority.
     """
     target = await resolve_canonical_conversation_target(store, inbound_message_id)
-    async with store.connection.execute(
-        "SELECT external_subject FROM external_identities WHERE principal_id = ? AND provider = 'kai'",
-        (target.requested_by_principal_id,),
-    ) as cursor:
-        identity_rows = list(await cursor.fetchall())
-    if len(identity_rows) != 1:
-        raise ConversationRunUnavailableError("Canonical human requires exactly one Kai runtime identity")
-    external_subject = str(identity_rows[0][0])
-    if not _RUNTIME_SUBJECT_PATTERN.fullmatch(external_subject):
-        raise ConversationRunUnavailableError("Kai runtime identity is not a positive configured-user ID")
+    try:
+        _, runtime_profile_id = await resolve_channel_runtime_profile(
+            store,
+            target.channel_id,
+            target.agent_id,
+        )
+        legacy_pool_key = compatibility_user_id(runtime_profile_id)
+    except WorkshopRuntimeAssignmentError as exc:
+        raise ConversationRunUnavailableError(str(exc)) from exc
 
     return CompatibilityConversationRunResolution(
         target=target,
-        _legacy_pool_key=int(external_subject),
+        _legacy_pool_key=legacy_pool_key,
     )
 
 

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -27,6 +27,7 @@ _REQUIRED_TABLES = {
     "workshop_memberships",
     "agents",
     "channel_bindings",
+    "channel_agent_runtime_assignments",
     "channel_memberships",
     "projection_checkpoints",
 }
@@ -75,6 +76,7 @@ class _ReplayState:
     workshop_memberships: dict[str, tuple[str, str, str]]
     channel_bindings: dict[str, tuple[str, str, str]]
     channel_memberships: dict[str, tuple[str, str, str]]
+    runtime_assignments: dict[str, tuple[str, str, str]]
     messages: tuple[_ReplayMessage, ...]
 
 
@@ -117,6 +119,10 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
                 ("telegram",),
             )
             channel_membership_count = _scalar(connection, "SELECT COUNT(*) FROM channel_memberships")
+            runtime_assignment_count = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM channel_agent_runtime_assignments",
+            )
             projection_count = _scalar(
                 connection,
                 "SELECT COUNT(*) FROM projection_checkpoints WHERE name = ?",
@@ -129,7 +135,12 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
 
     expected_memberships = 2 * (human_count if expected_humans is None else expected_humans)
     expected_state_present = (
-        expected_humans is None or (human_count >= expected_humans and telegram_binding_count >= expected_humans)
+        expected_humans is None
+        or (
+            human_count >= expected_humans
+            and telegram_binding_count >= expected_humans
+            and runtime_assignment_count >= expected_humans
+        )
     ) and channel_membership_count >= expected_memberships
     initialized = workshop_count >= 1 and agent_count >= 1 and projection_count == 1 and expected_state_present
     state = "initialized" if initialized else "pending"
@@ -139,7 +150,7 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
     return (
         f"Workshop bootstrap: {state}; workshops={workshop_count}, humans={human_count}, "
         f"Telegram bindings={telegram_binding_count}, channel memberships={channel_membership_count}, "
-        f"agents={agent_count}; {expectation}"
+        f"agents={agent_count}, runtime assignments={runtime_assignment_count}; {expectation}"
     )
 
 
@@ -297,6 +308,7 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
     workshop_memberships: dict[str, tuple[str, str, str]] = {}
     channel_bindings: dict[str, tuple[str, str, str]] = {}
     channel_memberships: dict[str, tuple[str, str, str]] = {}
+    runtime_assignments: dict[str, tuple[str, str, str]] = {}
     replayed: list[_ReplayMessage] = []
     for row in connection.execute("SELECT * FROM event_log ORDER BY position"):
         envelope = _event_from_row(row)
@@ -310,6 +322,7 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
                 WorkshopEventType.WORKSHOP_MEMBER_ADDED,
                 WorkshopEventType.CHANNEL_MEMBER_ADDED,
                 WorkshopEventType.TRANSPORT_CHANNEL_BOUND,
+                WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
                 WorkshopEventType.MESSAGE_CREATED,
             }
             and envelope.event_version != 1
@@ -362,6 +375,17 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
                 ),
             )
             continue
+        if envelope.event_type == WorkshopEventType.RUNTIME_PROFILE_ASSIGNED:
+            _insert_replayed_fact(
+                runtime_assignments,
+                aggregate_id,
+                (
+                    _required_payload_text(payload, "channel_id"),
+                    _required_payload_text(payload, "agent_id"),
+                    _required_payload_text(payload, "runtime_profile_id"),
+                ),
+            )
+            continue
         if envelope.event_type != WorkshopEventType.MESSAGE_CREATED:
             continue
 
@@ -394,6 +418,7 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
         workshop_memberships=workshop_memberships,
         channel_bindings=channel_bindings,
         channel_memberships=channel_memberships,
+        runtime_assignments=runtime_assignments,
         messages=tuple(replayed),
     )
 
@@ -451,6 +476,12 @@ def _projection_mismatches(connection: sqlite3.Connection, replayed: _ReplayStat
         str(row[0]): (str(row[1]), str(row[2]), str(row[3]))
         for row in connection.execute("SELECT id, channel_id, principal_id, role FROM channel_memberships").fetchall()
     }
+    actual_runtime_assignments = {
+        str(row[0]): (str(row[1]), str(row[2]), str(row[3]))
+        for row in connection.execute(
+            "SELECT id, channel_id, agent_id, runtime_profile_id FROM channel_agent_runtime_assignments"
+        ).fetchall()
+    }
     mismatches = (
         _mapping_mismatches(expected, actual)
         + _mapping_mismatches(replayed.principal_kinds, actual_principal_kinds)
@@ -458,6 +489,7 @@ def _projection_mismatches(connection: sqlite3.Connection, replayed: _ReplayStat
         + _mapping_mismatches(replayed.workshop_memberships, actual_workshop_memberships)
         + _mapping_mismatches(replayed.channel_bindings, actual_bindings)
         + _mapping_mismatches(replayed.channel_memberships, actual_channel_memberships)
+        + _mapping_mismatches(replayed.runtime_assignments, actual_runtime_assignments)
     )
     return len(actual), mismatches
 

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -30,6 +30,7 @@ class WorkshopEventType(StrEnum):
     TRANSPORT_CHANNEL_BOUND = "transport.channel_bound"
     AGENT_CREATED = "agent.created"
     CHANNEL_AGENT_ATTACHED = "channel.agent_attached"
+    RUNTIME_PROFILE_ASSIGNED = "runtime_profile.assigned"
     MESSAGE_CREATED = "message.created"
     ARTIFACT_CREATED = "artifact.created"
     DELIVERY_REQUESTED = "delivery.requested"
@@ -126,6 +127,10 @@ class ChannelAgentId(OpaqueId):
     prefix = "cag"
 
 
+class RuntimeAssignmentId(OpaqueId):
+    prefix = "rta"
+
+
 class MessageId(OpaqueId):
     prefix = "msg"
 
@@ -177,6 +182,7 @@ _ID_TYPES: dict[str, type[OpaqueId]] = {
         ChannelBindingId,
         AgentId,
         ChannelAgentId,
+        RuntimeAssignmentId,
         MessageId,
         ArtifactId,
         DeliveryId,

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -103,7 +103,7 @@ class WorkshopCanonicalExecutionCoordinator:
     """Own one canonical lane from accepted run through terminal settlement.
 
     The public execution input is only a canonical ``RunId``. Prompt, lane,
-    compatibility runtime identity, backend selection, owner, and delivery
+    protected runtime profile, backend selection, owner, and delivery
     authority are all derived behind this boundary.
     """
 

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -499,9 +499,8 @@ class CanonicalConversationProjection:
     """Rebuild the initial Workshop collaboration records from events."""
 
     name = "canonical_conversations"
-    # Run execution authority adds replayed attempt state and new run columns.
-    # Rebuild once so every installed projection shares the same v2 run rules.
-    version = 6
+    # Runtime-profile assignment becomes a replayed channel-agent policy.
+    version = 7
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -512,6 +511,7 @@ class CanonicalConversationProjection:
             "run_attempts",
             "runs",
             "messages",
+            "channel_agent_runtime_assignments",
             "channel_agents",
             "channel_bindings",
             "channel_memberships",
@@ -653,6 +653,20 @@ class CanonicalConversationProjection:
                     _required_text(payload, "channel_id"),
                     _required_text(payload, "agent_id"),
                     occurred_at,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.RUNTIME_PROFILE_ASSIGNED:
+            await connection.execute(
+                "INSERT INTO channel_agent_runtime_assignments "
+                "(id, channel_id, agent_id, runtime_profile_id, created_at, created_event_position) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    _required_text(payload, "channel_id"),
+                    _required_text(payload, "agent_id"),
+                    _required_text(payload, "runtime_profile_id"),
+                    occurred_at,
+                    event.position,
                 ),
             )
         elif envelope.event_type == WorkshopEventType.MESSAGE_CREATED:

--- a/src/kai/workshop/runtime_assignments.py
+++ b/src/kai/workshop/runtime_assignments.py
@@ -1,0 +1,240 @@
+"""Explicit runtime-profile policy for canonical Workshop channel agents."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from kai.workshop.domain import (
+    AgentId,
+    ChannelId,
+    EventEnvelope,
+    PrincipalId,
+    RuntimeAssignmentId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+
+_RUNTIME_PROFILE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+class WorkshopRuntimeAssignmentError(RuntimeError):
+    """Runtime policy is absent, ambiguous, or unauthorized."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopRuntimeAssignment:
+    assignment_id: RuntimeAssignmentId
+    workshop_id: WorkshopId
+    principal_id: PrincipalId
+    channel_id: ChannelId
+    agent_id: AgentId
+    runtime_profile_id: str
+    created: bool
+
+
+def normalize_runtime_profile_id(value: object) -> str:
+    if not isinstance(value, str) or not _RUNTIME_PROFILE_PATTERN.fullmatch(value):
+        raise WorkshopRuntimeAssignmentError(
+            "Runtime profile ID must contain 1 through 128 bounded identifier characters"
+        )
+    return value
+
+
+def runtime_assignment_envelope(
+    *,
+    workshop_id: WorkshopId,
+    assignment_id: RuntimeAssignmentId,
+    channel_id: ChannelId,
+    agent_id: AgentId,
+    runtime_profile_id: str,
+    occurred_at: datetime,
+    idempotency_key: str,
+    source: str,
+) -> EventEnvelope:
+    return EventEnvelope.create(
+        event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
+        event_version=1,
+        workshop_id=workshop_id,
+        aggregate_type="runtime_assignment",
+        aggregate_id=assignment_id,
+        occurred_at=occurred_at,
+        idempotency_key=idempotency_key,
+        payload={
+            "channel_id": channel_id,
+            "agent_id": agent_id,
+            "runtime_profile_id": normalize_runtime_profile_id(runtime_profile_id),
+        },
+        metadata={"source": source},
+    )
+
+
+async def resolve_channel_runtime_profile(
+    store: WorkshopEventStore,
+    channel_id: ChannelId,
+    agent_id: AgentId | None = None,
+) -> tuple[AgentId, str]:
+    """Resolve exactly one explicit runtime assignment for a channel agent."""
+    if not isinstance(channel_id, ChannelId):
+        raise WorkshopRuntimeAssignmentError("channel_id must be a ChannelId")
+    if agent_id is not None and not isinstance(agent_id, AgentId):
+        raise WorkshopRuntimeAssignmentError("agent_id must be an AgentId when provided")
+    parameters: tuple[object, ...]
+    agent_clause = ""
+    if agent_id is None:
+        parameters = (channel_id,)
+    else:
+        agent_clause = " AND ra.agent_id = ?"
+        parameters = (channel_id, agent_id)
+    async with store.connection.execute(
+        "SELECT ra.agent_id, ra.runtime_profile_id "
+        "FROM channel_agent_runtime_assignments ra "
+        "JOIN channel_agents ca ON ca.channel_id = ra.channel_id AND ca.agent_id = ra.agent_id "
+        "WHERE ra.channel_id = ?" + agent_clause,
+        parameters,
+    ) as cursor:
+        rows = list(await cursor.fetchall())
+    if len(rows) != 1:
+        raise WorkshopRuntimeAssignmentError("Channel agent requires exactly one explicit runtime profile assignment")
+    return AgentId(str(rows[0][0])), normalize_runtime_profile_id(str(rows[0][1]))
+
+
+def compatibility_user_id(runtime_profile_id: str) -> int:
+    """Adapt a protected profile ID to the current integer-keyed runtime pool."""
+    normalized = normalize_runtime_profile_id(runtime_profile_id)
+    if not normalized.isascii() or not normalized.isdigit() or normalized.startswith("0"):
+        raise WorkshopRuntimeAssignmentError(
+            "Runtime profile is not compatible with the current integer-keyed host runtime"
+        )
+    value = int(normalized)
+    if value <= 0:
+        raise WorkshopRuntimeAssignmentError(
+            "Runtime profile is not compatible with the current integer-keyed host runtime"
+        )
+    return value
+
+
+class WorkshopRuntimeAssignmentService:
+    """Grant a canonical channel agent one protected runtime profile."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def assign(
+        self,
+        principal_id: PrincipalId,
+        channel_id: ChannelId,
+        runtime_profile_id: str,
+    ) -> WorkshopRuntimeAssignment:
+        if not isinstance(principal_id, PrincipalId) or not isinstance(channel_id, ChannelId):
+            raise WorkshopRuntimeAssignmentError("Canonical principal and channel IDs are required")
+        normalized_profile = normalize_runtime_profile_id(runtime_profile_id)
+        compatibility_user_id(normalized_profile)
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            workshop_id, agent_id = await self._resolve_owned_channel_agent(
+                principal_id,
+                channel_id,
+            )
+            assignment_id = RuntimeAssignmentId.derived(
+                channel_id,
+                f"runtime-profile:{agent_id}",
+            )
+            existing = await self._existing_assignment(channel_id, agent_id)
+            if existing is not None:
+                if existing != (assignment_id, normalized_profile):
+                    raise WorkshopRuntimeAssignmentError(
+                        "Channel agent already has a different runtime profile assignment"
+                    )
+                await connection.commit()
+                return WorkshopRuntimeAssignment(
+                    assignment_id,
+                    workshop_id,
+                    principal_id,
+                    channel_id,
+                    agent_id,
+                    normalized_profile,
+                    False,
+                )
+            await self._ensure_profile_unassigned(normalized_profile)
+            event = runtime_assignment_envelope(
+                workshop_id=workshop_id,
+                assignment_id=assignment_id,
+                channel_id=channel_id,
+                agent_id=agent_id,
+                runtime_profile_id=normalized_profile,
+                occurred_at=datetime.now(UTC),
+                idempotency_key=f"operator:runtime-assignment:{channel_id}:{agent_id}",
+                source="operator_cli",
+            )
+            result = await self._store.append_in_transaction(event)
+            if not result.inserted:
+                raise WorkshopRuntimeAssignmentError("Runtime assignment event exists without its canonical projection")
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            await connection.commit()
+        except IdempotencyConflictError as exc:
+            await connection.rollback()
+            raise WorkshopRuntimeAssignmentError(
+                "Channel agent runtime assignment conflicts with an existing event"
+            ) from exc
+        except Exception:
+            await connection.rollback()
+            raise
+        return WorkshopRuntimeAssignment(
+            assignment_id,
+            workshop_id,
+            principal_id,
+            channel_id,
+            agent_id,
+            normalized_profile,
+            True,
+        )
+
+    async def _resolve_owned_channel_agent(
+        self,
+        principal_id: PrincipalId,
+        channel_id: ChannelId,
+    ) -> tuple[WorkshopId, AgentId]:
+        async with self._store.connection.execute(
+            "SELECT c.workshop_id, ca.agent_id FROM principals p "
+            "JOIN workshop_memberships wm ON wm.principal_id = p.id "
+            "JOIN channels c ON c.workshop_id = wm.workshop_id AND c.id = ? AND c.kind = 'direct' "
+            "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.principal_id = p.id "
+            "AND cm.role = 'owner' JOIN channel_agents ca ON ca.channel_id = c.id "
+            "WHERE p.id = ? AND p.kind = 'human'",
+            (channel_id, principal_id),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if len(rows) != 1:
+            raise WorkshopRuntimeAssignmentError(
+                "Canonical human must own a direct channel with exactly one attached agent"
+            )
+        return WorkshopId(str(rows[0][0])), AgentId(str(rows[0][1]))
+
+    async def _existing_assignment(
+        self,
+        channel_id: ChannelId,
+        agent_id: AgentId,
+    ) -> tuple[RuntimeAssignmentId, str] | None:
+        async with self._store.connection.execute(
+            "SELECT id, runtime_profile_id FROM channel_agent_runtime_assignments "
+            "WHERE channel_id = ? AND agent_id = ?",
+            (channel_id, agent_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        return RuntimeAssignmentId(str(row[0])), str(row[1])
+
+    async def _ensure_profile_unassigned(self, runtime_profile_id: str) -> None:
+        async with self._store.connection.execute(
+            "SELECT 1 FROM channel_agent_runtime_assignments WHERE runtime_profile_id = ?",
+            (runtime_profile_id,),
+        ) as cursor:
+            assigned = await cursor.fetchone() is not None
+        if assigned:
+            raise WorkshopRuntimeAssignmentError("Runtime profile is already assigned to another channel agent")

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 17
+WORKSHOP_SCHEMA_VERSION = 18
 
 
 @dataclass(frozen=True, slots=True)
@@ -719,6 +719,29 @@ _CLIENT_SECURITY_STATE_ISOLATION_SCHEMA = SchemaMigration(
     ),
 )
 
+_RUNTIME_ASSIGNMENT_SCHEMA = SchemaMigration(
+    version=18,
+    name="explicit_channel_agent_runtime_assignments",
+    statements=(
+        """
+        CREATE TABLE channel_agent_runtime_assignments (
+            id TEXT PRIMARY KEY,
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+            runtime_profile_id TEXT NOT NULL CHECK (
+                length(runtime_profile_id) BETWEEN 1 AND 128
+            ),
+            created_at TEXT NOT NULL,
+            created_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            UNIQUE (channel_id, agent_id),
+            UNIQUE (runtime_profile_id)
+        )
+        """,
+        "CREATE INDEX channel_agent_runtime_profile_idx ON channel_agent_runtime_assignments (runtime_profile_id)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -737,6 +760,7 @@ _MIGRATIONS = (
     _DURABLE_RUN_LIFECYCLE_SCHEMA,
     _RUN_EXECUTION_AUTHORITY_SCHEMA,
     _CLIENT_SECURITY_STATE_ISOLATION_SCHEMA,
+    _RUNTIME_ASSIGNMENT_SCHEMA,
 )
 
 

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -38,6 +38,10 @@ from kai.workshop.human_provisioning import (
     WorkshopHumanProvisioner,
     WorkshopHumanProvisioningError,
 )
+from kai.workshop.runtime_assignments import (
+    WorkshopRuntimeAssignmentError,
+    WorkshopRuntimeAssignmentService,
+)
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery import (
     TelegramWorkOutcome,
@@ -108,6 +112,13 @@ def _parser() -> argparse.ArgumentParser:
     provision.add_argument("--display-name", required=True)
     provision.add_argument("--role", required=True, choices=("admin", "member"))
     provision.add_argument("--workshop-id")
+    assign_runtime = client_actions.add_parser(
+        "assign-runtime",
+        help="assign one protected runtime profile to a human's direct-channel agent",
+    )
+    assign_runtime.add_argument("--principal-id", required=True)
+    assign_runtime.add_argument("--channel-id", required=True)
+    assign_runtime.add_argument("--runtime-profile-id", required=True)
     issue = client_actions.add_parser(
         "issue-enrollment",
         help="issue one short-lived enrollment token for a canonical human",
@@ -236,6 +247,24 @@ async def _run(args: argparse.Namespace) -> int:
                 print("Transport access: not assigned")
                 print("Runtime access: not assigned")
                 return 0
+            if args.action == "assign-runtime":
+                configured_profiles = {str(user.telegram_id) for user in load_config().user_configs.values()}
+                if args.runtime_profile_id not in configured_profiles:
+                    raise WorkshopRuntimeAssignmentError(
+                        "Runtime profile is not present in protected configured-user policy"
+                    )
+                assignment = await WorkshopRuntimeAssignmentService(store).assign(
+                    _principal_id(args.principal_id),
+                    _channel_id(args.channel_id),
+                    args.runtime_profile_id,
+                )
+                print(f"Principal: {assignment.principal_id}")
+                print(f"Direct channel: {assignment.channel_id}")
+                print(f"Agent: {assignment.agent_id}")
+                print(f"Runtime profile: {assignment.runtime_profile_id}")
+                print(f"Status: {'assigned' if assignment.created else 'already assigned'}")
+                print("Runtime authority is explicit channel-agent policy, not human or transport identity.")
+                return 0
             if args.action == "issue-enrollment":
                 if args.principal_id is not None:
                     if args.channel_id is None:
@@ -362,6 +391,8 @@ def cli(args: list[str]) -> None:
         raise SystemExit(f"Workshop client access failed: {exc}") from exc
     except WorkshopHumanProvisioningError as exc:
         raise SystemExit(f"Workshop human provisioning failed: {exc}") from exc
+    except WorkshopRuntimeAssignmentError as exc:
+        raise SystemExit(f"Workshop runtime assignment failed: {exc}") from exc
     except (DeliveryQualificationError, DeliveryTargetNotFoundError) as exc:
         if parsed.command == "client-access":
             raise SystemExit(f"Workshop client access failed: {exc}") from exc

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -267,7 +267,7 @@ class TestArtifactShadowRecording:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 6
+            assert checkpoint.version == 7
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_bootstrap.py
+++ b/tests/test_workshop_bootstrap.py
@@ -43,7 +43,7 @@ class TestBootstrapInput:
             ({"transport": "Telegram"}, "transport"),
             ({"external_subject": ""}, "external_subject"),
             ({"external_channel_id": ""}, "external_channel_id"),
-            ({"runtime_subject": ""}, "runtime_subject"),
+            ({"runtime_profile_id": ""}, "runtime_profile_id"),
         ],
     )
     def test_invalid_human_fails_before_database_changes(self, changes, match):
@@ -225,7 +225,7 @@ class TestDefaultWorkshopBootstrap:
         assert second.agent_id == first.agent_id
         assert second_events == first_events
 
-    async def test_rerun_adds_one_protected_runtime_identity_without_replacing_transport_identity(
+    async def test_rerun_adds_one_runtime_assignment_without_replacing_transport_identity(
         self,
         store,
     ):
@@ -240,7 +240,7 @@ class TestDefaultWorkshopBootstrap:
                     transport=original.transport,
                     external_subject=original.external_subject,
                     external_channel_id=original.external_channel_id,
-                    runtime_subject="101",
+                    runtime_profile_id="101",
                 )
             ],
         )
@@ -251,10 +251,11 @@ class TestDefaultWorkshopBootstrap:
         async with store.connection.execute(
             "SELECT provider, external_subject FROM external_identities ORDER BY provider"
         ) as cursor:
-            assert [tuple(row) for row in await cursor.fetchall()] == [
-                ("kai", "101"),
-                ("telegram", "101"),
-            ]
+            assert [tuple(row) for row in await cursor.fetchall()] == [("telegram", "101")]
+        async with store.connection.execute(
+            "SELECT runtime_profile_id FROM channel_agent_runtime_assignments"
+        ) as cursor:
+            assert [str(row[0]) for row in await cursor.fetchall()] == ["101"]
 
     async def test_input_order_does_not_change_event_or_projection_order(self, tmp_path: Path):
         first_store = await WorkshopEventStore.open(tmp_path / "first.db")
@@ -371,7 +372,16 @@ class TestWorkshopBootstrapStatus:
         try:
             await bootstrap_default_workshop(
                 event_store,
-                [_human(101, "Secret Name", role="admin")],
+                [
+                    BootstrapHuman(
+                        "Secret Name",
+                        "admin",
+                        "telegram",
+                        "101",
+                        "101",
+                        runtime_profile_id="101",
+                    )
+                ],
             )
         finally:
             await event_store.close()
@@ -380,7 +390,7 @@ class TestWorkshopBootstrapStatus:
 
         assert status == (
             "Workshop bootstrap: initialized; workshops=1, humans=1, Telegram bindings=1, "
-            "channel memberships=2, agents=1; expected humans=1"
+            "channel memberships=2, agents=1, runtime assignments=1; expected humans=1"
         )
         assert "Secret Name" not in status
         assert "101" not in status

--- a/tests/test_workshop_client_access.py
+++ b/tests/test_workshop_client_access.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from aiohttp import web
@@ -175,6 +176,8 @@ class TestWorkshopClientAccessCLI:
             workshop_cli._parser().parse_args(["client-access", "revoke-device", "--telegram-user-id", "101"])
         with pytest.raises(SystemExit):
             workshop_cli._parser().parse_args(["client-access", "revoke-enrollment", "--telegram-user-id", "101"])
+        with pytest.raises(SystemExit):
+            workshop_cli._parser().parse_args(["client-access", "assign-runtime"])
 
     def test_opaque_identifiers_are_type_checked(self):
         with pytest.raises(WorkshopClientAccessError, match="Invalid device ID"):
@@ -273,6 +276,45 @@ class TestWorkshopClientAccessCLI:
         assert "Expires:" in output
         assert output.count("kai_ws_enroll_v1.") == 1
         assert "stores only its hash" in output
+
+    async def test_assign_runtime_command_reports_explicit_channel_agent_policy(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        capsys,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        principal_id, channel_id = await _canonical_access_ids(store)
+        await store.close()
+        monkeypatch.setattr(workshop_cli, "DATA_DIR", tmp_path)
+        monkeypatch.setattr(
+            workshop_cli,
+            "load_config",
+            lambda: SimpleNamespace(
+                user_configs={101: SimpleNamespace(telegram_id=101)},
+            ),
+        )
+        args = workshop_cli._parser().parse_args(
+            [
+                "client-access",
+                "assign-runtime",
+                "--principal-id",
+                principal_id,
+                "--channel-id",
+                channel_id,
+                "--runtime-profile-id",
+                "101",
+            ]
+        )
+
+        assert await workshop_cli._run(args) == 0
+        output = capsys.readouterr().out
+        assert f"Principal: {principal_id}" in output
+        assert f"Direct channel: {channel_id}" in output
+        assert "Agent: agt_" in output
+        assert "Runtime profile: 101" in output
+        assert "Status: assigned" in output
+        assert "not human or transport identity" in output
 
 
 class TestWorkshopClientProductionRegistration:

--- a/tests/test_workshop_client_commands.py
+++ b/tests/test_workshop_client_commands.py
@@ -32,7 +32,7 @@ async def test_completed_client_command_preserves_history_session_and_memory(
     message = _message()
     run_id = RunId.new()
     accepted = SimpleNamespace(
-        runtime_config_id=101,
+        runtime_profile_id="101",
         command=SimpleNamespace(disposition=ConversationCommandDisposition.NEWLY_ACCEPTED),
         run=SimpleNamespace(run_id=run_id),
     )
@@ -97,7 +97,7 @@ async def test_terminal_replay_does_not_duplicate_compatibility_writes(monkeypat
     message = _message()
     run_id = RunId.new()
     accepted = SimpleNamespace(
-        runtime_config_id=101,
+        runtime_profile_id="101",
         command=SimpleNamespace(disposition=ConversationCommandDisposition.TERMINAL_REPLAY),
         run=SimpleNamespace(run_id=run_id),
     )

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -70,7 +70,7 @@ async def _open_client_store(
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
-                runtime_subject="101",
+                runtime_profile_id="101",
             ),
         ),
     )
@@ -317,7 +317,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 6
+            assert checkpoint.version == 7
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body
@@ -346,7 +346,7 @@ class TestAtomicClientConversationCommandAcceptance:
             assert accepted.command.message.inserted is True
             assert accepted.command.lifecycle.changed is True
             assert accepted.delivery.inserted is True
-            assert accepted.runtime_config_id == 101
+            assert accepted.runtime_profile_id == "101"
             assert accepted.delivery is not None
             assert accepted.delivery.delivery.message_id == accepted.command.message.event.envelope.aggregate_id
             assert accepted.delivery.delivery.channel_id == channel_id
@@ -420,15 +420,14 @@ class TestAtomicClientConversationCommandAcceptance:
                     transport="desktop",
                     external_subject="desktop-human",
                     external_channel_id="desktop-human",
-                    runtime_subject="101",
+                    runtime_profile_id="101",
                 ),
             ),
         )
         async with store.connection.execute(
-            "SELECT e.principal_id, c.id FROM external_identities e "
-            "JOIN channel_memberships cm ON cm.principal_id = e.principal_id "
+            "SELECT cm.principal_id, c.id FROM channel_memberships cm "
             "JOIN channels c ON c.id = cm.channel_id AND c.kind = 'direct' "
-            "WHERE e.provider = 'kai' AND e.external_subject = '101'"
+            "WHERE cm.role = 'owner'"
         ) as cursor:
             row = await cursor.fetchone()
         assert row is not None
@@ -438,7 +437,7 @@ class TestAtomicClientConversationCommandAcceptance:
             )
 
             assert accepted.command.disposition == ConversationCommandDisposition.NEWLY_ACCEPTED
-            assert accepted.runtime_config_id == 101
+            assert accepted.runtime_profile_id == "101"
             assert accepted.delivery is None
             async with store.connection.execute(
                 "SELECT event_type FROM event_log WHERE position >= ? ORDER BY position",

--- a/tests/test_workshop_conversation_runs.py
+++ b/tests/test_workshop_conversation_runs.py
@@ -35,7 +35,7 @@ async def _canonical_inbound(store: WorkshopEventStore, telegram_id: int = 101) 
                 transport="telegram",
                 external_subject=str(telegram_id),
                 external_channel_id=str(telegram_id),
-                runtime_subject=str(telegram_id),
+                runtime_profile_id=str(telegram_id),
             ),
         ),
     )
@@ -107,7 +107,7 @@ class TestCanonicalRunResolution:
                         transport="desktop",
                         external_subject="desktop-human",
                         external_channel_id="desktop-human",
-                        runtime_subject="202",
+                        runtime_profile_id="202",
                     ),
                 ),
             )
@@ -139,14 +139,14 @@ class TestCanonicalRunResolution:
         finally:
             await store.close()
 
-    async def test_rejects_missing_compatibility_identity(self, tmp_path: Path):
+    async def test_rejects_missing_runtime_assignment(self, tmp_path: Path):
         store = await WorkshopEventStore.open(tmp_path / "kai.db")
         try:
             inbound_id = await _canonical_inbound(store)
-            await store.connection.execute("DELETE FROM external_identities")
+            await store.connection.execute("DELETE FROM channel_agent_runtime_assignments")
             await store.connection.commit()
 
-            with pytest.raises(ConversationRunUnavailableError, match="exactly one Kai runtime"):
+            with pytest.raises(ConversationRunUnavailableError, match="explicit runtime profile assignment"):
                 await resolve_canonical_conversation_run(store, inbound_id)
         finally:
             await store.close()

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -21,6 +21,7 @@ from kai.workshop.domain import (
     EventId,
     MessageId,
     PrincipalId,
+    RuntimeAssignmentId,
     WorkshopEventType,
     WorkshopId,
 )
@@ -71,6 +72,7 @@ class TestWorkshopIdentifiers:
             (ArtifactId, "msg_00000000000000000000000000000001"),
             (DeliveryId, "msg_00000000000000000000000000000001"),
             (DeliveryAttemptId, "dlv_00000000000000000000000000000001"),
+            (RuntimeAssignmentId, "cag_00000000000000000000000000000001"),
             (EventId, "evt_000000000000000000000000000000011"),
         ],
     )
@@ -91,6 +93,7 @@ class TestEventEnvelope:
             "transport.channel_bound",
             "agent.created",
             "channel.agent_attached",
+            "runtime_profile.assigned",
             "message.created",
             "artifact.created",
             "delivery.requested",
@@ -175,6 +178,7 @@ class TestWorkshopSchema:
             "channel_bindings",
             "agents",
             "channel_agents",
+            "channel_agent_runtime_assignments",
             "messages",
             "artifacts",
             "deliveries",
@@ -189,7 +193,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 17
+        assert await workshop_store.schema_version() == 18
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -202,7 +206,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 17
+        assert await second.schema_version() == 18
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -223,7 +227,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -256,6 +260,7 @@ class TestWorkshopSchema:
                     15,
                     16,
                     17,
+                    18,
                 ]
         finally:
             await upgraded.close()
@@ -278,7 +283,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -319,7 +324,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -372,7 +377,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -416,7 +421,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -460,7 +465,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -504,7 +509,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -608,7 +613,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -721,7 +726,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_provisioning.py
+++ b/tests/test_workshop_human_provisioning.py
@@ -114,7 +114,7 @@ class TestWorkshopHumanProvisioner:
             )
             with pytest.raises(
                 ConversationCommandStateConflictError,
-                match="requires one Kai runtime identity",
+                match="explicit runtime profile assignment",
             ):
                 await WorkshopConversationCommandService(store).accept_client(
                     ClientInboundMessage(

--- a/tests/test_workshop_parity.py
+++ b/tests/test_workshop_parity.py
@@ -48,6 +48,7 @@ async def _build_conversation(db_path: Path) -> None:
                     transport="telegram",
                     external_subject="101",
                     external_channel_id="101",
+                    runtime_profile_id="101",
                 ),
             ),
         )
@@ -285,6 +286,27 @@ class TestWorkshopMessageParityStatus:
         store = await WorkshopEventStore.open(db_path)
         try:
             await store.connection.execute("DELETE FROM channel_memberships WHERE role = 'owner'")
+            await store.connection.commit()
+        finally:
+            await store.close()
+
+        status = workshop_message_parity_status(db_path, history_root)
+
+        assert "parity: diverged" in status
+        assert "replay mismatches=1" in status
+        assert "Secret" not in status
+
+    async def test_runtime_assignment_projection_drift_is_reported(self, tmp_path: Path):
+        db_path = tmp_path / "kai.db"
+        history_root = tmp_path / "history"
+        await _build_conversation(db_path)
+        _write_history(
+            history_root,
+            [_record("user", "Secret question", seconds=0), _record("assistant", "Secret answer", seconds=2)],
+        )
+        store = await WorkshopEventStore.open(db_path)
+        try:
+            await store.connection.execute("DELETE FROM channel_agent_runtime_assignments")
             await store.connection.commit()
         finally:
             await store.close()

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -64,7 +64,7 @@ async def _foundation(database: Path) -> None:
                     transport="telegram",
                     external_subject="101",
                     external_channel_id="101",
-                    runtime_subject="101",
+                    runtime_profile_id="101",
                 ),
             ),
         )

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -34,7 +34,7 @@ async def _accepted_run(path: Path, home: Path):
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
-                runtime_subject="101",
+                runtime_profile_id="101",
             ),
         ),
     )

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -366,7 +366,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 6
+            assert checkpoint.version == 7
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:
@@ -386,7 +386,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -165,7 +165,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 6
+            assert checkpoint.version == 7
             assert after == before
         finally:
             await store.close()
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -1,0 +1,151 @@
+"""Explicit Workshop channel-agent runtime authority contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.conversation_commands import WorkshopConversationCommandService
+from kai.workshop.conversation_runs import resolve_canonical_conversation_run
+from kai.workshop.domain import MessageId
+from kai.workshop.human_provisioning import WorkshopHumanProvisioner
+from kai.workshop.inbound import ClientInboundMessage
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.runtime_assignments import (
+    WorkshopRuntimeAssignmentError,
+    WorkshopRuntimeAssignmentService,
+    compatibility_user_id,
+    resolve_channel_runtime_profile,
+)
+from kai.workshop.store import WorkshopEventStore
+
+
+async def _store(path: Path) -> WorkshopEventStore:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (BootstrapHuman("Alice", "admin", "telegram", "101", "101", "101"),),
+    )
+    return store
+
+
+class TestRuntimeAssignmentPolicy:
+    async def test_provisioned_human_gains_runtime_only_after_explicit_assignment(
+        self,
+        tmp_path: Path,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            human = await WorkshopHumanProvisioner(store).provision(
+                "charlie",
+                "Charlie",
+                "member",
+            )
+            service = WorkshopRuntimeAssignmentService(store)
+
+            assigned = await service.assign(
+                human.principal_id,
+                human.channel_id,
+                "202",
+            )
+            retried = await service.assign(
+                human.principal_id,
+                human.channel_id,
+                "202",
+            )
+
+            assert assigned.created is True
+            assert retried.created is False
+            assert retried.assignment_id == assigned.assignment_id
+            assert await resolve_channel_runtime_profile(store, human.channel_id) == (
+                assigned.agent_id,
+                "202",
+            )
+            assert compatibility_user_id("202") == 202
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM external_identities WHERE principal_id = ?",
+                (human.principal_id,),
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+
+            accepted = await WorkshopConversationCommandService(store).accept_client(
+                ClientInboundMessage(
+                    principal_id=human.principal_id,
+                    channel_id=human.channel_id,
+                    client_message_id="charlie-command-1",
+                    body="Use only my explicitly assigned runtime",
+                    occurred_at=datetime.now(UTC),
+                )
+            )
+            resolution = await resolve_canonical_conversation_run(
+                store,
+                MessageId(str(accepted.command.message.event.envelope.aggregate_id)),
+            )
+
+            assert accepted.runtime_profile_id == "202"
+            assert resolution._legacy_pool_key == 202
+        finally:
+            await store.close()
+
+    async def test_assignment_rejects_cross_human_authority_and_profile_reuse(
+        self,
+        tmp_path: Path,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            charlie = await WorkshopHumanProvisioner(store).provision(
+                "charlie",
+                "Charlie",
+                "member",
+            )
+            dana = await WorkshopHumanProvisioner(store).provision(
+                "dana",
+                "Dana",
+                "member",
+            )
+            service = WorkshopRuntimeAssignmentService(store)
+
+            with pytest.raises(WorkshopRuntimeAssignmentError, match="must own"):
+                await service.assign(charlie.principal_id, dana.channel_id, "202")
+
+            await service.assign(charlie.principal_id, charlie.channel_id, "202")
+            with pytest.raises(WorkshopRuntimeAssignmentError, match="already assigned"):
+                await service.assign(dana.principal_id, dana.channel_id, "202")
+        finally:
+            await store.close()
+
+    async def test_projection_rebuild_restores_runtime_assignment(self, tmp_path: Path):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            human = await WorkshopHumanProvisioner(store).provision(
+                "charlie",
+                "Charlie",
+                "member",
+            )
+            assigned = await WorkshopRuntimeAssignmentService(store).assign(
+                human.principal_id,
+                human.channel_id,
+                "202",
+            )
+            await store.connection.execute("DELETE FROM channel_agent_runtime_assignments")
+            await store.connection.commit()
+
+            checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
+
+            assert checkpoint.version == 7
+            assert await resolve_channel_runtime_profile(store, human.channel_id) == (
+                assigned.agent_id,
+                "202",
+            )
+        finally:
+            await store.close()
+
+
+class TestRuntimeProfileCompatibilityBoundary:
+    @pytest.mark.parametrize("value", ("profile-daniel", "0", "01"))
+    def test_current_host_runtime_rejects_non_integer_profile_keys(self, value: str):
+        with pytest.raises(WorkshopRuntimeAssignmentError, match="integer-keyed"):
+            compatibility_user_id(value)

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -466,7 +466,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -370,7 +370,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 17
+            assert await upgraded.schema_version() == 18
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -52,7 +52,7 @@ async def _started_run(
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
-                runtime_subject="101",
+                runtime_profile_id="101",
             ),
         ),
     )
@@ -102,7 +102,7 @@ async def _started_client_run(
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
-                runtime_subject="101",
+                runtime_profile_id="101",
             ),
         ),
     )
@@ -152,15 +152,14 @@ async def _started_workshop_only_client_run(
                 transport="desktop",
                 external_subject="desktop-human",
                 external_channel_id="desktop-human",
-                runtime_subject="101",
+                runtime_profile_id="101",
             ),
         ),
     )
     async with store.connection.execute(
-        "SELECT e.principal_id, c.id FROM external_identities e "
-        "JOIN channel_memberships cm ON cm.principal_id = e.principal_id "
+        "SELECT cm.principal_id, c.id FROM channel_memberships cm "
         "JOIN channels c ON c.id = cm.channel_id AND c.kind = 'direct' "
-        "WHERE e.provider = 'kai' AND e.external_subject = '101'"
+        "WHERE cm.role = 'owner'"
     ) as cursor:
         row = await cursor.fetchone()
     assert row is not None


### PR DESCRIPTION
## Summary

- model backend execution authority as a durable, replayable assignment from a
  canonical Workshop channel-agent pair to one protected runtime profile
- bootstrap deterministic assignments for existing configured users while
  leaving newly provisioned Workshop humans without runtime authority
- resolve browser command acceptance and canonical run preparation from the
  explicit assignment instead of a `provider=kai` external identity
- add an operator command for assigning a runtime profile, validated against
  the protected configured-user policy
- include runtime assignments in authoritative install status, event replay,
  projection rebuilds, and drift detection

## Security boundary

Workshop collaboration identity no longer doubles as execution authority:

- human/workshop/channel membership grants only the corresponding canonical
  collaboration access
- Telegram and other external identities remain transport bindings, not
  backend authority
- a direct-channel agent must have exactly one explicit runtime-profile
  assignment before a command can execute
- one runtime profile cannot be assigned to another channel-agent, preventing
  accidental session, memory, home-directory, or credential sharing
- callers cannot provide or override the protected runtime profile on a run

The current compatibility runtime still indexes configured users by a positive
integer key. That conversion is now isolated at the host-runtime adapter; the
key is no longer represented or resolved as a human identity.

## Upgrade behavior

- adds Workshop schema migration 18 and projection version 7
- service startup creates deterministic assignments for all existing
  configured users before accepting work
- configured Telegram and browser behavior remains unchanged
- older `provider=kai` events may remain as historical facts, but production
  execution code no longer reads them and they grant no authority
- `make install-status` reports the non-secret runtime-assignment count

## Operator path

`python -m kai workshop client-access assign-runtime` requires canonical
principal and channel IDs plus a runtime profile present in protected
configured-user policy. It verifies that the human owns the direct channel,
that exactly one agent is attached, and that the profile is not assigned
elsewhere.

## Validation

- `make check`
- `make typecheck` (0 errors, 0 warnings)
- `make module-sizes`
- `.venv/bin/python -m pytest -q`
  - 5,570 passed, 1 skipped

Focused contracts also cover explicit assignment, semantic retry, cross-human
denial, profile-reuse denial, command/run resolution without external runtime
identity, projection rebuild, status counts, and replay-drift detection.
