### PR TITLE
Protect runtime profile service scopes

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -948,6 +948,22 @@ def _install_registry_model_ceiling(
     return checked or None
 
 
+def _migrated_service_scopes(entry: dict[object, object]) -> list[str]:
+    """Mirror users.yaml's effective service allowlist during migration."""
+    raw = entry.get("allowed_services", [])
+    if not isinstance(raw, list):
+        return []
+    checked: list[str] = []
+    for raw_service in raw:
+        if not isinstance(raw_service, str):
+            continue
+        service = raw_service.strip()
+        if not service or service == "*" or "/" in service or service in checked:
+            continue
+        checked.append(service)
+    return checked
+
+
 def _build_migrated_runtime_profiles(
     users_yaml_path: Path,
     *,
@@ -1029,6 +1045,7 @@ def _build_migrated_runtime_profiles(
             "provider": provider,
             "model": model,
             "timeout_seconds": timeout_seconds,
+            "allowed_services": _migrated_service_scopes(entry),
         }
         raw_os_user = entry.get("os_user")
         if raw_os_user is not None and str(raw_os_user).strip():
@@ -1057,7 +1074,7 @@ def _upgrade_runtime_policy_content(
     migrated_content: str,
     defaults: _RuntimePolicyDefaults,
 ) -> tuple[str, bool]:
-    """Add model/timeout policy to documents that predate those keys.
+    """Add execution-policy fields to documents that predate them.
 
     The major document version remains 1 so older Kai code ignores the new
     keys during rollback. Existing values are never overwritten. Profiles
@@ -1107,6 +1124,9 @@ def _upgrade_runtime_policy_content(
             profile["timeout_seconds"] = (
                 expected["timeout_seconds"] if isinstance(expected, dict) else defaults.timeout_seconds
             )
+            changed = True
+        if "allowed_services" not in profile:
+            profile["allowed_services"] = expected["allowed_services"] if isinstance(expected, dict) else []
             changed = True
     if not changed:
         return content, False
@@ -1164,12 +1184,20 @@ def _runtime_policy_apply_plan(
             raise ValueError(
                 "Protected runtime policy lost a required compatibility profile during validation"
             ) from exc
-        if (actual.backend, actual.provider, actual.os_user, actual.model, actual.timeout_seconds) != (
+        if (
+            actual.backend,
+            actual.provider,
+            actual.os_user,
+            actual.model,
+            actual.timeout_seconds,
+            actual.allowed_services,
+        ) != (
             expected.backend,
             expected.provider,
             expected.os_user,
             expected.model,
             expected.timeout_seconds,
+            expected.allowed_services,
         ):
             raise ValueError(
                 f"Protected runtime profile {actual.profile_id} conflicts with users.yaml fields still required "

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1190,14 +1190,14 @@ def _runtime_policy_apply_plan(
             actual.os_user,
             actual.model,
             actual.timeout_seconds,
-            actual.allowed_services,
+            frozenset(actual.allowed_services),
         ) != (
             expected.backend,
             expected.provider,
             expected.os_user,
             expected.model,
             expected.timeout_seconds,
-            expected.allowed_services,
+            frozenset(expected.allowed_services),
         ):
             raise ValueError(
                 f"Protected runtime profile {actual.profile_id} conflicts with users.yaml fields still required "

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -154,13 +154,26 @@ class SubprocessPool:
             if runtime_profiles is not None
             else config.allowed_user_ids
         )
+        protected_profiles_by_config_id = (
+            {profile.runtime_config_id: profile for profile in runtime_profiles.profiles}
+            if runtime_profiles is not None
+            else {}
+        )
         for chat_id in runtime_config_ids:
             user = config.get_user_config(chat_id)
-            requested = frozenset(user.allowed_services if user else [])
+            protected_profile = protected_profiles_by_config_id.get(chat_id)
+            if protected_profile is not None:
+                requested = frozenset(protected_profile.allowed_services)
+            elif user is not None:
+                requested = frozenset(user.allowed_services)
+            else:
+                requested = frozenset()
             unavailable = requested - available_service_names
             if unavailable:
+                source = "protected runtime profile" if protected_profile is not None else "users.yaml user"
                 log.warning(
-                    "users.yaml: user %d has unavailable allowed_services: %s; denying them",
+                    "%s %d has unavailable allowed_services: %s; denying them",
+                    source,
                     chat_id,
                     ", ".join(sorted(unavailable)),
                 )

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -109,6 +109,8 @@ def _registry_model_ceiling(
 
 def _service_scopes(value: object, *, profile_id: RuntimeProfileId) -> tuple[str, ...]:
     """Validate one explicit ordered service-scope list."""
+    if value is None:
+        raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: allowed_services is required")
     if not isinstance(value, list):
         raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: allowed_services must be a list")
     checked: list[str] = []
@@ -368,14 +370,14 @@ class WorkshopRuntimeProfileRegistry:
                 profile.os_user,
                 profile.model,
                 profile.timeout_seconds,
-                profile.allowed_services,
+                frozenset(profile.allowed_services),
             ) != (
                 backend,
                 provider,
                 user.os_user,
                 expected_model,
                 expected_timeout,
-                tuple(user.allowed_services),
+                frozenset(user.allowed_services),
             ):
                 raise WorkshopRuntimeProfileError(
                     f"Runtime profile {profile.profile_id} conflicts with the migrated users.yaml execution policy"

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -59,6 +59,7 @@ class ProtectedRuntimeProfile:
     provider: str
     model: str
     timeout_seconds: int
+    allowed_services: tuple[str, ...]
 
 
 def _compatibility_model(
@@ -104,6 +105,29 @@ def _registry_model_ceiling(
     raise WorkshopRuntimeProfileError(
         f"Runtime profile {profile_id}: backend registry entry for {backend!r} is invalid"
     )
+
+
+def _service_scopes(value: object, *, profile_id: RuntimeProfileId) -> tuple[str, ...]:
+    """Validate one explicit ordered service-scope list."""
+    if not isinstance(value, list):
+        raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: allowed_services must be a list")
+    checked: list[str] = []
+    for raw_service in value:
+        if not isinstance(raw_service, str):
+            raise WorkshopRuntimeProfileError(
+                f"Runtime profile {profile_id}: allowed_services entries must be service names"
+            )
+        service = raw_service.strip()
+        if not service or service == "*" or "/" in service:
+            raise WorkshopRuntimeProfileError(
+                f"Runtime profile {profile_id}: allowed service {raw_service!r} is invalid"
+            )
+        if service in checked:
+            raise WorkshopRuntimeProfileError(
+                f"Runtime profile {profile_id}: allowed service {service!r} is duplicated"
+            )
+        checked.append(service)
+    return tuple(checked)
 
 
 def runtime_profile_id_for_config_id(runtime_config_id: int) -> RuntimeProfileId:
@@ -197,6 +221,7 @@ class WorkshopRuntimeProfileRegistry:
                     provider=provider,
                     model=_compatibility_model(user, config, backend=backend, provider=provider),
                     timeout_seconds=user.timeout if user.timeout is not None else config.default_timeout,
+                    allowed_services=tuple(user.allowed_services),
                 )
             )
         return cls(tuple(profiles))
@@ -286,6 +311,10 @@ class WorkshopRuntimeProfileRegistry:
                     provider=provider,
                     model=model,
                     timeout_seconds=raw_timeout,
+                    allowed_services=_service_scopes(
+                        raw_profile.get("allowed_services"),
+                        profile_id=profile_id,
+                    ),
                 )
             )
         return cls(tuple(profiles))
@@ -326,7 +355,7 @@ class WorkshopRuntimeProfileRegistry:
         Backend selection is owned by this registry. While users.yaml still
         provisions the corresponding OS account, models, workspaces, and
         service grants for migrated profiles, the duplicated backend/provider/
-        OS-user/model/timeout fields must agree.
+        OS-user/model/timeout/service-scope fields must agree.
         """
         for runtime_config_id, user in config.user_configs.items():
             profile = self.for_config_id(runtime_config_id)
@@ -339,7 +368,15 @@ class WorkshopRuntimeProfileRegistry:
                 profile.os_user,
                 profile.model,
                 profile.timeout_seconds,
-            ) != (backend, provider, user.os_user, expected_model, expected_timeout):
+                profile.allowed_services,
+            ) != (
+                backend,
+                provider,
+                user.os_user,
+                expected_model,
+                expected_timeout,
+                tuple(user.allowed_services),
+            ):
                 raise WorkshopRuntimeProfileError(
                     f"Runtime profile {profile.profile_id} conflicts with the migrated users.yaml execution policy"
                 )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8569,6 +8569,62 @@ backends:
                 users_yaml,
             )
 
+    def test_existing_policy_accepts_migrated_service_scope_reordering(self, tmp_path, monkeypatch):
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            """users:
+  - telegram_id: 101
+    name: Daniel
+    role: admin
+    backend: codex
+    model: gpt-5.5
+    allowed_services:
+      - perplexity
+      - weather
+"""
+        )
+        profile_id = str(kai.install.runtime_profile_id_for_config_id(101))
+        policy = tmp_path / "runtime-profiles.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "version": 1,
+                    "runtime_profiles": {
+                        profile_id: {
+                            "display_name": "Daniel",
+                            "compatibility_runtime_config_id": 101,
+                            "backend": "codex",
+                            "provider": "openai",
+                            "model": "gpt-5.5",
+                            "timeout_seconds": 120,
+                            "allowed_services": ["weather", "perplexity"],
+                        }
+                    },
+                },
+                sort_keys=False,
+            )
+        )
+        monkeypatch.setattr("kai.install.RUNTIME_PROFILES_YAML", policy)
+        monkeypatch.setattr(
+            "kai.install._backend_registry_entries",
+            lambda *args: {"codex": {"allowed_models": ["gpt-5.5"]}},
+        )
+
+        action, content, profiles = _runtime_policy_apply_plan(
+            "kai",
+            {
+                "DEFAULT_BACKEND": "codex",
+                "DEFAULT_PROVIDER": "openai",
+                "DEFAULT_MODEL": "gpt-5.5",
+                "DEFAULT_TIMEOUT": "120",
+            },
+            users_yaml,
+        )
+
+        assert action == "preserve"
+        assert content == policy.read_text()
+        assert profiles.resolve(profile_id).allowed_services == ("weather", "perplexity")
+
 
 class TestApplyBackendRegistry:
     def test_build_registry_uses_discovered_global_commands(self, monkeypatch):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8270,6 +8270,13 @@ class TestIndependentRuntimePolicy:
     role: admin
     os_user: daniel
     backend: codex
+    allowed_services:
+      - perplexity
+      - ""
+      - "*"
+      - invalid/path
+      - perplexity
+      - 7
   - telegram_id: 202
     name: Scott
     role: user
@@ -8307,12 +8314,14 @@ class TestIndependentRuntimePolicy:
             "provider": "openai",
             "model": "gpt-5.5",
             "timeout_seconds": 120,
+            "allowed_services": ["perplexity"],
             "os_user": "daniel",
         }
         assert document["runtime_profiles"][scott_id]["backend"] == "claude"
         assert document["runtime_profiles"][scott_id]["provider"] == "anthropic"
         assert document["runtime_profiles"][scott_id]["model"] == "sonnet"
         assert document["runtime_profiles"][scott_id]["timeout_seconds"] == 120
+        assert document["runtime_profiles"][scott_id]["allowed_services"] == []
 
     def test_migration_validates_against_registry_being_installed(self, tmp_path, monkeypatch):
         users_yaml = tmp_path / "users.yaml"
@@ -8373,6 +8382,7 @@ backends:
                             "provider": "openai",
                             "model": "gpt-5.5",
                             "timeout_seconds": 120,
+                            "allowed_services": [],
                         }
                     },
                 }
@@ -8457,6 +8467,8 @@ backends:
     backend: codex
     model: gpt-5.6-sol
     timeout: 345
+    allowed_services:
+      - perplexity
 """
         )
         profile_id = str(kai.install.runtime_profile_id_for_config_id(101))
@@ -8507,7 +8519,22 @@ backends:
         assert document["runtime_profiles"][profile_id]["display_name"] == "Operator display name"
         assert document["runtime_profiles"][profile_id]["model"] == "gpt-5.6-sol"
         assert document["runtime_profiles"][profile_id]["timeout_seconds"] == 345
+        assert document["runtime_profiles"][profile_id]["allowed_services"] == ["perplexity"]
         assert profiles.resolve(profile_id).runtime_config_id == 101
+
+        policy.write_text(content)
+        next_action, next_content, next_profiles = _runtime_policy_apply_plan(
+            "kai",
+            {
+                "DEFAULT_PROVIDER": "openai",
+                "DEFAULT_TIMEOUT": "120",
+            },
+            users_yaml,
+        )
+
+        assert next_action == "preserve"
+        assert next_content == content
+        assert next_profiles.resolve(profile_id).allowed_services == ("perplexity",)
 
     def test_existing_policy_must_cover_every_migrated_profile(self, tmp_path, monkeypatch):
         users_yaml = tmp_path / "users.yaml"

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -47,6 +47,7 @@ class TestRuntimeAssignmentPolicy:
                         "provider": "openai",
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
+                        "allowed_services": [],
                     }
                 },
             },

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -10,6 +10,7 @@ import pytest
 
 from kai.backend import AgentResponse, StreamEvent
 from kai.config import Config, UserConfig
+from kai.internal_api_auth import InternalAPIScope
 from kai.workshop.domain import RuntimeProfileId
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.runtime_profiles import (
@@ -97,6 +98,7 @@ def test_protected_profile_selects_backend_and_os_user_over_compatibility_config
                 provider="openai",
                 model="gpt-5.6-sol",
                 timeout_seconds=345,
+                allowed_services=(),
             ),
         )
     )
