### PR TITLE
Address Workshop compatibility state by runtime profile

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -83,6 +83,7 @@ from kai.workshop.client_sessions import (
     WorkshopClientSessionManager,
 )
 from kai.workshop.client_shell import register_workshop_shell_routes
+from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.store import WorkshopEventStore
 
 log = logging.getLogger(__name__)
@@ -2590,10 +2591,16 @@ async def start(telegram_app, config) -> None:
     private_text_execution = telegram_app.bot_data.get("workshop_private_text_execution")
     if private_text_execution is None:
         raise RuntimeError("Workshop private-text execution service is unavailable")
+    workshop_runtime_pool = telegram_app.bot_data.get("workshop_runtime_pool")
+    if workshop_runtime_pool is None:
+        raise RuntimeError("Workshop runtime pool is unavailable")
     register_workshop_routes = await _register_workshop_client_api(
         _app,
         Path(config.session_db_path),
-        command_submitter=WorkshopClientCommandExecutor(private_text_execution, config),
+        command_submitter=WorkshopClientCommandExecutor(
+            private_text_execution,
+            WorkshopCompatibilityStateWriter(config, workshop_runtime_pool),
+        ),
     )
 
     _runner = web.AppRunner(_app, access_log=None)

--- a/src/kai/workshop/client_commands.py
+++ b/src/kai/workshop/client_commands.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from kai import sessions
-from kai.config import Config
-from kai.conversation_compatibility import reader_user, schedule_memory_ingestion
-from kai.history import log_message
+from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.conversation_commands import (
     ClientConversationCommandAcceptance,
     ConversationCommandDisposition,
@@ -32,21 +29,18 @@ class WorkshopClientCommandExecutor:
     def __init__(
         self,
         execution: WorkshopPrivateTextExecutionService,
-        config: Config,
+        compatibility_state: WorkshopCompatibilityStateWriter,
     ) -> None:
         self._execution = execution
-        self._config = config
+        self._compatibility_state = compatibility_state
 
     async def submit(self, message: ClientInboundMessage) -> ClientCommandResult:
         accepted = await self._execution.accept_client(message)
-        runtime_config_id = self._execution.runtime_config_id(accepted.runtime_profile_id)
-        mapped_reader = reader_user(self._config, runtime_config_id)
+        compatibility_state = self._compatibility_state.for_profile(accepted.runtime_profile_id)
         user_log = (
-            log_message(
+            compatibility_state.append_history(
                 direction="user",
-                chat_id=runtime_config_id,
                 text=message.body,
-                reader_user=mapped_reader,
             )
             if accepted.command.disposition == ConversationCommandDisposition.NEWLY_ACCEPTED
             else None
@@ -54,21 +48,20 @@ class WorkshopClientCommandExecutor:
 
         result = await self._execution.execute(accepted.run.run_id)
         if result.terminal is not None:
-            assistant_log = log_message(
+            assistant_log = compatibility_state.append_history(
                 direction="assistant",
-                chat_id=runtime_config_id,
                 text=result.terminal.body,
-                reader_user=mapped_reader,
             )
             if result.session_id and result.selection is not None:
-                await sessions.save_session(runtime_config_id, result.session_id, result.selection.model)
+                await compatibility_state.save_session(
+                    result.session_id,
+                    result.selection.model,
+                )
             if result.disposition == CanonicalExecutionDisposition.COMPLETED and result.workspace is not None:
-                schedule_memory_ingestion(
+                compatibility_state.schedule_memory_ingestion(
                     prompt=message.body,
                     assistant_text=result.terminal.body,
-                    chat_id=runtime_config_id,
                     session_id=result.session_id,
-                    config=self._config,
                     workspace=result.workspace,
                     user_log=user_log,
                     assistant_log=assistant_log,

--- a/src/kai/workshop/compatibility_state.py
+++ b/src/kai/workshop/compatibility_state.py
@@ -1,0 +1,81 @@
+"""Profile-addressed writes to Kai's remaining compatibility state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from kai import sessions
+from kai.config import Config
+from kai.conversation_compatibility import reader_user, schedule_memory_ingestion
+from kai.history import LogEntry, log_message
+from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.runtime_pool import WorkshopRuntimePool
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopProfileCompatibilityState:
+    """Write existing state for one protected runtime profile.
+
+    The integer key is deliberately private to this adapter. Existing JSONL,
+    session, and semantic-memory namespaces remain unchanged while canonical
+    Workshop callers address the state only through a runtime profile.
+    """
+
+    _runtime_config_id: int = field(repr=False)
+    _config: Config = field(repr=False)
+    _reader_user: str | None = field(repr=False)
+
+    def append_history(self, *, direction: str, text: str) -> LogEntry | None:
+        return log_message(
+            direction=direction,
+            chat_id=self._runtime_config_id,
+            text=text,
+            reader_user=self._reader_user,
+        )
+
+    async def save_session(self, session_id: str, model: str) -> None:
+        await sessions.save_session(self._runtime_config_id, session_id, model)
+
+    def schedule_memory_ingestion(
+        self,
+        *,
+        prompt: str | list,
+        assistant_text: str,
+        session_id: str | None,
+        workspace: str,
+        user_log: LogEntry | None,
+        assistant_log: LogEntry | None,
+    ) -> None:
+        schedule_memory_ingestion(
+            prompt=prompt,
+            assistant_text=assistant_text,
+            chat_id=self._runtime_config_id,
+            session_id=session_id,
+            config=self._config,
+            workspace=workspace,
+            user_log=user_log,
+            assistant_log=assistant_log,
+        )
+
+
+class WorkshopCompatibilityStateWriter:
+    """Bind protected runtime profiles to unchanged compatibility stores."""
+
+    def __init__(
+        self,
+        config: Config,
+        runtime_pool: WorkshopRuntimePool,
+    ) -> None:
+        self._config = config
+        self._runtime_pool = runtime_pool
+
+    def for_profile(
+        self,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> WorkshopProfileCompatibilityState:
+        runtime_config_id = self._runtime_pool.compatibility_runtime_config_id(runtime_profile_id)
+        return WorkshopProfileCompatibilityState(
+            runtime_config_id,
+            self._config,
+            reader_user(self._config, runtime_config_id),
+        )

--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -10,7 +10,7 @@ from kai.workshop.conversation_commands import (
     ConversationCommandAcceptance,
     WorkshopConversationCommandService,
 )
-from kai.workshop.domain import RunId, RuntimeProfileId
+from kai.workshop.domain import RunId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
     CanonicalExecutionResult,
@@ -86,10 +86,6 @@ class WorkshopPrivateTextExecutionService:
     @property
     def ready(self) -> bool:
         return not self._closed and self._task is not None and not self._task.done()
-
-    def runtime_config_id(self, runtime_profile_id: str | RuntimeProfileId) -> int:
-        """Resolve compatibility state only through protected profile policy."""
-        return self._runtime_pool.compatibility_runtime_config_id(runtime_profile_id)
 
     async def accept(self, message: InboundMessage) -> ConversationCommandAcceptance:
         if self._closed:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2379,6 +2379,7 @@ class TestNotificationChatIdMutations:
         telegram_app.bot_data = {
             "pool": MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
             "workshop_private_text_execution": AsyncMock(),
+            "workshop_runtime_pool": MagicMock(),
         }
 
         fake_runner = MagicMock()
@@ -2435,6 +2436,7 @@ class TestNotificationChatIdMutations:
         telegram_app.bot_data = {
             "pool": MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
             "workshop_private_text_execution": AsyncMock(),
+            "workshop_runtime_pool": MagicMock(),
         }
 
         apps: list[web.Application] = []

--- a/tests/test_workshop_client_commands.py
+++ b/tests/test_workshop_client_commands.py
@@ -27,9 +27,7 @@ def _message() -> ClientInboundMessage:
     )
 
 
-async def test_completed_client_command_preserves_history_session_and_memory(
-    monkeypatch,
-):
+async def test_completed_client_command_preserves_history_session_and_memory():
     message = _message()
     run_id = RunId.new()
     accepted = SimpleNamespace(
@@ -50,53 +48,43 @@ async def test_completed_client_command_preserves_history_session_and_memory(
     execution = SimpleNamespace(
         accept_client=AsyncMock(return_value=accepted),
         execute=AsyncMock(return_value=execution_result),
-        runtime_config_id=Mock(return_value=101),
     )
-    config = SimpleNamespace(
-        get_user_config=lambda chat_id: SimpleNamespace(os_user="daniel") if chat_id == 101 else None
+    profile_state = SimpleNamespace(
+        append_history=Mock(side_effect=["user-log", "assistant-log"]),
+        save_session=AsyncMock(),
+        schedule_memory_ingestion=Mock(),
     )
-    log = Mock(side_effect=["user-log", "assistant-log"])
-    save_session = AsyncMock()
-    schedule = Mock()
-    monkeypatch.setattr("kai.workshop.client_commands.log_message", log)
-    monkeypatch.setattr("kai.workshop.client_commands.sessions.save_session", save_session)
-    monkeypatch.setattr("kai.workshop.client_commands.schedule_memory_ingestion", schedule)
+    compatibility_state = SimpleNamespace(for_profile=Mock(return_value=profile_state))
 
-    result = await WorkshopClientCommandExecutor(execution, config).submit(message)
+    result = await WorkshopClientCommandExecutor(execution, compatibility_state).submit(message)
 
     assert result.acceptance is accepted
     assert result.execution is execution_result
     execution.accept_client.assert_awaited_once_with(message)
     execution.execute.assert_awaited_once_with(run_id)
-    execution.runtime_config_id.assert_called_once_with(profile_id(101))
-    assert log.call_args_list == [
+    compatibility_state.for_profile.assert_called_once_with(profile_id(101))
+    assert profile_state.append_history.call_args_list == [
         call(
             direction="user",
-            chat_id=101,
             text="Hello from Workshop",
-            reader_user="daniel",
         ),
         call(
             direction="assistant",
-            chat_id=101,
             text="Completed through the protected lane",
-            reader_user="daniel",
         ),
     ]
-    save_session.assert_awaited_once_with(101, "session-1", "gpt-5.6-sol")
-    schedule.assert_called_once_with(
+    profile_state.save_session.assert_awaited_once_with("session-1", "gpt-5.6-sol")
+    profile_state.schedule_memory_ingestion.assert_called_once_with(
         prompt="Hello from Workshop",
         assistant_text="Completed through the protected lane",
-        chat_id=101,
         session_id="session-1",
-        config=config,
         workspace="/workspace/project",
         user_log="user-log",
         assistant_log="assistant-log",
     )
 
 
-async def test_terminal_replay_does_not_duplicate_compatibility_writes(monkeypatch):
+async def test_terminal_replay_does_not_duplicate_compatibility_writes():
     message = _message()
     run_id = RunId.new()
     accepted = SimpleNamespace(
@@ -106,7 +94,6 @@ async def test_terminal_replay_does_not_duplicate_compatibility_writes(monkeypat
     )
     execution = SimpleNamespace(
         accept_client=AsyncMock(return_value=accepted),
-        runtime_config_id=Mock(return_value=101),
         execute=AsyncMock(
             return_value=CanonicalExecutionResult(
                 CanonicalExecutionDisposition.TERMINAL_REPLAY,
@@ -114,16 +101,16 @@ async def test_terminal_replay_does_not_duplicate_compatibility_writes(monkeypat
             )
         ),
     )
-    config = SimpleNamespace(get_user_config=lambda _chat_id: None)
-    log = Mock()
-    save_session = AsyncMock()
-    schedule = Mock()
-    monkeypatch.setattr("kai.workshop.client_commands.log_message", log)
-    monkeypatch.setattr("kai.workshop.client_commands.sessions.save_session", save_session)
-    monkeypatch.setattr("kai.workshop.client_commands.schedule_memory_ingestion", schedule)
+    profile_state = SimpleNamespace(
+        append_history=Mock(),
+        save_session=AsyncMock(),
+        schedule_memory_ingestion=Mock(),
+    )
+    compatibility_state = SimpleNamespace(for_profile=Mock(return_value=profile_state))
 
-    await WorkshopClientCommandExecutor(execution, config).submit(message)
+    await WorkshopClientCommandExecutor(execution, compatibility_state).submit(message)
 
-    log.assert_not_called()
-    save_session.assert_not_awaited()
-    schedule.assert_not_called()
+    compatibility_state.for_profile.assert_called_once_with(profile_id(101))
+    profile_state.append_history.assert_not_called()
+    profile_state.save_session.assert_not_awaited()
+    profile_state.schedule_memory_ingestion.assert_not_called()

--- a/tests/test_workshop_compatibility_state.py
+++ b/tests/test_workshop_compatibility_state.py
@@ -1,0 +1,68 @@
+"""Tests for profile-addressed compatibility-state writes."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, call
+
+from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
+from tests.workshop_profiles import profile_id
+
+
+async def test_profile_state_preserves_existing_storage_keys(monkeypatch):
+    config = SimpleNamespace(
+        get_user_config=lambda runtime_config_id: (
+            SimpleNamespace(os_user="daniel") if runtime_config_id == 101 else None
+        )
+    )
+    runtime_pool = SimpleNamespace(compatibility_runtime_config_id=Mock(return_value=101))
+    log = Mock(side_effect=["user-log", "assistant-log"])
+    save_session = AsyncMock()
+    schedule = Mock()
+    monkeypatch.setattr("kai.workshop.compatibility_state.log_message", log)
+    monkeypatch.setattr(
+        "kai.workshop.compatibility_state.sessions.save_session",
+        save_session,
+    )
+    monkeypatch.setattr(
+        "kai.workshop.compatibility_state.schedule_memory_ingestion",
+        schedule,
+    )
+
+    state = WorkshopCompatibilityStateWriter(config, runtime_pool).for_profile(profile_id(101))
+    user_log = state.append_history(direction="user", text="Hello")
+    assistant_log = state.append_history(direction="assistant", text="Hi")
+    await state.save_session("session-1", "gpt-5.6-sol")
+    state.schedule_memory_ingestion(
+        prompt="Hello",
+        assistant_text="Hi",
+        session_id="session-1",
+        workspace="/workspace/project",
+        user_log=user_log,
+        assistant_log=assistant_log,
+    )
+
+    runtime_pool.compatibility_runtime_config_id.assert_called_once_with(profile_id(101))
+    assert log.call_args_list == [
+        call(
+            direction="user",
+            chat_id=101,
+            text="Hello",
+            reader_user="daniel",
+        ),
+        call(
+            direction="assistant",
+            chat_id=101,
+            text="Hi",
+            reader_user="daniel",
+        ),
+    ]
+    save_session.assert_awaited_once_with(101, "session-1", "gpt-5.6-sol")
+    schedule.assert_called_once_with(
+        prompt="Hello",
+        assistant_text="Hi",
+        chat_id=101,
+        session_id="session-1",
+        config=config,
+        workspace="/workspace/project",
+        user_log="user-log",
+        assistant_log="assistant-log",
+    )


### PR DESCRIPTION
## Summary

- add a profile-addressed Workshop compatibility-state writer for history,
  session, and semantic-memory side effects
- keep numeric configured-user keys private to the compatibility adapter while
  preserving the existing JSONL, SQLite, and memory namespaces
- remove the numeric compatibility-key escape hatch from canonical private-text
  execution and compose the writer from the process-wide runtime pool
- pin the legacy storage contract and browser-command behavior with focused
  tests

## Why

Canonical Workshop commands already resolve protected runtime profiles before
execution, but the browser command executor converted that profile back into a
numeric configured-user ID and then wrote compatibility state directly. That
made a transport-facing canonical service aware of a legacy identity key and
spread the transitional mapping across another component.

This change keeps canonical callers profile-addressed. One compatibility
adapter now owns the temporary conversion and performs the unchanged writes.
It is deliberately not a storage migration: existing history paths, session
rows, memory user IDs, and reader ownership continue to use the same keys, so
installed systems retain their current history, sessions, and memory.

## Verification

- `make check`
- focused Workshop compatibility/runtime tests: 8 passed
- Workshop client API, shell, webhook, and command integration tests: 146
  passed
- complete suite: 5,586 passed, 1 skipped

## Installation impact

No configuration or data migration is required. After merge, the normal
`make install` flow is sufficient.
