### PR TITLE
Finish canonical Workshop storage namespaces

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -74,23 +74,71 @@ def configure_principal_storage_namespaces(
     _PRINCIPAL_STORAGE_REGISTRY = registry
 
 
+def principal_storage_search_directories(
+    chat_id: int,
+    *,
+    data_dir: Path,
+    namespace: str,
+) -> tuple[Path, ...]:
+    """Return canonical-first human storage directories for one runtime key."""
+    if namespace not in {"files", "home", "memory", "preferences"}:
+        raise ValueError(f"Unsupported principal storage namespace: {namespace}")
+    root = data_dir / namespace
+    canonical_name = principal_storage_name(chat_id)
+    canonical = root / canonical_name
+    legacy = root / str(chat_id)
+    return (canonical,) if canonical == legacy else (canonical, legacy)
+
+
+def principal_storage_name(chat_id: int) -> str:
+    """Resolve one runtime compatibility key to its canonical directory name."""
+    registry = _PRINCIPAL_STORAGE_REGISTRY
+    if registry is None:
+        return str(chat_id)
+    try:
+        namespace = registry.for_runtime_config_id(chat_id)
+    except Exception as exc:
+        raise PrincipalStorageResolutionError("Runtime configuration has no canonical storage principal") from exc
+    return str(namespace.principal_id)
+
+
 def preference_search_directories(
     chat_id: int,
     *,
     data_dir: Path,
 ) -> tuple[Path, ...]:
     """Return canonical-first preference directories for one runtime key."""
-    root = data_dir / "preferences"
-    registry = _PRINCIPAL_STORAGE_REGISTRY
-    if registry is None:
-        return (root / str(chat_id),)
-    try:
-        namespace = registry.for_runtime_config_id(chat_id)
-    except Exception as exc:
-        raise PrincipalStorageResolutionError("Runtime configuration has no canonical preference principal") from exc
-    canonical = root / str(namespace.principal_id)
-    legacy = root / str(chat_id)
-    return (canonical,) if canonical == legacy else (canonical, legacy)
+    return principal_storage_search_directories(
+        chat_id,
+        data_dir=data_dir,
+        namespace="preferences",
+    )
+
+
+def memory_search_directories(
+    chat_id: int,
+    *,
+    data_dir: Path,
+) -> tuple[Path, ...]:
+    """Return canonical-first personal-memory directories for one runtime key."""
+    return principal_storage_search_directories(
+        chat_id,
+        data_dir=data_dir,
+        namespace="memory",
+    )
+
+
+def home_search_directories(
+    chat_id: int,
+    *,
+    data_dir: Path,
+) -> tuple[Path, ...]:
+    """Return canonical-first managed-home directories for one runtime key."""
+    return principal_storage_search_directories(
+        chat_id,
+        data_dir=data_dir,
+        namespace="home",
+    )
 
 
 def _chmod_private_user_root(path: Path) -> None:
@@ -543,7 +591,7 @@ def build_session_context(
     # race and permission errors (same pattern as identity).
     #
     # Per-user scoping (#347): when chat_id is set, the file lives under
-    # memory/<chat_id>/MEMORY.md so each user has their own writable
+    # memory/<principal_id>/MEMORY.md so each human has their own writable
     # copy. The inner agent subprocess runs as that user's os_user
     # (via sudo -H -u), so ownership of the subdirectory is set to
     # match. A non-service user cannot write the legacy single-global
@@ -553,7 +601,17 @@ def build_session_context(
     # setups that never hit the multi-user pool path.
     if not memory_enabled:
         if chat_id is not None:
-            memory_path = data_dir / "memory" / str(chat_id) / "MEMORY.md"
+            memory_dirs = memory_search_directories(chat_id, data_dir=data_dir)
+            canonical_memory_path = memory_dirs[0] / "MEMORY.md"
+            memory_path = next(
+                (directory / "MEMORY.md" for directory in memory_dirs if (directory / "MEMORY.md").is_file()),
+                canonical_memory_path,
+            )
+            if defer_user_file_reads:
+                if len(memory_dirs) > 1 and not canonical_memory_path.parent.is_dir():
+                    memory_path = memory_dirs[1] / "MEMORY.md"
+                else:
+                    memory_path = canonical_memory_path
         else:
             memory_path = data_dir / "memory" / "MEMORY.md"
         if defer_user_file_reads and chat_id is not None:
@@ -705,7 +763,7 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
 
     Idempotent and cheap: a stat, a possible mkdir, a possible copy2.
     Called on every send() path before build_session_context() so that
-    a user without a pre-created `memory/<chat_id>/` (single-user dev,
+    a user without a pre-created personal-memory directory (single-user dev,
     test runs, or any deployment where the inner agent runs as the
     same identity as the bot) still gets a writable memory surface on
     their first message.
@@ -714,7 +772,7 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
 
     * Production multi-user (users.yaml entry has an explicit os_user
       different from the service user): the install step (install.py
-      `_apply_migrate`) pre-creates and chowns `memory/<chat_id>/` to
+      `_apply_migrate`) pre-creates and chowns `memory/<principal_id>/` to
       the user's os_user. mkdir here is then a no-op (the dir already
       exists), and the seed file is already in place. Good.
     * A user added to users.yaml AFTER install with a distinct os_user:
@@ -751,26 +809,46 @@ def ensure_user_memory(chat_id: int | None, data_dir: Path) -> None:
     if chat_id is None:
         user_memory_dir = memory_root
         user_memory_file = user_memory_dir / "MEMORY.md"
+        memory_dirs = (user_memory_dir,)
     else:
-        user_memory_dir = memory_root / str(chat_id)
+        try:
+            memory_dirs = memory_search_directories(chat_id, data_dir=data_dir)
+        except PrincipalStorageResolutionError:
+            log.exception("ensure_user_memory: could not resolve canonical principal")
+            return
+        user_memory_dir = memory_dirs[0]
         user_memory_file = user_memory_dir / "MEMORY.md"
 
     try:
+        if memory_root.is_symlink():
+            raise OSError(f"refusing symlinked memory root: {memory_root}")
+        if user_memory_dir.is_symlink():
+            raise OSError(f"refusing symlinked memory directory: {user_memory_dir}")
+        if user_memory_file.is_symlink():
+            raise OSError(f"refusing symlinked memory file: {user_memory_file}")
         memory_root.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_ROOT_MODE)
         _chmod_private_user_root(memory_root)
         user_memory_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
         if chat_id is not None:
             _chmod_private_user_dir(user_memory_dir)
         if not user_memory_file.exists():
-            # Seed from the template if one ships with the source tree.
-            template = PROJECT_ROOT / "templates" / ".claude" / "MEMORY.md"
-            if template.is_file():
-                shutil.copy2(template, user_memory_file)
+            legacy_memory_file = memory_dirs[1] / "MEMORY.md" if len(memory_dirs) > 1 else None
+            if legacy_memory_file is not None and legacy_memory_file.parent.is_symlink():
+                raise OSError(f"refusing symlinked legacy memory directory: {legacy_memory_file.parent}")
+            if legacy_memory_file is not None and legacy_memory_file.is_symlink():
+                raise OSError(f"refusing symlinked legacy memory file: {legacy_memory_file}")
+            if legacy_memory_file is not None and legacy_memory_file.is_file():
+                shutil.copy2(legacy_memory_file, user_memory_file)
             else:
-                # No template available (unusual - only happens when the
-                # install tree is incomplete). Create a minimal placeholder
-                # so the subprocess has a writable file to edit.
-                user_memory_file.write_text("# Memory\n")
+                # Seed from the template if one ships with the source tree.
+                template = PROJECT_ROOT / "templates" / ".claude" / "MEMORY.md"
+                if template.is_file():
+                    shutil.copy2(template, user_memory_file)
+                else:
+                    # No template available (unusual - only happens when the
+                    # install tree is incomplete). Create a minimal placeholder
+                    # so the subprocess has a writable file to edit.
+                    user_memory_file.write_text("# Memory\n")
         _chmod_private_user_file(user_memory_file)
     except OSError:
         log.warning(
@@ -951,7 +1029,7 @@ def ensure_user_home(chat_id: int | None, data_dir: Path, *, backend_name: str) 
     when users.yaml does not set an explicit home_workspace override.
     Idempotent and cheap: a stat and a possible mkdir. Used by development
     and single-user session initialization so a user without a pre-created
-    `home/<chat_id>/` still lands in a valid directory on first message.
+    `home/<principal_id>/` still lands in a valid directory on first message.
     Protected installs do not call this helper at runtime; their per-user
     directories are provisioned by ``make install`` under the target owner.
 
@@ -961,7 +1039,7 @@ def ensure_user_home(chat_id: int | None, data_dir: Path, *, backend_name: str) 
 
     * Production multi-user (users.yaml entry has an explicit os_user
       different from the service user): the install step (install.py
-      `_apply_migrate`) pre-creates and chowns `home/<chat_id>/` to the
+      `_apply_migrate`) pre-creates and chowns `home/<principal_id>/` to the
       user's os_user. mkdir here is then a no-op and the directory is
       already writable by the subprocess identity.
     * A user added to users.yaml AFTER install with a distinct os_user:
@@ -1000,12 +1078,24 @@ def ensure_user_home(chat_id: int | None, data_dir: Path, *, backend_name: str) 
     if chat_id is None:
         path = home_root / "anon"
     else:
-        path = home_root / str(chat_id)
+        home_dirs = home_search_directories(chat_id, data_dir=data_dir)
+        canonical_home = home_dirs[0]
+        # An unprotected first launch can bootstrap Workshop before the
+        # installer has copied an existing compatibility home. Keep using the
+        # existing home until the next install provisions the canonical tree.
+        if len(home_dirs) > 1 and not canonical_home.exists() and home_dirs[1].is_dir():
+            path = home_dirs[1]
+        else:
+            path = canonical_home
 
     # mkdir parents=True is load-bearing: on a brand-new install the
     # data_dir/home/ root may not exist yet (the installer creates it,
     # but dev paths and the tests go straight through lazy bootstrap).
     # exist_ok=True means this is safe to call on every session init.
+    if home_root.is_symlink():
+        raise RuntimeError(f"Refusing symlinked managed home root: {home_root}")
+    if path.is_symlink():
+        raise RuntimeError(f"Refusing symlinked managed user home: {path}")
     home_root.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_ROOT_MODE)
     _chmod_private_user_root(home_root)
     path.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
