### PR TITLE
Key compatibility history by Workshop channel

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -35,7 +35,7 @@ from kai.config import (
     get_user_backend_and_provider,
     validate_model_for_backend,
 )
-from kai.history import get_recent_history
+from kai.history import get_recent_history, history_search_directories
 
 log = logging.getLogger(__name__)
 
@@ -518,19 +518,33 @@ def build_session_context(
     if ws_prompt:
         parts.append(f"## Workspace Instructions\n\n{ws_prompt}")
 
-    # Always inject the per-user history directory path so the inner
-    # agent's grep/jq searches are naturally scoped to this user.
-    history_dir = str(data_dir / "history" / str(chat_id)) if chat_id is not None else str(data_dir / "history")
+    # Always inject the canonical per-channel history path so inner-agent
+    # grep/jq searches remain transport-independent. The old numeric tree is
+    # advertised only as a read-only archive while historical logs age out.
+    if chat_id is not None:
+        history_dirs = history_search_directories(
+            chat_id,
+            history_root=data_dir / "history",
+        )
+    else:
+        history_dirs = (data_dir / "history",)
+    history_dir = str(history_dirs[0])
+    history_archive_note = (
+        f" Earlier logs may remain in the read-only compatibility archive {history_dirs[1]}/."
+        if len(history_dirs) > 1
+        else ""
+    )
 
     # Inject recent conversation history for continuity.
     # Filter by chat_id so each user's session only sees their
     # own messages (Phase 2 per-user data isolation).
     recent = get_recent_history(chat_id=chat_id)
     if recent:
-        parts.append(f"[Recent conversations (search {history_dir}/ for full logs):]\n{recent}")
+        parts.append(f"[Recent conversations (search {history_dir}/ for full logs).{history_archive_note}]\n{recent}")
     else:
         parts.append(
-            f"[Chat history is stored in {history_dir}/ as daily JSONL files. Search with grep or jq when asked about past conversations.]"
+            f"[Chat history is stored in {history_dir}/ as daily JSONL files."
+            f"{history_archive_note} Search with grep or jq when asked about past conversations.]"
         )
 
     # Inject scheduling API info (always, so cron works from any workspace).

--- a/src/kai/history.py
+++ b/src/kai/history.py
@@ -6,8 +6,9 @@ Provides functionality to:
 2. Retrieve recent messages for injection into new Claude sessions
 3. Serve as the "episodic memory" layer of Kai's three-layer memory system
 
-Log files are stored in per-user subdirectories under DATA_DIR/history/
-(e.g., DATA_DIR/history/<chat_id>/2026-02-11.jsonl). Each line is a JSON
+Log files are stored in per-channel subdirectories under DATA_DIR/history/
+(e.g., DATA_DIR/history/<channel_id>/2026-02-11.jsonl). During the Workshop
+transition, readers also consult the prior transport-keyed directory. Each line is a JSON
 object with fields:
     ts       — ISO 8601 timestamp
     dir      — "user" or "assistant"
@@ -27,7 +28,8 @@ import os
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Literal
+from pathlib import Path
+from typing import Literal, Protocol, runtime_checkable
 
 from kai.config import DATA_DIR
 from kai.named_access import grant_named_read_access
@@ -39,6 +41,25 @@ log = logging.getLogger(__name__)
 # PROJECT_ROOT/history/. Intentionally NOT updated when workspace switches -
 # all conversation history stays in one canonical location.
 _LOG_DIR = DATA_DIR / "history"
+
+
+class _ChannelHistoryNamespace(Protocol):
+    channel_id: str
+    _legacy_chat_id: int
+
+
+@runtime_checkable
+class ChannelHistoryNamespaceResolver(Protocol):
+    """Narrow boundary supplied by Workshop after canonical bootstrap."""
+
+    def for_compatibility_chat_id(self, chat_id: int) -> _ChannelHistoryNamespace: ...
+
+
+class HistoryNamespaceResolutionError(RuntimeError):
+    """A compatibility key cannot resolve to canonical channel storage."""
+
+
+_CHANNEL_HISTORY_REGISTRY: ChannelHistoryNamespaceResolver | None = None
 
 # Limits for the recent-history summary injected at session start
 _MAX_RECENT_MESSAGES = 20
@@ -103,6 +124,78 @@ class LogEntry:
     sha256: str
 
 
+def configure_channel_history_namespaces(
+    registry: ChannelHistoryNamespaceResolver | None,
+) -> None:
+    """Install the canonical channel resolver used by compatibility history.
+
+    Production configures this once after Workshop bootstrap. Passing ``None``
+    is reserved for isolated tests and local compatibility tools; a running
+    protected service never falls back to creating transport-keyed trees.
+    """
+    global _CHANNEL_HISTORY_REGISTRY
+    if registry is not None and not isinstance(registry, ChannelHistoryNamespaceResolver):
+        raise TypeError("registry must implement ChannelHistoryNamespaceResolver")
+    _CHANNEL_HISTORY_REGISTRY = registry
+
+
+def history_search_directories(
+    chat_id: int,
+    *,
+    history_root: Path | None = None,
+) -> tuple[Path, ...]:
+    """Return canonical-first search paths for one compatibility chat key."""
+    root = _LOG_DIR if history_root is None else history_root
+    registry = _CHANNEL_HISTORY_REGISTRY
+    if registry is None:
+        return (root / str(chat_id),)
+    try:
+        namespace = registry.for_compatibility_chat_id(chat_id)
+    except Exception as exc:
+        raise HistoryNamespaceResolutionError("Compatibility chat ID has no canonical history namespace") from exc
+    canonical = root / str(namespace.channel_id)
+    legacy = root / str(namespace._legacy_chat_id)
+    return (canonical,) if canonical == legacy else (canonical, legacy)
+
+
+def _history_files_by_date(
+    chat_id: int,
+    *,
+    include_flat_legacy: bool,
+) -> list[tuple[str, list[Path]]]:
+    """Group canonical and compatibility JSONL files by date, newest first."""
+    grouped: dict[str, list[Path]] = {}
+    for directory in history_search_directories(chat_id):
+        if not directory.is_dir() or directory.is_symlink():
+            continue
+        for path in directory.glob("*.jsonl"):
+            if path.is_file() and not path.is_symlink():
+                grouped.setdefault(path.name, []).append(path)
+    if include_flat_legacy:
+        for path in _LOG_DIR.glob("*.jsonl"):
+            if path.is_file() and not path.is_symlink():
+                grouped.setdefault(path.name, []).append(path)
+    return [(name, sorted(paths)) for name, paths in sorted(grouped.items(), reverse=True)]
+
+
+def _read_history_day(chat_id: int, date: str) -> tuple[Literal["ok", "missing", "unreadable"], list[dict]]:
+    """Read and chronologically merge one day across canonical and legacy trees."""
+    paths = [directory / f"{date}.jsonl" for directory in history_search_directories(chat_id)]
+    existing = [path for path in paths if path.exists()]
+    if not existing:
+        return "missing", []
+    records: list[dict] = []
+    for path in existing:
+        if path.is_symlink() or not path.is_file():
+            return "unreadable", []
+        parsed = _read_jsonl_file(path)
+        if parsed is None:
+            return "unreadable", []
+        records.extend(parsed)
+    records.sort(key=lambda record: str(record.get("ts", "")))
+    return "ok", records
+
+
 def log_message(
     *,
     direction: str,
@@ -135,10 +228,14 @@ def log_message(
         reader_user: Optional mapped OS user allowed to search this user's
             otherwise service-private history.
     """
-    # Per-user subdirectory: DATA_DIR/history/<chat_id>/YYYY-MM-DD.jsonl
-    # Separates users on disk so grep/jq searches are naturally scoped
-    # and one user's history can be managed independently.
-    user_dir = _LOG_DIR / str(chat_id)
+    # Canonical per-channel directory. When the protected service has a
+    # namespace registry, failure to resolve is fatal to this write: silently
+    # recreating a numeric directory would reverse the migration boundary.
+    try:
+        user_dir = history_search_directories(chat_id)[0]
+    except HistoryNamespaceResolutionError:
+        log.exception("Failed to resolve canonical chat history namespace")
+        return None
     # Single `now` call so the ts written into the record and the date
     # baked into the filename can never drift across a midnight boundary
     # within one log_message invocation. The returned LogEntry carries
@@ -251,48 +348,49 @@ def get_recent_history(chat_id: int | None = None) -> str:
         return ""
 
     if chat_id is not None:
-        # Scan only this user's subdirectory for per-user isolation.
-        user_dir = _LOG_DIR / str(chat_id)
-        files = sorted(user_dir.glob("*.jsonl"), reverse=True) if user_dir.exists() else []
-        # Also include legacy flat files (pre-per-user migration) - the
-        # chat_id filter in the parsing loop handles mixed records correctly.
-        # These age out naturally as new writes go to per-user directories.
-        legacy = [f for f in _LOG_DIR.glob("*.jsonl") if f.is_file()]
-        files = sorted(set(files) | set(legacy), key=lambda p: p.name, reverse=True)
+        try:
+            file_groups = _history_files_by_date(chat_id, include_flat_legacy=True)
+        except HistoryNamespaceResolutionError:
+            log.exception("Failed to resolve canonical chat history namespace")
+            return ""
     else:
         # Scan all user directories (backward compat / admin view).
         # Sort by filename (date) not full path, so files from different
         # user directories on the same date interleave chronologically.
         files = sorted(_LOG_DIR.rglob("*.jsonl"), key=lambda p: p.name, reverse=True)
+        file_groups = [(path.name, [path]) for path in files]
 
-    if not files:
+    if not file_groups:
         return ""
 
     # Read files newest-first, collecting messages until we have enough.
     # We read entire files since individual files are small (one day of chat),
     # then take the last N from the combined pool.
     messages: list[dict] = []
-    for path in files:
+    for _date_name, paths in file_groups:
         file_messages: list[dict] = []
-        try:
-            raw = path.read_text(encoding="utf-8")
-        except OSError:
-            log.exception("Failed to read history file %s", path)
-            continue
-        for line in raw.splitlines():
-            if line.strip():
-                try:
-                    record = json.loads(line)
-                    # Skip messages from other users when filtering.
-                    # Records without a chat_id field predate Phase 2
-                    # and are included for all users (see docstring note).
-                    record_chat_id = record.get("chat_id")
-                    if chat_id is not None and record_chat_id is not None and record_chat_id != chat_id:
-                        continue
-                    file_messages.append(record)
-                except json.JSONDecodeError:
-                    # Skip individual bad lines rather than discarding the whole file
-                    log.debug("Skipping malformed JSON line in %s: %s", path.name, line[:100])
+        for path in paths:
+            try:
+                raw = path.read_text(encoding="utf-8")
+            except OSError:
+                log.exception("Failed to read history file %s", path)
+                continue
+            for line in raw.splitlines():
+                if line.strip():
+                    try:
+                        record = json.loads(line)
+                        # Skip messages from other users when filtering.
+                        # Records without a chat_id field predate Phase 2
+                        # and are included for all users (see docstring note).
+                        record_chat_id = record.get("chat_id")
+                        if chat_id is not None and record_chat_id is not None and record_chat_id != chat_id:
+                            continue
+                        file_messages.append(record)
+                    except json.JSONDecodeError:
+                        # Skip individual bad lines rather than discarding the whole file
+                        log.debug("Skipping malformed JSON line in %s: %s", path.name, line[:100])
+
+        file_messages.sort(key=lambda record: str(record.get("ts", "")))
 
         # Prepend this file's messages (older days go before newer days)
         messages = file_messages + messages
@@ -390,17 +488,18 @@ def get_recent_pairs(chat_id: int, n: int) -> list[tuple[str, str]]:
     if not _LOG_DIR.exists():
         return []
 
-    # Per-user subdirectory; ignore legacy flat files entirely. The
+    # Canonical channel directory plus the prior transport-keyed directory;
+    # ignore legacy flat files entirely. The
     # classifier path's strictness on chat_id provenance means
     # admin-restored backups in user_dir are also filtered out below
     # (records without `chat_id` are dropped) so even a misplaced
     # legacy file in the wrong subdirectory cannot leak across users.
-    user_dir = _LOG_DIR / str(chat_id)
-    if not user_dir.exists():
+    try:
+        file_groups = _history_files_by_date(chat_id, include_flat_legacy=False)
+    except HistoryNamespaceResolutionError:
+        log.exception("Failed to resolve canonical chat history namespace")
         return []
-
-    files = sorted(user_dir.glob("*.jsonl"), reverse=True)  # newest first
-    if not files:
+    if not file_groups:
         return []
 
     # Collect filtered records, building oldest-first by prepending
@@ -416,46 +515,35 @@ def get_recent_pairs(chat_id: int, n: int) -> list[tuple[str, str]]:
     # stays cheap even on heavy users.
     records: list[dict] = []
     pairs: list[tuple[str, str]] = []
-    for path in files:
+    for _date_name, paths in file_groups:
         file_records: list[dict] = []
-        try:
-            raw = path.read_text(encoding="utf-8")
-        except OSError:
-            log.exception("Failed to read history file %s", path)
-            continue
-        for line in raw.splitlines():
-            if not line.strip():
-                continue
+        for path in paths:
             try:
-                rec = json.loads(line)
-            except json.JSONDecodeError:
-                # Skip individual bad lines rather than discarding the
-                # whole file - matches the existing get_recent_history
-                # tolerance for partial corruption.
-                log.debug("Skipping malformed JSON line in %s", path.name)
+                raw = path.read_text(encoding="utf-8")
+            except OSError:
+                log.exception("Failed to read history file %s", path)
                 continue
-            # Drop records without a `chat_id` field (legacy pre-Phase-2).
-            # Greenfield divergence from get_recent_history: the
-            # classifier path needs strict provenance; legacy records
-            # have no way to confirm they belong to this chat.
-            if "chat_id" not in rec:
-                continue
-            # User partition: drop records belonging to other chats.
-            # Possible if a backup/restore mis-placed a file, or if a
-            # future operator action stages JSONL across chats.
-            if rec.get("chat_id") != chat_id:
-                continue
-            text = (rec.get("text") or "").strip()
-            if not text:
-                continue
-            direction = rec.get("dir")
-            # Synthetic-marker filter applies only to assistant records.
-            # A user message that quotes one of the marker shapes is
-            # legitimate prior context (the anchored regex shape catches
-            # only exact full-line matches; quoted prose is safe).
-            if direction == "assistant" and _SYNTHETIC_ASSISTANT_MARKERS.fullmatch(text):
-                continue
-            file_records.append({"dir": direction, "text": text})
+            for line in raw.splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    # Skip individual bad lines rather than discarding the
+                    # whole file - matches the existing get_recent_history
+                    # tolerance for partial corruption.
+                    log.debug("Skipping malformed JSON line in %s", path.name)
+                    continue
+                if "chat_id" not in rec or rec.get("chat_id") != chat_id:
+                    continue
+                text = (rec.get("text") or "").strip()
+                if not text:
+                    continue
+                direction = rec.get("dir")
+                if direction == "assistant" and _SYNTHETIC_ASSISTANT_MARKERS.fullmatch(text):
+                    continue
+                file_records.append({"dir": direction, "text": text, "ts": rec.get("ts", "")})
+        file_records.sort(key=lambda record: str(record.get("ts", "")))
         # Prepend so the running list stays oldest-first across files,
         # then re-pair. Pair count grows monotonically as we add
         # older records (newer pairs already exist; older records can
@@ -722,12 +810,15 @@ def fetch_transcript_context(
     user_text_sha256: str = provenance.user_text_sha256
     assistant_ts: str | None = provenance.assistant_ts
 
-    primary_path = _LOG_DIR / str(chat_id) / f"{date}.jsonl"
-    if not primary_path.exists():
+    try:
+        primary_status, primary_records = _read_history_day(chat_id, date)
+    except HistoryNamespaceResolutionError:
         _emit_drift_log(memory_id=memory_id, chat_id=chat_id, reason="file_missing")
         return TranscriptLookup(reason="file_missing", context=None)
-    primary_records = _read_jsonl_file(primary_path)
-    if primary_records is None:
+    if primary_status == "missing":
+        _emit_drift_log(memory_id=memory_id, chat_id=chat_id, reason="file_missing")
+        return TranscriptLookup(reason="file_missing", context=None)
+    if primary_status == "unreadable":
         _emit_drift_log(memory_id=memory_id, chat_id=chat_id, reason="unreadable")
         return TranscriptLookup(reason="unreadable", context=None)
 
@@ -753,9 +844,8 @@ def fetch_transcript_context(
         # (episode midnight cross) before giving up.
         assistant_index = _find_record_index(primary_records, ts=assistant_ts, direction="assistant")
         if assistant_index is None:
-            forward_path = _LOG_DIR / str(chat_id) / f"{_shift_date(date, 1)}.jsonl"
-            forward_records = _read_jsonl_file(forward_path) if forward_path.exists() else None
-            if forward_records is not None:
+            forward_status, forward_records = _read_history_day(chat_id, _shift_date(date, 1))
+            if forward_status == "ok":
                 forward_assistant_index = _find_record_index(forward_records, ts=assistant_ts, direction="assistant")
                 if forward_assistant_index is not None:
                     rec = forward_records[forward_assistant_index]
@@ -835,16 +925,14 @@ def _collect_before(
         if len(collected) >= before:
             break
     if len(collected) < before:
-        prev_path = _LOG_DIR / str(chat_id) / f"{_shift_date(date, -1)}.jsonl"
-        if prev_path.exists():
-            prev_records = _read_jsonl_file(prev_path)
-            if prev_records is not None:
-                for rec in reversed(prev_records):
-                    if _turn_is_synthetic(rec.get("text", "")):
-                        continue
-                    collected.append(_to_turn(rec))
-                    if len(collected) >= before:
-                        break
+        prev_status, prev_records = _read_history_day(chat_id, _shift_date(date, -1))
+        if prev_status == "ok":
+            for rec in reversed(prev_records):
+                if _turn_is_synthetic(rec.get("text", "")):
+                    continue
+                collected.append(_to_turn(rec))
+                if len(collected) >= before:
+                    break
     collected.reverse()
     return collected
 
@@ -893,23 +981,21 @@ def _collect_after(
         # any "after" turns following that assistant in the next file
         # itself, which is the same path the same-day branch would have
         # taken if the assistant lived locally.
-        next_path = _LOG_DIR / str(chat_id) / f"{_shift_date(date, 1)}.jsonl"
-        if next_path.exists():
-            next_records = _read_jsonl_file(next_path)
-            if next_records is not None:
-                # When the target_assistant lives in next_records, start
-                # after it; otherwise start at the beginning of the file.
-                start = 0
-                if target_assistant is not None:
-                    forward_assistant_index = _find_record_index(
-                        next_records, ts=target_assistant.ts, direction="assistant"
-                    )
-                    if forward_assistant_index is not None:
-                        start = forward_assistant_index + 1
-                for rec in next_records[start:]:
-                    if _turn_is_synthetic(rec.get("text", "")):
-                        continue
-                    collected.append(_to_turn(rec))
-                    if len(collected) >= after:
-                        break
+        next_status, next_records = _read_history_day(chat_id, _shift_date(date, 1))
+        if next_status == "ok":
+            # When the target_assistant lives in next_records, start
+            # after it; otherwise start at the beginning of the file.
+            start = 0
+            if target_assistant is not None:
+                forward_assistant_index = _find_record_index(
+                    next_records, ts=target_assistant.ts, direction="assistant"
+                )
+                if forward_assistant_index is not None:
+                    start = forward_assistant_index + 1
+            for rec in next_records[start:]:
+                if _turn_is_synthetic(rec.get("text", "")):
+                    continue
+                collected.append(_to_turn(rec))
+                if len(collected) >= after:
+                    break
     return collected

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -29,6 +29,7 @@ import pwd
 import re
 import secrets
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -3836,6 +3837,53 @@ def _secure_history_directories(
     print(f"  Secured conversation history under {history_root}")
 
 
+def _canonical_storage_reader_users(
+    data_path: Path,
+    legacy_reader_users: dict[str, str],
+) -> dict[str, str]:
+    """Map canonical principal/channel directories to their agent OS reader."""
+    db_path = data_path / "kai.db"
+    if db_path.is_symlink() or not db_path.is_file():
+        return {}
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            required = {
+                "channels",
+                "channel_bindings",
+                "channel_memberships",
+                "principals",
+            }
+            if not tables >= required:
+                return {}
+            rows = connection.execute(
+                "SELECT c.id, p.id, cb.external_channel_id "
+                "FROM channels c "
+                "JOIN channel_bindings cb ON cb.channel_id = c.id AND cb.transport = 'telegram' "
+                "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
+                "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+                "WHERE c.kind = 'direct'"
+            ).fetchall()
+        finally:
+            connection.close()
+    except sqlite3.Error:
+        # Database integrity is checked separately by the migration path.
+        # This compatibility lookup is optional for pre-Workshop databases.
+        return {}
+    canonical: dict[str, str] = {}
+    for channel_id, principal_id, external_channel_id in rows:
+        reader = legacy_reader_users.get(str(external_channel_id))
+        if reader is None:
+            continue
+        canonical[str(channel_id)] = reader
+        canonical[str(principal_id)] = reader
+    return canonical
+
+
 def _managed_identity_state(user_home: Path) -> tuple[Path, Path, str | None, str | None]:
     """Inspect and validate one managed user's canonical/compatibility files.
 
@@ -4039,6 +4087,9 @@ def _apply_migrate(
         per_user_ids[str(chat_id)] = (pwd_entry.pw_uid, pwd_entry.pw_gid)
         reader_users[str(chat_id)] = os_user
     known_user_dir_names = {str(chat_id) for chat_id, _os_user in memory_owners if chat_id is not None}
+    canonical_reader_users = _canonical_storage_reader_users(data_path, reader_users)
+    reader_users.update(canonical_reader_users)
+    known_user_dir_names.update(name for name in canonical_reader_users if name.startswith("prn_"))
 
     # Resolve the primary operator's chat_id (first yaml entry). When
     # users.yaml is absent or empty (first-ever install, single-user

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -320,6 +320,14 @@ def _start() -> None:
             "Workshop principal storage ready (namespaces=%d)",
             len(principal_storage.namespaces),
         )
+        channel_history = await sessions.load_workshop_channel_history_registry(runtime_profiles)
+        from kai.history import configure_channel_history_namespaces
+
+        configure_channel_history_namespaces(channel_history)
+        logging.info(
+            "Workshop channel history ready (namespaces=%d)",
+            len(channel_history.namespaces),
+        )
 
         # Load user-registered memory projects into the detection
         # cache. Must follow init_db (the rows live in the session

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -65,7 +65,10 @@ from kai.workshop.outbound import (
     record_outbound_message_with_streaming_finalization,
 )
 from kai.workshop.schema import migrate_workshop_schema
-from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
+from kai.workshop.storage_namespaces import (
+    WorkshopChannelHistoryRegistry,
+    WorkshopPrincipalStorageRegistry,
+)
 from kai.workshop.store import AppendResult, WorkshopEventStore
 from kai.workshop.streaming_preview import (
     ConfirmedTelegramStreamingPreview,
@@ -358,6 +361,20 @@ async def load_workshop_principal_storage_registry(
     async with _workshop_event_lock:
         store = WorkshopEventStore.from_initialized_connection(_get_db())
         return await WorkshopPrincipalStorageRegistry.from_store(
+            store,
+            runtime_profiles,
+        )
+
+
+async def load_workshop_channel_history_registry(
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
+) -> WorkshopChannelHistoryRegistry:
+    """Resolve canonical channel histories on Kai's initialized database."""
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        store = WorkshopEventStore.from_initialized_connection(_get_db())
+        return await WorkshopChannelHistoryRegistry.from_store(
             store,
             runtime_profiles,
         )

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from kai.workshop.domain import (
+    ChannelId,
     EventEnvelope,
     EventId,
     PrincipalId,
@@ -505,71 +506,91 @@ def _projection_mismatches(connection: sqlite3.Connection, replayed: _ReplayStat
     return len(actual), mismatches
 
 
-def _read_legacy_keys(history_root: Path, external_channel_id: str) -> tuple[list[tuple[str, str]], int, int]:
+def _read_legacy_keys(
+    history_root: Path,
+    external_channel_id: str,
+    channel_id: str,
+) -> tuple[list[tuple[str, str]], int, int]:
     if not _TELEGRAM_SUBJECT_PATTERN.fullmatch(external_channel_id):
+        return [], 0, 1
+    try:
+        canonical_channel_id = ChannelId(channel_id)
+    except (TypeError, ValueError):
         return [], 0, 1
     if history_root.is_symlink():
         return [], 0, 1
-    history_dir = history_root / external_channel_id
-    if history_dir.is_symlink():
-        return [], 0, 1
-    if not history_dir.is_dir():
-        return [], 0, 0
+    history_dirs = (
+        history_root / str(canonical_channel_id),
+        history_root / external_channel_id,
+    )
 
     keys: list[tuple[str, str]] = []
     pending_user_turn: bool | None = None
     malformed = 0
     unreadable = 0
-    for path in sorted(history_dir.glob("*.jsonl")):
-        if path.is_symlink():
+    records: list[dict] = []
+    for history_dir in history_dirs:
+        if history_dir.is_symlink():
             unreadable += 1
             continue
-        try:
-            lines = path.read_text(encoding="utf-8").splitlines()
-        except (OSError, UnicodeError):
+        if not history_dir.exists():
+            continue
+        if not history_dir.is_dir():
             unreadable += 1
             continue
-        for line in lines:
-            if not line.strip():
+        for path in sorted(history_dir.glob("*.jsonl")):
+            if path.is_symlink():
+                unreadable += 1
                 continue
             try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                malformed += 1
+                lines = path.read_text(encoding="utf-8").splitlines()
+            except (OSError, UnicodeError):
+                unreadable += 1
                 continue
-            if not isinstance(record, dict):
-                malformed += 1
-                continue
-            direction = record.get("dir")
-            text = record.get("text")
-            chat_id = record.get("chat_id")
-            if direction not in {"user", "assistant"} or not isinstance(text, str):
-                continue
-            if str(chat_id) != external_channel_id:
-                continue
-            if direction == "user":
-                media = record.get("media")
-                is_shadowed_message = media is None or (
-                    isinstance(media, dict)
-                    and media.get("type") in {"photo", "document", "voice"}
-                    and media.get("workshop_message_shadowed") is True
-                )
-                # Only the most recent user record can own the next ordinary
-                # assistant record. Abandoned historical turns must not queue
-                # indefinitely and suppress otherwise valid later history.
-                pending_user_turn = is_shadowed_message
-                if is_shadowed_message:
-                    keys.append((direction, hashlib.sha256(text.encode("utf-8")).hexdigest()))
-                continue
-            if text.startswith(_SCHEDULED_ASSISTANT_PREFIXES):
-                continue
-            if pending_user_turn is None:
-                continue
-            shadowed_turn = pending_user_turn
-            pending_user_turn = None
-            if not shadowed_turn or _SYNTHETIC_ASSISTANT_PATTERN.fullmatch(text):
-                continue
-            keys.append((direction, hashlib.sha256(text.encode("utf-8")).hexdigest()))
+            for line in lines:
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    malformed += 1
+                    continue
+                if not isinstance(record, dict):
+                    malformed += 1
+                    continue
+                records.append(record)
+    records.sort(key=lambda record: str(record.get("ts", "")))
+    for record in records:
+        direction = record.get("dir")
+        text = record.get("text")
+        chat_id = record.get("chat_id")
+        if direction not in {"user", "assistant"} or not isinstance(text, str):
+            continue
+        if str(chat_id) != external_channel_id:
+            continue
+        if direction == "user":
+            media = record.get("media")
+            is_shadowed_message = media is None or (
+                isinstance(media, dict)
+                and media.get("type") in {"photo", "document", "voice"}
+                and media.get("workshop_message_shadowed") is True
+            )
+            # Only the most recent user record can own the next ordinary
+            # assistant record. Abandoned historical turns must not queue
+            # indefinitely and suppress otherwise valid later history.
+            pending_user_turn = is_shadowed_message
+            if is_shadowed_message:
+                keys.append((direction, hashlib.sha256(text.encode("utf-8")).hexdigest()))
+            continue
+        if text.startswith(_SCHEDULED_ASSISTANT_PREFIXES):
+            continue
+        if pending_user_turn is None:
+            continue
+        shadowed_turn = pending_user_turn
+        pending_user_turn = None
+        if not shadowed_turn or _SYNTHETIC_ASSISTANT_PATTERN.fullmatch(text):
+            continue
+        keys.append((direction, hashlib.sha256(text.encode("utf-8")).hexdigest()))
     return keys, malformed, unreadable
 
 
@@ -650,6 +671,7 @@ def _legacy_parity(
         legacy_keys, channel_malformed, channel_unreadable = _read_legacy_keys(
             history_root,
             bindings[channel_id],
+            channel_id,
         )
         malformed += channel_malformed
         unreadable += channel_unreadable

--- a/src/kai/workshop/storage_namespaces.py
+++ b/src/kai/workshop/storage_namespaces.py
@@ -5,13 +5,134 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from kai.workshop.domain import PrincipalId, RuntimeProfileId
+from kai.workshop.domain import ChannelId, PrincipalId, RuntimeProfileId
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 from kai.workshop.store import WorkshopEventStore
 
 
 class WorkshopStorageNamespaceError(RuntimeError):
     """Protected runtime policy cannot resolve one canonical storage owner."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopChannelHistoryNamespace:
+    """One canonical channel's transitional transcript namespace."""
+
+    channel_id: ChannelId
+    _legacy_chat_id: int = field(repr=False)
+
+    def history_directory(self, data_dir: Path) -> Path:
+        """Return the transport-independent conversation-history directory."""
+        return data_dir / "history" / str(self.channel_id)
+
+    def legacy_history_directory(self, data_dir: Path) -> Path:
+        """Return the prior transport-keyed history directory during migration."""
+        return data_dir / "history" / str(self._legacy_chat_id)
+
+
+class WorkshopChannelHistoryRegistry:
+    """Resolve compatibility chat keys to canonical channel histories.
+
+    Telegram chat IDs remain adapter inputs while the compatibility runtime is
+    being retired. They are never used as new directory names once this
+    registry is configured. Runtime configuration IDs are also accepted as
+    aliases for direct-channel execution initiated by a non-Telegram client.
+    """
+
+    def __init__(
+        self,
+        namespaces: tuple[WorkshopChannelHistoryNamespace, ...],
+        *,
+        runtime_aliases: dict[int, ChannelId] | None = None,
+    ) -> None:
+        by_channel: dict[ChannelId, WorkshopChannelHistoryNamespace] = {}
+        by_compatibility_id: dict[int, WorkshopChannelHistoryNamespace] = {}
+        for namespace in namespaces:
+            if not isinstance(namespace, WorkshopChannelHistoryNamespace):
+                raise TypeError("namespaces must contain WorkshopChannelHistoryNamespace values")
+            if namespace.channel_id in by_channel:
+                raise WorkshopStorageNamespaceError("Duplicate channel history namespace")
+            existing = by_compatibility_id.get(namespace._legacy_chat_id)
+            if existing is not None and existing.channel_id != namespace.channel_id:
+                raise WorkshopStorageNamespaceError("Compatibility chat ID maps to multiple channels")
+            by_channel[namespace.channel_id] = namespace
+            by_compatibility_id[namespace._legacy_chat_id] = namespace
+        for compatibility_id, channel_id in (runtime_aliases or {}).items():
+            namespace = by_channel.get(channel_id)
+            if namespace is None:
+                raise WorkshopStorageNamespaceError("Runtime history alias references an unknown channel")
+            existing = by_compatibility_id.get(compatibility_id)
+            if existing is not None and existing.channel_id != channel_id:
+                raise WorkshopStorageNamespaceError("Compatibility chat ID maps to multiple channels")
+            by_compatibility_id[compatibility_id] = namespace
+        if not by_channel:
+            raise WorkshopStorageNamespaceError("At least one channel history namespace is required")
+        self._by_channel = by_channel
+        self._by_compatibility_id = by_compatibility_id
+
+    @classmethod
+    async def from_store(
+        cls,
+        store: WorkshopEventStore,
+        runtime_profiles: WorkshopRuntimeProfileRegistry,
+    ) -> WorkshopChannelHistoryRegistry:
+        """Resolve transport bindings and protected runtimes to channels."""
+        async with store.connection.execute(
+            "SELECT c.id, cb.external_channel_id "
+            "FROM channels c JOIN channel_bindings cb ON cb.channel_id = c.id "
+            "WHERE cb.transport = 'telegram' ORDER BY c.id"
+        ) as cursor:
+            binding_rows = list(await cursor.fetchall())
+
+        namespaces: list[WorkshopChannelHistoryNamespace] = []
+        for row in binding_rows:
+            try:
+                channel_id = ChannelId(str(row[0]))
+                legacy_chat_id = int(str(row[1]))
+            except (TypeError, ValueError) as exc:
+                raise WorkshopStorageNamespaceError(
+                    "Telegram channel history binding contains an invalid identifier"
+                ) from exc
+            if legacy_chat_id == 0:
+                raise WorkshopStorageNamespaceError("Telegram channel history binding cannot use chat ID zero")
+            namespaces.append(WorkshopChannelHistoryNamespace(channel_id, legacy_chat_id))
+
+        async with store.connection.execute(
+            "SELECT runtime_profile_id, channel_id FROM channel_agent_runtime_assignments ORDER BY runtime_profile_id"
+        ) as cursor:
+            assignment_rows = list(await cursor.fetchall())
+        channel_by_profile: dict[RuntimeProfileId, ChannelId] = {}
+        for row in assignment_rows:
+            try:
+                profile_id = RuntimeProfileId(str(row[0]))
+                channel_id = ChannelId(str(row[1]))
+            except (TypeError, ValueError) as exc:
+                raise WorkshopStorageNamespaceError(
+                    "Runtime history assignment contains an invalid opaque identifier"
+                ) from exc
+            if profile_id in channel_by_profile and channel_by_profile[profile_id] != channel_id:
+                raise WorkshopStorageNamespaceError("Runtime profile maps to multiple history channels")
+            channel_by_profile[profile_id] = channel_id
+
+        runtime_aliases: dict[int, ChannelId] = {}
+        for profile in runtime_profiles.profiles:
+            channel_id = channel_by_profile.get(profile.profile_id)
+            if channel_id is None:
+                raise WorkshopStorageNamespaceError("Protected runtime profile has no canonical history channel")
+            runtime_aliases[profile.runtime_config_id] = channel_id
+        return cls(tuple(namespaces), runtime_aliases=runtime_aliases)
+
+    @property
+    def namespaces(self) -> tuple[WorkshopChannelHistoryNamespace, ...]:
+        return tuple(sorted(self._by_channel.values(), key=lambda namespace: namespace.channel_id))
+
+    def for_compatibility_chat_id(self, chat_id: int) -> WorkshopChannelHistoryNamespace:
+        if isinstance(chat_id, bool) or not isinstance(chat_id, int) or chat_id == 0:
+            raise WorkshopStorageNamespaceError("Compatibility chat ID must be a non-zero integer")
+        namespace = self._by_compatibility_id.get(chat_id)
+        if namespace is None:
+            raise WorkshopStorageNamespaceError("Compatibility chat ID has no canonical history channel")
+        return namespace
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,7 +136,10 @@ def _isolate_history_dir(tmp_path):
     to the real history directory, regardless of whether individual
     tests remember to patch log_message.
     """
-    with patch("kai.history._LOG_DIR", tmp_path):
+    with (
+        patch("kai.history._LOG_DIR", tmp_path),
+        patch("kai.history._CHANNEL_HISTORY_REGISTRY", None),
+    ):
         yield
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -9,6 +9,11 @@ import pytest
 
 from kai import history
 from kai.history import get_recent_history, get_recent_pairs, log_message
+from kai.workshop.domain import ChannelId
+from kai.workshop.storage_namespaces import (
+    WorkshopChannelHistoryNamespace,
+    WorkshopChannelHistoryRegistry,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -1012,3 +1017,79 @@ class TestLogMessageMkdirFailure:
         monkeypatch.setattr(Path, "mkdir", boom)
         entry = log_message(direction="user", chat_id=99, text="x")
         assert entry is None
+
+
+class TestCanonicalChannelHistoryNamespace:
+    @staticmethod
+    def _registry() -> WorkshopChannelHistoryRegistry:
+        return WorkshopChannelHistoryRegistry(
+            (
+                WorkshopChannelHistoryNamespace(
+                    ChannelId("chn_" + "a" * 32),
+                    101,
+                ),
+            )
+        )
+
+    def test_new_writes_use_only_canonical_channel_directory(
+        self,
+        _log_dir,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(history, "_CHANNEL_HISTORY_REGISTRY", self._registry())
+
+        entry = log_message(direction="user", chat_id=101, text="canonical")
+
+        assert entry is not None
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
+        assert (_log_dir / ("chn_" + "a" * 32) / f"{today}.jsonl").is_file()
+        assert not (_log_dir / "101").exists()
+
+    def test_reads_merge_legacy_and_canonical_same_day_chronologically(
+        self,
+        _log_dir,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(history, "_CHANNEL_HISTORY_REGISTRY", self._registry())
+        legacy = _log_dir / "101" / "2026-08-13.jsonl"
+        canonical = _log_dir / ("chn_" + "a" * 32) / "2026-08-13.jsonl"
+        legacy.parent.mkdir(parents=True)
+        canonical.parent.mkdir(parents=True)
+        legacy.write_text(
+            json.dumps(
+                {
+                    "ts": "2026-08-13T09:00:00+00:00",
+                    "dir": "user",
+                    "chat_id": 101,
+                    "text": "before cutover",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        canonical.write_text(
+            json.dumps(
+                {
+                    "ts": "2026-08-13T09:01:00+00:00",
+                    "dir": "assistant",
+                    "chat_id": 101,
+                    "text": "after cutover",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        assert get_recent_pairs(101, 1) == [("before cutover", "after cutover")]
+        recent = get_recent_history(chat_id=101)
+        assert recent.index("before cutover") < recent.index("after cutover")
+
+    def test_unknown_chat_does_not_recreate_numeric_namespace(
+        self,
+        _log_dir,
+        monkeypatch,
+    ):
+        monkeypatch.setattr(history, "_CHANNEL_HISTORY_REGISTRY", self._registry())
+
+        assert log_message(direction="user", chat_id=202, text="refuse") is None
+        assert not (_log_dir / "202").exists()

--- a/tests/test_workshop_parity.py
+++ b/tests/test_workshop_parity.py
@@ -94,6 +94,35 @@ class TestWorkshopMessageParityStatus:
         assert "101" not in status
         assert "Private Operator Name" not in status
 
+    async def test_clean_status_reads_canonical_channel_history(self, tmp_path: Path):
+        db_path = tmp_path / "kai.db"
+        history_root = tmp_path / "history"
+        await _build_conversation(db_path)
+        store = await WorkshopEventStore.open(db_path)
+        try:
+            async with store.connection.execute(
+                "SELECT channel_id FROM channel_bindings WHERE transport = 'telegram' AND external_channel_id = '101'"
+            ) as cursor:
+                row = await cursor.fetchone()
+            assert row is not None
+            directory = history_root / str(row[0])
+            directory.mkdir(parents=True)
+            records = [
+                _record("user", "Secret question", seconds=0),
+                _record("assistant", "Secret answer", seconds=2),
+            ]
+            (directory / "2026-08-11.jsonl").write_text(
+                "\n".join(json.dumps(record) for record in records) + "\n",
+                encoding="utf-8",
+            )
+        finally:
+            await store.close()
+
+        status = workshop_message_parity_status(db_path, history_root)
+
+        assert "parity: clean" in status
+        assert "JSONL matched=2, JSONL missing=0, JSONL unmatched=0" in status
+
     async def test_outbound_only_notification_message_is_not_compared_to_direct_chat_jsonl(self, tmp_path: Path):
         db_path = tmp_path / "kai.db"
         history_root = tmp_path / "history"

--- a/tests/test_workshop_storage_namespaces.py
+++ b/tests/test_workshop_storage_namespaces.py
@@ -6,9 +6,12 @@ from pathlib import Path
 
 import pytest
 
+from kai.install import _canonical_storage_reader_users
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
-from kai.workshop.domain import PrincipalId
+from kai.workshop.domain import ChannelId, PrincipalId
 from kai.workshop.storage_namespaces import (
+    WorkshopChannelHistoryNamespace,
+    WorkshopChannelHistoryRegistry,
     WorkshopPrincipalStorageNamespace,
     WorkshopPrincipalStorageRegistry,
     WorkshopStorageNamespaceError,
@@ -54,6 +57,19 @@ async def _principal_for_telegram_subject(
         row = await cursor.fetchone()
     assert row is not None
     return PrincipalId(str(row[0]))
+
+
+async def _channel_for_telegram_subject(
+    store: WorkshopEventStore,
+    subject: str,
+) -> ChannelId:
+    async with store.connection.execute(
+        "SELECT channel_id FROM channel_bindings WHERE transport = 'telegram' AND external_channel_id = ?",
+        (subject,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return ChannelId(str(row[0]))
 
 
 class TestWorkshopPrincipalStorageRegistry:
@@ -130,3 +146,59 @@ class TestWorkshopPrincipalStorageRegistry:
             match="no canonical principal",
         ):
             registry.for_runtime_config_id(202)
+
+
+class TestWorkshopChannelHistoryRegistry:
+    async def test_resolves_transport_and_runtime_keys_to_canonical_channel(
+        self,
+        tmp_path: Path,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            registry = await WorkshopChannelHistoryRegistry.from_store(
+                store,
+                profile_registry(101, 202),
+            )
+            expected_channel = await _channel_for_telegram_subject(store, "101")
+            namespace = registry.for_compatibility_chat_id(101)
+
+            assert namespace.channel_id == expected_channel
+            assert namespace.history_directory(tmp_path) == (tmp_path / "history" / str(expected_channel))
+            assert namespace.legacy_history_directory(tmp_path) == (tmp_path / "history" / "101")
+        finally:
+            await store.close()
+
+    def test_unknown_compatibility_chat_fails_closed(self):
+        registry = WorkshopChannelHistoryRegistry(
+            (
+                WorkshopChannelHistoryNamespace(
+                    ChannelId("chn_" + "1" * 32),
+                    101,
+                ),
+            )
+        )
+
+        with pytest.raises(
+            WorkshopStorageNamespaceError,
+            match="no canonical history channel",
+        ):
+            registry.for_compatibility_chat_id(202)
+
+    async def test_installer_maps_canonical_principal_and_channel_to_os_reader(
+        self,
+        tmp_path: Path,
+    ):
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        store = await _store(data_path / "kai.db")
+        principal_id = await _principal_for_telegram_subject(store, "101")
+        channel_id = await _channel_for_telegram_subject(store, "101")
+        await store.close()
+
+        readers = _canonical_storage_reader_users(
+            data_path,
+            {"101": "daniel", "202": "scott"},
+        )
+
+        assert readers[str(principal_id)] == "daniel"
+        assert readers[str(channel_id)] == "daniel"


### PR DESCRIPTION
## Summary

- key new compatibility JSONL transcript writes by canonical Workshop channel ID
- keep existing transport-keyed transcript trees as read-only compatibility archives
- merge canonical and legacy reads for recent context, memory extraction, and transcript provenance
- advertise canonical transcript paths to backend agents while retaining explicit archive lookup
- teach installer ACL reconciliation and Workshop parity diagnostics about canonical principal/channel directories

## Security and migration properties

- a configured production service fails closed when a compatibility chat key has no canonical channel
- unknown chat keys cannot recreate numeric history directories
- no existing transcript directory is moved, rewritten, or deleted
- direct-channel histories retain their mapped OS-user read access after reinstall
- notification-group history is channel-owned and remains service-private
- the low-level history module depends only on a narrow resolver protocol, avoiding a Workshop/backend import cycle

## Validation

- `make check`
- focused history, backend, installer, namespace, parity, and startup tests: 793 passed
- full suite: 5,600 passed, 1 skipped
