### PR TITLE
Workshop: decouple runtime profiles from transport identity

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1905,3 +1905,30 @@ appears once in the bound Telegram chat, and the assistant response appears
 once in both clients. Retry and restart evidence must show no duplicate
 canonical messages, runs, echoes, finalizations, history entries, or memory
 ingestion, and `make install-status` must remain clean.
+
+## 39. Transport-neutral human and runtime authority
+
+**Implementation date:** 2026-08-13
+
+Workshop browser authority no longer requires a Telegram identity or binding.
+Operators can provision canonical humans and direct channels independently,
+issue enrollment to those principals, and optionally attach transport delivery
+later. Every executable channel-agent pair must also have exactly one explicit
+runtime-profile assignment; human identity, client enrollment, and transport
+bindings cannot select a backend process implicitly.
+
+Runtime-profile assignments now contain stable opaque `rtp_` identifiers. A
+process-local registry built only from protected operator configuration maps
+those identifiers to the configured backend/provider and OS execution user.
+Callers cannot submit the registry's private runtime-configuration key, and a
+structurally valid profile ID that is absent from protected policy fails
+closed. Existing numeric assignments are retained as historical events and
+superseded by a canonical `runtime_profile.reassigned` fact during bootstrap,
+so projection rebuilds reproduce the migration exactly.
+
+The current host runtime still uses the protected configured-user integer key
+behind this registry for subprocess pooling, settings, files, history, and
+memory compatibility. That key originates in the present `users.yaml` schema,
+whose primary record key is a Telegram user ID. It is no longer canonical
+Workshop assignment or caller authority, but retiring it from those storage
+namespaces is the next bounded migration seam.

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -48,10 +48,14 @@ from kai.bot import create_bot
 from kai.config import DATA_DIR, PROJECT_ROOT, _read_protected_file, load_config
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 from kai.workshop.telegram_delivery_runtime import WorkshopTelegramConversationDeliveryService
 
 
-def _workshop_bootstrap_humans(config) -> tuple[BootstrapHuman, ...]:
+def _workshop_bootstrap_humans(
+    config,
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
+) -> tuple[BootstrapHuman, ...]:
     """Map authorized humans to their interactive direct-channel bindings."""
     return tuple(
         BootstrapHuman(
@@ -60,7 +64,7 @@ def _workshop_bootstrap_humans(config) -> tuple[BootstrapHuman, ...]:
             transport="telegram",
             external_subject=str(user.telegram_id),
             external_channel_id=str(user.telegram_id),
-            runtime_profile_id=str(user.telegram_id),
+            runtime_profile_id=runtime_profiles.for_config_id(user.telegram_id).profile_id,
         )
         for user in sorted(config.user_configs.values(), key=lambda user: user.telegram_id)
     )
@@ -298,8 +302,9 @@ def _start() -> None:
         # Notification groups are outbound-only channels: they share existing
         # principals but never create an inbound identity or alter live GitHub
         # routing through this migration.
