### PR TITLE
Protect runtime model and timeout policy

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -866,6 +866,39 @@ def _model_allowed_by_registry(model: str, backend: str, allowed_models: tuple[s
     return False
 
 
+def validate_model_for_backend_policy(
+    model: str,
+    backend: str,
+    eff_provider: str,
+    *,
+    allowed_models: tuple[str, ...] | None = None,
+) -> bool:
+    """Validate a model against backend rules and an explicit ceiling.
+
+    ``None`` means that no registry-level ceiling applies. An empty tuple
+    means that an authoritative registry failed closed and therefore permits
+    no model. Keeping this pure lets protected policy validation use the
+    already-loaded backend registry instead of consulting ambient process
+    state a second time.
+    """
+    if backend == "codex":
+        base_allowed = model in CODEX_MODELS
+    elif backend == "opencode":
+        base_allowed = is_opencode_model_shape(model)
+    elif backend == "pi":
+        base_allowed = is_pi_model_shape(model, eff_provider)
+    elif (backend == "claude" or (backend == "goose" and eff_provider == "anthropic")) and model.startswith("claude-"):
+        base_allowed = True
+    else:
+        base_allowed = validate_model_for_provider(model, eff_provider)
+
+    if not base_allowed:
+        return False
+    if allowed_models is None:
+        return True
+    return _model_allowed_by_registry(model, backend, allowed_models)
+
+
 def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> bool:
     """Check if a model is valid for the active backend.
 
@@ -901,24 +934,13 @@ def validate_model_for_backend(model: str, backend: str, eff_provider: str) -> b
     codebase routes through this function so backends share no
     fallback path.
     """
-    if backend == "codex":
-        base_allowed = model in CODEX_MODELS
-    elif backend == "opencode":
-        base_allowed = is_opencode_model_shape(model)
-    elif backend == "pi":
-        base_allowed = is_pi_model_shape(model, eff_provider)
-    elif (backend == "claude" or (backend == "goose" and eff_provider == "anthropic")) and model.startswith("claude-"):
-        base_allowed = True
-    else:
-        base_allowed = validate_model_for_provider(model, eff_provider)
-
-    if not base_allowed:
-        return False
-
     registry_allowed = _backend_registry_allowed_models(backend)
-    if registry_allowed is None:
-        return True
-    return _model_allowed_by_registry(model, backend, registry_allowed)
+    return validate_model_for_backend_policy(
+        model,
+        backend,
+        eff_provider,
+        allowed_models=registry_allowed,
+    )
 
 
 # (context, matched legacy key) pairs that have already emitted a

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -61,6 +61,7 @@ from kai.config import (
     _resolve_renamed_key,
     canonicalize_model_for_backend,
     get_default_model_for_backend,
+    get_effective_provider,
     models_for_backend,
     normalize_workshop_lan_host,
     validate_model_for_backend,
@@ -924,7 +925,15 @@ def _build_migrated_runtime_profiles(
         raise ValueError(f"Protected users.yaml must contain a 'users' list: {users_yaml_path}")
 
     default_backend = _resolve_install_default_backend(env, _discover_backend_commands(service_user))
-    default_provider = str(env.get("DEFAULT_PROVIDER") or "").strip().lower()
+    default_provider = get_effective_provider(
+        default_backend,
+        str(env.get("DEFAULT_PROVIDER") or "").strip().lower(),
+    )
+    default_model = canonicalize_model_for_backend(
+        str(env.get("DEFAULT_MODEL") or "").strip() or get_default_model_for_backend(default_backend, default_provider),
+        default_backend,
+    )
+    default_timeout = _runtime_policy_default_timeout(env)
     profiles: dict[str, dict[str, object]] = {}
     seen: set[int] = set()
     for entry in entries:
@@ -948,12 +957,35 @@ def _build_migrated_runtime_profiles(
             provider = "anthropic"
         elif backend == "codex":
             provider = "openai"
+        raw_model = entry.get("model")
+        model = ""
+        if raw_model is not None:
+            model = canonicalize_model_for_backend(str(raw_model).strip().lower(), backend)
+            if not validate_model_for_backend(model, backend, provider):
+                model = ""
+        if not model:
+            model = (
+                default_model
+                if backend == default_backend and provider == default_provider
+                else get_default_model_for_backend(backend, provider)
+            )
+        raw_timeout = entry.get("timeout")
+        try:
+            if isinstance(raw_timeout, bool):
+                raise ValueError
+            timeout_seconds = int(raw_timeout) if raw_timeout is not None else default_timeout
+            if timeout_seconds <= 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            timeout_seconds = default_timeout
         profile_id = runtime_profile_id_for_config_id(runtime_config_id)
         profile: dict[str, object] = {
             "display_name": display_name,
             "compatibility_runtime_config_id": runtime_config_id,
             "backend": backend,
             "provider": provider,
+            "model": model,
+            "timeout_seconds": timeout_seconds,
         }
         raw_os_user = entry.get("os_user")
         if raw_os_user is not None and str(raw_os_user).strip():
@@ -964,6 +996,86 @@ def _build_migrated_runtime_profiles(
         sort_keys=False,
         default_flow_style=False,
     )
+
+
+def _runtime_policy_default_timeout(env: dict[str, str]) -> int:
+    raw = str(env.get("DEFAULT_TIMEOUT") or env.get("AGENT_TIMEOUT_SECONDS") or "120").strip()
+    try:
+        value = int(raw)
+        if value <= 0:
+            raise ValueError
+    except (TypeError, ValueError) as exc:
+        raise ValueError("DEFAULT_TIMEOUT must be a positive integer before runtime-policy migration") from exc
+    return value
+
+
+def _upgrade_runtime_policy_content(
+    content: str,
+    migrated_content: str,
+    env: dict[str, str],
+) -> tuple[str, bool]:
+    """Add model/timeout policy to the pre-#923 format without new authority.
+
+    The major document version remains 1 so older Kai code ignores the new
+    keys during rollback. Existing values are never overwritten. Profiles
+    migrated from users.yaml receive the exact pre-cutover effective values;
+    independently authored profiles receive deterministic backend defaults.
+    """
+    try:
+        document = yaml.safe_load(content)
+        migrated = yaml.safe_load(migrated_content)
+    except yaml.YAMLError:
+        return content, False
+    if not isinstance(document, dict) or not isinstance(document.get("runtime_profiles"), dict):
+        return content, False
+    migrated_profiles = migrated.get("runtime_profiles") if isinstance(migrated, dict) else None
+    if not isinstance(migrated_profiles, dict):
+        return content, False
+    expected_by_config_id = {
+        profile.get("compatibility_runtime_config_id"): profile
+        for profile in migrated_profiles.values()
+        if isinstance(profile, dict)
+    }
+    default_backend = str(env.get("DEFAULT_BACKEND") or "").strip().lower()
+    default_provider = get_effective_provider(
+        default_backend,
+        str(env.get("DEFAULT_PROVIDER") or "").strip().lower(),
+    )
+    default_model = canonicalize_model_for_backend(
+        str(env.get("DEFAULT_MODEL") or "").strip() or get_default_model_for_backend(default_backend, default_provider),
+        default_backend,
+    )
+    default_timeout = _runtime_policy_default_timeout(env)
+    changed = False
+    for profile in document["runtime_profiles"].values():
+        if not isinstance(profile, dict):
+            continue
+        expected = expected_by_config_id.get(profile.get("compatibility_runtime_config_id"))
+        if "model" not in profile:
+            if isinstance(expected, dict):
+                profile["model"] = expected["model"]
+            else:
+                backend = str(profile.get("backend") or "").strip().lower()
+                provider = str(profile.get("provider") or "").strip().lower()
+                try:
+                    profile["model"] = (
+                        default_model
+                        if backend == default_backend and provider == default_provider
+                        else get_default_model_for_backend(backend, provider)
+                    )
+                except LookupError:
+                    # Leave malformed independently-authored profiles alone;
+                    # the canonical parser below will report the invalid
+                    # backend/provider rather than hiding it with a migration
+                    # lookup failure.
+                    continue
+            changed = True
+        if "timeout_seconds" not in profile:
+            profile["timeout_seconds"] = expected["timeout_seconds"] if isinstance(expected, dict) else default_timeout
+            changed = True
+    if not changed:
+        return content, False
+    return yaml.safe_dump(document, sort_keys=False, default_flow_style=False), True
 
 
 def _runtime_policy_apply_plan(
@@ -983,7 +1095,8 @@ def _runtime_policy_apply_plan(
             content = RUNTIME_PROFILES_YAML.read_text(encoding="utf-8")
         except OSError as exc:
             raise ValueError(f"Could not read protected runtime policy {RUNTIME_PROFILES_YAML}: {exc}") from exc
-        action = "preserve"
+        content, upgraded = _upgrade_runtime_policy_content(content, migrated_content, env)
+        action = "upgrade" if upgraded else "preserve"
     else:
         content = migrated_content
         action = "initialize"
@@ -1015,10 +1128,12 @@ def _runtime_policy_apply_plan(
             raise ValueError(
                 "Protected runtime policy lost a required compatibility profile during validation"
             ) from exc
-        if (actual.backend, actual.provider, actual.os_user) != (
+        if (actual.backend, actual.provider, actual.os_user, actual.model, actual.timeout_seconds) != (
             expected.backend,
             expected.provider,
             expected.os_user,
+            expected.model,
+            expected.timeout_seconds,
         ):
             raise ValueError(
                 f"Protected runtime profile {actual.profile_id} conflicts with users.yaml fields still required "
@@ -1041,12 +1156,17 @@ def _runtime_policy_has_config_id(
 def _apply_runtime_policy(action: str, content: str, dry_run: bool) -> None:
     """Install or secure the already-validated protected runtime policy."""
     if dry_run:
-        verb = "initialize" if action == "initialize" else "secure existing"
+        verb = {
+            "initialize": "initialize",
+            "upgrade": "upgrade existing",
+            "preserve": "secure existing",
+        }[action]
         print(f"[DRY RUN] Would {verb}: {RUNTIME_PROFILES_YAML} (mode 0600, root-owned)")
         return
-    if action == "initialize":
+    if action in {"initialize", "upgrade"}:
         RUNTIME_PROFILES_YAML.write_text(content, encoding="utf-8")
-        print(f"  Initialized {RUNTIME_PROFILES_YAML}")
+        verb = "Initialized" if action == "initialize" else "Upgraded"
+        print(f"  {verb} {RUNTIME_PROFILES_YAML}")
     os.chmod(RUNTIME_PROFILES_YAML, 0o600)
     os.chown(RUNTIME_PROFILES_YAML, 0, 0)
     if action == "preserve":
@@ -5265,8 +5385,9 @@ def _cmd_apply() -> None:
         raise SystemExit(f"{msg} {remedy} Valid models: {valid_list}")
 
     # Resolve and validate the protected runtime-policy transition before
-    # stopping a healthy service. Existing policy is preserved verbatim;
-    # absence produces the deterministic one-time users.yaml migration.
+    # stopping a healthy service. Existing policy is preserved except for
+    # backward-compatible schema enrichment; absence produces the
+    # deterministic one-time users.yaml migration.
     try:
         runtime_policy_action, runtime_policy_content, _runtime_policy = _runtime_policy_apply_plan(
             service_user,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -37,6 +37,7 @@ import tempfile
 import textwrap
 import time
 from collections.abc import Iterable
+from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
 
@@ -65,6 +66,7 @@ from kai.config import (
     models_for_backend,
     normalize_workshop_lan_host,
     validate_model_for_backend,
+    validate_model_for_backend_policy,
 )
 from kai.named_access import replace_named_read_access
 from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
@@ -900,11 +902,57 @@ def _protected_user_assignments(users_yaml_path: Path) -> list[tuple[int, str, s
     return assignments
 
 
+@dataclass(frozen=True, slots=True)
+class _RuntimePolicyDefaults:
+    backend: str
+    provider: str
+    model: str
+    timeout_seconds: int
+
+
+def _runtime_policy_defaults(
+    env: dict[str, str],
+    registry_entries: dict[str, dict[str, object]],
+) -> _RuntimePolicyDefaults:
+    installed = {backend: str(entry.get("command") or backend) for backend, entry in registry_entries.items()}
+    backend = _resolve_install_default_backend(env, installed)
+    provider = get_effective_provider(
+        backend,
+        str(env.get("DEFAULT_PROVIDER") or "").strip().lower(),
+    )
+    model = canonicalize_model_for_backend(
+        str(env.get("DEFAULT_MODEL") or "").strip() or get_default_model_for_backend(backend, provider),
+        backend,
+    )
+    return _RuntimePolicyDefaults(
+        backend=backend,
+        provider=provider,
+        model=model,
+        timeout_seconds=_runtime_policy_default_timeout(env),
+    )
+
+
+def _install_registry_model_ceiling(
+    backend: str,
+    registry_entries: dict[str, dict[str, object]],
+) -> tuple[str, ...] | None:
+    entry = registry_entries.get(backend)
+    if not isinstance(entry, dict):
+        raise ValueError(f"Generated backend registry has no valid entry for {backend!r}")
+    raw = entry.get("allowed_models")
+    if raw is None:
+        return None
+    if not isinstance(raw, list) or any(not isinstance(item, str) for item in raw):
+        raise ValueError(f"Generated backend registry allowed_models for {backend!r} is invalid")
+    checked = tuple(item.strip() for item in raw if item.strip())
+    return checked or None
+
+
 def _build_migrated_runtime_profiles(
     users_yaml_path: Path,
-    env: dict[str, str],
     *,
-    service_user: str,
+    registry_entries: dict[str, dict[str, object]],
+    defaults: _RuntimePolicyDefaults,
 ) -> str:
     """Render the deterministic first protected runtime-policy document.
 
@@ -924,16 +972,6 @@ def _build_migrated_runtime_profiles(
     if not isinstance(entries, list):
         raise ValueError(f"Protected users.yaml must contain a 'users' list: {users_yaml_path}")
 
-    default_backend = _resolve_install_default_backend(env, _discover_backend_commands(service_user))
-    default_provider = get_effective_provider(
-        default_backend,
-        str(env.get("DEFAULT_PROVIDER") or "").strip().lower(),
-    )
-    default_model = canonicalize_model_for_backend(
-        str(env.get("DEFAULT_MODEL") or "").strip() or get_default_model_for_backend(default_backend, default_provider),
-        default_backend,
-    )
-    default_timeout = _runtime_policy_default_timeout(env)
     profiles: dict[str, dict[str, object]] = {}
     seen: set[int] = set()
     for entry in entries:
@@ -951,8 +989,8 @@ def _build_migrated_runtime_profiles(
         if runtime_config_id <= 0 or not display_name or role not in _VALID_ROLES or runtime_config_id in seen:
             continue
         seen.add(runtime_config_id)
-        backend = str(entry.get("backend") or default_backend).strip().lower()
-        provider = str(entry.get("provider") or default_provider).strip().lower()
+        backend = str(entry.get("backend") or defaults.backend).strip().lower()
+        provider = str(entry.get("provider") or defaults.provider).strip().lower()
         if backend == "claude":
             provider = "anthropic"
         elif backend == "codex":
@@ -961,23 +999,28 @@ def _build_migrated_runtime_profiles(
         model = ""
         if raw_model is not None:
             model = canonicalize_model_for_backend(str(raw_model).strip().lower(), backend)
-            if not validate_model_for_backend(model, backend, provider):
+            if not validate_model_for_backend_policy(
+                model,
+                backend,
+                provider,
+                allowed_models=_install_registry_model_ceiling(backend, registry_entries),
+            ):
                 model = ""
         if not model:
             model = (
-                default_model
-                if backend == default_backend and provider == default_provider
+                defaults.model
+                if backend == defaults.backend and provider == defaults.provider
                 else get_default_model_for_backend(backend, provider)
             )
         raw_timeout = entry.get("timeout")
         try:
             if isinstance(raw_timeout, bool):
                 raise ValueError
-            timeout_seconds = int(raw_timeout) if raw_timeout is not None else default_timeout
+            timeout_seconds = int(raw_timeout) if raw_timeout is not None else defaults.timeout_seconds
             if timeout_seconds <= 0:
                 raise ValueError
         except (TypeError, ValueError):
-            timeout_seconds = default_timeout
+            timeout_seconds = defaults.timeout_seconds
         profile_id = runtime_profile_id_for_config_id(runtime_config_id)
         profile: dict[str, object] = {
             "display_name": display_name,
@@ -1012,9 +1055,9 @@ def _runtime_policy_default_timeout(env: dict[str, str]) -> int:
 def _upgrade_runtime_policy_content(
     content: str,
     migrated_content: str,
-    env: dict[str, str],
+    defaults: _RuntimePolicyDefaults,
 ) -> tuple[str, bool]:
-    """Add model/timeout policy to the pre-#923 format without new authority.
+    """Add model/timeout policy to documents that predate those keys.
 
     The major document version remains 1 so older Kai code ignores the new
     keys during rollback. Existing values are never overwritten. Profiles
@@ -1036,16 +1079,6 @@ def _upgrade_runtime_policy_content(
         for profile in migrated_profiles.values()
         if isinstance(profile, dict)
     }
-    default_backend = str(env.get("DEFAULT_BACKEND") or "").strip().lower()
-    default_provider = get_effective_provider(
-        default_backend,
-        str(env.get("DEFAULT_PROVIDER") or "").strip().lower(),
-    )
-    default_model = canonicalize_model_for_backend(
-        str(env.get("DEFAULT_MODEL") or "").strip() or get_default_model_for_backend(default_backend, default_provider),
-        default_backend,
-    )
-    default_timeout = _runtime_policy_default_timeout(env)
     changed = False
     for profile in document["runtime_profiles"].values():
         if not isinstance(profile, dict):
@@ -1059,8 +1092,8 @@ def _upgrade_runtime_policy_content(
                 provider = str(profile.get("provider") or "").strip().lower()
                 try:
                     profile["model"] = (
-                        default_model
-                        if backend == default_backend and provider == default_provider
+                        defaults.model
+                        if backend == defaults.backend and provider == defaults.provider
                         else get_default_model_for_backend(backend, provider)
                     )
                 except LookupError:
@@ -1071,7 +1104,9 @@ def _upgrade_runtime_policy_content(
                     continue
             changed = True
         if "timeout_seconds" not in profile:
-            profile["timeout_seconds"] = expected["timeout_seconds"] if isinstance(expected, dict) else default_timeout
+            profile["timeout_seconds"] = (
+                expected["timeout_seconds"] if isinstance(expected, dict) else defaults.timeout_seconds
+            )
             changed = True
     if not changed:
         return content, False
@@ -1085,17 +1120,18 @@ def _runtime_policy_apply_plan(
 ) -> tuple[str, str, WorkshopRuntimeProfileRegistry]:
     """Validate existing policy or prepare the one-time migration before apply."""
     registry_entries = _backend_registry_entries(service_user, env, users_yaml_path)
+    defaults = _runtime_policy_defaults(env, registry_entries)
     migrated_content = _build_migrated_runtime_profiles(
         users_yaml_path,
-        env,
-        service_user=service_user,
+        registry_entries=registry_entries,
+        defaults=defaults,
     )
     if RUNTIME_PROFILES_YAML.is_file():
         try:
             content = RUNTIME_PROFILES_YAML.read_text(encoding="utf-8")
         except OSError as exc:
             raise ValueError(f"Could not read protected runtime policy {RUNTIME_PROFILES_YAML}: {exc}") from exc
-        content, upgraded = _upgrade_runtime_policy_content(content, migrated_content, env)
+        content, upgraded = _upgrade_runtime_policy_content(content, migrated_content, defaults)
         action = "upgrade" if upgraded else "preserve"
     else:
         content = migrated_content

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -280,28 +280,34 @@ class SubprocessPool:
         # the backend; no codex-specific patch needed here.
         global_provider = get_effective_provider(self._config.default_backend, self._config.default_provider)
 
-        # Per-user model. When the user's effective backend differs
-        # from the global one, the global default_model may not be
-        # valid; fall back to the per-backend default instead.
-        if user and user.model:
-            model = user.model
-        elif backend == self._config.default_backend and effective_provider == global_provider:
-            model = self._config.default_model
-            # Catch the case where the global backend itself is an open-ended
-            # provider and DEFAULT_MODEL is a backend-specific value
-            # that may be invalid for the open-ended provider.
-            # Startup validation passes because open-ended providers accept
-            # any model string, but the provider API will reject it.
-            if effective_provider in OPEN_ENDED_PROVIDERS:
-                log.warning(
-                    "No model configured for open-ended provider '%s' (chat %d); "
-                    "using global default '%s' which may not be valid for this provider",
-                    effective_provider,
-                    chat_id,
-                    model,
-                )
+        # Protected Workshop policy owns the effective conversational model.
+        # The compatibility cascade remains only for Telegram groups and
+        # uninstalled/dev runs that do not resolve a protected profile.
+        if protected_profile is not None:
+            model = protected_profile.model
         else:
-            model = get_default_model_for_backend(backend, effective_provider)
+            # Per-user model. When the user's effective backend differs
+            # from the global one, the global default_model may not be
+            # valid; fall back to the per-backend default instead.
+            if user and user.model:
+                model = user.model
+            elif backend == self._config.default_backend and effective_provider == global_provider:
+                model = self._config.default_model
+                # Catch the case where the global backend itself is an open-ended
+                # provider and DEFAULT_MODEL is a backend-specific value
+                # that may be invalid for the open-ended provider.
+                # Startup validation passes because open-ended providers accept
+                # any model string, but the provider API will reject it.
+                if effective_provider in OPEN_ENDED_PROVIDERS:
+                    log.warning(
+                        "No model configured for open-ended provider '%s' (chat %d); "
+                        "using global default '%s' which may not be valid for this provider",
+                        effective_provider,
+                        chat_id,
+                        model,
+                    )
+            else:
+                model = get_default_model_for_backend(backend, effective_provider)
 
         # Canonicalize retired backend-specific spellings after the
         # complete precedence cascade and before constructing a backend.
@@ -310,7 +316,12 @@ class SubprocessPool:
         # family shorthand.
         model = canonicalize_model_for_backend(model, backend)
 
-        timeout = user.timeout if user and user.timeout is not None else self._config.default_timeout
+        if protected_profile is not None:
+            timeout = protected_profile.timeout_seconds
+        elif user and user.timeout is not None:
+            timeout = user.timeout
+        else:
+            timeout = self._config.default_timeout
         # home_ws is what the backend treats as "home" for the foreign-
         # workspace reminder. Same resolution as the workspace above so
         # the two cannot drift; pre-#353 this took a different path that

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -101,10 +101,9 @@ def _registry_model_ceiling(
             )
         checked = tuple(item.strip() for item in raw if item.strip())
         return checked or None
-    # Focused tests may provide an opaque sentinel when only backend
-    # membership is under test. Production loaders use one of the two
-    # concrete forms above.
-    return None
+    raise WorkshopRuntimeProfileError(
+        f"Runtime profile {profile_id}: backend registry entry for {backend!r} is invalid"
+    )
 
 
 def runtime_profile_id_for_config_id(runtime_config_id: int) -> RuntimeProfileId:

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -13,7 +13,18 @@ from typing import Any
 import yaml
 
 from kai.backend_registry import BackendRegistryEntry, load_backend_registry
-from kai.config import BACKEND_PROVIDERS, VALID_BACKENDS, Config, _read_protected_file, get_user_backend_and_provider
+from kai.config import (
+    BACKEND_PROVIDERS,
+    VALID_BACKENDS,
+    Config,
+    UserConfig,
+    _read_protected_file,
+    canonicalize_model_for_backend,
+    get_default_model_for_backend,
+    get_effective_provider,
+    get_user_backend_and_provider,
+    validate_model_for_backend_policy,
+)
 from kai.workshop.domain import RuntimeProfileId
 
 _PROFILE_DERIVATION_DOMAIN = b"kai-workshop-runtime-profile:v1\0"
@@ -46,6 +57,54 @@ class ProtectedRuntimeProfile:
     os_user: str | None
     backend: str
     provider: str
+    model: str
+    timeout_seconds: int
+
+
+def _compatibility_model(
+    user: UserConfig | None,
+    config: Config,
+    *,
+    backend: str,
+    provider: str,
+) -> str:
+    """Mirror the conversational pool's pre-cutover model cascade."""
+    global_provider = get_effective_provider(config.default_backend, config.default_provider)
+    if user is not None and user.model:
+        model = user.model
+    elif backend == config.default_backend and provider == global_provider:
+        model = config.default_model
+    else:
+        model = get_default_model_for_backend(backend, provider)
+    return canonicalize_model_for_backend(model, backend)
+
+
+def _registry_model_ceiling(
+    backend: str,
+    installed: Mapping[str, BackendRegistryEntry | object] | None,
+    *,
+    profile_id: RuntimeProfileId,
+) -> tuple[str, ...] | None:
+    """Read one already-loaded backend entry's optional model ceiling."""
+    if installed is None:
+        return None
+    entry = installed[backend]
+    if isinstance(entry, BackendRegistryEntry):
+        return entry.allowed_models or None
+    if isinstance(entry, Mapping):
+        raw = entry.get("allowed_models")
+        if raw is None:
+            return None
+        if not isinstance(raw, list) or any(not isinstance(item, str) for item in raw):
+            raise WorkshopRuntimeProfileError(
+                f"Runtime profile {profile_id}: backend registry allowed_models is invalid"
+            )
+        checked = tuple(item.strip() for item in raw if item.strip())
+        return checked or None
+    # Focused tests may provide an opaque sentinel when only backend
+    # membership is under test. Production loaders use one of the two
+    # concrete forms above.
+    return None
 
 
 def runtime_profile_id_for_config_id(runtime_config_id: int) -> RuntimeProfileId:
@@ -137,6 +196,8 @@ class WorkshopRuntimeProfileRegistry:
                     os_user=user.os_user,
                     backend=backend,
                     provider=provider,
+                    model=_compatibility_model(user, config, backend=backend, provider=provider),
+                    timeout_seconds=user.timeout if user.timeout is not None else config.default_timeout,
                 )
             )
         return cls(tuple(profiles))
@@ -190,6 +251,25 @@ class WorkshopRuntimeProfileRegistry:
                     f"Runtime profile {profile_id}: provider {provider!r} is not valid for backend {backend!r}; "
                     f"expected one of: {allowed}"
                 )
+            model = canonicalize_model_for_backend(str(raw_profile.get("model") or "").strip(), backend)
+            if not model:
+                raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: model is required")
+            allowed_models = _registry_model_ceiling(backend, installed, profile_id=profile_id)
+            if not validate_model_for_backend_policy(
+                model,
+                backend,
+                provider,
+                allowed_models=allowed_models,
+            ):
+                raise WorkshopRuntimeProfileError(
+                    f"Runtime profile {profile_id}: model {model!r} is not valid for "
+                    f"backend {backend!r} and provider {provider!r}"
+                )
+            raw_timeout = raw_profile.get("timeout_seconds")
+            if isinstance(raw_timeout, bool) or not isinstance(raw_timeout, int) or raw_timeout <= 0:
+                raise WorkshopRuntimeProfileError(
+                    f"Runtime profile {profile_id}: timeout_seconds must be a positive integer"
+                )
             raw_os_user = raw_profile.get("os_user")
             os_user = None if raw_os_user is None else str(raw_os_user).strip() or None
             if os_user is not None and _OS_USER_RE.fullmatch(os_user) is None:
@@ -205,6 +285,8 @@ class WorkshopRuntimeProfileRegistry:
                     os_user=os_user,
                     backend=backend,
                     provider=provider,
+                    model=model,
+                    timeout_seconds=raw_timeout,
                 )
             )
         return cls(tuple(profiles))
@@ -245,12 +327,20 @@ class WorkshopRuntimeProfileRegistry:
         Backend selection is owned by this registry. While users.yaml still
         provisions the corresponding OS account, models, workspaces, and
         service grants for migrated profiles, the duplicated backend/provider/
-        OS-user fields must agree.
+        OS-user/model/timeout fields must agree.
         """
         for runtime_config_id, user in config.user_configs.items():
             profile = self.for_config_id(runtime_config_id)
             backend, provider = get_user_backend_and_provider(user, config)
-            if (profile.backend, profile.provider, profile.os_user) != (backend, provider, user.os_user):
+            expected_model = _compatibility_model(user, config, backend=backend, provider=provider)
+            expected_timeout = user.timeout if user.timeout is not None else config.default_timeout
+            if (
+                profile.backend,
+                profile.provider,
+                profile.os_user,
+                profile.model,
+                profile.timeout_seconds,
+            ) != (backend, provider, user.os_user, expected_model, expected_timeout):
                 raise WorkshopRuntimeProfileError(
                     f"Runtime profile {profile.profile_id} conflicts with the migrated users.yaml execution policy"
                 )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8297,10 +8297,14 @@ class TestIndependentRuntimePolicy:
             "compatibility_runtime_config_id": 101,
             "backend": "codex",
             "provider": "openai",
+            "model": "gpt-5.5",
+            "timeout_seconds": 120,
             "os_user": "daniel",
         }
         assert document["runtime_profiles"][scott_id]["backend"] == "claude"
         assert document["runtime_profiles"][scott_id]["provider"] == "anthropic"
+        assert document["runtime_profiles"][scott_id]["model"] == "sonnet"
+        assert document["runtime_profiles"][scott_id]["timeout_seconds"] == 120
 
     def test_status_reports_only_profile_count_and_backend_ids(self, tmp_path):
         profile_id = str(kai.install.runtime_profile_id_for_config_id(101))
@@ -8315,6 +8319,8 @@ class TestIndependentRuntimePolicy:
                             "compatibility_runtime_config_id": 101,
                             "backend": "codex",
                             "provider": "openai",
+                            "model": "gpt-5.5",
+                            "timeout_seconds": 120,
                         }
                     },
                 }
@@ -8373,6 +8379,84 @@ class TestIndependentRuntimePolicy:
         _apply_runtime_policy("preserve", "replacement-must-not-land\n", dry_run=False)
 
         assert policy.read_text() == "operator-authored\n"
+
+    def test_apply_writes_backward_compatible_policy_enrichment(self, tmp_path, monkeypatch):
+        policy = tmp_path / "runtime-profiles.yaml"
+        policy.write_text("old-policy\n")
+        monkeypatch.setattr("kai.install.RUNTIME_PROFILES_YAML", policy)
+        monkeypatch.setattr("kai.install.os.chown", lambda *args: None)
+
+        _apply_runtime_policy("upgrade", "enriched-policy\n", dry_run=False)
+
+        assert policy.read_text() == "enriched-policy\n"
+
+    def test_apply_plan_enriches_existing_policy_without_replacing_profile_identity(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            """users:
+  - telegram_id: 101
+    name: Daniel
+    role: admin
+    os_user: daniel
+    backend: codex
+    model: gpt-5.6-sol
+    timeout: 345
+"""
+        )
+        profile_id = str(kai.install.runtime_profile_id_for_config_id(101))
+        policy = tmp_path / "runtime-profiles.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "version": 1,
+                    "runtime_profiles": {
+                        profile_id: {
+                            "display_name": "Operator display name",
+                            "compatibility_runtime_config_id": 101,
+                            "os_user": "daniel",
+                            "backend": "codex",
+                            "provider": "openai",
+                        }
+                    },
+                },
+                sort_keys=False,
+            )
+        )
+        monkeypatch.setattr("kai.install.RUNTIME_PROFILES_YAML", policy)
+        monkeypatch.setattr(
+            "kai.install._discover_backend_commands",
+            lambda _service_user: {"codex": "/usr/local/bin/codex"},
+        )
+        monkeypatch.setattr(
+            "kai.install._backend_registry_entries",
+            lambda *args: {
+                "codex": {
+                    "allowed_models": ["gpt-5.5", "gpt-5.6-sol"],
+                }
+            },
+        )
+
+        action, content, profiles = _runtime_policy_apply_plan(
+            "kai",
+            {
+                "DEFAULT_BACKEND": "codex",
+                "DEFAULT_PROVIDER": "openai",
+                "DEFAULT_TIMEOUT": "120",
+            },
+            users_yaml,
+        )
+
+        document = yaml.safe_load(content)
+        assert action == "upgrade"
+        assert list(document["runtime_profiles"]) == [profile_id]
+        assert document["runtime_profiles"][profile_id]["display_name"] == "Operator display name"
+        assert document["runtime_profiles"][profile_id]["model"] == "gpt-5.6-sol"
+        assert document["runtime_profiles"][profile_id]["timeout_seconds"] == 345
+        assert profiles.resolve(profile_id).runtime_config_id == 101
 
     def test_existing_policy_must_cover_every_migrated_profile(self, tmp_path, monkeypatch):
         users_yaml = tmp_path / "users.yaml"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8284,8 +8284,16 @@ class TestIndependentRuntimePolicy:
 
         rendered = _build_migrated_runtime_profiles(
             users_yaml,
-            {"DEFAULT_BACKEND": "codex", "DEFAULT_PROVIDER": "openai"},
-            service_user="kai",
+            registry_entries={
+                "codex": {"allowed_models": sorted(kai.install.CODEX_MODELS)},
+                "claude": {"allowed_models": ["haiku", "opus", "sonnet", "claude-*"]},
+            },
+            defaults=kai.install._RuntimePolicyDefaults(
+                backend="codex",
+                provider="openai",
+                model="gpt-5.5",
+                timeout_seconds=120,
+            ),
         )
         document = yaml.safe_load(rendered)
 
@@ -8305,6 +8313,50 @@ class TestIndependentRuntimePolicy:
         assert document["runtime_profiles"][scott_id]["provider"] == "anthropic"
         assert document["runtime_profiles"][scott_id]["model"] == "sonnet"
         assert document["runtime_profiles"][scott_id]["timeout_seconds"] == 120
+
+    def test_migration_validates_against_registry_being_installed(self, tmp_path, monkeypatch):
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            """users:
+  - telegram_id: 101
+    name: Daniel
+    role: admin
+    backend: codex
+    model: gpt-5.6-sol
+"""
+        )
+        old_registry = tmp_path / "backends.yaml"
+        old_registry.write_text(
+            """version: 1
+backends:
+  codex:
+    driver: codex
+    runtime: local_process
+    command: /usr/local/bin/codex
+    allowed_models:
+      - gpt-5.5
+"""
+        )
+        monkeypatch.setenv("KAI_BACKENDS_YAML", str(old_registry))
+
+        rendered = _build_migrated_runtime_profiles(
+            users_yaml,
+            registry_entries={
+                "codex": {
+                    "command": "/usr/local/bin/codex",
+                    "allowed_models": ["gpt-5.5", "gpt-5.6-sol"],
+                }
+            },
+            defaults=kai.install._RuntimePolicyDefaults(
+                backend="codex",
+                provider="openai",
+                model="gpt-5.5",
+                timeout_seconds=120,
+            ),
+        )
+
+        profile = next(iter(yaml.safe_load(rendered)["runtime_profiles"].values()))
+        assert profile["model"] == "gpt-5.6-sol"
 
     def test_status_reports_only_profile_count_and_backend_ids(self, tmp_path):
         profile_id = str(kai.install.runtime_profile_id_for_config_id(101))
@@ -8443,7 +8495,6 @@ class TestIndependentRuntimePolicy:
         action, content, profiles = _runtime_policy_apply_plan(
             "kai",
             {
-                "DEFAULT_BACKEND": "codex",
                 "DEFAULT_PROVIDER": "openai",
                 "DEFAULT_TIMEOUT": "120",
             },

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -45,6 +45,8 @@ class TestRuntimeAssignmentPolicy:
                         "display_name": "Browser coding",
                         "backend": "codex",
                         "provider": "openai",
+                        "model": "gpt-5.5",
+                        "timeout_seconds": 120,
                     }
                 },
             },

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -50,7 +50,7 @@ class TestRuntimeAssignmentPolicy:
                     }
                 },
             },
-            backend_registry={"codex": object()},
+            backend_registry={"codex": {}},
         )
         try:
             human = await WorkshopHumanProvisioner(store).provision(

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -95,6 +95,8 @@ def test_protected_profile_selects_backend_and_os_user_over_compatibility_config
                 os_user="protected-user",
                 backend="codex",
                 provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=345,
             ),
         )
     )
@@ -104,6 +106,8 @@ def test_protected_profile_selects_backend_and_os_user_over_compatibility_config
 
     assert instance.backend_name == "codex"
     assert instance.codex_user == "protected-user"
+    assert instance.model == "gpt-5.6-sol"
+    assert instance.timeout_seconds == 345
 
 
 def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, monkeypatch):
@@ -127,6 +131,8 @@ def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, mon
                 os_user=None,
                 backend="codex",
                 provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
             ),
         )
     )
@@ -161,6 +167,8 @@ def test_negative_group_key_retains_legacy_compatibility_runtime(tmp_path, monke
                 os_user=None,
                 backend="codex",
                 provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
             ),
         )
     )
@@ -196,6 +204,8 @@ def test_positive_configuration_key_without_profile_fails_closed(tmp_path, monke
                 os_user=None,
                 backend="codex",
                 provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
             ),
         )
     )

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from kai.backend_registry import BackendRegistryEntry
 from kai.config import Config, UserConfig
 from kai.workshop.domain import RuntimeProfileId
 from kai.workshop.runtime_profiles import (
@@ -55,9 +56,13 @@ def test_registry_exposes_opaque_stable_profiles_with_protected_policy():
     assert daniel.os_user == "daniel"
     assert daniel.backend == "codex"
     assert daniel.provider == "openai"
+    assert daniel.model == "gpt-5.6-sol"
+    assert daniel.timeout_seconds == 120
     assert scott.os_user == "sellison"
     assert scott.backend == "claude"
     assert scott.provider == "anthropic"
+    assert scott.model == "sonnet"
+    assert scott.timeout_seconds == 120
 
 
 @pytest.mark.parametrize("value", (0, -1, True, "101"))
@@ -81,6 +86,8 @@ def test_registry_rejects_duplicate_configuration_authority():
         "daniel",
         "codex",
         "openai",
+        "gpt-5.6-sol",
+        120,
     )
 
     with pytest.raises(WorkshopRuntimeProfileError, match="Duplicate runtime profile ID"):
@@ -99,6 +106,8 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
                     "os_user": "daniel",
                     "backend": "codex",
                     "provider": "openai",
+                    "model": "gpt-5.6-sol",
+                    "timeout_seconds": 240,
                 }
             },
         },
@@ -111,6 +120,8 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
     assert profile.os_user == "daniel"
     assert profile.backend == "codex"
     assert profile.provider == "openai"
+    assert profile.model == "gpt-5.6-sol"
+    assert profile.timeout_seconds == 240
 
 
 def test_non_telegram_profile_derives_stable_private_compatibility_key():
@@ -123,6 +134,8 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
                     "display_name": "Browser-only coding",
                     "backend": "pi",
                     "provider": "openai-codex",
+                    "model": "openai-codex/gpt-5.5",
+                    "timeout_seconds": 120,
                 }
             },
         },
@@ -136,6 +149,8 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
                     "display_name": "Browser-only coding",
                     "backend": "pi",
                     "provider": "openai-codex",
+                    "model": "openai-codex/gpt-5.5",
+                    "timeout_seconds": 120,
                 }
             },
         },
@@ -149,16 +164,16 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
 
 
 @pytest.mark.parametrize(
-    ("backend", "provider"),
+    ("backend", "provider", "model"),
     (
-        ("claude", "anthropic"),
-        ("codex", "openai"),
-        ("goose", "openai"),
-        ("opencode", "anthropic"),
-        ("pi", "openai-codex"),
+        ("claude", "anthropic", "sonnet"),
+        ("codex", "openai", "gpt-5.5"),
+        ("goose", "openai", "gpt-5.5-pro"),
+        ("opencode", "anthropic", "anthropic/claude-sonnet-4-6"),
+        ("pi", "openai-codex", "openai-codex/gpt-5.5"),
     ),
 )
-def test_document_accepts_each_registered_backend_without_priority(backend, provider):
+def test_document_accepts_each_registered_backend_without_priority(backend, provider, model):
     profile_id = RuntimeProfileId("rtp_22222222222222222222222222222222")
     registry = WorkshopRuntimeProfileRegistry.from_document(
         {
@@ -168,6 +183,8 @@ def test_document_accepts_each_registered_backend_without_priority(backend, prov
                     "display_name": f"{backend} runtime",
                     "backend": backend,
                     "provider": provider,
+                    "model": model,
+                    "timeout_seconds": 120,
                 }
             },
         },
@@ -189,6 +206,8 @@ def test_document_rejects_backend_absent_from_protected_registry():
                         "display_name": "Unavailable runtime",
                         "backend": "codex",
                         "provider": "openai",
+                        "model": "gpt-5.5",
+                        "timeout_seconds": 120,
                     }
                 },
             },
@@ -209,6 +228,8 @@ def test_document_rejects_provider_not_supported_by_backend(backend):
                         "display_name": "Invalid provider",
                         "backend": backend,
                         "provider": "not-a-provider",
+                        "model": "sonnet",
+                        "timeout_seconds": 120,
                     }
                 },
             },
@@ -229,6 +250,8 @@ def test_single_provider_backend_defaults_only_when_provider_is_omitted(backend,
                 str(profile_id): {
                     "display_name": "Single-provider runtime",
                     "backend": backend,
+                    "model": "sonnet" if backend == "claude" else "gpt-5.5",
+                    "timeout_seconds": 120,
                 }
             },
         },
@@ -251,10 +274,71 @@ def test_document_rejects_invalid_os_user():
                         "os_user": "../../root",
                         "backend": "codex",
                         "provider": "openai",
+                        "model": "gpt-5.5",
+                        "timeout_seconds": 120,
                     }
                 },
             },
             backend_registry={"codex": object()},
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("model", None, "model is required"),
+        ("model", "not-a-codex-model", "not valid"),
+        ("timeout_seconds", None, "positive integer"),
+        ("timeout_seconds", 0, "positive integer"),
+        ("timeout_seconds", True, "positive integer"),
+    ),
+)
+def test_document_fails_closed_on_invalid_model_or_timeout(field, value, message):
+    profile_id = RuntimeProfileId("rtp_37373737373737373737373737373737")
+    profile = {
+        "display_name": "Protected runtime",
+        "backend": "codex",
+        "provider": "openai",
+        "model": "gpt-5.5",
+        "timeout_seconds": 120,
+    }
+    if value is None:
+        profile.pop(field)
+    else:
+        profile[field] = value
+
+    with pytest.raises(WorkshopRuntimeProfileError, match=message):
+        WorkshopRuntimeProfileRegistry.from_document(
+            {"version": 1, "runtime_profiles": {str(profile_id): profile}},
+            backend_registry={"codex": object()},
+        )
+
+
+def test_document_enforces_loaded_backend_registry_model_ceiling():
+    profile_id = RuntimeProfileId("rtp_38383838383838383838383838383838")
+    backend = BackendRegistryEntry(
+        id="codex",
+        driver="codex",
+        runtime="local_process",
+        command="/usr/local/bin/codex",
+        allowed_models=("gpt-5.4",),
+    )
+
+    with pytest.raises(WorkshopRuntimeProfileError, match="not valid"):
+        WorkshopRuntimeProfileRegistry.from_document(
+            {
+                "version": 1,
+                "runtime_profiles": {
+                    str(profile_id): {
+                        "display_name": "Disallowed model",
+                        "backend": "codex",
+                        "provider": "openai",
+                        "model": "gpt-5.5",
+                        "timeout_seconds": 120,
+                    }
+                },
+            },
+            backend_registry={"codex": backend},
         )
 
 
@@ -292,6 +376,8 @@ runtime_profiles:
     display_name: Browser runtime
     backend: pi
     provider: openai-codex
+    model: openai-codex/gpt-5.5
+    timeout_seconds: 120
 """
     )
     monkeypatch.setattr(
@@ -326,11 +412,38 @@ runtime_profiles:
     os_user: daniel
     backend: claude
     provider: anthropic
+    model: sonnet
+    timeout_seconds: 120
 """
     )
     monkeypatch.setattr(
         "kai.workshop.runtime_profiles.load_backend_registry",
         lambda: {"claude": object(), "codex": object()},
+    )
+
+    with pytest.raises(WorkshopRuntimeProfileError, match=r"conflicts with the migrated users\.yaml"):
+        WorkshopRuntimeProfileRegistry.load(_config(), path=policy)
+
+
+def test_loaded_policy_fails_when_migrated_model_or_timeout_drifts(tmp_path, monkeypatch):
+    profile_id = runtime_profile_id_for_config_id(101)
+    policy = tmp_path / "runtime-profiles.yaml"
+    policy.write_text(
+        f"""version: 1
+runtime_profiles:
+  {profile_id}:
+    display_name: Daniel
+    compatibility_runtime_config_id: 101
+    os_user: daniel
+    backend: codex
+    provider: openai
+    model: gpt-5.5
+    timeout_seconds: 999
+"""
+    )
+    monkeypatch.setattr(
+        "kai.workshop.runtime_profiles.load_backend_registry",
+        lambda: {"codex": object(), "claude": object()},
     )
 
     with pytest.raises(WorkshopRuntimeProfileError, match=r"conflicts with the migrated users\.yaml"):

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -111,7 +111,7 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
                 }
             },
         },
-        backend_registry={"codex": object()},
+        backend_registry={"codex": {}},
     )
 
     profile = registry.resolve(profile_id)
@@ -139,7 +139,7 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
                 }
             },
         },
-        backend_registry={"pi": object()},
+        backend_registry={"pi": {}},
     )
     second = WorkshopRuntimeProfileRegistry.from_document(
         {
@@ -154,7 +154,7 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
                 }
             },
         },
-        backend_registry={"pi": object()},
+        backend_registry={"pi": {}},
     )
 
     expected = compatibility_runtime_config_id_for_profile_id(profile_id)
@@ -188,7 +188,7 @@ def test_document_accepts_each_registered_backend_without_priority(backend, prov
                 }
             },
         },
-        backend_registry={backend: object()},
+        backend_registry={backend: {}},
     )
 
     assert registry.resolve(profile_id).backend == backend
@@ -211,7 +211,7 @@ def test_document_rejects_backend_absent_from_protected_registry():
                     }
                 },
             },
-            backend_registry={"pi": object()},
+            backend_registry={"pi": {}},
         )
 
 
@@ -233,7 +233,7 @@ def test_document_rejects_provider_not_supported_by_backend(backend):
                     }
                 },
             },
-            backend_registry={backend: object()},
+            backend_registry={backend: {}},
         )
 
 
@@ -255,7 +255,7 @@ def test_single_provider_backend_defaults_only_when_provider_is_omitted(backend,
                 }
             },
         },
-        backend_registry={backend: object()},
+        backend_registry={backend: {}},
     )
 
     assert registry.resolve(profile_id).provider == canonical_provider
@@ -279,7 +279,7 @@ def test_document_rejects_invalid_os_user():
                     }
                 },
             },
-            backend_registry={"codex": object()},
+            backend_registry={"codex": {}},
         )
 
 
@@ -310,7 +310,7 @@ def test_document_fails_closed_on_invalid_model_or_timeout(field, value, message
     with pytest.raises(WorkshopRuntimeProfileError, match=message):
         WorkshopRuntimeProfileRegistry.from_document(
             {"version": 1, "runtime_profiles": {str(profile_id): profile}},
-            backend_registry={"codex": object()},
+            backend_registry={"codex": {}},
         )
 
 
@@ -342,6 +342,27 @@ def test_document_enforces_loaded_backend_registry_model_ceiling():
         )
 
 
+def test_document_rejects_unknown_backend_registry_entry_type():
+    profile_id = RuntimeProfileId("rtp_39393939393939393939393939393939")
+
+    with pytest.raises(WorkshopRuntimeProfileError, match=r"registry entry.*invalid"):
+        WorkshopRuntimeProfileRegistry.from_document(
+            {
+                "version": 1,
+                "runtime_profiles": {
+                    str(profile_id): {
+                        "display_name": "Invalid registry entry",
+                        "backend": "codex",
+                        "provider": "openai",
+                        "model": "gpt-5.5",
+                        "timeout_seconds": 120,
+                    }
+                },
+            },
+            backend_registry={"codex": object()},
+        )
+
+
 @pytest.mark.parametrize(
     "document, message",
     (
@@ -363,7 +384,7 @@ def test_document_enforces_loaded_backend_registry_model_ceiling():
 )
 def test_document_fails_closed_on_incomplete_policy(document, message):
     with pytest.raises(WorkshopRuntimeProfileError, match=message):
-        WorkshopRuntimeProfileRegistry.from_document(document, backend_registry={"goose": object()})
+        WorkshopRuntimeProfileRegistry.from_document(document, backend_registry={"goose": {}})
 
 
 def test_explicit_policy_file_is_loaded_instead_of_config_projection(tmp_path, monkeypatch):
@@ -382,7 +403,7 @@ runtime_profiles:
     )
     monkeypatch.setattr(
         "kai.workshop.runtime_profiles.load_backend_registry",
-        lambda: {"pi": object()},
+        lambda: {"pi": {}},
     )
 
     config = Config(
@@ -418,7 +439,7 @@ runtime_profiles:
     )
     monkeypatch.setattr(
         "kai.workshop.runtime_profiles.load_backend_registry",
-        lambda: {"claude": object(), "codex": object()},
+        lambda: {"claude": {}, "codex": {}},
     )
 
     with pytest.raises(WorkshopRuntimeProfileError, match=r"conflicts with the migrated users\.yaml"):
@@ -443,7 +464,7 @@ runtime_profiles:
     )
     monkeypatch.setattr(
         "kai.workshop.runtime_profiles.load_backend_registry",
-        lambda: {"codex": object(), "claude": object()},
+        lambda: {"codex": {}, "claude": {}},
     )
 
     with pytest.raises(WorkshopRuntimeProfileError, match=r"conflicts with the migrated users\.yaml"):

--- a/tests/workshop_profiles.py
+++ b/tests/workshop_profiles.py
@@ -23,6 +23,8 @@ def profile_registry(*runtime_config_ids: int) -> WorkshopRuntimeProfileRegistry
                 os_user=None,
                 backend="codex",
                 provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
             )
             for runtime_config_id in runtime_config_ids
         )


### PR DESCRIPTION
## Summary

- make protected Workshop runtime profiles authoritative for the conversational model and timeout, alongside backend, provider, and OS user
- validate profile models against both backend rules and the already-loaded protected backend-registry ceiling
- enrich the existing version-1 policy in place during `make install`, preserving profile IDs, compatibility keys, operator-authored values, and rollback readability
- keep Telegram group compatibility behavior and post-start database model/timeout overrides unchanged

## Migration and rollback

Existing `/etc/kai/runtime-profiles.yaml` files from #922 do not yet contain `model` or `timeout_seconds`. Install preflight now computes the exact pre-cutover values from the still-authoritative compatibility configuration and adds only the missing keys. Existing values are never overwritten.

Because this one-time enrichment uses the standard YAML parser and renderer, it normalizes YAML formatting and does not preserve comments in the policy file. It preserves all parsed keys, values, profile IDs, compatibility keys, and mapping order.

The document remains `version: 1`. Older Kai code ignores the added keys, so reverting code remains possible without rewriting the policy. New code fails closed if either field is missing or invalid.

Independently authored profiles that are not projected from `users.yaml` receive deterministic backend defaults only when the new keys are absent.

Migration validation uses the backend registry being installed in the same transaction, not the older deployed registry. Default backend/provider/model/timeout values are resolved once and shared by rendering and enrichment.

## Authority boundary

For protected profiles, `SubprocessPool` now takes these fields from protected runtime policy:

- backend
- provider
- OS user
- conversational model
- timeout

The compatibility projection still checks migrated `users.yaml` entries for drift during this transition. Negative Telegram group keys retain their bounded legacy fallback. Positive private/runtime keys without a protected profile continue to fail closed.

## Validation

- focused runtime-profile, pool, and installer tests: 617 passed
- full test suite: 5,686 passed, 1 skipped
- `make check`
- `make typecheck`
- `git diff --check`

Closes #923
Part of #921
Part of #917
