### PR TITLE
Key preferences by Workshop principal

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -23,6 +23,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Protocol, runtime_checkable
 
 from kai.agent_failure import AgentFailureKind, classify_agent_failure
 from kai.config import (
@@ -43,6 +44,53 @@ _PRIVATE_USER_ROOT_MODE = 0o711
 _PRIVATE_USER_DIR_MODE = 0o700
 _PRIVATE_USER_FILE_MODE = 0o600
 _CLAUDE_IDENTITY_ADAPTER = "@../AGENTS.md\n"
+
+
+class _PrincipalStorageNamespace(Protocol):
+    principal_id: str
+
+
+@runtime_checkable
+class PrincipalStorageNamespaceResolver(Protocol):
+    """Narrow principal-storage boundary supplied by Workshop bootstrap."""
+
+    def for_runtime_config_id(self, runtime_config_id: int) -> _PrincipalStorageNamespace: ...
+
+
+class PrincipalStorageResolutionError(RuntimeError):
+    """A compatibility runtime key has no canonical human principal."""
+
+
+_PRINCIPAL_STORAGE_REGISTRY: PrincipalStorageNamespaceResolver | None = None
+
+
+def configure_principal_storage_namespaces(
+    registry: PrincipalStorageNamespaceResolver | None,
+) -> None:
+    """Install the canonical human-principal resolver for compatibility files."""
+    global _PRINCIPAL_STORAGE_REGISTRY
+    if registry is not None and not isinstance(registry, PrincipalStorageNamespaceResolver):
+        raise TypeError("registry must implement PrincipalStorageNamespaceResolver")
+    _PRINCIPAL_STORAGE_REGISTRY = registry
+
+
+def preference_search_directories(
+    chat_id: int,
+    *,
+    data_dir: Path,
+) -> tuple[Path, ...]:
+    """Return canonical-first preference directories for one runtime key."""
+    root = data_dir / "preferences"
+    registry = _PRINCIPAL_STORAGE_REGISTRY
+    if registry is None:
+        return (root / str(chat_id),)
+    try:
+        namespace = registry.for_runtime_config_id(chat_id)
+    except Exception as exc:
+        raise PrincipalStorageResolutionError("Runtime configuration has no canonical preference principal") from exc
+    canonical = root / str(namespace.principal_id)
+    legacy = root / str(chat_id)
+    return (canonical,) if canonical == legacy else (canonical, legacy)
 
 
 def _chmod_private_user_root(path: Path) -> None:
@@ -450,8 +498,20 @@ def build_session_context(
     # (one-shot CLI invocations) the block is omitted entirely; there
     # is no global-fallback PREFERENCES.md.
     if chat_id is not None:
-        pref_path = data_dir / "preferences" / str(chat_id) / "PREFERENCES.md"
+        preference_dirs = preference_search_directories(chat_id, data_dir=data_dir)
+        canonical_pref_path = preference_dirs[0] / "PREFERENCES.md"
+        pref_path = next(
+            (directory / "PREFERENCES.md" for directory in preference_dirs if (directory / "PREFERENCES.md").is_file()),
+            canonical_pref_path,
+        )
         if defer_user_file_reads:
+            # A first protected install predates Workshop bootstrap and can
+            # provision only the compatibility directory. Use it until the
+            # next install creates the canonical principal directory.
+            if len(preference_dirs) > 1 and not canonical_pref_path.parent.is_dir():
+                pref_path = preference_dirs[1] / "PREFERENCES.md"
+            else:
+                pref_path = canonical_pref_path
             parts.append(
                 f"[Your personal preferences are stored at {pref_path}. "
                 "Read this file before applying personal preference instructions.]"
@@ -726,11 +786,10 @@ def ensure_user_preferences(chat_id: int | None, data_dir: Path) -> None:
 
     Sibling to ensure_user_memory(). Same idempotency, same OSError
     swallow behavior, same multi-user ownership caveats - the install
-    step (install.py `_apply_migrate`) pre-creates `preferences/<chat_id>/`
-    for every entry in users.yaml and chowns it to that user's os_user
-    when one is set; lazy bootstrap is the runtime fallback for chat_ids
-    added between installs (a reinstall picks up the ownership in the
-    `-- PREFERENCES.md directory ownership --` pass).
+    step (install.py `_apply_migrate`) pre-creates the canonical
+    `preferences/<principal_id>/` directory and chowns it to that user's
+    os_user when one is set. The prior transport-keyed file remains a
+    read-only migration source.
 
     When chat_id is None we are on a one-shot CLI / test path: there
     is no per-user PREFERENCES.md to seed because the inject path
@@ -750,26 +809,41 @@ def ensure_user_preferences(chat_id: int | None, data_dir: Path) -> None:
         return
 
     preferences_root = data_dir / "preferences"
-    user_pref_dir = preferences_root / str(chat_id)
+    try:
+        preference_dirs = preference_search_directories(chat_id, data_dir=data_dir)
+    except PrincipalStorageResolutionError:
+        log.exception("ensure_user_preferences: could not resolve canonical principal")
+        return
+    user_pref_dir = preference_dirs[0]
     user_pref_file = user_pref_dir / "PREFERENCES.md"
 
     try:
+        if preferences_root.is_symlink():
+            raise OSError(f"refusing symlinked preferences root: {preferences_root}")
+        if user_pref_dir.is_symlink():
+            raise OSError(f"refusing symlinked preferences directory: {user_pref_dir}")
+        if user_pref_file.is_symlink():
+            raise OSError(f"refusing symlinked preferences file: {user_pref_file}")
         preferences_root.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_ROOT_MODE)
         _chmod_private_user_root(preferences_root)
         user_pref_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
         _chmod_private_user_dir(user_pref_dir)
         if not user_pref_file.exists():
-            # Seed from the template if one ships with the source tree.
-            template = PROJECT_ROOT / "templates" / ".claude" / "PREFERENCES.md"
-            if template.is_file():
-                shutil.copy2(template, user_pref_file)
+            legacy_pref_file = preference_dirs[1] / "PREFERENCES.md" if len(preference_dirs) > 1 else None
+            if legacy_pref_file is not None and legacy_pref_file.parent.is_symlink():
+                raise OSError(f"refusing symlinked legacy preferences directory: {legacy_pref_file.parent}")
+            if legacy_pref_file is not None and legacy_pref_file.is_symlink():
+                raise OSError(f"refusing symlinked legacy preferences file: {legacy_pref_file}")
+            # Preserve customized compatibility content when it is readable;
+            # the installer performs the authoritative protected-mode copy.
+            if legacy_pref_file is not None and legacy_pref_file.is_file():
+                shutil.copy2(legacy_pref_file, user_pref_file)
             else:
-                # No template available (unusual - only happens when
-                # the install tree is incomplete). Create a minimal
-                # placeholder so the subprocess has a writable file
-                # to edit. Matches ensure_user_memory's `# Memory\n`
-                # precedent for symmetry.
-                user_pref_file.write_text("# Preferences\n")
+                template = PROJECT_ROOT / "templates" / ".claude" / "PREFERENCES.md"
+                if template.is_file():
+                    shutil.copy2(template, user_pref_file)
+                else:
+                    user_pref_file.write_text("# Preferences\n")
         _chmod_private_user_file(user_pref_file)
     except OSError:
         log.warning(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3837,14 +3837,11 @@ def _secure_history_directories(
     print(f"  Secured conversation history under {history_root}")
 
 
-def _canonical_storage_reader_users(
-    data_path: Path,
-    legacy_reader_users: dict[str, str],
-) -> dict[str, str]:
-    """Map canonical principal/channel directories to their agent OS reader."""
+def _canonical_storage_rows(data_path: Path) -> list[tuple[str, str, str]]:
+    """Read direct-channel, human-principal, and compatibility-key tuples."""
     db_path = data_path / "kai.db"
     if db_path.is_symlink() or not db_path.is_file():
-        return {}
+        return []
     try:
         connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
         try:
@@ -3859,7 +3856,7 @@ def _canonical_storage_reader_users(
                 "principals",
             }
             if not tables >= required:
-                return {}
+                return []
             rows = connection.execute(
                 "SELECT c.id, p.id, cb.external_channel_id "
                 "FROM channels c "
@@ -3873,15 +3870,31 @@ def _canonical_storage_reader_users(
     except sqlite3.Error:
         # Database integrity is checked separately by the migration path.
         # This compatibility lookup is optional for pre-Workshop databases.
-        return {}
+        return []
+    return [(str(channel), str(principal), str(legacy)) for channel, principal, legacy in rows]
+
+
+def _canonical_storage_reader_users(
+    data_path: Path,
+    legacy_reader_users: dict[str, str],
+) -> dict[str, str]:
+    """Map canonical principal/channel directories to their agent OS reader."""
     canonical: dict[str, str] = {}
-    for channel_id, principal_id, external_channel_id in rows:
-        reader = legacy_reader_users.get(str(external_channel_id))
+    for channel_id, principal_id, external_channel_id in _canonical_storage_rows(data_path):
+        reader = legacy_reader_users.get(external_channel_id)
         if reader is None:
             continue
-        canonical[str(channel_id)] = reader
-        canonical[str(principal_id)] = reader
+        canonical[channel_id] = reader
+        canonical[principal_id] = reader
     return canonical
+
+
+def _canonical_principal_storage_names(data_path: Path) -> dict[str, str]:
+    """Map legacy configured-user keys to canonical principal directory names."""
+    return {
+        external_channel_id: principal_id
+        for _channel_id, principal_id, external_channel_id in _canonical_storage_rows(data_path)
+    }
 
 
 def _managed_identity_state(user_home: Path) -> tuple[Path, Path, str | None, str | None]:
@@ -4088,8 +4101,13 @@ def _apply_migrate(
         reader_users[str(chat_id)] = os_user
     known_user_dir_names = {str(chat_id) for chat_id, _os_user in memory_owners if chat_id is not None}
     canonical_reader_users = _canonical_storage_reader_users(data_path, reader_users)
+    canonical_principal_names = _canonical_principal_storage_names(data_path)
     reader_users.update(canonical_reader_users)
-    known_user_dir_names.update(name for name in canonical_reader_users if name.startswith("prn_"))
+    known_user_dir_names.update(canonical_principal_names.values())
+    for legacy_name, principal_name in canonical_principal_names.items():
+        owner = per_user_ids.get(legacy_name)
+        if owner is not None:
+            per_user_ids[principal_name] = owner
 
     # Resolve the primary operator's chat_id (first yaml entry). When
     # users.yaml is absent or empty (first-ever install, single-user
@@ -4265,8 +4283,8 @@ def _apply_migrate(
 
     # -- PREFERENCES.md per-user pre-creation --
     # Mirror the MEMORY.md per-user pattern. For every users.yaml
-    # entry we pre-create DATA_DIR/preferences/<chat_id>/ and seed
-    # PREFERENCES.md from the example template if it does not exist.
+    # entry we pre-create DATA_DIR/preferences/<principal_id>/ and preserve
+    # the prior transport-keyed PREFERENCES.md when it exists.
     # Initial ownership is set by the ownership pass below, not here;
     # keeping the chown in a single block makes the os_user-change
     # idempotency case fall out naturally rather than requiring a
@@ -4279,12 +4297,24 @@ def _apply_migrate(
     for chat_id, _os_user in memory_owners:
         if chat_id is None:
             continue
-        pref_dir = preferences_tree / str(chat_id)
+        legacy_name = str(chat_id)
+        canonical_name = canonical_principal_names.get(legacy_name, legacy_name)
+        pref_dir = preferences_tree / canonical_name
         pref_dst = pref_dir / "PREFERENCES.md"
+        legacy_dir = preferences_tree / legacy_name
+        legacy_pref = legacy_dir / "PREFERENCES.md"
+        if pref_dir.is_symlink() or pref_dst.is_symlink():
+            raise RuntimeError(f"Refusing symlinked canonical preferences path: {pref_dst}")
+        if legacy_pref != pref_dst and legacy_dir.is_symlink():
+            raise RuntimeError(f"Refusing symlinked legacy preferences directory: {legacy_dir}")
+        if legacy_pref != pref_dst and legacy_pref.is_symlink():
+            raise RuntimeError(f"Refusing symlinked legacy preferences file: {legacy_pref}")
 
         if dry_run:
             if not pref_dst.exists():
-                if preferences_template.is_file():
+                if legacy_pref != pref_dst and legacy_pref.is_file():
+                    print(f"[DRY RUN] Would copy {legacy_pref} -> {pref_dst}")
+                elif preferences_template.is_file():
                     print(f"[DRY RUN] Would seed {pref_dst} from {preferences_template}")
                 else:
                     print(f"[DRY RUN] Would seed {pref_dst} with placeholder (template missing)")
@@ -4292,7 +4322,10 @@ def _apply_migrate(
 
         pref_dir.mkdir(parents=True, exist_ok=True)
         if not pref_dst.exists():
-            if preferences_template.is_file():
+            if legacy_pref != pref_dst and legacy_pref.is_file():
+                shutil.copy2(legacy_pref, pref_dst)
+                print(f"  Copied preferences {legacy_pref} -> {pref_dst}")
+            elif preferences_template.is_file():
                 shutil.copy2(preferences_template, pref_dst)
                 print(f"  Seeded {pref_dst} from preferences template")
             else:

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -316,6 +316,9 @@ def _start() -> None:
             workshop_bootstrap.existing_events,
         )
         principal_storage = await sessions.load_workshop_principal_storage_registry(runtime_profiles)
+        from kai.backend import configure_principal_storage_namespaces
+
+        configure_principal_storage_namespaces(principal_storage)
         logging.info(
             "Workshop principal storage ready (namespaces=%d)",
             len(principal_storage.namespaces),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,10 @@ def _isolate_backend_data_dir(tmp_path):
     their own patch / monkeypatch; the autouse fixture only sets
     the safe default.
     """
-    with patch("kai.backend.DATA_DIR", tmp_path):
+    with (
+        patch("kai.backend.DATA_DIR", tmp_path),
+        patch("kai.backend._PRINCIPAL_STORAGE_REGISTRY", None),
+    ):
         yield
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1557,6 +1557,109 @@ class TestEnsureUserPreferences:
         )
 
 
+class _PrincipalPreferenceNamespace:
+    principal_id = "prn_" + "a" * 32
+
+
+class _PrincipalPreferenceRegistry:
+    def for_runtime_config_id(self, runtime_config_id: int):
+        if runtime_config_id != 42:
+            raise LookupError("unknown runtime")
+        return _PrincipalPreferenceNamespace()
+
+
+class TestCanonicalPrincipalPreferences:
+    def test_deferred_context_uses_canonical_principal_path(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "data"
+        canonical = data_dir / "preferences" / _PrincipalPreferenceNamespace.principal_id
+        canonical.mkdir(parents=True)
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=tmp_path,
+                home_workspace=tmp_path,
+                api=ApiContext(webhook_port=8080, webhook_secret=None),
+                workspace_config=None,
+                chat_id=42,
+                data_dir=data_dir,
+                defer_user_file_reads=True,
+            )
+
+        assert str(canonical / "PREFERENCES.md") in result
+        assert str(data_dir / "preferences" / "42" / "PREFERENCES.md") not in result
+
+    def test_deferred_context_falls_back_for_greenfield_first_install(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "data"
+        legacy = data_dir / "preferences" / "42"
+        legacy.mkdir(parents=True)
+        (legacy / "PREFERENCES.md").write_text("existing")
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=tmp_path,
+                home_workspace=tmp_path,
+                api=ApiContext(webhook_port=8080, webhook_secret=None),
+                workspace_config=None,
+                chat_id=42,
+                data_dir=data_dir,
+                defer_user_file_reads=True,
+            )
+
+        assert str(legacy / "PREFERENCES.md") in result
+
+    def test_lazy_bootstrap_copies_legacy_content_without_deleting_it(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "data"
+        legacy = data_dir / "preferences" / "42" / "PREFERENCES.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("custom preference")
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        ensure_user_preferences(42, data_dir)
+
+        canonical = data_dir / "preferences" / _PrincipalPreferenceNamespace.principal_id / "PREFERENCES.md"
+        assert canonical.read_text() == "custom preference"
+        assert legacy.read_text() == "custom preference"
+
+    def test_unknown_runtime_cannot_recreate_numeric_preference_directory(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        ensure_user_preferences(99, tmp_path)
+
+        assert not (tmp_path / "preferences" / "99").exists()
+
+    def test_lazy_bootstrap_refuses_symlinked_legacy_file(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "data"
+        outside = tmp_path / "outside.md"
+        outside.write_text("outside preference")
+        legacy = data_dir / "preferences" / "42" / "PREFERENCES.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.symlink_to(outside)
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        ensure_user_preferences(42, data_dir)
+
+        canonical = data_dir / "preferences" / _PrincipalPreferenceNamespace.principal_id / "PREFERENCES.md"
+        assert not canonical.exists()
+        assert outside.read_text() == "outside preference"
+
+
 class TestPerUserMemoryIsolation:
     """Writes to one user's MEMORY.md never appear in another user's context."""
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -77,6 +77,9 @@ from kai.install import (
     _webhook_secret_migration_status,
     cli,
 )
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id
 
 
 @pytest.fixture(autouse=True)
@@ -6244,6 +6247,53 @@ class TestApplyMigratePerUserPreferences:
         )
 
         assert target.read_text() == "operator-customized rules"
+
+    async def test_copies_legacy_preferences_to_canonical_principal_without_deleting(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        data_path = self._setup(tmp_path, monkeypatch)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 7777\n    name: primary\n    role: admin\n")
+        legacy = data_path / "preferences" / "7777" / "PREFERENCES.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("operator-customized rules")
+        store = await WorkshopEventStore.open(data_path / "kai.db")
+        await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    "Primary",
+                    "admin",
+                    "telegram",
+                    "7777",
+                    "7777",
+                    profile_id(7777),
+                ),
+            ),
+        )
+        async with store.connection.execute(
+            "SELECT principal_id FROM external_identities WHERE provider = 'telegram' AND external_subject = '7777'"
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        principal_id = str(row[0])
+        await store.close()
+        monkeypatch.setattr("kai.install.os.chown", lambda *args: None)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        canonical = data_path / "preferences" / principal_id / "PREFERENCES.md"
+        assert canonical.read_text() == "operator-customized rules"
+        assert legacy.read_text() == "operator-customized rules"
 
     def test_template_missing_writes_placeholder(self, tmp_path, monkeypatch, capsys):
         """When the template is absent, write '# Preferences\\n' placeholder + warn."""


### PR DESCRIPTION
## Summary

- key per-human preference storage by canonical Workshop `prn_*` identifiers
  instead of Telegram IDs once Workshop principal resolution is available
- preserve customized numeric `PREFERENCES.md` files through a non-destructive,
  canonical-first migration during install and runtime bootstrap
- fail closed for unmapped protected runtimes and reject symlinked migration
  sources or destinations
- retain the numeric path only as a first-install and development compatibility
  fallback before canonical Workshop storage can be provisioned

## Why

Workshop humans are transport-independent identities. Keeping preferences under
Telegram IDs would leave a core human-owned data surface coupled to one client
adapter and would allow a transport key to remain an implicit identity key.
This change makes the Workshop principal the durable namespace while preserving
existing operator preferences and greenfield installation behavior.

## Migration behavior

- an initialized Workshop database maps each configured runtime key to its
  canonical human principal
- `make install` copies an existing customized numeric `PREFERENCES.md` into
  `preferences/<principal_id>/PREFERENCES.md` when the canonical file is absent
- the existing numeric directory and file are not removed or overwritten
- subsequent runtime reads prefer the canonical file and use the numeric file
  only as the compatibility fallback
- ownership and private modes are applied to the new canonical directory using
  the same OS-user mapping as the prior numeric directory

## Validation

- `make check`
- focused migration/runtime suite: `704 passed`
- full suite: `5606 passed, 1 skipped`