+        runtime_profiles = WorkshopRuntimeProfileRegistry.from_config(config)
         workshop_bootstrap = await sessions.bootstrap_workshop_foundation(
-            _workshop_bootstrap_humans(config),
+            _workshop_bootstrap_humans(config, runtime_profiles),
             notification_channels=await _workshop_bootstrap_notification_channels(config),
         )
         logging.info(
@@ -434,6 +439,7 @@ def _start() -> None:
                 config.session_db_path,
                 app.bot_data["pool"],
                 registered_backend_ids=_workshop_registered_backend_ids(config),
+                runtime_profiles=runtime_profiles,
             )
             app.bot_data["workshop_private_text_execution"] = private_text_execution
             logging.info("Workshop private-text execution is ready")

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -74,6 +74,7 @@ from kai.workshop.streaming_preview import (
 
 if TYPE_CHECKING:
     from kai.config import Config, WorkspaceConfig
+    from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 
 log = logging.getLogger(__name__)
 
@@ -358,13 +359,14 @@ async def record_workshop_inbound_message(message: InboundMessage) -> AppendResu
 
 async def resolve_workshop_conversation_run(
     inbound_message_id: MessageId,
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
 ) -> CompatibilityConversationRunResolution:
     """Resolve one canonical inbound message for transport-neutral execution."""
     if _workshop_event_lock is None:
         raise RuntimeError("Database not initialized - call init_db() first")
     async with _workshop_event_lock:
         store = WorkshopEventStore.from_initialized_connection(_get_db())
-        return await resolve_canonical_conversation_run(store, inbound_message_id)
+        return await resolve_canonical_conversation_run(store, inbound_message_id, runtime_profiles)
 
 
 async def record_workshop_inbound_artifact(

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -20,6 +20,7 @@ from kai.workshop.domain import (
     OpaqueId,
     PrincipalId,
     RuntimeAssignmentId,
+    RuntimeProfileId,
     WorkshopEventType,
     WorkshopId,
     WorkshopMembershipId,
@@ -38,7 +39,7 @@ class BootstrapHuman:
     transport: str
     external_subject: str
     external_channel_id: str
-    runtime_profile_id: str | None = None
+    runtime_profile_id: RuntimeProfileId | None = None
 
     def __post_init__(self) -> None:
         if not self.display_name.strip():
@@ -51,14 +52,8 @@ class BootstrapHuman:
             raise ValueError("external_subject must be non-empty")
         if not self.external_channel_id.strip():
             raise ValueError("external_channel_id must be non-empty")
-        if self.runtime_profile_id is not None and not self.runtime_profile_id.strip():
-            raise ValueError("runtime_profile_id must be non-empty when provided")
-        if self.runtime_profile_id is not None and (
-            not self.runtime_profile_id.isascii()
-            or not self.runtime_profile_id.isdigit()
-            or self.runtime_profile_id.startswith("0")
-        ):
-            raise ValueError("runtime_profile_id must identify a positive integer-keyed configured runtime")
+        if self.runtime_profile_id is not None and not isinstance(self.runtime_profile_id, RuntimeProfileId):
+            raise ValueError("runtime_profile_id must be an opaque RuntimeProfileId")
 
 
 @dataclass(frozen=True, slots=True)
@@ -314,20 +309,39 @@ async def bootstrap_default_workshop(
             payload={"channel_id": channel_id, "agent_id": agent_id},
         )
         if human.runtime_profile_id is not None:
-            await ensure(
-                idempotency_key=_idempotency_key("runtime-assignment", channel_token),
-                event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
-                aggregate_type="runtime_assignment",
-                aggregate_id=RuntimeAssignmentId.derived(
-                    channel_id,
-                    f"runtime-profile:{agent_id}",
-                ),
-                payload={
-                    "channel_id": channel_id,
-                    "agent_id": agent_id,
-                    "runtime_profile_id": human.runtime_profile_id,
-                },
+            assignment_id = RuntimeAssignmentId.derived(channel_id, f"runtime-profile:{agent_id}")
+            previous_key = _idempotency_key("runtime-assignment", channel_token)
+            assignment_key = _idempotency_key("runtime-assignment-v2", channel_token)
+            reassignment_key = _idempotency_key(
+                "runtime-reassignment-v2",
+                f"{channel_token}:{human.runtime_profile_id}",
             )
+            if await store.event_by_idempotency_key(assignment_key) is not None or await store.event_by_idempotency_key(reassignment_key) is not None:
+                existing_events += 1
+            elif await store.event_by_idempotency_key(previous_key) is not None:
+                await ensure(
+                    idempotency_key=reassignment_key,
+                    event_type=WorkshopEventType.RUNTIME_PROFILE_REASSIGNED,
+                    aggregate_type="runtime_assignment",
+                    aggregate_id=assignment_id,
+                    payload={
+                        "channel_id": channel_id,
+                        "agent_id": agent_id,
+                        "runtime_profile_id": human.runtime_profile_id,
+                    },
+                )
+            else:
+                await ensure(
+                    idempotency_key=assignment_key,
+                    event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
+                    aggregate_type="runtime_assignment",
+                    aggregate_id=assignment_id,
+                    payload={
+                        "channel_id": channel_id,
+                        "agent_id": agent_id,
+                        "runtime_profile_id": human.runtime_profile_id,
+                    },
+                )
 
     for notification in ordered_notifications:
         channel_token = _stable_token(notification.transport, notification.external_channel_id)

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -316,7 +316,10 @@ async def bootstrap_default_workshop(
                 "runtime-reassignment-v2",
                 f"{channel_token}:{human.runtime_profile_id}",
             )
-            if await store.event_by_idempotency_key(assignment_key) is not None or await store.event_by_idempotency_key(reassignment_key) is not None:
+            if (
+                await store.event_by_idempotency_key(assignment_key) is not None
+                or await store.event_by_idempotency_key(reassignment_key) is not None
+            ):
                 existing_events += 1
             elif await store.event_by_idempotency_key(previous_key) is not None:
                 await ensure(

--- a/src/kai/workshop/client_commands.py
+++ b/src/kai/workshop/client_commands.py
@@ -18,7 +18,6 @@ from kai.workshop.execution_coordinator import (
 )
 from kai.workshop.inbound import ClientInboundMessage
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
-from kai.workshop.runtime_assignments import compatibility_user_id
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,7 +39,7 @@ class WorkshopClientCommandExecutor:
 
     async def submit(self, message: ClientInboundMessage) -> ClientCommandResult:
         accepted = await self._execution.accept_client(message)
-        runtime_config_id = compatibility_user_id(accepted.runtime_profile_id)
+        runtime_config_id = self._execution.runtime_config_id(accepted.runtime_profile_id)
         mapped_reader = reader_user(self._config, runtime_config_id)
         user_log = (
             log_message(

--- a/src/kai/workshop/conversation_commands.py
+++ b/src/kai/workshop/conversation_commands.py
@@ -11,7 +11,7 @@ from kai.workshop.delivery_outbox import (
     DeliveryRequestResult,
     WorkshopDeliveryOutbox,
 )
-from kai.workshop.domain import ChannelBindingId, ChannelId, MessageId, PrincipalId
+from kai.workshop.domain import ChannelBindingId, ChannelId, MessageId, PrincipalId, RuntimeProfileId
 from kai.workshop.inbound import (
     ClientInboundMessage,
     InboundMessage,
@@ -61,7 +61,7 @@ class ClientConversationCommandAcceptance:
 
     command: ConversationCommandAcceptance
     delivery: DeliveryRequestResult | None
-    runtime_profile_id: str
+    runtime_profile_id: RuntimeProfileId
 
     @property
     def run(self) -> DurableRun:

--- a/src/kai/workshop/conversation_runs.py
+++ b/src/kai/workshop/conversation_runs.py
@@ -11,9 +11,9 @@ from kai.backend import StreamEvent
 from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, WorkshopId
 from kai.workshop.runtime_assignments import (
     WorkshopRuntimeAssignmentError,
-    compatibility_user_id,
     resolve_channel_runtime_profile,
 )
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError, WorkshopRuntimeProfileRegistry
 from kai.workshop.store import WorkshopEventStore
 
 type AgentPrompt = str | list[dict[str, str]]
@@ -39,7 +39,7 @@ class CompatibilityConversationRunResolution:
     """Canonical target plus the private key required by the current pool."""
 
     target: CanonicalConversationRunTarget
-    _legacy_pool_key: int = field(repr=False, compare=False)
+    _runtime_config_id: int = field(repr=False, compare=False)
 
 
 class ConversationPool(Protocol):
@@ -89,6 +89,7 @@ async def resolve_canonical_conversation_target(
 async def resolve_canonical_conversation_run(
     store: WorkshopEventStore,
     inbound_message_id: MessageId,
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
 ) -> CompatibilityConversationRunResolution:
     """Resolve a canonical target plus the current private pool adapter key.
 
@@ -105,13 +106,13 @@ async def resolve_canonical_conversation_run(
             target.channel_id,
             target.agent_id,
         )
-        legacy_pool_key = compatibility_user_id(runtime_profile_id)
-    except WorkshopRuntimeAssignmentError as exc:
+        runtime_config_id = runtime_profiles.resolve(runtime_profile_id).runtime_config_id
+    except (WorkshopRuntimeAssignmentError, WorkshopRuntimeProfileError) as exc:
         raise ConversationRunUnavailableError(str(exc)) from exc
 
     return CompatibilityConversationRunResolution(
         target=target,
-        _legacy_pool_key=legacy_pool_key,
+        _runtime_config_id=runtime_config_id,
     )
 
 
@@ -122,16 +123,16 @@ class PreparedConversationRun:
     target: CanonicalConversationRunTarget
     model: str
     _pool: ConversationPool = field(repr=False, compare=False)
-    _legacy_pool_key: int = field(repr=False, compare=False)
+    _runtime_config_id: int = field(repr=False, compare=False)
 
     async def stream(self, prompt: AgentPrompt) -> AsyncIterator[StreamEvent]:
         """Stream normalized harness events without exposing the pool key."""
-        async for event in self._pool.send(prompt, chat_id=self._legacy_pool_key):
+        async for event in self._pool.send(prompt, chat_id=self._runtime_config_id):
             yield event
 
     async def effective_workspace(self) -> Path:
         """Return the run's effective project workspace through the adapter."""
-        return await self._pool.get_effective_workspace(self._legacy_pool_key)
+        return await self._pool.get_effective_workspace(self._runtime_config_id)
 
 
 class WorkshopConversationRunService:
@@ -152,7 +153,7 @@ class WorkshopConversationRunService:
             raise ConversationRunUnavailableError("Run resolver returned a different inbound message")
         return PreparedConversationRun(
             target=target,
-            model=self._pool.get_model(resolution._legacy_pool_key),
+            model=self._pool.get_model(resolution._runtime_config_id),
             _pool=self._pool,
-            _legacy_pool_key=resolution._legacy_pool_key,
+            _runtime_config_id=resolution._runtime_config_id,
         )

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -385,6 +385,18 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
                 ),
             )
             continue
+        if envelope.event_type == WorkshopEventType.RUNTIME_PROFILE_REASSIGNED:
+            prior = runtime_assignments.get(aggregate_id)
+            channel_id = _required_payload_text(payload, "channel_id")
+            agent_id = _required_payload_text(payload, "agent_id")
+            if prior is None or prior[:2] != (channel_id, agent_id):
+                raise ValueError("Workshop runtime reassignment has no matching replayed assignment")
+            runtime_assignments[aggregate_id] = (
+                channel_id,
+                agent_id,
+                _required_payload_text(payload, "runtime_profile_id"),
+            )
+            continue
         if envelope.event_type != WorkshopEventType.MESSAGE_CREATED:
             continue
 

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -31,6 +31,7 @@ class WorkshopEventType(StrEnum):
     AGENT_CREATED = "agent.created"
     CHANNEL_AGENT_ATTACHED = "channel.agent_attached"
     RUNTIME_PROFILE_ASSIGNED = "runtime_profile.assigned"
+    RUNTIME_PROFILE_REASSIGNED = "runtime_profile.reassigned"
     MESSAGE_CREATED = "message.created"
     ARTIFACT_CREATED = "artifact.created"
     DELIVERY_REQUESTED = "delivery.requested"
@@ -121,6 +122,10 @@ class ChannelBindingId(OpaqueId):
 
 class AgentId(OpaqueId):
     prefix = "agt"
+
+
+class RuntimeProfileId(OpaqueId):
+    prefix = "rtp"
 
 
 class ChannelAgentId(OpaqueId):

--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -11,7 +11,7 @@ from kai.workshop.conversation_commands import (
     ConversationCommandAcceptance,
     WorkshopConversationCommandService,
 )
-from kai.workshop.domain import RunId
+from kai.workshop.domain import RunId, RuntimeProfileId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
     CanonicalExecutionResult,
@@ -20,6 +20,7 @@ from kai.workshop.execution_coordinator import (
 )
 from kai.workshop.inbound import ClientInboundMessage, InboundMessage
 from kai.workshop.protected_execution import WorkshopProtectedExecutionPreparationService
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 from kai.workshop.store import WorkshopEventStore
 
 _RECOVERY_INTERVAL_SECONDS = 5.0
@@ -34,11 +35,13 @@ class WorkshopPrivateTextExecutionService:
         coordinator: WorkshopCanonicalExecutionCoordinator,
         command_service: WorkshopConversationCommandService,
         database_lock: asyncio.Lock,
+        runtime_profiles: WorkshopRuntimeProfileRegistry,
     ) -> None:
         self._store = store
         self._coordinator = coordinator
         self._command_service = command_service
         self._database_lock = database_lock
+        self._runtime_profiles = runtime_profiles
         self._stop_event = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
         self._closed = False
@@ -50,6 +53,7 @@ class WorkshopPrivateTextExecutionService:
         pool: SubprocessPool,
         *,
         registered_backend_ids: frozenset[str],
+        runtime_profiles: WorkshopRuntimeProfileRegistry,
     ) -> WorkshopPrivateTextExecutionService:
         store = await WorkshopEventStore.open(database_path)
         database_lock = asyncio.Lock()
@@ -59,11 +63,18 @@ class WorkshopPrivateTextExecutionService:
                 store,
                 pool,
                 registered_backend_ids=registered_backend_ids,
+                runtime_profiles=runtime_profiles,
             ),
             registered_backend_ids=registered_backend_ids,
             database_lock=database_lock,
         )
-        service = cls(store, coordinator, WorkshopConversationCommandService(store), database_lock)
+        service = cls(
+            store,
+            coordinator,
+            WorkshopConversationCommandService(store),
+            database_lock,
+            runtime_profiles,
+        )
         try:
             await coordinator.recover_expired()
             service._task = asyncio.create_task(
@@ -78,6 +89,10 @@ class WorkshopPrivateTextExecutionService:
     @property
     def ready(self) -> bool:
         return not self._closed and self._task is not None and not self._task.done()
+
+    def runtime_config_id(self, runtime_profile_id: str | RuntimeProfileId) -> int:
+        """Resolve compatibility state only through protected profile policy."""
+        return self._runtime_profiles.resolve(runtime_profile_id).runtime_config_id
 
     async def accept(self, message: InboundMessage) -> ConversationCommandAcceptance:
         if self._closed:

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -499,8 +499,8 @@ class CanonicalConversationProjection:
     """Rebuild the initial Workshop collaboration records from events."""
 
     name = "canonical_conversations"
-    # Runtime-profile assignment becomes a replayed channel-agent policy.
-    version = 7
+    # Runtime-profile assignments can migrate to stable protected profiles.
+    version = 8
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -669,6 +669,23 @@ class CanonicalConversationProjection:
                     event.position,
                 ),
             )
+        elif envelope.event_type == WorkshopEventType.RUNTIME_PROFILE_REASSIGNED:
+            channel_id = _required_text(payload, "channel_id")
+            agent_id = _required_text(payload, "agent_id")
+            cursor = await connection.execute(
+                "UPDATE channel_agent_runtime_assignments "
+                "SET runtime_profile_id = ?, created_event_position = ? "
+                "WHERE id = ? AND channel_id = ? AND agent_id = ?",
+                (
+                    _required_text(payload, "runtime_profile_id"),
+                    event.position,
+                    envelope.aggregate_id,
+                    channel_id,
+                    agent_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError("Workshop runtime reassignment has no matching channel-agent assignment")
         elif envelope.event_type == WorkshopEventType.MESSAGE_CREATED:
             reply_to = payload.get("reply_to_message_id")
             if reply_to is not None and not isinstance(reply_to, str):

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -13,6 +13,7 @@ from kai.workshop.conversation_runs import resolve_canonical_conversation_run
 from kai.workshop.domain import RunId
 from kai.workshop.run_execution_authority import RunExecutionSelection
 from kai.workshop.run_lifecycle import DurableRun, RunStatus, WorkshopRunLifecycle
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 from kai.workshop.store import WorkshopEventStore
 
 type AgentPrompt = str | list[dict[str, str]]
@@ -52,6 +53,7 @@ class WorkshopProtectedExecutionPreparationService:
         pool: SubprocessPool,
         *,
         registered_backend_ids: frozenset[str],
+        runtime_profiles: WorkshopRuntimeProfileRegistry,
     ) -> None:
         if not registered_backend_ids:
             raise ValueError("registered_backend_ids must not be empty")
@@ -61,6 +63,7 @@ class WorkshopProtectedExecutionPreparationService:
         self._store = store
         self._pool = pool
         self._registered_backend_ids = registered_backend_ids
+        self._runtime_profiles = runtime_profiles
 
     async def prepare(self, run_id: RunId) -> PreparedWorkshopExecution:
         if not isinstance(run_id, RunId):
@@ -69,7 +72,11 @@ class WorkshopProtectedExecutionPreparationService:
         if run.status != RunStatus.ACCEPTED or run.cancellation_requested_at is not None:
             raise ProtectedExecutionPreparationError("Only an uncancelled accepted run can prepare execution")
 
-        resolution = await resolve_canonical_conversation_run(self._store, run.inbound_message_id)
+        resolution = await resolve_canonical_conversation_run(
+            self._store,
+            run.inbound_message_id,
+            self._runtime_profiles,
+        )
         target = resolution.target
         if (
             target.workshop_id != run.workshop_id
@@ -79,7 +86,7 @@ class WorkshopProtectedExecutionPreparationService:
         ):
             raise ProtectedExecutionPreparationError("Canonical run authority changed after acceptance")
 
-        runtime = await self._pool.prepare_execution(resolution._legacy_pool_key)
+        runtime = await self._pool.prepare_execution(resolution._runtime_config_id)
         prepared = runtime.selection
         if prepared.backend not in self._registered_backend_ids:
             raise ProtectedExecutionPreparationError("Effective backend is not present in the protected registry")

--- a/src/kai/workshop/runtime_assignments.py
+++ b/src/kai/workshop/runtime_assignments.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -12,13 +11,13 @@ from kai.workshop.domain import (
     EventEnvelope,
     PrincipalId,
     RuntimeAssignmentId,
+    RuntimeProfileId,
     WorkshopEventType,
     WorkshopId,
 )
 from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError, WorkshopRuntimeProfileRegistry
 from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
-
-_RUNTIME_PROFILE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 class WorkshopRuntimeAssignmentError(RuntimeError):
@@ -32,16 +31,15 @@ class WorkshopRuntimeAssignment:
     principal_id: PrincipalId
     channel_id: ChannelId
     agent_id: AgentId
-    runtime_profile_id: str
+    runtime_profile_id: RuntimeProfileId
     created: bool
 
 
-def normalize_runtime_profile_id(value: object) -> str:
-    if not isinstance(value, str) or not _RUNTIME_PROFILE_PATTERN.fullmatch(value):
-        raise WorkshopRuntimeAssignmentError(
-            "Runtime profile ID must contain 1 through 128 bounded identifier characters"
-        )
-    return value
+def normalize_runtime_profile_id(value: object) -> RuntimeProfileId:
+    try:
+        return value if isinstance(value, RuntimeProfileId) else RuntimeProfileId(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise WorkshopRuntimeAssignmentError("Runtime profile ID must be an opaque rtp_ identifier") from exc
 
 
 def runtime_assignment_envelope(
@@ -50,7 +48,7 @@ def runtime_assignment_envelope(
     assignment_id: RuntimeAssignmentId,
     channel_id: ChannelId,
     agent_id: AgentId,
-    runtime_profile_id: str,
+    runtime_profile_id: str | RuntimeProfileId,
     occurred_at: datetime,
     idempotency_key: str,
     source: str,
@@ -76,7 +74,7 @@ async def resolve_channel_runtime_profile(
     store: WorkshopEventStore,
     channel_id: ChannelId,
     agent_id: AgentId | None = None,
-) -> tuple[AgentId, str]:
+) -> tuple[AgentId, RuntimeProfileId]:
     """Resolve exactly one explicit runtime assignment for a channel agent."""
     if not isinstance(channel_id, ChannelId):
         raise WorkshopRuntimeAssignmentError("channel_id must be a ChannelId")
@@ -102,37 +100,26 @@ async def resolve_channel_runtime_profile(
     return AgentId(str(rows[0][0])), normalize_runtime_profile_id(str(rows[0][1]))
 
 
-def compatibility_user_id(runtime_profile_id: str) -> int:
-    """Adapt a protected profile ID to the current integer-keyed runtime pool."""
-    normalized = normalize_runtime_profile_id(runtime_profile_id)
-    if not normalized.isascii() or not normalized.isdigit() or normalized.startswith("0"):
-        raise WorkshopRuntimeAssignmentError(
-            "Runtime profile is not compatible with the current integer-keyed host runtime"
-        )
-    value = int(normalized)
-    if value <= 0:
-        raise WorkshopRuntimeAssignmentError(
-            "Runtime profile is not compatible with the current integer-keyed host runtime"
-        )
-    return value
-
-
 class WorkshopRuntimeAssignmentService:
     """Grant a canonical channel agent one protected runtime profile."""
 
-    def __init__(self, store: WorkshopEventStore) -> None:
+    def __init__(self, store: WorkshopEventStore, profiles: WorkshopRuntimeProfileRegistry) -> None:
         self._store = store
+        self._profiles = profiles
 
     async def assign(
         self,
         principal_id: PrincipalId,
         channel_id: ChannelId,
-        runtime_profile_id: str,
+        runtime_profile_id: str | RuntimeProfileId,
     ) -> WorkshopRuntimeAssignment:
         if not isinstance(principal_id, PrincipalId) or not isinstance(channel_id, ChannelId):
             raise WorkshopRuntimeAssignmentError("Canonical principal and channel IDs are required")
         normalized_profile = normalize_runtime_profile_id(runtime_profile_id)
-        compatibility_user_id(normalized_profile)
+        try:
+            self._profiles.resolve(normalized_profile)
+        except WorkshopRuntimeProfileError as exc:
+            raise WorkshopRuntimeAssignmentError(str(exc)) from exc
         connection = self._store.connection
         try:
             await connection.execute("BEGIN IMMEDIATE")

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -1,0 +1,101 @@
+"""Protected, transport-neutral Workshop runtime-profile registry."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from kai.config import Config, get_user_backend_and_provider
+from kai.workshop.domain import RuntimeProfileId
+
+_PROFILE_DERIVATION_DOMAIN = b"kai-workshop-runtime-profile:v1\0"
+
+
+class WorkshopRuntimeProfileError(RuntimeError):
+    """A canonical runtime profile is missing or conflicts with policy."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProtectedRuntimeProfile:
+    """One operator-configured execution identity behind an opaque ID.
+
+    ``runtime_config_id`` is deliberately private compatibility state. The
+    current host runtime still stores settings, files, memory, and subprocess
+    instances under the configured-user integer key. Canonical Workshop
+    assignments and callers see only ``profile_id``.
+    """
+
+    profile_id: RuntimeProfileId
+    runtime_config_id: int
+    display_name: str
+    os_user: str | None
+    backend: str
+    provider: str
+
+
+def runtime_profile_id_for_config_id(runtime_config_id: int) -> RuntimeProfileId:
+    """Derive a stable opaque profile ID from protected configured-user state."""
+    if isinstance(runtime_config_id, bool) or not isinstance(runtime_config_id, int) or runtime_config_id <= 0:
+        raise WorkshopRuntimeProfileError("Runtime configuration ID must be a positive integer")
+    digest = hashlib.sha256(_PROFILE_DERIVATION_DOMAIN + str(runtime_config_id).encode("ascii")).hexdigest()[:32]
+    return RuntimeProfileId(f"rtp_{digest}")
+
+
+class WorkshopRuntimeProfileRegistry:
+    """Resolve canonical profiles only through protected operator policy."""
+
+    def __init__(self, profiles: tuple[ProtectedRuntimeProfile, ...]) -> None:
+        by_id: dict[RuntimeProfileId, ProtectedRuntimeProfile] = {}
+        by_config_id: dict[int, ProtectedRuntimeProfile] = {}
+        for profile in profiles:
+            if not isinstance(profile, ProtectedRuntimeProfile):
+                raise TypeError("profiles must contain ProtectedRuntimeProfile values")
+            if profile.profile_id in by_id:
+                raise WorkshopRuntimeProfileError("Duplicate runtime profile ID")
+            if profile.runtime_config_id in by_config_id:
+                raise WorkshopRuntimeProfileError("Duplicate runtime configuration ID")
+            by_id[profile.profile_id] = profile
+            by_config_id[profile.runtime_config_id] = profile
+        if not by_id:
+            raise WorkshopRuntimeProfileError("At least one protected runtime profile is required")
+        self._by_id = by_id
+        self._by_config_id = by_config_id
+
+    @classmethod
+    def from_config(cls, config: Config) -> WorkshopRuntimeProfileRegistry:
+        profiles: list[ProtectedRuntimeProfile] = []
+        for runtime_config_id, user in sorted(config.user_configs.items()):
+            if user.telegram_id != runtime_config_id:
+                raise WorkshopRuntimeProfileError("Configured-user key does not match its protected user record")
+            backend, provider = get_user_backend_and_provider(user, config)
+            profiles.append(
+                ProtectedRuntimeProfile(
+                    profile_id=runtime_profile_id_for_config_id(runtime_config_id),
+                    runtime_config_id=runtime_config_id,
+                    display_name=user.name,
+                    os_user=user.os_user,
+                    backend=backend,
+                    provider=provider,
+                )
+            )
+        return cls(tuple(profiles))
+
+    @property
+    def profiles(self) -> tuple[ProtectedRuntimeProfile, ...]:
+        return tuple(sorted(self._by_id.values(), key=lambda profile: profile.profile_id))
+
+    def resolve(self, profile_id: str | RuntimeProfileId) -> ProtectedRuntimeProfile:
+        try:
+            normalized = profile_id if isinstance(profile_id, RuntimeProfileId) else RuntimeProfileId(profile_id)
+        except (TypeError, ValueError) as exc:
+            raise WorkshopRuntimeProfileError("Runtime profile ID is invalid") from exc
+        profile = self._by_id.get(normalized)
+        if profile is None:
+            raise WorkshopRuntimeProfileError("Runtime profile is not present in protected operator policy")
+        return profile
+
+    def for_config_id(self, runtime_config_id: int) -> ProtectedRuntimeProfile:
+        profile = self._by_config_id.get(runtime_config_id)
+        if profile is None:
+            raise WorkshopRuntimeProfileError("Configured user has no protected runtime profile")
+        return profile

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -42,6 +42,7 @@ from kai.workshop.runtime_assignments import (
     WorkshopRuntimeAssignmentError,
     WorkshopRuntimeAssignmentService,
 )
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError, WorkshopRuntimeProfileRegistry
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery import (
     TelegramWorkOutcome,
@@ -112,6 +113,10 @@ def _parser() -> argparse.ArgumentParser:
     provision.add_argument("--display-name", required=True)
     provision.add_argument("--role", required=True, choices=("admin", "member"))
     provision.add_argument("--workshop-id")
+    client_actions.add_parser(
+        "list-runtime-profiles",
+        help="list protected transport-neutral runtime profiles",
+    )
     assign_runtime = client_actions.add_parser(
         "assign-runtime",
         help="assign one protected runtime profile to a human's direct-channel agent",
@@ -247,13 +252,18 @@ async def _run(args: argparse.Namespace) -> int:
                 print("Transport access: not assigned")
                 print("Runtime access: not assigned")
                 return 0
+            if args.action == "list-runtime-profiles":
+                profiles = WorkshopRuntimeProfileRegistry.from_config(load_config()).profiles
+                for profile in profiles:
+                    print(f"Runtime profile: {profile.profile_id}")
+                    print(f"Configured user: {profile.display_name}")
+                    print(f"OS user: {profile.os_user or 'Kai service account'}")
+                    print(f"Backend: {profile.backend}")
+                    print(f"Provider: {profile.provider}")
+                return 0
             if args.action == "assign-runtime":
-                configured_profiles = {str(user.telegram_id) for user in load_config().user_configs.values()}
-                if args.runtime_profile_id not in configured_profiles:
-                    raise WorkshopRuntimeAssignmentError(
-                        "Runtime profile is not present in protected configured-user policy"
-                    )
-                assignment = await WorkshopRuntimeAssignmentService(store).assign(
+                profiles = WorkshopRuntimeProfileRegistry.from_config(load_config())
+                assignment = await WorkshopRuntimeAssignmentService(store, profiles).assign(
                     _principal_id(args.principal_id),
                     _channel_id(args.channel_id),
                     args.runtime_profile_id,
@@ -393,6 +403,8 @@ def cli(args: list[str]) -> None:
         raise SystemExit(f"Workshop human provisioning failed: {exc}") from exc
     except WorkshopRuntimeAssignmentError as exc:
         raise SystemExit(f"Workshop runtime assignment failed: {exc}") from exc
+    except WorkshopRuntimeProfileError as exc:
+        raise SystemExit(f"Workshop runtime profile failed: {exc}") from exc
     except (DeliveryQualificationError, DeliveryTargetNotFoundError) as exc:
         if parsed.command == "client-access":
             raise SystemExit(f"Workshop client access failed: {exc}") from exc

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3786,7 +3786,7 @@ class TestHandleResponse:
             ),
             model="sonnet",
             _pool=pool,
-            _legacy_pool_key=12345,
+            _runtime_config_id=12345,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,6 +27,7 @@ from kai.main import (
     _workshop_bootstrap_notification_channels,
     setup_logging,
 )
+from tests.workshop_profiles import profile_id, profile_registry
 
 
 class TestWorkshopBootstrapMapping:
@@ -42,12 +43,13 @@ class TestWorkshopBootstrapMapping:
             }
         )
 
-        humans = _workshop_bootstrap_humans(config)
+        humans = _workshop_bootstrap_humans(config, profile_registry(101))
 
         assert len(humans) == 1
         assert humans[0].external_subject == "101"
         assert humans[0].external_channel_id == "101"
         assert humans[0].role == "admin"
+        assert humans[0].runtime_profile_id == profile_id(101)
         assert "-999" not in repr(humans)
 
     async def test_effective_negative_destinations_become_deduplicated_notification_channels(self):

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -267,7 +267,7 @@ class TestArtifactShadowRecording:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 7
+            assert checkpoint.version == 8
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_bootstrap.py
+++ b/tests/test_workshop_bootstrap.py
@@ -280,8 +280,7 @@ class TestDefaultWorkshopBootstrap:
                 aggregate_id=assignment_id,
                 occurred_at=datetime.now(UTC),
                 idempotency_key=(
-                    "workshop-bootstrap:v1:runtime-assignment:"
-                    + hashlib.sha256(b"telegram\x00101").hexdigest()
+                    "workshop-bootstrap:v1:runtime-assignment:" + hashlib.sha256(b"telegram\x00101").hexdigest()
                 ),
                 payload={
                     "channel_id": channel_id,

--- a/tests/test_workshop_bootstrap.py
+++ b/tests/test_workshop_bootstrap.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -9,7 +11,10 @@ import pytest
 from kai import sessions
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel, bootstrap_default_workshop
 from kai.workshop.diagnostics import workshop_bootstrap_status
+from kai.workshop.domain import ChannelId, EventEnvelope, RuntimeAssignmentId, WorkshopEventType
+from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id
 
 
 @pytest.fixture
@@ -240,7 +245,7 @@ class TestDefaultWorkshopBootstrap:
                     transport=original.transport,
                     external_subject=original.external_subject,
                     external_channel_id=original.external_channel_id,
-                    runtime_profile_id="101",
+                    runtime_profile_id=profile_id(101),
                 )
             ],
         )
@@ -255,7 +260,59 @@ class TestDefaultWorkshopBootstrap:
         async with store.connection.execute(
             "SELECT runtime_profile_id FROM channel_agent_runtime_assignments"
         ) as cursor:
-            assert [str(row[0]) for row in await cursor.fetchall()] == ["101"]
+            assert [str(row[0]) for row in await cursor.fetchall()] == [profile_id(101)]
+
+    async def test_existing_numeric_assignment_is_canonically_reassigned(self, store):
+        human = _human(101, "Admin", role="admin")
+        initial = await bootstrap_default_workshop(store, [human])
+        async with store.connection.execute("SELECT id FROM channels WHERE kind = 'direct'") as cursor:
+            channel_id = ChannelId(str((await cursor.fetchone())[0]))
+        assignment_id = RuntimeAssignmentId.derived(
+            channel_id,
+            f"runtime-profile:{initial.agent_id}",
+        )
+        await store.append(
+            EventEnvelope.create(
+                event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
+                event_version=1,
+                workshop_id=initial.workshop_id,
+                aggregate_type="runtime_assignment",
+                aggregate_id=assignment_id,
+                occurred_at=datetime.now(UTC),
+                idempotency_key=(
+                    "workshop-bootstrap:v1:runtime-assignment:"
+                    + hashlib.sha256(b"telegram\x00101").hexdigest()
+                ),
+                payload={
+                    "channel_id": channel_id,
+                    "agent_id": initial.agent_id,
+                    "runtime_profile_id": "101",
+                },
+                metadata={"source": "bootstrap"},
+            )
+        )
+        await store.rebuild_projection(CanonicalConversationProjection())
+
+        migrated = await bootstrap_default_workshop(
+            store,
+            [
+                BootstrapHuman(
+                    human.display_name,
+                    human.role,
+                    human.transport,
+                    human.external_subject,
+                    human.external_channel_id,
+                    profile_id(101),
+                )
+            ],
+        )
+
+        assert migrated.created_events == 1
+        assert (await store.read_events())[-1].envelope.event_type == WorkshopEventType.RUNTIME_PROFILE_REASSIGNED
+        async with store.connection.execute(
+            "SELECT runtime_profile_id FROM channel_agent_runtime_assignments"
+        ) as cursor:
+            assert str((await cursor.fetchone())[0]) == profile_id(101)
 
     async def test_input_order_does_not_change_event_or_projection_order(self, tmp_path: Path):
         first_store = await WorkshopEventStore.open(tmp_path / "first.db")
@@ -379,7 +436,7 @@ class TestWorkshopBootstrapStatus:
                         "telegram",
                         "101",
                         "101",
-                        runtime_profile_id="101",
+                        runtime_profile_id=profile_id(101),
                     )
                 ],
             )

--- a/tests/test_workshop_client_access.py
+++ b/tests/test_workshop_client_access.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from kai import webhook, workshop_cli
+from kai.config import Config, UserConfig
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.client_access import WorkshopClientAccess, WorkshopClientAccessError
 from kai.workshop.client_sessions import (
@@ -20,6 +20,7 @@ from kai.workshop.client_sessions import (
 from kai.workshop.domain import ChannelId, DeviceId, EnrollmentGrantId, PrincipalId
 from kai.workshop.human_provisioning import WorkshopHumanProvisioningError
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id
 
 
 async def _store(path: Path) -> WorkshopEventStore:
@@ -290,8 +291,13 @@ class TestWorkshopClientAccessCLI:
         monkeypatch.setattr(
             workshop_cli,
             "load_config",
-            lambda: SimpleNamespace(
-                user_configs={101: SimpleNamespace(telegram_id=101)},
+            lambda: Config(
+                telegram_bot_token="test",
+                allowed_user_ids={101},
+                default_backend="codex",
+                default_provider="openai",
+                default_model="gpt-5.6-sol",
+                user_configs={101: UserConfig(telegram_id=101, name="Alice")},
             ),
         )
         args = workshop_cli._parser().parse_args(
@@ -303,7 +309,7 @@ class TestWorkshopClientAccessCLI:
                 "--channel-id",
                 channel_id,
                 "--runtime-profile-id",
-                "101",
+                profile_id(101),
             ]
         )
 
@@ -312,7 +318,7 @@ class TestWorkshopClientAccessCLI:
         assert f"Principal: {principal_id}" in output
         assert f"Direct channel: {channel_id}" in output
         assert "Agent: agt_" in output
-        assert "Runtime profile: 101" in output
+        assert f"Runtime profile: {profile_id(101)}" in output
         assert "Status: assigned" in output
         assert "not human or transport identity" in output
 

--- a/tests/test_workshop_client_commands.py
+++ b/tests/test_workshop_client_commands.py
@@ -14,6 +14,7 @@ from kai.workshop.execution_coordinator import (
     CanonicalExecutionResult,
 )
 from kai.workshop.inbound import ClientInboundMessage
+from tests.workshop_profiles import profile_id
 
 
 def _message() -> ClientInboundMessage:
@@ -32,7 +33,7 @@ async def test_completed_client_command_preserves_history_session_and_memory(
     message = _message()
     run_id = RunId.new()
     accepted = SimpleNamespace(
-        runtime_profile_id="101",
+        runtime_profile_id=profile_id(101),
         command=SimpleNamespace(disposition=ConversationCommandDisposition.NEWLY_ACCEPTED),
         run=SimpleNamespace(run_id=run_id),
     )
@@ -49,6 +50,7 @@ async def test_completed_client_command_preserves_history_session_and_memory(
     execution = SimpleNamespace(
         accept_client=AsyncMock(return_value=accepted),
         execute=AsyncMock(return_value=execution_result),
+        runtime_config_id=Mock(return_value=101),
     )
     config = SimpleNamespace(
         get_user_config=lambda chat_id: SimpleNamespace(os_user="daniel") if chat_id == 101 else None
@@ -66,6 +68,7 @@ async def test_completed_client_command_preserves_history_session_and_memory(
     assert result.execution is execution_result
     execution.accept_client.assert_awaited_once_with(message)
     execution.execute.assert_awaited_once_with(run_id)
+    execution.runtime_config_id.assert_called_once_with(profile_id(101))
     assert log.call_args_list == [
         call(
             direction="user",
@@ -97,12 +100,13 @@ async def test_terminal_replay_does_not_duplicate_compatibility_writes(monkeypat
     message = _message()
     run_id = RunId.new()
     accepted = SimpleNamespace(
-        runtime_profile_id="101",
+        runtime_profile_id=profile_id(101),
         command=SimpleNamespace(disposition=ConversationCommandDisposition.TERMINAL_REPLAY),
         run=SimpleNamespace(run_id=run_id),
     )
     execution = SimpleNamespace(
         accept_client=AsyncMock(return_value=accepted),
+        runtime_config_id=Mock(return_value=101),
         execute=AsyncMock(
             return_value=CanonicalExecutionResult(
                 CanonicalExecutionDisposition.TERMINAL_REPLAY,

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -24,6 +24,7 @@ from kai.workshop.run_execution_authority import (
 )
 from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
 from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+from tests.workshop_profiles import profile_id
 
 _NOW = datetime(2026, 8, 12, 20, 0, tzinfo=UTC)
 
@@ -70,7 +71,7 @@ async def _open_client_store(
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
-                runtime_profile_id="101",
+                runtime_profile_id=profile_id(101),
             ),
         ),
     )
@@ -317,7 +318,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 7
+            assert checkpoint.version == 8
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body
@@ -346,7 +347,7 @@ class TestAtomicClientConversationCommandAcceptance:
             assert accepted.command.message.inserted is True
             assert accepted.command.lifecycle.changed is True
             assert accepted.delivery.inserted is True
-            assert accepted.runtime_profile_id == "101"
+            assert accepted.runtime_profile_id == profile_id(101)
             assert accepted.delivery is not None
             assert accepted.delivery.delivery.message_id == accepted.command.message.event.envelope.aggregate_id
             assert accepted.delivery.delivery.channel_id == channel_id
@@ -420,7 +421,7 @@ class TestAtomicClientConversationCommandAcceptance:
                     transport="desktop",
                     external_subject="desktop-human",
                     external_channel_id="desktop-human",
-                    runtime_profile_id="101",
+                    runtime_profile_id=profile_id(101),
                 ),
             ),
         )
@@ -437,7 +438,7 @@ class TestAtomicClientConversationCommandAcceptance:
             )
 
             assert accepted.command.disposition == ConversationCommandDisposition.NEWLY_ACCEPTED
-            assert accepted.runtime_profile_id == "101"
+            assert accepted.runtime_profile_id == profile_id(101)
             assert accepted.delivery is None
             async with store.connection.execute(
                 "SELECT event_type FROM event_log WHERE position >= ? ORDER BY position",

--- a/tests/test_workshop_conversation_runs.py
+++ b/tests/test_workshop_conversation_runs.py
@@ -156,9 +156,7 @@ class TestCanonicalRunResolution:
         store = await WorkshopEventStore.open(tmp_path / "kai.db")
         try:
             inbound_id = await _canonical_inbound(store)
-            target = (
-                await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))
-            ).target
+            target = (await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))).target
             second_principal = PrincipalId.new()
             second_agent = AgentId.new()
             await store.connection.execute(

--- a/tests/test_workshop_conversation_runs.py
+++ b/tests/test_workshop_conversation_runs.py
@@ -21,6 +21,7 @@ from kai.workshop.conversation_runs import (
 from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, WorkshopId
 from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
 
 _NOW = datetime(2026, 8, 12, 12, 0, tzinfo=UTC)
 
@@ -35,7 +36,7 @@ async def _canonical_inbound(store: WorkshopEventStore, telegram_id: int = 101) 
                 transport="telegram",
                 external_subject=str(telegram_id),
                 external_channel_id=str(telegram_id),
-                runtime_profile_id=str(telegram_id),
+                runtime_profile_id=profile_id(telegram_id),
             ),
         ),
     )
@@ -70,7 +71,7 @@ class TestCanonicalRunResolution:
         try:
             inbound_id = await _canonical_inbound(store, telegram_id=101)
 
-            resolution = await resolve_canonical_conversation_run(store, inbound_id)
+            resolution = await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))
             target = resolution.target
 
             assert target.inbound_message_id == inbound_id
@@ -78,7 +79,7 @@ class TestCanonicalRunResolution:
             assert isinstance(target.channel_id, ChannelId)
             assert isinstance(target.requested_by_principal_id, PrincipalId)
             assert isinstance(target.agent_id, AgentId)
-            assert resolution._legacy_pool_key == 101
+            assert resolution._runtime_config_id == 101
         finally:
             await store.close()
 
@@ -88,7 +89,7 @@ class TestCanonicalRunResolution:
             await _canonical_inbound(store)
 
             with pytest.raises(ConversationRunUnavailableError, match="one human channel member"):
-                await resolve_canonical_conversation_run(store, MessageId.new())
+                await resolve_canonical_conversation_run(store, MessageId.new(), profile_registry(101))
         finally:
             await store.close()
 
@@ -107,7 +108,7 @@ class TestCanonicalRunResolution:
                         transport="desktop",
                         external_subject="desktop-human",
                         external_channel_id="desktop-human",
-                        runtime_profile_id="202",
+                        runtime_profile_id=profile_id(202),
                     ),
                 ),
             )