@@ -108,6 +110,59 @@ def test_protected_profile_selects_backend_and_os_user_over_compatibility_config
     assert instance.codex_user == "protected-user"
     assert instance.model == "gpt-5.6-sol"
     assert instance.timeout_seconds == 345
+
+
+def test_protected_profile_service_scopes_override_compatibility_config(tmp_path, monkeypatch):
+    from kai.pool import SubprocessPool
+
+    monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+    services_info = [
+        {"name": "perplexity", "method": "POST", "description": "search"},
+        {"name": "weather", "method": "GET", "description": "weather"},
+    ]
+    config = Config(
+        telegram_bot_token="test",
+        allowed_user_ids={111},
+        default_backend="codex",
+        default_provider="openai",
+        default_model="gpt-5.6-sol",
+        user_configs={
+            111: UserConfig(
+                telegram_id=111,
+                name="Alice",
+                allowed_services=["weather"],
+            )
+        },
+    )
+    profiles = WorkshopRuntimeProfileRegistry(
+        (
+            ProtectedRuntimeProfile(
+                profile_id=RuntimeProfileId("rtp_15151515151515151515151515151515"),
+                runtime_config_id=111,
+                display_name="Protected coding runtime",
+                os_user=None,
+                backend="codex",
+                provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
+                allowed_services=("perplexity",),
+            ),
+        )
+    )
+
+    pool = SubprocessPool(
+        config=config,
+        services_info=services_info,
+        runtime_profiles=profiles,
+    )
+    instance = pool.get(111)
+    principal = pool.internal_api_auth.authenticate(instance._api_context.webhook_secret)
+
+    assert instance._api_context.services_info == [services_info[0]]
+    assert principal is not None
+    assert principal.allows(InternalAPIScope.SERVICES_CALL)
+    assert principal.allows_service("perplexity")
+    assert not principal.allows_service("weather")
 
 
 def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, monkeypatch):
