### PR TITLE
Workshop: address runtime pool by profile identity

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1927,8 +1927,36 @@ superseded by a canonical `runtime_profile.reassigned` fact during bootstrap,
 so projection rebuilds reproduce the migration exactly.
 
 The current host runtime still uses the protected configured-user integer key
-behind this registry for subprocess pooling, settings, files, history, and
-memory compatibility. That key originates in the present `users.yaml` schema,
-whose primary record key is a Telegram user ID. It is no longer canonical
-Workshop assignment or caller authority, but retiring it from those storage
-namespaces is the next bounded migration seam.
+behind this registry for compatibility settings, files, history, memory, and
+the physical subprocess-pool implementation. That key originates in the
+present `users.yaml` schema, whose primary record key is a Telegram user ID. It
+is no longer canonical Workshop assignment or caller authority. A protected
+profile-addressed pool facade now owns the physical pool conversion; retiring
+the integer from the remaining compatibility storage namespaces is the next
+bounded migration seam.
+
+## 40. Profile-addressed Workshop runtime pool
+
+**Implementation date:** 2026-08-13
+
+Canonical run resolution now returns the channel-agent assignment's opaque
+`rtp_` identifier directly. It does not receive, derive, or expose the
+configured-user integer key. Both durable private-text execution and the
+older Telegram conversation-run bridge address backend preparation, model
+selection, streaming, and workspace resolution through a single
+`WorkshopRuntimePool` facade.
+
+The facade validates every profile against the protected registry before it
+touches the compatibility subprocess pool. It is the only pool boundary that
+converts a Workshop profile to the current configured-user key, so browser and
+Telegram turns for the same runtime profile reuse the same live backend rather
+than creating parallel processes. Unknown or retired profiles fail before any
+pool operation. Application construction must supply the already-built
+protected registry explicitly; the bot factory cannot invent runtime policy.
+
+The subprocess pool itself remains shared with the v2 Telegram compatibility
+application and therefore retains its integer-keyed implementation internally.
+Compatibility history, session, memory, settings, and file operations likewise
+still require that key. Those storage concerns remain behind the profile facade
+and should move one namespace at a time without changing the canonical
+Workshop identity model.

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -99,6 +99,8 @@ from kai.workshop.execution_coordinator import (
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
+from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
 from kai.workspace_utils import is_workspace_allowed
 
@@ -5311,7 +5313,12 @@ async def _handle_response(
 # ── Application factory ─────────────────────────────────────────────
 
 
-def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
+def create_bot(
+    config: Config,
+    *,
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
+    use_webhook: bool = True,
+) -> Application:
     """
     Build and configure the Telegram Application with all handlers.
 
@@ -5327,6 +5334,7 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
 
     Args:
         config: The application Config instance.
+        runtime_profiles: Protected runtime policy constructed by startup.
         use_webhook: If True, suppress the default Updater (updates arrive via
             webhook POST). If False, keep the Updater for long-polling mode.
 
@@ -5354,8 +5362,13 @@ def create_bot(config: Config, *, use_webhook: bool = True) -> Application:
         services_info=services.get_available_services(),
     )
     app.bot_data["pool"] = pool
-    app.bot_data["workshop_conversation_run_service"] = WorkshopConversationRunService(
+    workshop_runtime_pool = WorkshopRuntimePool(
         pool,
+        runtime_profiles,
+    )
+    app.bot_data["workshop_runtime_pool"] = workshop_runtime_pool
+    app.bot_data["workshop_conversation_run_service"] = WorkshopConversationRunService(
+        workshop_runtime_pool,
         sessions.resolve_workshop_conversation_run,
     )
 

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -325,7 +325,11 @@ def _start() -> None:
 
         load_db_registry(await sessions.get_memory_project_rows())
 
-        app = create_bot(config, use_webhook=use_webhook)
+        app = create_bot(
+            config,
+            use_webhook=use_webhook,
+            runtime_profiles=runtime_profiles,
+        )
         conversation_delivery: WorkshopTelegramConversationDeliveryService | None = None
         private_text_execution: WorkshopPrivateTextExecutionService | None = None
 
@@ -437,9 +441,8 @@ def _start() -> None:
 
             private_text_execution = await WorkshopPrivateTextExecutionService.open_and_start(
                 config.session_db_path,
-                app.bot_data["pool"],
+                app.bot_data["workshop_runtime_pool"],
                 registered_backend_ids=_workshop_registered_backend_ids(config),
-                runtime_profiles=runtime_profiles,
             )
             app.bot_data["workshop_private_text_execution"] = private_text_execution
             logging.info("Workshop private-text execution is ready")

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -51,7 +51,7 @@ from kai.workshop.bootstrap import (
     bootstrap_default_workshop,
 )
 from kai.workshop.conversation_runs import (
-    CompatibilityConversationRunResolution,
+    CanonicalConversationRunResolution,
     resolve_canonical_conversation_run,
 )
 from kai.workshop.domain import MessageId
@@ -74,7 +74,6 @@ from kai.workshop.streaming_preview import (
 
 if TYPE_CHECKING:
     from kai.config import Config, WorkspaceConfig
-    from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 
 log = logging.getLogger(__name__)
 
@@ -359,14 +358,13 @@ async def record_workshop_inbound_message(message: InboundMessage) -> AppendResu
 
 async def resolve_workshop_conversation_run(
     inbound_message_id: MessageId,
-    runtime_profiles: WorkshopRuntimeProfileRegistry,
-) -> CompatibilityConversationRunResolution:
+) -> CanonicalConversationRunResolution:
     """Resolve one canonical inbound message for transport-neutral execution."""
     if _workshop_event_lock is None:
         raise RuntimeError("Database not initialized - call init_db() first")
     async with _workshop_event_lock:
         store = WorkshopEventStore.from_initialized_connection(_get_db())
-        return await resolve_canonical_conversation_run(store, inbound_message_id, runtime_profiles)
+        return await resolve_canonical_conversation_run(store, inbound_message_id)
 
 
 async def record_workshop_inbound_artifact(

--- a/src/kai/workshop/conversation_runs.py
+++ b/src/kai/workshop/conversation_runs.py
@@ -8,12 +8,12 @@ from pathlib import Path
 from typing import Protocol
 
 from kai.backend import StreamEvent
-from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, WorkshopId
+from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, RuntimeProfileId, WorkshopId
 from kai.workshop.runtime_assignments import (
     WorkshopRuntimeAssignmentError,
     resolve_channel_runtime_profile,
 )
-from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError, WorkshopRuntimeProfileRegistry
+from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.store import WorkshopEventStore
 
 type AgentPrompt = str | list[dict[str, str]]
@@ -35,21 +35,29 @@ class CanonicalConversationRunTarget:
 
 
 @dataclass(frozen=True, slots=True)
-class CompatibilityConversationRunResolution:
-    """Canonical target plus the private key required by the current pool."""
+class CanonicalConversationRunResolution:
+    """Canonical target plus its explicitly assigned protected runtime."""
 
     target: CanonicalConversationRunTarget
-    _runtime_config_id: int = field(repr=False, compare=False)
+    runtime_profile_id: RuntimeProfileId
 
 
 class ConversationPool(Protocol):
-    """The narrow existing-pool surface hidden behind the run service."""
+    """The narrow profile-addressed runtime surface used by run preparation."""
 
-    def get_model(self, chat_id: int) -> str: ...
+    def get_model(self, runtime_profile_id: str | RuntimeProfileId) -> str: ...
 
-    def send(self, prompt: AgentPrompt, *, chat_id: int) -> AsyncIterator[StreamEvent]: ...
+    def send(
+        self,
+        prompt: AgentPrompt,
+        *,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> AsyncIterator[StreamEvent]: ...
 
-    async def get_effective_workspace(self, chat_id: int) -> Path: ...
+    async def get_effective_workspace(
+        self,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> Path: ...
 
 
 async def resolve_canonical_conversation_target(
@@ -89,15 +97,13 @@ async def resolve_canonical_conversation_target(
 async def resolve_canonical_conversation_run(
     store: WorkshopEventStore,
     inbound_message_id: MessageId,
-    runtime_profiles: WorkshopRuntimeProfileRegistry,
-) -> CompatibilityConversationRunResolution:
-    """Resolve a canonical target plus the current private pool adapter key.
+) -> CanonicalConversationRunResolution:
+    """Resolve a canonical target plus its assigned opaque runtime profile.
 
     The public run request contains only a canonical message ID. During the
-    migration, the channel-agent's protected runtime-profile assignment
-    supplies the existing pool/config key internally. A caller cannot provide
-    or override that key, and human or transport identities are not execution
-    authority.
+    migration, the channel-agent's protected runtime-profile assignment is the
+    only execution identity. Protected pool policy validates and resolves that
+    profile later; human or transport identities are not execution authority.
     """
     target = await resolve_canonical_conversation_target(store, inbound_message_id)
     try:
@@ -106,33 +112,35 @@ async def resolve_canonical_conversation_run(
             target.channel_id,
             target.agent_id,
         )
-        runtime_config_id = runtime_profiles.resolve(runtime_profile_id).runtime_config_id
-    except (WorkshopRuntimeAssignmentError, WorkshopRuntimeProfileError) as exc:
+    except WorkshopRuntimeAssignmentError as exc:
         raise ConversationRunUnavailableError(str(exc)) from exc
 
-    return CompatibilityConversationRunResolution(
+    return CanonicalConversationRunResolution(
         target=target,
-        _runtime_config_id=runtime_config_id,
+        runtime_profile_id=runtime_profile_id,
     )
 
 
 @dataclass(frozen=True, slots=True)
 class PreparedConversationRun:
-    """One canonical run prepared against the current compatibility runtime."""
+    """One canonical run prepared against a protected runtime profile."""
 
     target: CanonicalConversationRunTarget
     model: str
     _pool: ConversationPool = field(repr=False, compare=False)
-    _runtime_config_id: int = field(repr=False, compare=False)
+    _runtime_profile_id: RuntimeProfileId = field(repr=False, compare=False)
 
     async def stream(self, prompt: AgentPrompt) -> AsyncIterator[StreamEvent]:
         """Stream normalized harness events without exposing the pool key."""
-        async for event in self._pool.send(prompt, chat_id=self._runtime_config_id):
+        async for event in self._pool.send(
+            prompt,
+            runtime_profile_id=self._runtime_profile_id,
+        ):
             yield event
 
     async def effective_workspace(self) -> Path:
         """Return the run's effective project workspace through the adapter."""
-        return await self._pool.get_effective_workspace(self._runtime_config_id)
+        return await self._pool.get_effective_workspace(self._runtime_profile_id)
 
 
 class WorkshopConversationRunService:
@@ -140,8 +148,8 @@ class WorkshopConversationRunService:
 
     def __init__(
         self,
-        pool: ConversationPool,
-        resolver: Callable[[MessageId], Awaitable[CompatibilityConversationRunResolution]],
+        pool: WorkshopRuntimePool,
+        resolver: Callable[[MessageId], Awaitable[CanonicalConversationRunResolution]],
     ) -> None:
         self._pool = pool
         self._resolver = resolver
@@ -153,7 +161,7 @@ class WorkshopConversationRunService:
             raise ConversationRunUnavailableError("Run resolver returned a different inbound message")
         return PreparedConversationRun(
             target=target,
-            model=self._pool.get_model(resolution._runtime_config_id),
+            model=self._pool.get_model(resolution.runtime_profile_id),
             _pool=self._pool,
-            _runtime_config_id=resolution._runtime_config_id,
+            _runtime_profile_id=resolution.runtime_profile_id,
         )

--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
-from kai.pool import SubprocessPool
 from kai.workshop.conversation_commands import (
     ClientConversationCommandAcceptance,
     ConversationCommandAcceptance,
@@ -20,7 +19,7 @@ from kai.workshop.execution_coordinator import (
 )
 from kai.workshop.inbound import ClientInboundMessage, InboundMessage
 from kai.workshop.protected_execution import WorkshopProtectedExecutionPreparationService
-from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.store import WorkshopEventStore
 
 _RECOVERY_INTERVAL_SECONDS = 5.0
@@ -35,13 +34,13 @@ class WorkshopPrivateTextExecutionService:
         coordinator: WorkshopCanonicalExecutionCoordinator,
         command_service: WorkshopConversationCommandService,
         database_lock: asyncio.Lock,
-        runtime_profiles: WorkshopRuntimeProfileRegistry,
+        runtime_pool: WorkshopRuntimePool,
     ) -> None:
         self._store = store
         self._coordinator = coordinator
         self._command_service = command_service
         self._database_lock = database_lock
-        self._runtime_profiles = runtime_profiles
+        self._runtime_pool = runtime_pool
         self._stop_event = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
         self._closed = False
@@ -50,10 +49,9 @@ class WorkshopPrivateTextExecutionService:
     async def open_and_start(
         cls,
         database_path: Path,
-        pool: SubprocessPool,
+        runtime_pool: WorkshopRuntimePool,
         *,
         registered_backend_ids: frozenset[str],
-        runtime_profiles: WorkshopRuntimeProfileRegistry,
     ) -> WorkshopPrivateTextExecutionService:
         store = await WorkshopEventStore.open(database_path)
         database_lock = asyncio.Lock()
@@ -61,9 +59,8 @@ class WorkshopPrivateTextExecutionService:
             store,
             WorkshopProtectedExecutionPreparationService(
                 store,
-                pool,
+                runtime_pool,
                 registered_backend_ids=registered_backend_ids,
-                runtime_profiles=runtime_profiles,
             ),
             registered_backend_ids=registered_backend_ids,
             database_lock=database_lock,
@@ -73,7 +70,7 @@ class WorkshopPrivateTextExecutionService:
             coordinator,
             WorkshopConversationCommandService(store),
             database_lock,
-            runtime_profiles,
+            runtime_pool,
         )
         try:
             await coordinator.recover_expired()
@@ -92,7 +89,7 @@ class WorkshopPrivateTextExecutionService:
 
     def runtime_config_id(self, runtime_profile_id: str | RuntimeProfileId) -> int:
         """Resolve compatibility state only through protected profile policy."""
-        return self._runtime_profiles.resolve(runtime_profile_id).runtime_config_id
+        return self._runtime_pool.compatibility_runtime_config_id(runtime_profile_id)
 
     async def accept(self, message: InboundMessage) -> ConversationCommandAcceptance:
         if self._closed:

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -8,12 +8,12 @@ from pathlib import Path
 
 from kai.backend import StreamEvent
 from kai.config import VALID_BACKENDS, validate_model_for_backend
-from kai.pool import PreparedBackendExecution, SubprocessPool
+from kai.pool import PreparedBackendExecution
 from kai.workshop.conversation_runs import resolve_canonical_conversation_run
 from kai.workshop.domain import RunId
 from kai.workshop.run_execution_authority import RunExecutionSelection
 from kai.workshop.run_lifecycle import DurableRun, RunStatus, WorkshopRunLifecycle
-from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.store import WorkshopEventStore
 
 type AgentPrompt = str | list[dict[str, str]]
@@ -50,10 +50,9 @@ class WorkshopProtectedExecutionPreparationService:
     def __init__(
         self,
         store: WorkshopEventStore,
-        pool: SubprocessPool,
+        pool: WorkshopRuntimePool,
         *,
         registered_backend_ids: frozenset[str],
-        runtime_profiles: WorkshopRuntimeProfileRegistry,
     ) -> None:
         if not registered_backend_ids:
             raise ValueError("registered_backend_ids must not be empty")
@@ -63,7 +62,6 @@ class WorkshopProtectedExecutionPreparationService:
         self._store = store
         self._pool = pool
         self._registered_backend_ids = registered_backend_ids
-        self._runtime_profiles = runtime_profiles
 
     async def prepare(self, run_id: RunId) -> PreparedWorkshopExecution:
         if not isinstance(run_id, RunId):
@@ -72,11 +70,7 @@ class WorkshopProtectedExecutionPreparationService:
         if run.status != RunStatus.ACCEPTED or run.cancellation_requested_at is not None:
             raise ProtectedExecutionPreparationError("Only an uncancelled accepted run can prepare execution")
 
-        resolution = await resolve_canonical_conversation_run(
-            self._store,
-            run.inbound_message_id,
-            self._runtime_profiles,
-        )
+        resolution = await resolve_canonical_conversation_run(self._store, run.inbound_message_id)
         target = resolution.target
         if (
             target.workshop_id != run.workshop_id
@@ -86,7 +80,7 @@ class WorkshopProtectedExecutionPreparationService:
         ):
             raise ProtectedExecutionPreparationError("Canonical run authority changed after acceptance")
 
-        runtime = await self._pool.prepare_execution(resolution._runtime_config_id)
+        runtime = await self._pool.prepare_execution(resolution.runtime_profile_id)
         prepared = runtime.selection
         if prepared.backend not in self._registered_backend_ids:
             raise ProtectedExecutionPreparationError("Effective backend is not present in the protected registry")

--- a/src/kai/workshop/runtime_pool.py
+++ b/src/kai/workshop/runtime_pool.py
@@ -1,0 +1,65 @@
+"""Protected runtime-profile facade over Kai's compatibility subprocess pool."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from kai.backend import StreamEvent
+from kai.pool import PreparedBackendExecution, SubprocessPool
+from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+
+type AgentPrompt = str | list[dict[str, str]]
+
+
+class WorkshopRuntimePool:
+    """Address compatibility runtimes only by protected Workshop profile.
+
+    The underlying host pool and compatibility stores still require the
+    configured-user integer key. This facade owns that conversion so canonical
+    run resolution and execution services never receive or select it.
+    """
+
+    def __init__(
+        self,
+        pool: SubprocessPool,
+        profiles: WorkshopRuntimeProfileRegistry,
+    ) -> None:
+        self._pool = pool
+        self._profiles = profiles
+
+    def compatibility_runtime_config_id(
+        self,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> int:
+        """Return the private compatibility key for non-pool migrations."""
+        return self._profiles.resolve(runtime_profile_id).runtime_config_id
+
+    async def prepare_execution(
+        self,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> PreparedBackendExecution:
+        runtime_config_id = self.compatibility_runtime_config_id(runtime_profile_id)
+        return await self._pool.prepare_execution(runtime_config_id)
+
+    def get_model(self, runtime_profile_id: str | RuntimeProfileId) -> str:
+        runtime_config_id = self.compatibility_runtime_config_id(runtime_profile_id)
+        return self._pool.get_model(runtime_config_id)
+
+    async def send(
+        self,
+        prompt: AgentPrompt,
+        *,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> AsyncIterator[StreamEvent]:
+        runtime_config_id = self.compatibility_runtime_config_id(runtime_profile_id)
+        async for event in self._pool.send(prompt, chat_id=runtime_config_id):
+            yield event
+
+    async def get_effective_workspace(
+        self,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> Path:
+        runtime_config_id = self.compatibility_runtime_config_id(runtime_profile_id)
+        return await self._pool.get_effective_workspace(runtime_config_id)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -88,12 +88,14 @@ from kai.workshop.conversation_runs import (
     PreparedConversationRun,
     WorkshopConversationRunService,
 )
-from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, RunId, WorkshopId
+from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, RunId, RuntimeProfileId, WorkshopId
 from kai.workshop.execution_coordinator import CanonicalCancellationDisposition
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
+from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
 from kai.workspace_utils import is_workspace_allowed
+from tests.workshop_profiles import profile_registry
 
 # ── _backend_name_for_instance ───────────────────────────────────────
 
@@ -731,17 +733,17 @@ class TestCreateBotTransportMode:
     def test_webhook_mode_suppresses_updater(self):
         """In webhook mode, the Updater is suppressed (None)."""
         config = _make_config()
-        app = create_bot(config, use_webhook=True)
+        app = create_bot(config, use_webhook=True, runtime_profiles=profile_registry(1))
         assert app.updater is None
 
     def test_polling_mode_keeps_updater(self):
         """In polling mode, the Updater is present for start_polling()."""
         config = _make_config()
-        app = create_bot(config, use_webhook=False)
+        app = create_bot(config, use_webhook=False, runtime_profiles=profile_registry(1))
         assert app.updater is not None
 
     def test_installs_workshop_shadow_recorder(self):
-        app = create_bot(_make_config())
+        app = create_bot(_make_config(), runtime_profiles=profile_registry(1))
 
         assert app.bot_data["workshop_inbound_recorder"] is sessions.record_workshop_inbound_message
         assert app.bot_data["workshop_artifact_recorder"] is sessions.record_workshop_inbound_artifact
@@ -749,10 +751,11 @@ class TestCreateBotTransportMode:
         assert app.bot_data["workshop_delivery_recorder"] is sessions.record_workshop_delivery_observation
         assert app.bot_data["workshop_streaming_preview_recorder"] is sessions.record_workshop_streaming_preview
         assert app.bot_data["workshop_streaming_finalizer"] is sessions.record_workshop_streaming_finalization
+        assert isinstance(app.bot_data["workshop_runtime_pool"], WorkshopRuntimePool)
         assert isinstance(app.bot_data["workshop_conversation_run_service"], WorkshopConversationRunService)
 
     def test_does_not_register_durable_run_lifecycle_before_cutover(self):
-        app = create_bot(_make_config())
+        app = create_bot(_make_config(), runtime_profiles=profile_registry(1))
 
         # The durable lifecycle remains deliberately unregistered until the
         # run-authority cutover gates in the Workshop map are satisfied.
@@ -3786,7 +3789,7 @@ class TestHandleResponse:
             ),
             model="sonnet",
             _pool=pool,
-            _runtime_config_id=12345,
+            _runtime_profile_id=RuntimeProfileId("rtp_00000000000000000000000000000001"),
         )
 
     @pytest.mark.asyncio
@@ -6686,7 +6689,7 @@ class TestCommandMenu:
         from telegram.ext import CommandHandler as CH
 
         config = _make_config()
-        app = create_bot(config)
+        app = create_bot(config, runtime_profiles=profile_registry(1))
 
         # Collect all command names from registered CommandHandlers
         registered: set[str] = set()
@@ -6702,7 +6705,7 @@ class TestCommandMenu:
         """Every command except the narrow recovery set defaults to TOTP."""
         from telegram.ext import CommandHandler as CH
 
-        app = create_bot(_make_config())
+        app = create_bot(_make_config(), runtime_profiles=profile_registry(1))
         callbacks: dict[str, object] = {}
         for group_handlers in app.handlers.values():
             for handler in group_handlers:
@@ -6721,7 +6724,7 @@ class TestCommandMenu:
         """Model, voice, workspace, and memory buttons cannot bypass TOTP."""
         from telegram.ext import CallbackQueryHandler as CQH
 
-        app = create_bot(_make_config())
+        app = create_bot(_make_config(), runtime_profiles=profile_registry(1))
         callbacks = [
             handler.callback
             for group_handlers in app.handlers.values()

--- a/tests/test_workshop_conversation_runs.py
+++ b/tests/test_workshop_conversation_runs.py
@@ -12,8 +12,8 @@ import pytest
 from kai.backend import AgentResponse, StreamEvent
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.conversation_runs import (
+    CanonicalConversationRunResolution,
     CanonicalConversationRunTarget,
-    CompatibilityConversationRunResolution,
     ConversationRunUnavailableError,
     WorkshopConversationRunService,
     resolve_canonical_conversation_run,
@@ -21,7 +21,7 @@ from kai.workshop.conversation_runs import (
 from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, WorkshopId
 from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.store import WorkshopEventStore
-from tests.workshop_profiles import profile_id, profile_registry
+from tests.workshop_profiles import profile_id
 
 _NOW = datetime(2026, 8, 12, 12, 0, tzinfo=UTC)
 
@@ -71,7 +71,7 @@ class TestCanonicalRunResolution:
         try:
             inbound_id = await _canonical_inbound(store, telegram_id=101)
 
-            resolution = await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))
+            resolution = await resolve_canonical_conversation_run(store, inbound_id)
             target = resolution.target
 
             assert target.inbound_message_id == inbound_id
@@ -79,7 +79,7 @@ class TestCanonicalRunResolution:
             assert isinstance(target.channel_id, ChannelId)
             assert isinstance(target.requested_by_principal_id, PrincipalId)
             assert isinstance(target.agent_id, AgentId)
-            assert resolution._runtime_config_id == 101
+            assert resolution.runtime_profile_id == profile_id(101)
         finally:
             await store.close()
 
@@ -89,7 +89,7 @@ class TestCanonicalRunResolution:
             await _canonical_inbound(store)
 
             with pytest.raises(ConversationRunUnavailableError, match="one human channel member"):
-                await resolve_canonical_conversation_run(store, MessageId.new(), profile_registry(101))
+                await resolve_canonical_conversation_run(store, MessageId.new())
         finally:
             await store.close()
 
@@ -126,9 +126,9 @@ class TestCanonicalRunResolution:
             )
             inbound_id = MessageId(str(inbound.event.envelope.aggregate_id))
 
-            resolution = await resolve_canonical_conversation_run(store, inbound_id, profile_registry(202))
+            resolution = await resolve_canonical_conversation_run(store, inbound_id)
 
-            assert resolution._runtime_config_id == 202
+            assert resolution.runtime_profile_id == profile_id(202)
             async with store.connection.execute(
                 "SELECT COUNT(*) FROM external_identities WHERE provider = 'telegram'"
             ) as cursor:
@@ -148,7 +148,7 @@ class TestCanonicalRunResolution:
             await store.connection.commit()
 
             with pytest.raises(ConversationRunUnavailableError, match="explicit runtime profile assignment"):
-                await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))
+                await resolve_canonical_conversation_run(store, inbound_id)
         finally:
             await store.close()
 
@@ -156,7 +156,7 @@ class TestCanonicalRunResolution:
         store = await WorkshopEventStore.open(tmp_path / "kai.db")
         try:
             inbound_id = await _canonical_inbound(store)
-            target = (await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))).target
+            target = (await resolve_canonical_conversation_run(store, inbound_id)).target
             second_principal = PrincipalId.new()
             second_agent = AgentId.new()
             await store.connection.execute(
@@ -174,7 +174,7 @@ class TestCanonicalRunResolution:
             await store.connection.commit()
 
             with pytest.raises(ConversationRunUnavailableError, match="one attached agent"):
-                await resolve_canonical_conversation_run(store, inbound_id, profile_registry(101))
+                await resolve_canonical_conversation_run(store, inbound_id)
         finally:
             await store.close()
 
@@ -182,7 +182,7 @@ class TestCanonicalRunResolution:
 class TestWorkshopConversationRunService:
     async def test_hides_compatibility_key_behind_canonical_request(self):
         inbound_id = MessageId.new()
-        target = CompatibilityConversationRunResolution(
+        target = CanonicalConversationRunResolution(
             target=CanonicalConversationRunTarget(
                 inbound_message_id=inbound_id,
                 workshop_id=WorkshopId.new(),
@@ -190,7 +190,7 @@ class TestWorkshopConversationRunService:
                 requested_by_principal_id=PrincipalId.new(),
                 agent_id=AgentId.new(),
             ),
-            _runtime_config_id=101,
+            runtime_profile_id=profile_id(101),
         )
         resolver = AsyncMock(return_value=target)
         pool = MagicMock()
@@ -204,9 +204,12 @@ class TestWorkshopConversationRunService:
         workspace = await prepared.effective_workspace()
 
         resolver.assert_awaited_once_with(inbound_id)
-        pool.get_model.assert_called_once_with(101)
-        pool.send.assert_called_once_with("hello", chat_id=101)
-        pool.get_effective_workspace.assert_awaited_once_with(101)
+        pool.get_model.assert_called_once_with(profile_id(101))
+        pool.send.assert_called_once_with(
+            "hello",
+            runtime_profile_id=profile_id(101),
+        )
+        pool.get_effective_workspace.assert_awaited_once_with(profile_id(101))
         assert prepared.target.inbound_message_id == inbound_id
         assert prepared.model == "gpt-5.6-sol"
         assert events[0].response is not None and events[0].response.text == "Done."
@@ -214,7 +217,7 @@ class TestWorkshopConversationRunService:
 
     async def test_rejects_resolver_substitution(self):
         requested_id = MessageId.new()
-        target = CompatibilityConversationRunResolution(
+        target = CanonicalConversationRunResolution(
             target=CanonicalConversationRunTarget(
                 inbound_message_id=MessageId.new(),
                 workshop_id=WorkshopId.new(),
@@ -222,7 +225,7 @@ class TestWorkshopConversationRunService:
                 requested_by_principal_id=PrincipalId.new(),
                 agent_id=AgentId.new(),
             ),
-            _runtime_config_id=101,
+            runtime_profile_id=profile_id(101),
         )
         pool = MagicMock()
         service = WorkshopConversationRunService(pool, AsyncMock(return_value=target))

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -18,6 +18,7 @@ from kai.workshop.execution_coordinator import (
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.run_lifecycle import RunStatus
+from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id, profile_registry
 
@@ -93,9 +94,8 @@ async def test_owner_accepts_executes_and_atomically_enqueues_terminal_reply(tmp
     pool = SimpleNamespace(prepare_execution=AsyncMock(return_value=runtime))
     service = await WorkshopPrivateTextExecutionService.open_and_start(
         database,
-        pool,  # type: ignore[arg-type]
+        WorkshopRuntimePool(pool, profile_registry(101)),  # type: ignore[arg-type]
         registered_backend_ids=frozenset({"codex"}),
-        runtime_profiles=profile_registry(101),
     )
     observed: list[str] = []
     try:
@@ -136,9 +136,8 @@ async def test_owner_routes_stop_to_exact_active_runtime_and_terminal_cancellati
     pool = SimpleNamespace(prepare_execution=AsyncMock(return_value=runtime))
     service = await WorkshopPrivateTextExecutionService.open_and_start(
         database,
-        pool,  # type: ignore[arg-type]
+        WorkshopRuntimePool(pool, profile_registry(101)),  # type: ignore[arg-type]
         registered_backend_ids=frozenset({"codex"}),
-        runtime_profiles=profile_registry(101),
     )
     try:
         accepted = await service.accept(_message())

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -18,6 +18,7 @@ from kai.workshop.protected_execution import (
     WorkshopProtectedExecutionPreparationService,
 )
 from kai.workshop.run_execution_authority import RunExecutionSelection, WorkshopRunExecutionAuthority
+from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id, profile_registry
 
@@ -85,9 +86,8 @@ class TestProtectedExecutionPreparation:
             ):
                 prepared = await WorkshopProtectedExecutionPreparationService(
                     store,
-                    pool,
+                    WorkshopRuntimePool(pool, profiles),
                     registered_backend_ids=frozenset({"claude"}),
-                    runtime_profiles=profiles,
                 ).prepare(run.run_id)
 
             assert prepared.run == run
@@ -113,9 +113,8 @@ class TestProtectedExecutionPreparation:
             ):
                 await WorkshopProtectedExecutionPreparationService(
                     store,
-                    pool,
+                    WorkshopRuntimePool(pool, profiles),
                     registered_backend_ids=frozenset({"codex"}),
-                    runtime_profiles=profiles,
                 ).prepare(run.run_id)
         finally:
             await pool.shutdown()
@@ -142,9 +141,8 @@ class TestProtectedExecutionPreparation:
             ):
                 await WorkshopProtectedExecutionPreparationService(
                     store,
-                    pool,
+                    WorkshopRuntimePool(pool, profiles),
                     registered_backend_ids=frozenset({"claude"}),
-                    runtime_profiles=profiles,
                 ).prepare(run.run_id)
             prepare.assert_not_awaited()
         finally:

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -84,11 +84,10 @@ class TestRuntimeAssignmentPolicy:
             resolution = await resolve_canonical_conversation_run(
                 store,
                 MessageId(str(accepted.command.message.event.envelope.aggregate_id)),
-                profiles,
             )
 
             assert accepted.runtime_profile_id == profile_id(202)
-            assert resolution._runtime_config_id == 202
+            assert resolution.runtime_profile_id == profile_id(202)
         finally:
             await store.close()
 

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -1,0 +1,64 @@
+"""Protected profile-addressed Workshop runtime-pool contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kai.backend import AgentResponse, StreamEvent
+from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError
+from tests.workshop_profiles import profile_id, profile_registry
+
+
+async def _events():
+    yield StreamEvent(
+        text_so_far="Done.",
+        done=True,
+        response=AgentResponse(text="Done.", success=True),
+    )
+
+
+async def test_profile_facade_owns_every_compatibility_pool_conversion():
+    runtime = SimpleNamespace(selection="selection", workspace=Path("/srv/project"))
+    pool = MagicMock()
+    pool.prepare_execution = AsyncMock(return_value=runtime)
+    pool.get_model.return_value = "gpt-5.6-sol"
+    pool.send.return_value = _events()
+    pool.get_effective_workspace = AsyncMock(return_value=Path("/srv/project"))
+    profiles = WorkshopRuntimePool(pool, profile_registry(101))
+
+    prepared = await profiles.prepare_execution(profile_id(101))
+    model = profiles.get_model(profile_id(101))
+    events = [event async for event in profiles.send("hello", runtime_profile_id=profile_id(101))]
+    workspace = await profiles.get_effective_workspace(profile_id(101))
+
+    assert prepared is runtime
+    assert model == "gpt-5.6-sol"
+    assert events[0].response is not None and events[0].response.text == "Done."
+    assert workspace == Path("/srv/project")
+    pool.prepare_execution.assert_awaited_once_with(101)
+    pool.get_model.assert_called_once_with(101)
+    pool.send.assert_called_once_with("hello", chat_id=101)
+    pool.get_effective_workspace.assert_awaited_once_with(101)
+
+
+async def test_unknown_profile_fails_before_touching_compatibility_pool():
+    pool = MagicMock()
+    profiles = WorkshopRuntimePool(pool, profile_registry(101))
+
+    with pytest.raises(WorkshopRuntimeProfileError, match="protected operator policy"):
+        await profiles.prepare_execution(RuntimeProfileId.new())
+
+    pool.prepare_execution.assert_not_called()
+
+
+def test_profile_facade_does_not_expose_transport_named_methods():
+    profiles = WorkshopRuntimePool(MagicMock(), profile_registry(101))
+
+    assert not hasattr(profiles, "chat_id")
+    assert not hasattr(profiles, "telegram_user_id")


### PR DESCRIPTION
## Summary

- add one process-wide, profile-addressed `WorkshopRuntimePool` facade
- make canonical run resolution return only its assigned opaque `rtp_` ID
- route durable browser execution and the Telegram conversation bridge through
  the same protected facade and underlying backend instance
- require startup to supply protected runtime policy explicitly to the bot
  factory
- keep legacy Telegram-only pool callers unchanged during the transition

## Why

After #899, canonical assignments used transport-neutral runtime profile IDs,
but run resolution immediately translated them back into the integer key used
by `users.yaml` and the compatibility subprocess pool. That allowed a Telegram-
shaped implementation detail to leak back into Workshop execution services.

This PR moves that conversion to one protected boundary. Canonical resolution,
prepared runs, protected execution, cancellation, model selection, streaming,
and workspace lookup now carry only an opaque runtime profile ID.

## Runtime boundary

Startup constructs one protected runtime registry, passes it explicitly into
the bot factory, and installs one `WorkshopRuntimePool` over the existing
`SubprocessPool`. Both Workshop execution routes use that exact facade:

- durable private-text execution used by browser and Telegram clients
- the older Telegram conversation-run bridge retained during migration

The facade validates each `rtp_` ID against protected operator policy before
touching the compatibility pool. Unknown or retired profiles fail before any
pool operation. A browser turn and a Telegram turn assigned to the same
profile resolve to the same underlying subprocess; this does not create a
second backend instance.

## Compatibility boundary

The physical `SubprocessPool` remains integer-keyed because it is still shared
with v2 Telegram-only handlers. Compatibility history, sessions, memory,
settings, and file namespaces also still use that protected configured-user
key. Those details are now behind the profile facade and can be migrated one
namespace at a time without changing canonical Workshop authority.

## Construction safety

`create_bot()` no longer attempts to rebuild or infer runtime profiles. Its
caller must provide the already-built protected registry, preventing the bot
factory from becoming a second runtime-policy source.

## Validation

- `make check`
- `make typecheck`
- `git diff --check`
- broader Workshop and bot suite: 909 passed
- full suite: 5,585 passed, 1 skipped