@@ -125,9 +126,9 @@ class TestCanonicalRunResolution:
             )
             inbound_id = MessageId(str(inbound.event.envelope.aggregate_id))
 
-            resolution = await resolve_canonical_conversation_run(store, inbound_id)
+            resolution = await resolve_canonical_conversation_run(store, inbound_id, profile_registry(202))
 
-            assert resolution._legacy_pool_key == 202
+            assert resolution._runtime_config_id == 202
             async with store.connection.execute(
                 "SELECT COUNT(*) FROM external_identities WHERE provider = 'telegram'"
             ) as cursor:
@@ -147,7 +148,7 @@ class TestCanonicalRunResolution:
             await store.connection.commit()
 
             with pytest.raises(ConversationRunUnavailableError, match="explicit runtime profile assignment"):
-                await resolve_canonical_conversation_run(store, inbound_id)
+                await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))
         finally:
             await store.close()
 
@@ -155,7 +156,9 @@ class TestCanonicalRunResolution:
         store = await WorkshopEventStore.open(tmp_path / "kai.db")
         try:
             inbound_id = await _canonical_inbound(store)
-            target = (await resolve_canonical_conversation_run(store, inbound_id)).target
+            target = (
+                await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))
+            ).target
             second_principal = PrincipalId.new()
             second_agent = AgentId.new()
             await store.connection.execute(
@@ -173,7 +176,7 @@ class TestCanonicalRunResolution:
             await store.connection.commit()
 
             with pytest.raises(ConversationRunUnavailableError, match="one attached agent"):
-                await resolve_canonical_conversation_run(store, inbound_id)
+                await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))
         finally:
             await store.close()
 