@@ -133,6 +188,48 @@ def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, mon
                 provider="openai",
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
+                allowed_services=("perplexity",),
+            ),
+        )
+    )
+
+    services_info = [{"name": "perplexity", "method": "POST", "description": "search"}]
+    pool = SubprocessPool(config=config, services_info=services_info, runtime_profiles=profiles)
+    instance = pool.get(runtime_config_id)
+    principal = pool.internal_api_auth.authenticate(instance._api_context.webhook_secret)
+
+    assert instance.backend_name == "codex"
+    assert principal is not None
+    assert principal.chat_id == runtime_config_id
+    assert principal.allowed_services == frozenset({"perplexity"})
+    assert instance._api_context.services_info == services_info
+
+
+def test_unavailable_protected_service_is_denied_with_warning(tmp_path, monkeypatch, caplog):
+    from kai.pool import SubprocessPool
+
+    monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+    config = Config(
+        telegram_bot_token="test",
+        allowed_user_ids=set(),
+        default_backend="codex",
+        default_provider="openai",
+        default_model="gpt-5.6-sol",
+        user_configs={},
+    )
+    runtime_config_id = 987654321012346
+    profiles = WorkshopRuntimeProfileRegistry(
+        (
+            ProtectedRuntimeProfile(
+                profile_id=RuntimeProfileId("rtp_25252525252525252525252525252525"),
+                runtime_config_id=runtime_config_id,
+                display_name="Browser-only runtime",
+                os_user=None,
+                backend="codex",
+                provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
+                allowed_services=("missing",),
             ),
         )
     )
