### PR TITLE
Fix protected context reads after principal storage migration

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -548,11 +548,12 @@ def build_session_context(
     if chat_id is not None:
         preference_dirs = preference_search_directories(chat_id, data_dir=data_dir)
         canonical_pref_path = preference_dirs[0] / "PREFERENCES.md"
-        pref_path = next(
-            (directory / "PREFERENCES.md" for directory in preference_dirs if (directory / "PREFERENCES.md").is_file()),
-            canonical_pref_path,
-        )
         if defer_user_file_reads:
+            # Protected installs deliberately make each per-user directory
+            # unreadable to the outer service.  Do not probe files inside
+            # either namespace before handing the path to the user-owned
+            # backend process: Path.is_file() raises PermissionError rather
+            # than returning False when the directory is mode 0700.
             # A first protected install predates Workshop bootstrap and can
             # provision only the compatibility directory. Use it until the
             # next install creates the canonical principal directory.
@@ -565,6 +566,14 @@ def build_session_context(
                 "Read this file before applying personal preference instructions.]"
             )
         else:
+            pref_path = next(
+                (
+                    directory / "PREFERENCES.md"
+                    for directory in preference_dirs
+                    if (directory / "PREFERENCES.md").is_file()
+                ),
+                canonical_pref_path,
+            )
             try:
                 pref_text = pref_path.read_text().strip()
                 if pref_text:
@@ -603,15 +612,16 @@ def build_session_context(
         if chat_id is not None:
             memory_dirs = memory_search_directories(chat_id, data_dir=data_dir)
             canonical_memory_path = memory_dirs[0] / "MEMORY.md"
-            memory_path = next(
-                (directory / "MEMORY.md" for directory in memory_dirs if (directory / "MEMORY.md").is_file()),
-                canonical_memory_path,
-            )
             if defer_user_file_reads:
                 if len(memory_dirs) > 1 and not canonical_memory_path.parent.is_dir():
                     memory_path = memory_dirs[1] / "MEMORY.md"
                 else:
                     memory_path = canonical_memory_path
+            else:
+                memory_path = next(
+                    (directory / "MEMORY.md" for directory in memory_dirs if (directory / "MEMORY.md").is_file()),
+                    canonical_memory_path,
+                )
         else:
             memory_path = data_dir / "memory" / "MEMORY.md"
         if defer_user_file_reads and chat_id is not None:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1587,6 +1587,42 @@ class _PrincipalPreferenceRegistry:
 
 
 class TestCanonicalPrincipalPreferences:
+    def test_deferred_context_does_not_stat_private_context_files(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "data"
+        principal_id = _PrincipalPreferenceNamespace.principal_id
+        canonical_preferences = data_dir / "preferences" / principal_id
+        canonical_memory = data_dir / "memory" / principal_id
+        canonical_preferences.mkdir(parents=True)
+        canonical_memory.mkdir(parents=True)
+        monkeypatch.setattr(
+            "kai.backend._PRINCIPAL_STORAGE_REGISTRY",
+            _PrincipalPreferenceRegistry(),
+        )
+
+        original_is_file = Path.is_file
+
+        def reject_private_file_probe(path):
+            if path.name in {"PREFERENCES.md", "MEMORY.md"}:
+                raise PermissionError(f"private user file: {path}")
+            return original_is_file(path)
+
+        monkeypatch.setattr(Path, "is_file", reject_private_file_probe)
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=tmp_path,
+                home_workspace=tmp_path,
+                api=ApiContext(webhook_port=8080, webhook_secret=None),
+                workspace_config=None,
+                chat_id=42,
+                data_dir=data_dir,
+                memory_enabled=False,
+                defer_user_file_reads=True,
+            )
+
+        assert str(canonical_preferences / "PREFERENCES.md") in result
+        assert str(canonical_memory / "MEMORY.md") in result
+
     def test_deferred_context_uses_canonical_principal_path(self, tmp_path, monkeypatch):
         data_dir = tmp_path / "data"
         canonical = data_dir / "preferences" / _PrincipalPreferenceNamespace.principal_id


### PR DESCRIPTION
## Summary

- stop the protected Kai daemon from probing user-owned preference files
- apply the same deferred-path rule to personal memory files
- preserve the canonical-principal path with the existing greenfield compatibility fallback

## Root cause

PR #905 correctly made canonical per-user storage private to each target OS user. On the first turn of a protected backend session, `build_session_context()` still called `Path.is_file()` while selecting `PREFERENCES.md`, before checking `defer_user_file_reads`.

Python raises `PermissionError` when the outer `kai` service tries to stat a file inside the target user's mode-0700 directory. The durable execution coordinator then settled the run with its bounded `execution_interrupted` outcome, producing:

> Kai was interrupted while the configured agent was working. This request was not retried.

The disabled-semantic-memory path contained the same latent ordering flaw for `MEMORY.md`.

## Fix

Protected mode now chooses the canonical path without probing the private file. It checks only whether the canonical namespace directory has been provisioned; if not, it retains the existing first-install compatibility-path fallback. Non-protected installations keep their current content-discovery behavior.

No directory permissions are weakened and no data is migrated or deleted.

## Verification

- `tests/test_backend.py`: 116 passed
- full suite: 5618 passed, 1 skipped
- `make check`: passed
- replayed production context assembly as the `kai` service user against `/var/lib/kai`: succeeded with semantic memory enabled and disabled