@@ -189,7 +192,7 @@ class TestWorkshopConversationRunService:
                 requested_by_principal_id=PrincipalId.new(),
                 agent_id=AgentId.new(),
             ),
-            _legacy_pool_key=101,
+            _runtime_config_id=101,
         )
         resolver = AsyncMock(return_value=target)
         pool = MagicMock()
@@ -221,7 +224,7 @@ class TestWorkshopConversationRunService:
                 requested_by_principal_id=PrincipalId.new(),
                 agent_id=AgentId.new(),
             ),
-            _legacy_pool_key=101,
+            _runtime_config_id=101,
         )
         pool = MagicMock()
         service = WorkshopConversationRunService(pool, AsyncMock(return_value=target))

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -22,6 +22,7 @@ from kai.workshop.domain import (
     MessageId,
     PrincipalId,
     RuntimeAssignmentId,
+    RuntimeProfileId,
     WorkshopEventType,
     WorkshopId,
 )
@@ -73,6 +74,7 @@ class TestWorkshopIdentifiers:
             (DeliveryId, "msg_00000000000000000000000000000001"),
             (DeliveryAttemptId, "dlv_00000000000000000000000000000001"),
             (RuntimeAssignmentId, "cag_00000000000000000000000000000001"),
+            (RuntimeProfileId, "101"),
             (EventId, "evt_000000000000000000000000000000011"),
         ],
     )