@@ -141,9 +238,11 @@ def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, mon
     instance = pool.get(runtime_config_id)
     principal = pool.internal_api_auth.authenticate(instance._api_context.webhook_secret)
 
-    assert instance.backend_name == "codex"
     assert principal is not None
-    assert principal.chat_id == runtime_config_id
+    assert principal.allowed_services == frozenset()
+    assert instance._api_context.services_info == []
+    assert "protected runtime profile" in caplog.text
+    assert "unavailable allowed_services: missing; denying them" in caplog.text
 
 
 def test_negative_group_key_retains_legacy_compatibility_runtime(tmp_path, monkeypatch):
@@ -169,6 +268,7 @@ def test_negative_group_key_retains_legacy_compatibility_runtime(tmp_path, monke
                 provider="openai",
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
+                allowed_services=(),
             ),
         )
     )
@@ -206,6 +306,7 @@ def test_positive_configuration_key_without_profile_fails_closed(tmp_path, monke
                 provider="openai",
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
+                allowed_services=(),
             ),
         )
     )

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -328,7 +328,7 @@ def test_document_fails_closed_on_invalid_model_or_timeout(field, value, message
 @pytest.mark.parametrize(
     ("value", "message"),
     (
-        (None, "must be a list"),
+        (None, "is required"),
         ("perplexity", "must be a list"),
         ([1], "must be service names"),
         ([""], "is invalid"),
@@ -543,6 +543,46 @@ runtime_profiles:
 
     with pytest.raises(WorkshopRuntimeProfileError, match=r"conflicts with the migrated users\.yaml"):
         WorkshopRuntimeProfileRegistry.load(_config(), path=policy)
+
+
+def test_loaded_policy_accepts_migrated_service_scope_reordering(tmp_path, monkeypatch):
+    config = _config()
+    config.user_configs[101].allowed_services.extend(("perplexity", "weather"))
+    profile_id = runtime_profile_id_for_config_id(101)
+    policy = tmp_path / "runtime-profiles.yaml"
+    policy.write_text(
+        f"""version: 1
+runtime_profiles:
+  {profile_id}:
+    display_name: Daniel
+    compatibility_runtime_config_id: 101
+    os_user: daniel
+    backend: codex
+    provider: openai
+    model: gpt-5.6-sol
+    timeout_seconds: 120
+    allowed_services:
+      - weather
+      - perplexity
+  {runtime_profile_id_for_config_id(202)}:
+    display_name: Scott
+    compatibility_runtime_config_id: 202
+    os_user: sellison
+    backend: claude
+    provider: anthropic
+    model: sonnet
+    timeout_seconds: 120
+    allowed_services: []
+"""
+    )
+    monkeypatch.setattr(
+        "kai.workshop.runtime_profiles.load_backend_registry",
+        lambda: {"codex": {}, "claude": {}},
+    )
+
+    registry = WorkshopRuntimeProfileRegistry.load(config, path=policy)
+
+    assert registry.resolve(profile_id).allowed_services == ("weather", "perplexity")
 
 
 def test_uninstalled_development_without_policy_uses_compatibility_projection(monkeypatch):

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -88,6 +88,7 @@ def test_registry_rejects_duplicate_configuration_authority():
         "openai",
         "gpt-5.6-sol",
         120,
+        (),
     )
 
     with pytest.raises(WorkshopRuntimeProfileError, match="Duplicate runtime profile ID"):
@@ -108,6 +109,7 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
                     "provider": "openai",
                     "model": "gpt-5.6-sol",
                     "timeout_seconds": 240,
+                    "allowed_services": ["perplexity", "weather"],
                 }
             },
         },