@@ -1080,7 +1170,7 @@ def resolve_home_workspace(
     Resolution order:
     1. `user.home_workspace` from users.yaml when set (admin override,
        returned as-is with no second-guessing).
-    2. `<data_dir>/home/<chat_id>/`. Development and single-user runs lazily
+    2. `<data_dir>/home/<principal_id>/`. Development and single-user runs lazily
        create it via ensure_user_home(). Protected installs require it to have
        been provisioned by ``make install``. For notification-only chat_ids (a
        chat that received a routed notification but has no users.yaml entry of
@@ -1140,10 +1230,10 @@ def resolve_home_workspace(
     # user: doing so produces the wrong owner and defeats the private 0700
     # boundary. The installer is the authoritative provisioning step.
     if chat_id is not None and getattr(config, "protected_install", False) is True:
-        path = data_dir / "home" / str(chat_id)
+        path = home_search_directories(chat_id, data_dir=data_dir)[0]
         if not path.is_dir():
             raise RuntimeError(
-                f"Protected user home is not provisioned for chat_id {chat_id}: "
+                f"Protected user home is not provisioned for the canonical principal: "
                 f"{path}. Run `make install` to provision configured users."
             )
         return path

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -63,6 +63,7 @@ from kai.backend import (
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_context_files,
+    principal_storage_name,
     sanitize_agent_environment,
 )
 from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
@@ -188,10 +189,12 @@ def write_turn_image_file(
     # the filename.
     subtype = media_type.split("/", 1)[-1]
     suffix = f".{subtype}" if subtype.isalnum() else ".img"
-    principal = "unscoped" if chat_id is None else str(chat_id)
+    principal = "unscoped" if chat_id is None else principal_storage_name(chat_id)
     principal_dir = _TURN_IMAGE_DIR / principal
     path: Path | None = None
     try:
+        if _TURN_IMAGE_DIR.is_symlink() or principal_dir.is_symlink():
+            raise OSError(f"refusing symlinked Codex image staging path: {principal_dir}")
         _TURN_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
         _TURN_IMAGE_DIR.chmod(0o711)
         principal_dir.mkdir(parents=True, exist_ok=True)

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -2551,7 +2551,7 @@ def _load_user_configs(
                 if not home_workspace.is_dir():
                     # Null it out and let the runtime resolver
                     # (backend.resolve_home_workspace) fall through to
-                    # DATA_DIR/home/<chat_id>/. There is no longer a
+                    # DATA_DIR/home/<principal_id>/. There is no longer a
                     # shared "global default" directory - that was the
                     # multi-user privacy hazard #353 removed.
                     log.warning(

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1257,7 +1257,7 @@ def _cmd_config() -> None:
 
         if admin_os_user is not None:
             # No wizard prompt for home_workspace post-#353. The admin lands
-            # in DATA_DIR/home/<chat_id>/ like any other user; the per-user
+            # in DATA_DIR/home/<principal_id>/ like any other user; the per-human
             # default is private to them. An admin who wants a path outside
             # DATA_DIR can add `home_workspace` to users.yaml by hand.
             admin_home_workspace = None
@@ -3897,6 +3897,214 @@ def _canonical_principal_storage_names(data_path: Path) -> dict[str, str]:
     }
 
 
+def _rewrite_managed_home_path(value: str, legacy_home: Path, canonical_home: Path) -> str | None:
+    """Rewrite an exact managed-home prefix without resolving symlinks."""
+    try:
+        relative = Path(value).relative_to(legacy_home)
+    except ValueError:
+        return None
+    return str(canonical_home / relative)
+
+
+def _copy_managed_home_tree(source: Path, destination: Path) -> None:
+    """Copy one stopped-service home through a private atomic staging path."""
+    if destination.exists():
+        raise FileExistsError(destination)
+    temporary = Path(
+        tempfile.mkdtemp(
+            prefix=f".{destination.name}.migrating-",
+            dir=destination.parent,
+        )
+    )
+    temporary.rmdir()
+    try:
+        shutil.copytree(source, temporary, symlinks=True)
+        temporary.replace(destination)
+    except BaseException:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+        raise
+
+
+def _migrate_managed_home_database_paths(
+    data_path: Path,
+    migrations: dict[int, tuple[Path, Path]],
+    *,
+    dry_run: bool,
+    validate_only: bool = False,
+) -> None:
+    """Move Kai-held workspace references to canonical managed homes."""
+    if not migrations:
+        return
+    db_path = data_path / "kai.db"
+    if db_path.is_symlink():
+        raise RuntimeError(f"Refusing symlinked database during managed-home migration: {db_path}")
+    if not db_path.is_file():
+        return
+
+    if dry_run or validate_only:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+    else:
+        connection = sqlite3.connect(db_path)
+    try:
+        tables = {
+            str(row[0]) for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+        }
+        original_settings = (
+            {str(key): str(value) for key, value in connection.execute("SELECT key, value FROM settings").fetchall()}
+            if "settings" in tables
+            else {}
+        )
+        migrated_settings = dict(original_settings)
+        for chat_id, (legacy_home, canonical_home) in migrations.items():
+            workspace_key = f"workspace:{chat_id}"
+            current_workspace = migrated_settings.get(workspace_key)
+            if current_workspace is not None:
+                rewritten = _rewrite_managed_home_path(current_workspace, legacy_home, canonical_home)
+                if rewritten is not None:
+                    migrated_settings[workspace_key] = rewritten
+
+            prefix = f"ws_config:{chat_id}:"
+            for key, value in tuple(migrated_settings.items()):
+                if not key.startswith(prefix):
+                    continue
+                path_and_field = key[len(prefix) :]
+                workspace_path, separator, field = path_and_field.rpartition(":")
+                if not separator or not field:
+                    continue
+                rewritten = _rewrite_managed_home_path(workspace_path, legacy_home, canonical_home)
+                if rewritten is None:
+                    continue
+                new_key = f"{prefix}{rewritten}:{field}"
+                existing = migrated_settings.get(new_key)
+                if existing is not None and new_key != key and existing != value:
+                    raise RuntimeError(f"Conflicting workspace settings during home migration: {new_key}")
+                del migrated_settings[key]
+                migrated_settings[new_key] = value
+
+        original_allowed = (
+            {
+                (int(chat_id), str(path))
+                for chat_id, path in connection.execute("SELECT chat_id, path FROM allowed_workspaces").fetchall()
+            }
+            if "allowed_workspaces" in tables
+            else set()
+        )
+        migrated_allowed: set[tuple[int, str]] = set()
+        for chat_id, path in original_allowed:
+            migration = migrations.get(chat_id)
+            rewritten = _rewrite_managed_home_path(path, *migration) if migration is not None else None
+            migrated_allowed.add((chat_id, rewritten if rewritten is not None else path))
+
+        original_history = (
+            [
+                (str(path), int(chat_id), last_used_at)
+                for path, chat_id, last_used_at in connection.execute(
+                    "SELECT path, chat_id, last_used_at FROM workspace_history"
+                ).fetchall()
+            ]
+            if "workspace_history" in tables
+            else []
+        )
+        migrated_history: dict[tuple[str, int], object] = {}
+        for path, chat_id, last_used_at in original_history:
+            migration = migrations.get(chat_id)
+            rewritten = _rewrite_managed_home_path(path, *migration) if migration is not None else None
+            key = (rewritten if rewritten is not None else path, chat_id)
+            prior = migrated_history.get(key)
+            if prior is None or (last_used_at is not None and str(last_used_at) > str(prior)):
+                migrated_history[key] = last_used_at
+
+        original_projects = (
+            [
+                (str(project_id), str(workspace_root), int(created_by))
+                for project_id, workspace_root, created_by in connection.execute(
+                    "SELECT project_id, workspace_root, created_by FROM memory_projects"
+                ).fetchall()
+            ]
+            if "memory_projects" in tables
+            else []
+        )
+        project_updates: dict[str, str] = {}
+        claimed_project_roots = {
+            workspace_root: project_id for project_id, workspace_root, _created_by in original_projects
+        }
+        for project_id, workspace_root, created_by in original_projects:
+            migration = migrations.get(created_by)
+            rewritten = _rewrite_managed_home_path(workspace_root, *migration) if migration is not None else None
+            if rewritten is None or rewritten == workspace_root:
+                continue
+            conflict = claimed_project_roots.get(rewritten)
+            if conflict is not None and conflict != project_id:
+                raise RuntimeError(f"Conflicting memory project root during home migration: {rewritten}")
+            project_updates[project_id] = rewritten
+
+        setting_deletes = set(original_settings) - set(migrated_settings)
+        setting_upserts = {
+            key: value for key, value in migrated_settings.items() if original_settings.get(key) != value
+        }
+        allowed_deletes = original_allowed - migrated_allowed
+        allowed_inserts = migrated_allowed - original_allowed
+        original_history_by_key = {(path, chat_id): last_used_at for path, chat_id, last_used_at in original_history}
+        history_deletes = set(original_history_by_key) - set(migrated_history)
+        history_upserts = {
+            key: value for key, value in migrated_history.items() if original_history_by_key.get(key) != value
+        }
+        change_count = (
+            len(setting_deletes)
+            + len(setting_upserts)
+            + len(allowed_deletes)
+            + len(allowed_inserts)
+            + len(history_deletes)
+            + len(history_upserts)
+            + len(project_updates)
+        )
+        if not change_count or validate_only:
+            return
+        if dry_run:
+            print(f"[DRY RUN] Would migrate Kai database paths for {len(migrations)} canonical managed home(s)")
+            return
+
+        connection.execute("BEGIN IMMEDIATE")
+        if "settings" in tables:
+            connection.executemany("DELETE FROM settings WHERE key = ?", [(key,) for key in sorted(setting_deletes)])
+            connection.executemany(
+                "INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+                sorted(setting_upserts.items()),
+            )
+        if "allowed_workspaces" in tables:
+            connection.executemany(
+                "DELETE FROM allowed_workspaces WHERE chat_id = ? AND path = ?",
+                sorted(allowed_deletes),
+            )
+            connection.executemany(
+                "INSERT OR IGNORE INTO allowed_workspaces (chat_id, path) VALUES (?, ?)",
+                sorted(allowed_inserts),
+            )
+        if "workspace_history" in tables:
+            connection.executemany(
+                "DELETE FROM workspace_history WHERE path = ? AND chat_id = ?",
+                sorted(history_deletes),
+            )
+            connection.executemany(
+                "INSERT OR REPLACE INTO workspace_history (path, chat_id, last_used_at) VALUES (?, ?, ?)",
+                [(path, chat_id, last_used_at) for (path, chat_id), last_used_at in sorted(history_upserts.items())],
+            )
+        if "memory_projects" in tables:
+            for project_id, workspace_root in project_updates.items():
+                connection.execute(
+                    "UPDATE memory_projects SET workspace_root = ? WHERE project_id = ?",
+                    (workspace_root, project_id),
+                )
+        connection.commit()
+        print(f"  Migrated Kai database paths for {len(migrations)} canonical managed home(s)")
+    except BaseException:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
 def _managed_identity_state(user_home: Path) -> tuple[Path, Path, str | None, str | None]:
     """Inspect and validate one managed user's canonical/compatibility files.
 
@@ -4054,7 +4262,7 @@ def _apply_migrate(
 
     # -- MEMORY.md migration --
     # One-time: land personal memory at the per-user path
-    # DATA_DIR/memory/<chat_id>/MEMORY.md. The "primary operator"
+    # DATA_DIR/memory/<principal_id>/MEMORY.md. The "primary operator"
     # (first entry in users.yaml, typically an admin) gets any legacy
     # content from DATA_DIR/memory/MEMORY.md (pre-#347 global location).
     # legacy_global is moved (not copied) so the DATA_DIR global path
@@ -4073,6 +4281,8 @@ def _apply_migrate(
     memory_root = data_path / "memory"
     legacy_global = memory_root / "MEMORY.md"
     template = PROJECT_ROOT / "templates" / ".claude" / "MEMORY.md"
+    if memory_root.is_symlink() or legacy_global.is_symlink():
+        raise RuntimeError(f"Refusing symlinked memory migration path under {memory_root}")
 
     # Resolve every os_user against the host's passwd database BEFORE
     # touching disk. If users.yaml names an OS user that does not exist
@@ -4117,65 +4327,58 @@ def _apply_migrate(
     primary_chat_id: int | None = memory_owners[0][0] if memory_owners else None
 
     if primary_chat_id is not None:
-        primary_dir = memory_root / str(primary_chat_id)
-        primary_dst = primary_dir / "MEMORY.md"
-
-        if not primary_dst.exists():
-            if dry_run:
-                if legacy_global.is_file():
-                    print(f"[DRY RUN] Would move {legacy_global} -> {primary_dst}")
-                elif template.is_file():
-                    print(f"[DRY RUN] Would seed {primary_dst} from {template}")
-                else:
-                    # Mirror the real branch's last-resort placeholder
-                    # below: when none of the source files exist (minimal
-                    # host, broken install tree), the real path writes
-                    # `# Memory\n` and prints "Created empty ...". Without
-                    # this `else` the dry-run prints nothing and the
-                    # operator sees a silent gap they cannot diagnose.
-                    print(f"[DRY RUN] Would create empty {primary_dst} (no template found)")
-            else:
-                primary_dir.mkdir(parents=True, exist_ok=True)
-                if legacy_global.is_file():
-                    # Move, not copy - the legacy global path must not
-                    # survive this migration, or a stale file will shadow
-                    # the per-user read once one user's subdir fills up.
-                    shutil.move(str(legacy_global), str(primary_dst))
-                    print(f"  Migrated MEMORY.md to {primary_dst}")
-                elif template.is_file():
-                    shutil.copy2(template, primary_dst)
-                    print(f"  Seeded {primary_dst} from memory template")
-                else:
-                    # Last-resort placeholder so the file is writable.
-                    primary_dst.write_text("# Memory\n")
-                    print(f"  Created empty {primary_dst}")
-
-        # Seed every other known user from the memory template. Skips
-        # the primary (handled above) and any user whose subdir already
-        # has a MEMORY.md (idempotent across reinstalls).
-        for chat_id, _os_user in memory_owners[1:]:
-            user_dir = memory_root / str(chat_id)
+        for index, (chat_id, _os_user) in enumerate(memory_owners):
+            if chat_id is None:
+                continue
+            legacy_name = str(chat_id)
+            canonical_name = canonical_principal_names.get(legacy_name, legacy_name)
+            user_dir = memory_root / canonical_name
             user_dst = user_dir / "MEMORY.md"
+            legacy_dir = memory_root / legacy_name
+            legacy_user_file = legacy_dir / "MEMORY.md"
+            if user_dir.is_symlink() or user_dst.is_symlink():
+                raise RuntimeError(f"Refusing symlinked canonical memory path: {user_dst}")
+            if legacy_user_file != user_dst and legacy_dir.is_symlink():
+                raise RuntimeError(f"Refusing symlinked legacy memory directory: {legacy_dir}")
+            if legacy_user_file != user_dst and legacy_user_file.is_symlink():
+                raise RuntimeError(f"Refusing symlinked legacy memory file: {legacy_user_file}")
             if user_dst.exists():
                 continue
+
+            source: Path | None = None
+            move_source = False
+            if legacy_user_file != user_dst and legacy_user_file.is_file():
+                source = legacy_user_file
+            elif index == 0 and legacy_global.is_file():
+                source = legacy_global
+                move_source = True
+            elif template.is_file():
+                source = template
+
             if dry_run:
-                # Match the real branch below: the template may not ship
-                # with the install tree, in which case the real path
-                # writes a placeholder. Printing "from memory template"
-                # unconditionally misleads operators on hosts where the
-                # template is missing.
-                if template.is_file():
-                    print(f"[DRY RUN] Would seed {user_dst} from memory template")
-                else:
+                if source is None:
                     print(f"[DRY RUN] Would create empty {user_dst} (no memory template)")
+                elif move_source:
+                    print(f"[DRY RUN] Would move {source} -> {user_dst}")
+                elif source == legacy_user_file:
+                    print(f"[DRY RUN] Would copy {source} -> {user_dst}")
+                else:
+                    print(f"[DRY RUN] Would seed {user_dst} from {source}")
                 continue
+
             user_dir.mkdir(parents=True, exist_ok=True)
-            if template.is_file():
-                shutil.copy2(template, user_dst)
-                print(f"  Seeded {user_dst} from memory template")
-            else:
+            if source is None:
                 user_dst.write_text("# Memory\n")
                 print(f"  Created empty {user_dst}")
+            elif move_source:
+                shutil.move(str(source), str(user_dst))
+                print(f"  Migrated MEMORY.md to {user_dst}")
+            else:
+                shutil.copy2(source, user_dst)
+                if source == legacy_user_file:
+                    print(f"  Copied memory {source} -> {user_dst}")
+                else:
+                    print(f"  Seeded {user_dst} from memory template")
 
     # -- Uploaded files migration --
     # One-time: copy user-uploaded files from the install tree
@@ -4247,7 +4450,7 @@ def _apply_migrate(
     #       Init_memory() creates qdrant/ and mem0_history.db at runtime
     #       in the main process (service user), so they must be writable
     #       by the service user.
-    #   (b) Per-user-owned: memory/<chat_id>/ subdirectories whose chat_id
+    #   (b) Per-user-owned: memory/<principal_id>/ subdirectories whose owner
     #       maps to a users.yaml entry with an explicit os_user. The
     #       inner Claude subprocess for that user runs via sudo -H -u
     #       <os_user>, so MEMORY.md ownership must match or writes fail
@@ -4278,7 +4481,7 @@ def _apply_migrate(
                     _set_private_user_tree_modes(entry)
                 else:
                     # qdrant/, mem0_history.db, extractor_cwd/, and any
-                    # memory/<chat_id>/ whose user has no os_user set.
+                    # personal-memory directories whose user has no os_user set.
                     _set_ownership(entry, svc_uid, svc_gid, recursive=True)
 
     # -- PREFERENCES.md per-user pre-creation --
@@ -4372,11 +4575,11 @@ def _apply_migrate(
     # entry we pre-create the directory the inner Claude subprocess
     # (sudo -H -u <os_user>) will write into on first message. Three
     # cases, all handled below:
-    #   1. No override: create DATA_DIR/home/<chat_id>/.
+    #   1. No override: create DATA_DIR/home/<principal_id>/.
     #   2. Override path under DATA_DIR (rare, but valid): create the
     #      override path itself, since it lives in our tree and
     #      resolve_home_workspace() will route the user there at
-    #      runtime. Creating DATA_DIR/home/<chat_id>/ instead would
+    #      runtime. Creating a separate canonical default instead would
     #      leave the actual runtime directory un-provisioned and the
     #      user's first write would fail.
     #   3. Override path outside DATA_DIR: skip entirely - the override
@@ -4387,6 +4590,33 @@ def _apply_migrate(
     # service-owned tier, matching the memory tier-(a) rule above.
     home_root = data_path / "home"
     home_overrides = _collect_user_home_overrides(users_yaml_path)
+    managed_home_migrations: dict[int, tuple[Path, Path]] = {}
+    for chat_id, _os_user in memory_owners:
+        if chat_id is None or chat_id in home_overrides:
+            continue
+        legacy_name = str(chat_id)
+        canonical_name = canonical_principal_names.get(legacy_name, legacy_name)
+        if canonical_name == legacy_name:
+            continue
+        legacy_home = home_root / legacy_name
+        canonical_home = home_root / canonical_name
+        if legacy_home.is_symlink() or canonical_home.is_symlink():
+            raise RuntimeError(f"Refusing symlinked managed-home migration: {legacy_home} -> {canonical_home}")
+        if legacy_home.exists() and not legacy_home.is_dir():
+            raise RuntimeError(f"Refusing non-directory legacy managed home: {legacy_home}")
+        if canonical_home.exists() and not canonical_home.is_dir():
+            raise RuntimeError(f"Refusing non-directory canonical managed home: {canonical_home}")
+        managed_home_migrations[chat_id] = (legacy_home, canonical_home)
+
+    # Validate every database rewrite before copying a workspace tree. The
+    # service is stopped during install, so the later copy and transaction see
+    # a stable source. Legacy homes remain untouched as rollback archives.
+    _migrate_managed_home_database_paths(
+        data_path,
+        managed_home_migrations,
+        dry_run=dry_run,
+        validate_only=not dry_run,
+    )
     # Defensive: `_apply_directories` already creates home_root with
     # the right ownership, but we cannot assume ordering (future
     # refactors could split these steps). A missing home_root here
@@ -4423,13 +4653,26 @@ def _apply_migrate(
             continue
         # Case 2: override under DATA_DIR - provision THAT path, since
         # resolve_home_workspace returns it verbatim at runtime. Case
-        # 1: no override - provision the per-user default slot.
-        user_dir = override if override is not None else home_root / str(chat_id)
+        # 1: no override - provision the canonical human default slot.
+        migration = managed_home_migrations.get(chat_id)
+        if override is not None:
+            user_dir = override
+        elif migration is not None:
+            legacy_home, canonical_home = migration
+            user_dir = canonical_home
+            if not canonical_home.exists() and legacy_home.is_dir():
+                if dry_run:
+                    print(f"[DRY RUN] Would copy managed home {legacy_home} -> {canonical_home}")
+                else:
+                    _copy_managed_home_tree(legacy_home, canonical_home)
+                    print(f"  Copied managed home {legacy_home} -> {canonical_home}")
+        else:
+            user_dir = home_root / str(chat_id)
         if user_dir.is_symlink():
             raise RuntimeError(f"Refusing symlinked managed user home: {user_dir}")
         if user_dir.exists() and not user_dir.is_dir():
             raise RuntimeError(f"Refusing non-directory managed user home: {user_dir}")
-        user_dir_exists = user_dir.exists()
+        user_dir_exists = user_dir.exists() or (dry_run and migration is not None and migration[0].is_dir())
         if dry_run:
             if str(chat_id) in per_user_ids:
                 uid, gid = per_user_ids[str(chat_id)]
@@ -4446,9 +4689,9 @@ def _apply_migrate(
         os.chmod(user_dir, _PRIVATE_USER_DIR_MODE)
         if str(chat_id) in per_user_ids:
             uid, gid = per_user_ids[str(chat_id)]
-            _set_ownership(user_dir, uid, gid, recursive=False)
+            _set_ownership(user_dir, uid, gid, recursive=migration is not None)
         else:
-            _set_ownership(user_dir, svc_uid, svc_gid, recursive=False)
+            _set_ownership(user_dir, svc_uid, svc_gid, recursive=migration is not None)
         if not user_dir_exists:
             print(f"  Created {user_dir}")
 
@@ -4471,8 +4714,18 @@ def _apply_migrate(
         override = home_overrides.get(chat_id)
         if override is not None and not override.is_relative_to(data_path_resolved):
             continue
-        user_home = override if override is not None else home_root / str(chat_id)
-        agents_path, claude_path, agents_content, claude_content = _managed_identity_state(user_home)
+        migration = None
+        if override is not None:
+            user_home = override
+        else:
+            migration = managed_home_migrations.get(chat_id)
+            user_home = migration[1] if migration is not None else home_root / str(chat_id)
+        inspection_home = user_home
+        if dry_run and migration is not None and not user_home.exists() and migration[0].is_dir():
+            inspection_home = migration[0]
+        _source_agents, _source_claude, agents_content, claude_content = _managed_identity_state(inspection_home)
+        agents_path = user_home / "AGENTS.md"
+        claude_path = user_home / ".claude" / "CLAUDE.md"
         managed_identities.append(
             (
                 chat_id,
@@ -4482,6 +4735,13 @@ def _apply_migrate(
                 agents_content,
                 claude_content,
             )
+        )
+
+    if not dry_run:
+        _migrate_managed_home_database_paths(
+            data_path,
+            managed_home_migrations,
+            dry_run=False,
         )
 
     for chat_id, backend_name, agents_path, claude_path, agents_content, claude_content in managed_identities:
@@ -5146,13 +5406,13 @@ def _apply_directories(
         (data_path / "history", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         (data_path / "memory", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         # Per-user preferences root (#400). Top-level dir is service-
-        # owned so the bot can lazily create new preferences/<chat_id>/
+        # owned so the bot can lazily create new preferences/<principal_id>/
         # subdirs at first message; per-user subdirs are pre-created
         # and chowned in _apply_migrate when the user has a distinct
         # os_user.
         (data_path / "preferences", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         # Per-user home root (#353). Top-level dir is service-owned so
-        # the bot can lazily create new home/<chat_id>/ subdirs at first
+        # the bot can lazily create new home/<principal_id>/ subdirs at first
         # message; per-user subdirs are pre-created and chowned in
         # _apply_migrate when the user has a distinct os_user.
         (data_path / "home", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
@@ -5420,7 +5680,7 @@ def _migrate_recalled_memory_section(
     Args:
         identity_dst: The per-user AGENTS.md to append to. Path returned
             by the per-user seed loop's resolution of
-            `<DATA_DIR>/home/<chat_id>/AGENTS.md`.
+            `<DATA_DIR>/home/<principal_id>/AGENTS.md`.
         template_path: The tracked template
             (`templates/AGENTS.md`). Section text is extracted
             from here on every call so a future revision to the
@@ -5551,7 +5811,7 @@ def _retire_install_home_claude(install_path: Path, dry_run: bool) -> None:
 
     Both paths predate the per-user `home_workspace` migration in #353.
     Since #353 every session resolves identity from the per-user
-    `<DATA_DIR>/home/<chat_id>/AGENTS.md`; nothing in the
+    `<DATA_DIR>/home/<principal_id>/AGENTS.md`; nothing in the
     runtime reads either of the paths this helper deletes. Issue #447
     retires the install-tree scaffolding entirely. The per-user
     `AGENTS.md` is seeded by `_apply_migrate`'s home block (eager,

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -377,7 +377,7 @@ def _start() -> None:
         # SubprocessPool. Each user's workspace is restored lazily on
         # their first message (in pool.send()). No startup restore needed.
 
-        # Personal MEMORY.md is now per-user under memory/<chat_id>/
+        # Personal MEMORY.md is now per-human under memory/<principal_id>/
         # and is bootstrapped lazily by the backend on first session
         # (backend.ensure_user_memory). No startup bootstrap is needed;
         # that call is intentionally gone. See issue #347.

--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -50,13 +50,43 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import sqlite3
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from kai.config import Config
 
 log = logging.getLogger(__name__)
+
+
+def _default_human_report_directory(config: Config, user_id: str, report_name: str) -> Path:
+    """Resolve admin artifacts under the canonical Workshop human home."""
+    from kai.config import DATA_DIR
+
+    db_path_value = getattr(config, "session_db_path", None)
+    if not isinstance(db_path_value, (str, Path)):
+        return DATA_DIR / "home" / user_id / "docs" / report_name
+    db_path = Path(db_path_value)
+    if db_path.is_symlink() or not db_path.is_file():
+        return DATA_DIR / "home" / user_id / "docs" / report_name
+    connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+    try:
+        tables = {
+            str(row[0]) for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+        }
+        if "external_identities" not in tables:
+            return DATA_DIR / "home" / user_id / "docs" / report_name
+        rows = connection.execute(
+            "SELECT principal_id FROM external_identities WHERE provider = 'telegram' AND external_subject = ?",
+            (user_id,),
+        ).fetchall()
+    finally:
+        connection.close()
+    if len(rows) != 1:
+        raise RuntimeError("Memory admin user has no unique canonical Workshop principal")
+    return DATA_DIR / "home" / str(rows[0][0]) / "docs" / report_name
 
 
 # ── Known source values ─────────────────────────────────────────────
@@ -439,12 +469,11 @@ def _cmd_reclassify(args: argparse.Namespace) -> int:
     if config is None:
         return 1
 
-    from pathlib import Path
-
     from kai import memory_reclassify
-    from kai.config import DATA_DIR
 
-    out_dir = Path(args.out_dir) if args.out_dir else DATA_DIR / "home" / args.user_id / "docs" / "reclassify"
+    out_dir = (
+        Path(args.out_dir) if args.out_dir else _default_human_report_directory(config, args.user_id, "reclassify")
+    )
 
     if not mutating:
         return asyncio.run(
@@ -587,11 +616,11 @@ def _cmd_backfill_provenance(args: argparse.Namespace) -> int:
     if config is None:
         return 1
 
-    from pathlib import Path
-
-    from kai.config import DATA_DIR
-
-    out_dir = Path(args.out_dir) if args.out_dir else DATA_DIR / "home" / args.user_id / "docs" / "backfill-provenance"
+    out_dir = (
+        Path(args.out_dir)
+        if args.out_dir
+        else _default_human_report_directory(config, args.user_id, "backfill-provenance")
+    )
 
     if not mutating:
         return asyncio.run(

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -230,7 +230,7 @@ class SubprocessPool:
         user = self._config.get_user_config(chat_id)
 
         # Resolve through the single backend.resolve_home_workspace
-        # helper: users.yaml override first, else DATA_DIR/home/<chat_id>/.
+        # helper: users.yaml override first, else DATA_DIR/home/<principal_id>/.
         # The old global home field on Config was removed by #353 because
         # it pointed every unconfigured user at a shared directory.
         workspace = resolve_home_workspace(chat_id, self._config)

--- a/src/kai/workshop/storage_namespaces.py
+++ b/src/kai/workshop/storage_namespaces.py
@@ -151,6 +151,18 @@ class WorkshopPrincipalStorageNamespace:
         """Return the prior configured-user directory during migration."""
         return data_dir / "files" / str(self._runtime_config_id)
 
+    def home_directory(self, data_dir: Path) -> Path:
+        """Return the transport-independent managed home directory."""
+        return data_dir / "home" / str(self.principal_id)
+
+    def memory_directory(self, data_dir: Path) -> Path:
+        """Return the transport-independent personal-memory directory."""
+        return data_dir / "memory" / str(self.principal_id)
+
+    def preferences_directory(self, data_dir: Path) -> Path:
+        """Return the transport-independent personal-preferences directory."""
+        return data_dir / "preferences" / str(self.principal_id)
+
 
 class WorkshopPrincipalStorageRegistry:
     """Resolve protected runtimes to canonical human-owned storage."""

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1071,6 +1071,24 @@ class TestResolveHomeWorkspace:
         assert result == home
         ensure_home.assert_not_called()
 
+    def test_protected_install_uses_canonical_principal_home(self, tmp_path, monkeypatch):
+        config = self._config(
+            user_configs={42: UserConfig(telegram_id=42, name="real-user", os_user="alice")},
+            protected_install=True,
+        )
+        principal_id = "prn_" + "a" * 32
+        home = tmp_path / "home" / principal_id
+        home.mkdir(parents=True)
+        registry = MagicMock()
+        registry.for_runtime_config_id.return_value.principal_id = principal_id
+        monkeypatch.setattr("kai.backend._PRINCIPAL_STORAGE_REGISTRY", registry)
+
+        with patch("kai.backend.ensure_user_home") as ensure_home:
+            result = resolve_home_workspace(42, config, data_dir=tmp_path)
+
+        assert result == home
+        ensure_home.assert_not_called()
+
     def test_protected_install_requires_install_provisioning(self, tmp_path):
         config = self._config(
             user_configs={42: UserConfig(telegram_id=42, name="real-user", os_user="alice")},
@@ -1658,6 +1676,76 @@ class TestCanonicalPrincipalPreferences:
         canonical = data_dir / "preferences" / _PrincipalPreferenceNamespace.principal_id / "PREFERENCES.md"
         assert not canonical.exists()
         assert outside.read_text() == "outside preference"
+
+    def test_lazy_memory_bootstrap_copies_legacy_content(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "data"
+        legacy = data_dir / "memory" / "42" / "MEMORY.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("durable personal memory")
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        ensure_user_memory(42, data_dir)
+
+        canonical = data_dir / "memory" / _PrincipalPreferenceNamespace.principal_id / "MEMORY.md"
+        assert canonical.read_text() == "durable personal memory"
+        assert legacy.read_text() == "durable personal memory"
+
+    def test_disabled_memory_context_prefers_canonical_principal(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "data"
+        canonical = data_dir / "memory" / _PrincipalPreferenceNamespace.principal_id / "MEMORY.md"
+        canonical.parent.mkdir(parents=True)
+        canonical.write_text("canonical memory")
+        legacy = data_dir / "memory" / "42" / "MEMORY.md"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text("legacy memory")
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=tmp_path,
+                home_workspace=tmp_path,
+                api=ApiContext(webhook_port=8080, webhook_secret=None),
+                workspace_config=None,
+                chat_id=42,
+                data_dir=data_dir,
+                memory_enabled=False,
+            )
+
+        assert "canonical memory" in result
+        assert "legacy memory" not in result
+        assert str(canonical) in result
+
+    def test_managed_home_uses_canonical_principal_directory(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        home = ensure_user_home(42, tmp_path, backend_name="codex")
+
+        assert home == tmp_path / "home" / _PrincipalPreferenceNamespace.principal_id
+        assert home.is_dir()
+        assert not (tmp_path / "home" / "42").exists()
+
+    def test_managed_home_keeps_first_install_legacy_fallback(self, tmp_path, monkeypatch):
+        legacy = tmp_path / "home" / "42"
+        legacy.mkdir(parents=True)
+        (legacy / "operator.txt").write_text("preserved")
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        home = ensure_user_home(42, tmp_path, backend_name="codex")
+
+        assert home == legacy
+        assert (home / "operator.txt").read_text() == "preserved"
 
 
 class TestPerUserMemoryIsolation:

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1342,6 +1342,40 @@ class TestWriteTurnImageFile:
             first.unlink()
             second.unlink()
 
+    def test_turn_image_directory_uses_canonical_workshop_principal(self):
+        registry = MagicMock()
+        registry.for_runtime_config_id.return_value.principal_id = "prn_" + "b" * 32
+        with patch("kai.backend._PRINCIPAL_STORAGE_REGISTRY", registry):
+            path = write_turn_image_file(
+                _anthropic_image_block(),
+                chat_id=111,
+                reader_user=None,
+            )
+
+        assert path is not None
+        try:
+            assert path.parent.name == "prn_" + "b" * 32
+            assert path.parent.name != "111"
+        finally:
+            path.unlink()
+
+    def test_turn_image_write_refuses_symlinked_staging_root(self, tmp_path):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        staging = tmp_path / "files" / "codex_turn_images"
+        staging.parent.mkdir()
+        staging.symlink_to(outside, target_is_directory=True)
+
+        with patch("kai.codex._TURN_IMAGE_DIR", staging):
+            path = write_turn_image_file(
+                _anthropic_image_block(),
+                chat_id=111,
+                reader_user=None,
+            )
+
+        assert path is None
+        assert not list(outside.iterdir())
+
     def test_macos_cross_user_file_gets_named_read_acl(self):
         completed = MagicMock(returncode=0, stderr="")
         with (

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,6 +6,7 @@ import os
 import pwd
 import shutil
 import signal
+import sqlite3
 import stat
 import subprocess
 import time
@@ -39,6 +40,7 @@ from kai.install import (
     _collect_backends_from_yaml,
     _collect_os_users_from_yaml,
     _collect_user_memory_owners,
+    _copy_managed_home_tree,
     _copy_tree,
     _deployed_webhook_secret_migration_status,
     _file_checksum,
@@ -49,6 +51,7 @@ from kai.install import (
     _generate_systemd_unit,
     _generate_users_yaml,
     _migrate_identity_to_claude_md,
+    _migrate_managed_home_database_paths,
     _optional_file_checksum,
     _prompt_choice,
     _prompt_optional_choice,
@@ -5934,6 +5937,52 @@ class TestApplyMigratePerUserHome:
         monkeypatch.setattr("kai.install.os.chown", lambda *a: None)
         return data_path
 
+    def test_atomic_copy_removes_partial_staging_tree(self, tmp_path, monkeypatch):
+        source = tmp_path / "legacy"
+        source.mkdir()
+        destination = tmp_path / ("prn_" + "a" * 32)
+
+        def fail_after_partial_copy(_source, temporary, *, symlinks):
+            assert symlinks is True
+            temporary.mkdir()
+            (temporary / "partial.txt").write_text("partial")
+            raise OSError("simulated copy failure")
+
+        monkeypatch.setattr("kai.install.shutil.copytree", fail_after_partial_copy)
+
+        with pytest.raises(OSError, match="simulated copy failure"):
+            _copy_managed_home_tree(source, destination)
+
+        assert not destination.exists()
+        assert not list(tmp_path.glob(f".{destination.name}.migrating-*"))
+
+    def test_database_path_migration_handles_missing_optional_tables(self, tmp_path):
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        db_path = data_path / "kai.db"
+        connection = sqlite3.connect(db_path)
+        connection.execute("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        legacy_home = data_path / "home" / "42"
+        canonical_home = data_path / "home" / ("prn_" + "d" * 32)
+        connection.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?)",
+            ("workspace:42", str(legacy_home / "project")),
+        )
+        connection.commit()
+        connection.close()
+
+        _migrate_managed_home_database_paths(
+            data_path,
+            {42: (legacy_home, canonical_home)},
+            dry_run=False,
+        )
+
+        connection = sqlite3.connect(db_path)
+        assert connection.execute("SELECT value FROM settings WHERE key = 'workspace:42'").fetchone() == (
+            str(canonical_home / "project"),
+        )
+        connection.close()
+
     def test_no_override_creates_home_chat_id_dir(self, tmp_path, monkeypatch):
         """
         Case 1 (default): a user with no users.yaml home_workspace lands
@@ -6151,6 +6200,155 @@ class TestApplyMigratePerUserHome:
             "Override under symlinked DATA_DIR was not provisioned - "
             "is_relative_to comparison did not resolve data_path"
         )
+
+    async def test_copies_complete_home_and_rewrites_kai_database_paths(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        data_path = self._setup(tmp_path, monkeypatch)
+        users_yaml = tmp_path / "users.yaml"
+        self._write_users_yaml(
+            users_yaml,
+            "users:\n  - telegram_id: 7777\n    name: primary\n    role: admin\n",
+        )
+        legacy_home = data_path / "home" / "7777"
+        project = legacy_home / "project"
+        project.mkdir(parents=True)
+        (legacy_home / "AGENTS.md").write_text("# Operator identity\n")
+        executable = project / "run.sh"
+        executable.write_text("#!/bin/sh\n")
+        executable.chmod(0o755)
+        legacy_memory = data_path / "memory" / "7777" / "MEMORY.md"
+        legacy_memory.parent.mkdir(parents=True)
+        legacy_memory.write_text("operator memory")
+
+        store = await WorkshopEventStore.open(data_path / "kai.db")
+        await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    "Primary",
+                    "admin",
+                    "telegram",
+                    "7777",
+                    "7777",
+                    profile_id(7777),
+                ),
+            ),
+        )
+        async with store.connection.execute(
+            "SELECT principal_id FROM external_identities WHERE provider = 'telegram' AND external_subject = '7777'"
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        principal_id = str(row[0])
+        await store.close()
+
+        connection = sqlite3.connect(data_path / "kai.db")
+        connection.executescript(
+            "CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);"
+            "CREATE TABLE IF NOT EXISTS allowed_workspaces ("
+            "chat_id INTEGER NOT NULL, path TEXT NOT NULL, PRIMARY KEY (chat_id, path));"
+            "CREATE TABLE IF NOT EXISTS workspace_history ("
+            "path TEXT NOT NULL, chat_id INTEGER NOT NULL, last_used_at TIMESTAMP, "
+            "PRIMARY KEY (path, chat_id));"
+            "CREATE TABLE IF NOT EXISTS memory_projects ("
+            "project_id TEXT PRIMARY KEY, display_name TEXT NOT NULL, "
+            "workspace_root TEXT NOT NULL UNIQUE, memory_enabled INTEGER NOT NULL, "
+            "default_scope_for_new_facts TEXT, created_by INTEGER NOT NULL, "
+            "created_at TIMESTAMP);"
+        )
+        legacy_project = str(project)
+        connection.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?)",
+            ("workspace:7777", legacy_project),
+        )
+        connection.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?)",
+            (f"ws_config:7777:{legacy_project}:model", "gpt-test"),
+        )
+        connection.execute(
+            "INSERT INTO allowed_workspaces (chat_id, path) VALUES (?, ?)",
+            (7777, legacy_project),
+        )
+        connection.execute(
+            "INSERT INTO workspace_history (path, chat_id, last_used_at) VALUES (?, ?, ?)",
+            (legacy_project, 7777, "2026-08-13 05:00:00"),
+        )
+        connection.execute(
+            "INSERT INTO memory_projects "
+            "(project_id, display_name, workspace_root, memory_enabled, "
+            "default_scope_for_new_facts, created_by, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("project", "Project", legacy_project, 1, None, 7777, "2026-08-13 05:00:00"),
+        )
+        connection.commit()
+        connection.close()
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=True,
+            users_yaml_path=users_yaml,
+        )
+        canonical_home = data_path / "home" / principal_id
+        assert not canonical_home.exists()
+        connection = sqlite3.connect(data_path / "kai.db")
+        assert connection.execute("SELECT value FROM settings WHERE key = 'workspace:7777'").fetchone() == (
+            legacy_project,
+        )
+        connection.close()
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+
+        canonical_project = canonical_home / "project"
+        assert (canonical_home / "AGENTS.md").read_text() == "# Operator identity\n"
+        assert (canonical_project / "run.sh").stat().st_mode & 0o777 == 0o755
+        assert (legacy_home / "project" / "run.sh").is_file()
+        canonical_memory = data_path / "memory" / principal_id / "MEMORY.md"
+        assert canonical_memory.read_text() == "operator memory"
+        assert legacy_memory.read_text() == "operator memory"
+
+        connection = sqlite3.connect(data_path / "kai.db")
+        canonical_project_text = str(canonical_project)
+        assert connection.execute("SELECT value FROM settings WHERE key = 'workspace:7777'").fetchone() == (
+            canonical_project_text,
+        )
+        assert connection.execute(
+            "SELECT value FROM settings WHERE key = ?",
+            (f"ws_config:7777:{canonical_project_text}:model",),
+        ).fetchone() == ("gpt-test",)
+        assert connection.execute("SELECT path FROM allowed_workspaces WHERE chat_id = 7777").fetchone() == (
+            canonical_project_text,
+        )
+        assert connection.execute("SELECT path FROM workspace_history WHERE chat_id = 7777").fetchone() == (
+            canonical_project_text,
+        )
+        assert connection.execute(
+            "SELECT workspace_root FROM memory_projects WHERE project_id = 'project'"
+        ).fetchone() == (canonical_project_text,)
+        connection.close()
+
+        (canonical_home / "canonical-only.txt").write_text("new state")
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=501,
+            svc_gid=20,
+            dry_run=False,
+            users_yaml_path=users_yaml,
+        )
+        assert (canonical_home / "canonical-only.txt").read_text() == "new state"
 
 
 # ── Per-user PREFERENCES.md migration (#400) ─────────────────────────