@@ -94,6 +96,7 @@ class TestEventEnvelope:
             "agent.created",
             "channel.agent_attached",
             "runtime_profile.assigned",
+            "runtime_profile.reassigned",
             "message.created",
             "artifact.created",
             "delivery.requested",

--- a/tests/test_workshop_human_provisioning.py
+++ b/tests/test_workshop_human_provisioning.py
@@ -21,13 +21,14 @@ from kai.workshop.human_provisioning import (
 )
 from kai.workshop.inbound import ClientInboundMessage
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id
 
 
 async def _store(path: Path) -> WorkshopEventStore:
     store = await WorkshopEventStore.open(path)
     await bootstrap_default_workshop(
         store,
-        (BootstrapHuman("Alice", "admin", "telegram", "101", "101", "101"),),
+        (BootstrapHuman("Alice", "admin", "telegram", "101", "101", profile_id(101)),),
     )
     return store
 

--- a/tests/test_workshop_parity.py
+++ b/tests/test_workshop_parity.py
@@ -13,6 +13,7 @@ from kai.workshop.domain import MessageId
 from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.outbound import OutboundMessage, record_outbound_message
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id
 
 _NOW = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
 
@@ -48,7 +49,7 @@ async def _build_conversation(db_path: Path) -> None:
                     transport="telegram",
                     external_subject="101",
                     external_channel_id="101",