@@ -122,6 +124,7 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
     assert profile.provider == "openai"
     assert profile.model == "gpt-5.6-sol"
     assert profile.timeout_seconds == 240
+    assert profile.allowed_services == ("perplexity", "weather")
 
 
 def test_non_telegram_profile_derives_stable_private_compatibility_key():
@@ -136,6 +139,7 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
                     "provider": "openai-codex",
                     "model": "openai-codex/gpt-5.5",
                     "timeout_seconds": 120,
+                    "allowed_services": [],
                 }
             },
         },
@@ -151,6 +155,7 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
                     "provider": "openai-codex",
                     "model": "openai-codex/gpt-5.5",
                     "timeout_seconds": 120,
+                    "allowed_services": [],
                 }
             },
         },
@@ -185,6 +190,7 @@ def test_document_accepts_each_registered_backend_without_priority(backend, prov
                     "provider": provider,
                     "model": model,
                     "timeout_seconds": 120,
+                    "allowed_services": [],
                 }
             },
         },
@@ -208,6 +214,7 @@ def test_document_rejects_backend_absent_from_protected_registry():
                         "provider": "openai",
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
+                        "allowed_services": [],
                     }
                 },
             },
@@ -230,6 +237,7 @@ def test_document_rejects_provider_not_supported_by_backend(backend):
                         "provider": "not-a-provider",
                         "model": "sonnet",
                         "timeout_seconds": 120,