--- a/tests/test_memory_admin.py
+++ b/tests/test_memory_admin.py
@@ -9,11 +9,39 @@ which has its own coverage in tests/test_memory.py.
 
 from __future__ import annotations
 
+import sqlite3
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from kai import memory_admin
+
+
+def test_default_report_directory_uses_canonical_workshop_principal(tmp_path, monkeypatch):
+    db_path = tmp_path / "kai.db"
+    connection = sqlite3.connect(db_path)
+    connection.execute(
+        "CREATE TABLE external_identities ("
+        "principal_id TEXT NOT NULL, provider TEXT NOT NULL, external_subject TEXT NOT NULL)"
+    )
+    principal_id = "prn_" + "c" * 32
+    connection.execute(
+        "INSERT INTO external_identities (principal_id, provider, external_subject) VALUES (?, ?, ?)",
+        (principal_id, "telegram", "42"),
+    )
+    connection.commit()
+    connection.close()
+    monkeypatch.setattr("kai.config.DATA_DIR", tmp_path / "data")
+
+    result = memory_admin._default_human_report_directory(
+        SimpleNamespace(session_db_path=db_path),
+        "42",
+        "reclassify",
+    )
+
+    assert result == tmp_path / "data" / "home" / principal_id / "docs" / "reclassify"
+
 
 # ── _build_parser: arg surface ───────────────────────────────────────
 