-                    runtime_profile_id="101",
+                    runtime_profile_id=profile_id(101),
                 ),
             ),
         )

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -19,6 +19,7 @@ from kai.workshop.inbound import InboundMessage
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.run_lifecycle import RunStatus
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
 
 _NOW = datetime(2026, 1, 1, 23, 0, tzinfo=UTC)
 
@@ -64,7 +65,7 @@ async def _foundation(database: Path) -> None:
                     transport="telegram",
                     external_subject="101",
                     external_channel_id="101",
-                    runtime_profile_id="101",
+                    runtime_profile_id=profile_id(101),
                 ),
             ),
         )
@@ -94,6 +95,7 @@ async def test_owner_accepts_executes_and_atomically_enqueues_terminal_reply(tmp
         database,
         pool,  # type: ignore[arg-type]
         registered_backend_ids=frozenset({"codex"}),
+        runtime_profiles=profile_registry(101),
     )
     observed: list[str] = []
     try:
@@ -136,6 +138,7 @@ async def test_owner_routes_stop_to_exact_active_runtime_and_terminal_cancellati
         database,
         pool,  # type: ignore[arg-type]
         registered_backend_ids=frozenset({"codex"}),
+        runtime_profiles=profile_registry(101),
     )
     try:
         accepted = await service.accept(_message())

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -19,6 +19,7 @@ from kai.workshop.protected_execution import (
 )
 from kai.workshop.run_execution_authority import RunExecutionSelection, WorkshopRunExecutionAuthority
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
 
 _NOW = datetime(2026, 8, 12, 21, 0, tzinfo=UTC)
 