+                        "allowed_services": [],
                     }
                 },
             },
@@ -252,6 +260,7 @@ def test_single_provider_backend_defaults_only_when_provider_is_omitted(backend,
                     "backend": backend,
                     "model": "sonnet" if backend == "claude" else "gpt-5.5",
                     "timeout_seconds": 120,
+                    "allowed_services": [],
                 }
             },
         },
@@ -276,6 +285,7 @@ def test_document_rejects_invalid_os_user():
                         "provider": "openai",
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
+                        "allowed_services": [],
                     }
                 },
             },
@@ -301,11 +311,43 @@ def test_document_fails_closed_on_invalid_model_or_timeout(field, value, message
         "provider": "openai",
         "model": "gpt-5.5",
         "timeout_seconds": 120,
+        "allowed_services": [],
     }
     if value is None:
         profile.pop(field)
     else:
         profile[field] = value
+
+    with pytest.raises(WorkshopRuntimeProfileError, match=message):
+        WorkshopRuntimeProfileRegistry.from_document(
+            {"version": 1, "runtime_profiles": {str(profile_id): profile}},
+            backend_registry={"codex": {}},
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    (
+        (None, "must be a list"),
+        ("perplexity", "must be a list"),
+        ([1], "must be service names"),
+        ([""], "is invalid"),
+        (["*"], "is invalid"),
+        (["service/path"], "is invalid"),
+        (["perplexity", "perplexity"], "is duplicated"),
+    ),
+)
+def test_document_fails_closed_on_invalid_service_scopes(value, message):
+    profile_id = RuntimeProfileId("rtp_40404040404040404040404040404040")
+    profile = {
+        "display_name": "Protected runtime",
+        "backend": "codex",
+        "provider": "openai",
+        "model": "gpt-5.5",
+        "timeout_seconds": 120,
+    }
+    if value is not None:
+        profile["allowed_services"] = value
 
     with pytest.raises(WorkshopRuntimeProfileError, match=message):
         WorkshopRuntimeProfileRegistry.from_document(
@@ -335,6 +377,7 @@ def test_document_enforces_loaded_backend_registry_model_ceiling():
                         "provider": "openai",
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
+                        "allowed_services": [],
                     }
                 },
             },