--- a/tests/test_workshop_storage_namespaces.py
+++ b/tests/test_workshop_storage_namespaces.py
@@ -93,6 +93,9 @@ class TestWorkshopPrincipalStorageRegistry:
             assert alice.files_directory(tmp_path) == (tmp_path / "files" / str(alice.principal_id))
             assert alice.legacy_files_directory(tmp_path) == (tmp_path / "files" / "101")
             assert alice.files_directory(tmp_path).name != "101"
+            assert alice.home_directory(tmp_path) == (tmp_path / "home" / str(alice.principal_id))
+            assert alice.memory_directory(tmp_path) == (tmp_path / "memory" / str(alice.principal_id))
+            assert alice.preferences_directory(tmp_path) == (tmp_path / "preferences" / str(alice.principal_id))
         finally:
             await store.close()
 


### PR DESCRIPTION
## Summary

- finish canonical `prn_*` namespaces for Kai-managed human homes and
  personal `MEMORY.md` files
- route Codex transient image staging and memory-admin report defaults through
  the same Workshop principal authority
- copy existing managed homes atomically and non-destructively, preserving
  project contents, executable modes, and legacy rollback archives
- transactionally rewrite Kai-held workspace paths beneath migrated homes
- reconcile canonical ownership on every install and fail closed on unsafe
  symlinks, ambiguous principals, or conflicting saved paths