@@ -34,7 +35,7 @@ async def _accepted_run(path: Path, home: Path):
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
-                runtime_profile_id="101",
+                runtime_profile_id=profile_id(101),
             ),
         ),
     )
@@ -69,14 +70,14 @@ async def _accepted_run(path: Path, home: Path):
             )
         },
     )
-    return store, accepted.run, SubprocessPool(config=config, services_info=[])
+    return store, accepted.run, SubprocessPool(config=config, services_info=[]), profile_registry(101)
 
 
 class TestProtectedExecutionPreparation:
     async def test_resolves_effective_registered_selection_and_hides_transport_key(self, tmp_path: Path):
         home = tmp_path / "home"
         home.mkdir()
-        store, run, pool = await _accepted_run(tmp_path / "kai.db", home)
+        store, run, pool, profiles = await _accepted_run(tmp_path / "kai.db", home)
         try:
             with (
                 patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
@@ -86,6 +87,7 @@ class TestProtectedExecutionPreparation:
                     store,
                     pool,
                     registered_backend_ids=frozenset({"claude"}),
+                    runtime_profiles=profiles,
                 ).prepare(run.run_id)
 
             assert prepared.run == run
@@ -102,7 +104,7 @@ class TestProtectedExecutionPreparation:
     async def test_unregistered_effective_backend_fails_closed(self, tmp_path: Path):
         home = tmp_path / "home"
         home.mkdir()
-        store, run, pool = await _accepted_run(tmp_path / "kai.db", home)
+        store, run, pool, profiles = await _accepted_run(tmp_path / "kai.db", home)
         try:
             with (
                 patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
@@ -113,6 +115,7 @@ class TestProtectedExecutionPreparation:
                     store,
                     pool,
                     registered_backend_ids=frozenset({"codex"}),
+                    runtime_profiles=profiles,
                 ).prepare(run.run_id)
         finally:
             await pool.shutdown()
@@ -121,7 +124,7 @@ class TestProtectedExecutionPreparation:
     async def test_cancellation_pending_run_never_prepares_a_runtime(self, tmp_path: Path):
         home = tmp_path / "home"
         home.mkdir()
-        store, run, pool = await _accepted_run(tmp_path / "kai.db", home)
+        store, run, pool, profiles = await _accepted_run(tmp_path / "kai.db", home)
         try:
             authority = WorkshopRunExecutionAuthority(
                 store,
@@ -141,6 +144,7 @@ class TestProtectedExecutionPreparation:
                     store,
                     pool,
                     registered_backend_ids=frozenset({"claude"}),
+                    runtime_profiles=profiles,
                 ).prepare(run.run_id)
             prepare.assert_not_awaited()
         finally:

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -366,7 +366,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 7
+            assert checkpoint.version == 8
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -165,7 +165,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 7
+            assert checkpoint.version == 8
             assert after == before
         finally:
             await store.close()

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -17,17 +17,18 @@ from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.runtime_assignments import (
     WorkshopRuntimeAssignmentError,
     WorkshopRuntimeAssignmentService,
-    compatibility_user_id,
     resolve_channel_runtime_profile,
 )
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
 
 
 async def _store(path: Path) -> WorkshopEventStore:
     store = await WorkshopEventStore.open(path)
     await bootstrap_default_workshop(
         store,
-        (BootstrapHuman("Alice", "admin", "telegram", "101", "101", "101"),),
+        (BootstrapHuman("Alice", "admin", "telegram", "101", "101", profile_id(101)),),
     )
     return store
 
@@ -44,17 +45,18 @@ class TestRuntimeAssignmentPolicy:
                 "Charlie",
                 "member",
             )
-            service = WorkshopRuntimeAssignmentService(store)
+            profiles = profile_registry(101, 202)
+            service = WorkshopRuntimeAssignmentService(store, profiles)
 
             assigned = await service.assign(
                 human.principal_id,
                 human.channel_id,
-                "202",
+                profile_id(202),
             )
             retried = await service.assign(
                 human.principal_id,
                 human.channel_id,
-                "202",
+                profile_id(202),
             )
 
             assert assigned.created is True
@@ -62,9 +64,8 @@ class TestRuntimeAssignmentPolicy:
             assert retried.assignment_id == assigned.assignment_id
             assert await resolve_channel_runtime_profile(store, human.channel_id) == (
                 assigned.agent_id,
-                "202",
+                profile_id(202),
             )
-            assert compatibility_user_id("202") == 202
             async with store.connection.execute(
                 "SELECT COUNT(*) FROM external_identities WHERE principal_id = ?",
                 (human.principal_id,),
@@ -83,10 +84,11 @@ class TestRuntimeAssignmentPolicy:
             resolution = await resolve_canonical_conversation_run(
                 store,
                 MessageId(str(accepted.command.message.event.envelope.aggregate_id)),
+                profiles,
             )
 
-            assert accepted.runtime_profile_id == "202"
-            assert resolution._legacy_pool_key == 202
+            assert accepted.runtime_profile_id == profile_id(202)
+            assert resolution._runtime_config_id == 202
         finally:
             await store.close()
 
@@ -106,14 +108,14 @@ class TestRuntimeAssignmentPolicy:
                 "Dana",
                 "member",
             )
-            service = WorkshopRuntimeAssignmentService(store)
+            service = WorkshopRuntimeAssignmentService(store, profile_registry(101, 202))
 
             with pytest.raises(WorkshopRuntimeAssignmentError, match="must own"):
-                await service.assign(charlie.principal_id, dana.channel_id, "202")
+                await service.assign(charlie.principal_id, dana.channel_id, profile_id(202))
 
-            await service.assign(charlie.principal_id, charlie.channel_id, "202")
+            await service.assign(charlie.principal_id, charlie.channel_id, profile_id(202))
             with pytest.raises(WorkshopRuntimeAssignmentError, match="already assigned"):
-                await service.assign(dana.principal_id, dana.channel_id, "202")
+                await service.assign(dana.principal_id, dana.channel_id, profile_id(202))
         finally:
             await store.close()
 
@@ -125,20 +127,20 @@ class TestRuntimeAssignmentPolicy:
                 "Charlie",
                 "member",
             )