@@ -356,6 +399,7 @@ def test_document_rejects_unknown_backend_registry_entry_type():
                         "provider": "openai",
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
+                        "allowed_services": [],
                     }
                 },
             },
@@ -399,6 +443,7 @@ runtime_profiles:
     provider: openai-codex
     model: openai-codex/gpt-5.5
     timeout_seconds: 120
+    allowed_services: []
 """
     )
     monkeypatch.setattr(
@@ -435,6 +480,7 @@ runtime_profiles:
     provider: anthropic
     model: sonnet
     timeout_seconds: 120
+    allowed_services: []
 """
     )
     monkeypatch.setattr(
@@ -460,6 +506,34 @@ runtime_profiles:
     provider: openai
     model: gpt-5.5
     timeout_seconds: 999
+    allowed_services: []
+"""
+    )
+    monkeypatch.setattr(
+        "kai.workshop.runtime_profiles.load_backend_registry",
+        lambda: {"codex": {}, "claude": {}},
+    )
+
+    with pytest.raises(WorkshopRuntimeProfileError, match=r"conflicts with the migrated users\.yaml"):
+        WorkshopRuntimeProfileRegistry.load(_config(), path=policy)
+
+
+def test_loaded_policy_fails_when_migrated_service_scopes_drift(tmp_path, monkeypatch):
+    profile_id = runtime_profile_id_for_config_id(101)
+    policy = tmp_path / "runtime-profiles.yaml"
+    policy.write_text(
+        f"""version: 1
+runtime_profiles:
+  {profile_id}:
+    display_name: Daniel
+    compatibility_runtime_config_id: 101
+    os_user: daniel
+    backend: codex
+    provider: openai
+    model: gpt-5.6-sol
+    timeout_seconds: 120
+    allowed_services:
+      - perplexity
 """
     )
     monkeypatch.setattr(

--- a/tests/workshop_profiles.py
+++ b/tests/workshop_profiles.py
@@ -25,6 +25,7 @@ def profile_registry(*runtime_config_ids: int) -> WorkshopRuntimeProfileRegistry
                 provider="openai",
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
+                allowed_services=(),
             )
             for runtime_config_id in runtime_config_ids
         )


### PR DESCRIPTION
## Summary

- make each protected Workshop runtime profile explicitly declare its internal-service scopes
- derive backend-visible service metadata and process-local internal API credentials from protected profile policy
- migrate current `users.yaml` grants into the independent runtime policy without changing profile identity
- enrich older version-1 policy documents in place while keeping rollback compatibility
- deny malformed, duplicate, wildcard, path-like, and unavailable service names

## Security boundary

Before this change, backend, OS-user, model, and timeout authority had moved into `/etc/kai/runtime-profiles.yaml`, but service-call authority still came directly from the Telegram-keyed compatibility configuration. A writable or stale compatibility record could therefore influence the service scopes attached to an agent credential.

After this change, installed startup parses `allowed_services` as part of the protected runtime profile. `SubprocessPool` uses that protected list for both the service descriptions exposed to the backend and the service allowlist embedded in its internal API principal. The compatibility configuration cannot expand those grants.

Unavailable configured services remain fail-closed and produce an operator-visible warning. Existing negative Telegram group compatibility runtimes continue to receive no service scopes.

## Migration and rollback

- Fresh policy migration copies the existing effective ordered allowlist from `users.yaml`.
- Existing version-1 policy is enriched only when `allowed_services` is absent.
- Migrated profiles receive their existing effective list; independently authored profiles receive the safe default `[]`.
- Existing explicit profile values are never overwritten.
- Re-running the apply plan after enrichment is idempotent.
- The document remains version 1, so the previous release ignores the additional key during rollback.
- While compatibility provisioning remains, startup requires duplicated service-scope values in `users.yaml` and protected runtime policy to agree.

## Tests

- focused runtime-profile, pool, assignment, and installer contracts: 637 passed
- full suite: 5,698 passed, 1 skipped
- Ruff check and formatting: clean
- Pyright: 0 errors, 0 warnings

Closes #925
Part of #921
Part of #917
