### PR TITLE
Workshop: realign legacy parity diagnostics

### DIFF
--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import re
 import sqlite3
-from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -506,7 +505,7 @@ def _read_legacy_keys(history_root: Path, external_channel_id: str) -> tuple[lis
         return [], 0, 0
 
     keys: list[tuple[str, str]] = []
-    pending_user_turns: deque[bool] = deque()
+    pending_user_turn: bool | None = None
     malformed = 0
     unreadable = 0
     for path in sorted(history_dir.glob("*.jsonl")):
@@ -543,15 +542,19 @@ def _read_legacy_keys(history_root: Path, external_channel_id: str) -> tuple[lis
                     and media.get("type") in {"photo", "document", "voice"}
                     and media.get("workshop_message_shadowed") is True
                 )
-                pending_user_turns.append(is_shadowed_message)
+                # Only the most recent user record can own the next ordinary
+                # assistant record. Abandoned historical turns must not queue
+                # indefinitely and suppress otherwise valid later history.
+                pending_user_turn = is_shadowed_message
                 if is_shadowed_message:
                     keys.append((direction, hashlib.sha256(text.encode("utf-8")).hexdigest()))
                 continue
             if text.startswith(_SCHEDULED_ASSISTANT_PREFIXES):
                 continue
-            if not pending_user_turns:
+            if pending_user_turn is None:
                 continue
-            shadowed_turn = pending_user_turns.popleft()
+            shadowed_turn = pending_user_turn
+            pending_user_turn = None
             if not shadowed_turn or _SYNTHETIC_ASSISTANT_PATTERN.fullmatch(text):
                 continue
             keys.append((direction, hashlib.sha256(text.encode("utf-8")).hexdigest()))
@@ -566,16 +569,15 @@ def _compare_legacy_suffix(
     if not canonical_keys:
         return 0, 0, 0
 
+    suffix_matches = _longest_common_subsequence_suffix_lengths(
+        canonical_keys[1:],
+        legacy_keys,
+    )
     candidates: list[tuple[int, int, int, int]] = []
     for start, legacy_key in enumerate(legacy_keys):
         if legacy_key != canonical_keys[0]:
             continue
-        canonical_index = 0
-        matched = 0
-        for candidate in legacy_keys[start:]:
-            if canonical_index < len(canonical_keys) and candidate == canonical_keys[canonical_index]:
-                canonical_index += 1
-                matched += 1
+        matched = 1 + suffix_matches[start + 1]
         missing = len(canonical_keys) - matched
         unmatched = len(legacy_keys) - start - matched
         candidates.append((matched, missing, unmatched, start))
@@ -586,6 +588,27 @@ def _compare_legacy_suffix(
         key=lambda result: (-result[0], result[1] + result[2], -result[3]),
     )
     return matched, missing, unmatched
+
+
+def _longest_common_subsequence_suffix_lengths(
+    canonical_keys: list[tuple[str, str]],
+    legacy_keys: list[tuple[str, str]],
+) -> list[int]:
+    """Return ordered-match counts for every legacy suffix in linear memory."""
+    following = [0] * (len(legacy_keys) + 1)
+    for canonical_key in reversed(canonical_keys):
+        current = [0] * (len(legacy_keys) + 1)
+        for legacy_index in range(len(legacy_keys) - 1, -1, -1):
+            legacy_key = legacy_keys[legacy_index]
+            if canonical_key == legacy_key:
+                current[legacy_index] = following[legacy_index + 1] + 1
+            else:
+                current[legacy_index] = max(
+                    following[legacy_index],
+                    current[legacy_index + 1],
+                )
+        following = current
+    return following
 
 
 def _legacy_parity(

--- a/tests/test_workshop_parity.py
+++ b/tests/test_workshop_parity.py
@@ -349,6 +349,71 @@ class TestWorkshopMessageParityStatus:
         assert "parity: diverged" in status
         assert "JSONL matched=1, JSONL missing=1" in status
 
+    async def test_isolated_jsonl_gap_does_not_cascade_over_later_matches(self, tmp_path: Path):
+        db_path = tmp_path / "kai.db"
+        history_root = tmp_path / "history"
+        await _build_conversation(db_path)
+        store = await WorkshopEventStore.open(db_path)
+        try:
+            second_inbound = await record_inbound_message(
+                store,
+                InboundMessage(
+                    "telegram",
+                    "9002",
+                    "43",
+                    "101",
+                    "101",
+                    "Second question",
+                    _NOW + timedelta(seconds=4),
+                ),
+            )
+            await record_outbound_message(
+                store,
+                OutboundMessage(
+                    MessageId(str(second_inbound.event.envelope.aggregate_id)),
+                    "Second answer",
+                    _NOW + timedelta(seconds=6),
+                ),
+            )
+        finally:
+            await store.close()
+        _write_history(
+            history_root,
+            [
+                _record("user", "Secret question", seconds=0),
+                _record("user", "Second question", seconds=4),
+                _record("assistant", "Second answer", seconds=6),
+            ],
+        )
+
+        status = workshop_message_parity_status(db_path, history_root)
+
+        assert "parity: diverged" in status
+        assert "JSONL matched=3, JSONL missing=1, JSONL unmatched=0" in status
+
+    async def test_abandoned_unshadowed_media_does_not_poison_later_turns(self, tmp_path: Path):
+        db_path = tmp_path / "kai.db"
+        history_root = tmp_path / "history"
+        await _build_conversation(db_path)
+        _write_history(
+            history_root,
+            [
+                _record(
+                    "user",
+                    "Older unshadowed photo",
+                    seconds=-4,
+                    media={"type": "photo"},
+                ),
+                _record("user", "Secret question", seconds=0),
+                _record("assistant", "Secret answer", seconds=2),
+            ],
+        )
+
+        status = workshop_message_parity_status(db_path, history_root)
+
+        assert "parity: clean" in status
+        assert "JSONL matched=2, JSONL missing=0, JSONL unmatched=0" in status
+
     async def test_newer_unshadowed_jsonl_turn_is_reported(self, tmp_path: Path):
         db_path = tmp_path / "kai.db"
         history_root = tmp_path / "history"


### PR DESCRIPTION
## Summary

- prevent abandoned legacy user turns from remaining queued indefinitely and
  suppressing valid later assistant history
- replace greedy suffix comparison with ordered sequence alignment that
  recovers after isolated canonical or JSONL gaps
- keep alignment bounded to linear memory and one dynamic-programming pass,
  even when the first canonical message text occurs repeatedly

## Why

After #897, authoritative install status correctly reported:

- 81 canonical messages
- 81 projected messages
- 0 event-replay/projection mismatches

But legacy JSONL parity reported 13 missing and 10 unmatched entries. Read-only
metadata analysis showed that an abandoned older media turn poisoned the
legacy pairing queue. The greedy comparison then could not recover after the
first apparent gap, so every later valid message was misclassified.

Against the deployed data, this correction produces the accurate result:

- 79 JSONL matches
- 1 canonical message absent from JSONL
- 0 unmatched JSONL messages

The remaining gap is retained rather than hidden. It is a historical
`execution_interrupted` recovery response that is durable in canonical
Workshop history but was not written to the compatibility JSONL log. Canonical
event replay and projection remain exact.

## Safety

- read-only diagnostic behavior only
- no database, event, projection, or JSONL mutations
- no message content or identity data added to operator output
- existing pre-shadow JSONL prefixes remain permitted

## Validation

- `make check`
- `make typecheck` (0 errors, 0 warnings)
- `.venv/bin/python -m pytest -q`
  - 5,572 passed, 1 skipped
- verified read-only against the deployed database/history:
  `canonical=81, projected=81, replay mismatches=0, JSONL matched=79,
  JSONL missing=1, JSONL unmatched=0`

New tests pin recovery after an isolated gap and prevent an abandoned
unshadowed-media turn from contaminating subsequent parity.