## Why

Workshop humans are independent of Telegram and other client transports. The
remaining numeric home and personal-memory directories still treated a
Telegram/runtime compatibility key as the durable human identity. This PR
finishes that transition in one install migration rather than continuing with
one directory per PR.

Paths that are intentionally unchanged:

- `tmp/<os_user>` remains keyed by the operating-system execution identity
- global semantic-memory state (`memory/qdrant`, `mem0_history.db`, and
  extractor state) remains service-owned application data
- explicit `home_workspace` overrides remain operator-owned paths and are not
  copied or rewritten

## Migration behavior

- `home/<telegram_id>` is copied through a private temporary tree and atomically
  renamed to `home/<principal_id>`; the old home is retained unchanged
- `memory/<telegram_id>/MEMORY.md` is copied to
  `memory/<principal_id>/MEMORY.md`; the old file is retained unchanged
- an existing canonical destination always wins, making repeated installs
  idempotent and preventing stale compatibility data from overwriting new state
- saved workspace selection, workspace configuration keys, allowed workspaces,
  workspace history, and registered memory-project roots beneath an old managed
  home are rewritten in one SQLite transaction
- external paths and other users' paths are not rewritten
- canonical managed-home ownership is recursively reconciled on every install,
  including recovery after an interrupted earlier attempt
- dry-run opens SQLite read-only and reports copies/path rewrites without
  changing files or database rows

## Runtime behavior

- protected runtimes require the canonical `prn_*` home and fail with an
  install instruction if it is missing
- development and first-install compatibility can temporarily use an existing
  numeric home until install provisions the canonical copy
- personal memory and preferences are canonical-first with a read-only legacy
  fallback during migration
- unmapped protected runtime identities fail closed rather than creating a new
  numeric directory

## Validation

- `make check`
- focused storage/install/backend suite: `939 passed`
- full suite: `5617 passed, 1 skipped`