-            assigned = await WorkshopRuntimeAssignmentService(store).assign(
+            assigned = await WorkshopRuntimeAssignmentService(store, profile_registry(101, 202)).assign(
                 human.principal_id,
                 human.channel_id,
-                "202",
+                profile_id(202),
             )
             await store.connection.execute("DELETE FROM channel_agent_runtime_assignments")
             await store.connection.commit()
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 7
+            assert checkpoint.version == 8
             assert await resolve_channel_runtime_profile(store, human.channel_id) == (
                 assigned.agent_id,
-                "202",
+                profile_id(202),
             )
         finally:
             await store.close()
@@ -146,6 +148,12 @@ class TestRuntimeAssignmentPolicy:
 
 class TestRuntimeProfileCompatibilityBoundary:
     @pytest.mark.parametrize("value", ("profile-daniel", "0", "01"))
-    def test_current_host_runtime_rejects_non_integer_profile_keys(self, value: str):
-        with pytest.raises(WorkshopRuntimeAssignmentError, match="integer-keyed"):
-            compatibility_user_id(value)
+    def test_protected_registry_rejects_non_profile_ids(self, value: str):
+        with pytest.raises(WorkshopRuntimeProfileError, match="invalid"):
+            profile_registry(101).resolve(value)
+
+    def test_opaque_profile_does_not_encode_runtime_configuration_key(self):
+        profile = profile_registry(202).resolve(profile_id(202))
+
+        assert profile.profile_id != str(profile.runtime_config_id)
+        assert "202" not in profile.profile_id

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -1,0 +1,84 @@
+"""Protected transport-neutral Workshop runtime-profile contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from kai.config import Config, UserConfig
+from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.runtime_profiles import (
+    ProtectedRuntimeProfile,
+    WorkshopRuntimeProfileError,
+    WorkshopRuntimeProfileRegistry,
+    runtime_profile_id_for_config_id,
+)
+
+
+def _config() -> Config:
+    return Config(
+        telegram_bot_token="test",
+        allowed_user_ids={101, 202},
+        default_backend="codex",
+        default_provider="openai",
+        default_model="gpt-5.6-sol",
+        user_configs={
+            101: UserConfig(
+                telegram_id=101,
+                name="Daniel",
+                os_user="daniel",
+                backend="codex",
+            ),
+            202: UserConfig(
+                telegram_id=202,
+                name="Scott",
+                os_user="sellison",
+                backend="claude",
+            ),
+        },
+    )
+
+
+def test_registry_exposes_opaque_stable_profiles_with_protected_policy():
+    first = WorkshopRuntimeProfileRegistry.from_config(_config())
+    second = WorkshopRuntimeProfileRegistry.from_config(_config())
+
+    daniel = first.for_config_id(101)
+    scott = first.for_config_id(202)
+
+    assert isinstance(daniel.profile_id, RuntimeProfileId)
+    assert daniel.profile_id == second.for_config_id(101).profile_id
+    assert daniel.profile_id != scott.profile_id
+    assert daniel.runtime_config_id == 101
+    assert daniel.os_user == "daniel"
+    assert daniel.backend == "codex"
+    assert daniel.provider == "openai"
+    assert scott.os_user == "sellison"
+    assert scott.backend == "claude"
+    assert scott.provider == "anthropic"
+
+
+@pytest.mark.parametrize("value", (0, -1, True, "101"))
+def test_profile_derivation_rejects_non_positive_integer_configuration_ids(value):
+    with pytest.raises(WorkshopRuntimeProfileError, match="positive integer"):
+        runtime_profile_id_for_config_id(value)  # type: ignore[arg-type]
+
+
+def test_registry_rejects_unknown_profile_even_when_it_is_structurally_valid():
+    registry = WorkshopRuntimeProfileRegistry.from_config(_config())
+
+    with pytest.raises(WorkshopRuntimeProfileError, match="protected operator policy"):
+        registry.resolve(RuntimeProfileId.new())
+
+
+def test_registry_rejects_duplicate_configuration_authority():
+    profile = ProtectedRuntimeProfile(
+        runtime_profile_id_for_config_id(101),
+        101,
+        "Daniel",
+        "daniel",
+        "codex",
+        "openai",
+    )
+
+    with pytest.raises(WorkshopRuntimeProfileError, match="Duplicate runtime profile ID"):
+        WorkshopRuntimeProfileRegistry((profile, profile))

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -35,6 +35,7 @@ from kai.workshop.terminal_transactions import (
     TerminalTransactionStateConflictError,
     WorkshopRunTerminalTransactionCoordinator,
 )
+from tests.workshop_profiles import profile_id
 
 _NOW = datetime(2026, 8, 12, 21, 0, tzinfo=UTC)
 
@@ -52,7 +53,7 @@ async def _started_run(
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
-                runtime_profile_id="101",
+                runtime_profile_id=profile_id(101),
             ),
         ),
     )
@@ -102,7 +103,7 @@ async def _started_client_run(
                 transport="telegram",
                 external_subject="101",
                 external_channel_id="101",
-                runtime_profile_id="101",
+                runtime_profile_id=profile_id(101),
             ),
         ),
     )
@@ -152,7 +153,7 @@ async def _started_workshop_only_client_run(
                 transport="desktop",
                 external_subject="desktop-human",
                 external_channel_id="desktop-human",
-                runtime_profile_id="101",
+                runtime_profile_id=profile_id(101),
             ),
         ),
     )

--- a/tests/workshop_profiles.py
+++ b/tests/workshop_profiles.py
@@ -1,0 +1,29 @@
+"""Shared protected runtime-profile fixtures for Workshop tests."""
+
+from __future__ import annotations
+
+from kai.workshop.runtime_profiles import (
+    ProtectedRuntimeProfile,
+    WorkshopRuntimeProfileRegistry,
+    runtime_profile_id_for_config_id,
+)
+
+
+def profile_id(runtime_config_id: int):
+    return runtime_profile_id_for_config_id(runtime_config_id)
+
+
+def profile_registry(*runtime_config_ids: int) -> WorkshopRuntimeProfileRegistry:
+    return WorkshopRuntimeProfileRegistry(
+        tuple(
+            ProtectedRuntimeProfile(
+                profile_id=profile_id(runtime_config_id),
+                runtime_config_id=runtime_config_id,
+                display_name=f"User {runtime_config_id}",
+                os_user=None,
+                backend="codex",
+                provider="openai",
+            )
+            for runtime_config_id in runtime_config_ids
+        )
+    )


### PR DESCRIPTION
## Summary

- introduce a protected Workshop runtime-profile registry with stable opaque
  `rtp_` identifiers
- map canonical runtime assignments to backend/provider and OS execution
  identity only through protected operator configuration
- migrate existing numeric runtime assignments by appending a canonical
  `runtime_profile.reassigned` event
- keep projection rebuilds and deployed-state replay deterministic across the
  migration
- add an operator command to list assignable protected runtime profiles

## Why

Workshop humans are canonical identities and Telegram is now only one client
transport. Runtime authority therefore must not be expressed using a Telegram
user ID. Before this change, a channel-agent assignment stored that numeric
transport identity directly and callers adapted it into the subprocess pool.

This change gives runtime authority its own namespace. Canonical events,
projections, assignment APIs, execution preparation, and operator commands now
use opaque `rtp_` IDs. A structurally valid profile that is not present in the
protected registry fails closed.

## Migration and replay

- new bootstraps write opaque runtime assignments directly
- an installation with the previous numeric bootstrap assignment appends one
  idempotent `runtime_profile.reassigned` event
- the historical assignment remains in the event log
- projection version 8 applies the reassignment only to the matching existing
  channel-agent assignment
- diagnostic replay enforces the same predecessor relationship, so a rebuild
  reproduces the deployed state exactly

## Execution boundary

The registry is built once from protected configuration at startup and is
passed into Workshop execution services. Client submission, canonical run
resolution, and manual runtime assignment cannot convert or select numeric
configuration keys themselves.

For operator inspection, `kai workshop client-access list-runtime-profiles`
lists the opaque ID and its configured display user, OS user, backend, and
provider. `assign-runtime` accepts only an opaque profile registered in that
same protected policy.

## Deliberate remaining compatibility seam

The current host runtime still indexes subprocess pools, settings, files,
history, and memory using the protected configured-user integer key behind the
registry. That key originates in the current `users.yaml` schema. It is no
longer canonical Workshop assignment or caller authority, but replacing those
internal storage namespaces is a separate bounded migration.

## Validation

- `make lint`
- `make typecheck`
- `git diff --check`
- `.venv/bin/python -m pytest -q`
  - 5,582 passed
  - 1 skipped

