### PR TITLE
Protect runtime workspace policy

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -1173,6 +1173,9 @@ def resolve_home_workspace(
     chat_id: int | None,
     config: Config,
     data_dir: Path | None = None,
+    *,
+    use_user_config: bool = True,
+    provisioned_runtime: bool = False,
 ) -> Path:
     """
     Return the user's home workspace path.
@@ -1192,6 +1195,10 @@ def resolve_home_workspace(
     Config directly - that field was removed by issue #353. The old
     global fallback (issue #353) was a multi-user privacy hazard
     (every user landed in a directory every other user could read).
+
+    A protected runtime profile can set ``provisioned_runtime`` to bypass the
+    notification-only compatibility check. This does not create a directory;
+    protected installs still require the installer to have provisioned it.
 
     Passing `config` (not just its admin home field) keeps the
     resolution decision local: the caller does not need to know whether
@@ -1213,7 +1220,7 @@ def resolve_home_workspace(
     # load_config) already filtered out bad paths, and a path that
     # became invalid post-load (unmounted drive, etc.) is the admin's
     # problem to fix, not ours to paper over.
-    user = config.get_user_config(chat_id) if chat_id is not None else None
+    user = config.get_user_config(chat_id) if chat_id is not None and use_user_config else None
     if user and user.home_workspace:
         return user.home_workspace
 
@@ -1232,7 +1239,7 @@ def resolve_home_workspace(
     # the path without bootstrapping leaves the downstream caller
     # to fail naturally on a missing directory, which is the right
     # behavior for a chat_id without an interactive session.
-    if _is_notification_only_chat_id(chat_id, config):
+    if not provisioned_runtime and _is_notification_only_chat_id(chat_id, config):
         return data_dir / "home" / str(chat_id)
 
     # A protected install has a separate service identity and backend OS

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -1250,8 +1250,9 @@ def resolve_home_workspace(
         path = home_search_directories(chat_id, data_dir=data_dir)[0]
         if not path.is_dir():
             raise RuntimeError(
-                f"Protected user home is not provisioned for the canonical principal: "
-                f"{path}. Run `make install` to provision configured users."
+                f"Protected runtime home is not provisioned for the canonical principal: {path}. "
+                "Run `make install` for configured users; profile-only runtimes require an explicit "
+                "home_workspace or an operator-provisioned canonical directory."
             )
         return path
 

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -60,7 +60,7 @@ from telegram.ext import (
 
 from kai import github_api, memory_command, review, services, sessions, webhook
 from kai.agent_failure import render_agent_failure
-from kai.backend import require_backend_name, resolve_home_workspace
+from kai.backend import require_backend_name
 from kai.config import (
     DATA_DIR,
     ONESHOT_REASONER_BACKENDS,
@@ -1690,10 +1690,7 @@ async def _do_switch_workspace(context: ContextTypes.DEFAULT_TYPE, chat_id: int,
     """
     pool = _get_pool(context)
     config: Config = context.bot_data["config"]
-    # "home" for this user is per-user post-#353. Same resolver pool.py
-    # uses, so the equality check below matches the directory the user
-    # would land in on `/workspace home` or session restart.
-    home = resolve_home_workspace(chat_id, config)
+    home = pool.get_home_workspace(chat_id)
 
     # Layer DB overrides (from /workspace config) on top of YAML baseline.
     yaml_config = config.get_workspace_config(path)
@@ -1722,10 +1719,7 @@ async def _switch_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE, 
     """
     assert update.message is not None
     pool = _get_pool(context)
-    config: Config = context.bot_data["config"]
-    # Per-user resolution: this is what `/workspace home` would route to
-    # for THIS user, not a shared default.
-    home = resolve_home_workspace(_chat_id(update), config)
+    home = pool.get_home_workspace(_chat_id(update))
 
     if path == await pool.get_effective_workspace(_chat_id(update)):
         await update.message.reply_text("Already in that workspace.")
@@ -2138,15 +2132,13 @@ async def handle_workspaces(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     """Handle /workspaces - show an inline keyboard of recent workspaces."""
     assert update.message is not None
     chat_id = _chat_id(update)
-    config: Config = context.bot_data["config"]
-    # Resolve per-user workspace access (workspace_base + allowed list)
-    base, allowed = await sessions.resolve_workspace_access(chat_id, config)
-    history = await sessions.get_workspace_history(chat_id)
     pool = _get_pool(context)
+    base, allowed = await pool.resolve_workspace_access(chat_id)
+    history = await sessions.get_workspace_history(chat_id)
     current = str(await pool.get_effective_workspace(chat_id))
     # Per-user home for the listing's "Home" pin and the empty-state
     # short-circuit below.
-    home = str(resolve_home_workspace(chat_id, config))
+    home = str(pool.get_home_workspace(chat_id))
 
     if not history and not allowed and current == home:
         await update.message.reply_text("No workspace history yet.\nUse /workspace new <name> to create one.")
@@ -2177,10 +2169,10 @@ async def handle_workspace_callback(update: Update, context: ContextTypes.DEFAUL
     pool = _get_pool(context)
     # Per-user resolution: the "Home" keyboard button maps to THIS user's
     # home directory, not a shared one.
-    home = resolve_home_workspace(chat_id, config)
+    home = pool.get_home_workspace(chat_id)
 
     # Resolve per-user workspace access for this user
-    base, allowed = await sessions.resolve_workspace_access(chat_id, config)
+    base, allowed = await pool.resolve_workspace_access(chat_id)
 
     # Resolve target path from callback data
     if data == "home":
@@ -2269,7 +2261,7 @@ async def _handle_workspace_allow(
     """Handle /workspace allow <path> - add an allowed workspace."""
     assert update.message is not None
     chat_id = _chat_id(update)
-    config: Config = context.bot_data["config"]
+    pool = _get_pool(context)
 
     # Parse path from target string ("allow /path/to/dir")
     parts = target.split(None, 1)
@@ -2296,7 +2288,7 @@ async def _handle_workspace_allow(
         return
 
     # Check for redundancy: already under workspace_base?
-    base, allowed = await sessions.resolve_workspace_access(chat_id, config)
+    base, allowed = await pool.resolve_workspace_access(chat_id)
     if base:
         resolved_base = base.resolve()
         if str(resolved).startswith(str(resolved_base) + "/") or resolved == resolved_base:
@@ -2324,6 +2316,7 @@ async def _handle_workspace_deny(
     """Handle /workspace deny <path> - remove an allowed workspace."""
     assert update.message is not None
     chat_id = _chat_id(update)
+    pool = _get_pool(context)
 
     parts = target.split(None, 1)
     if len(parts) < 2:
@@ -2348,6 +2341,13 @@ async def _handle_workspace_deny(
     else:
         # Check if it's a global entry (can't be removed via Telegram)
         config: Config = context.bot_data["config"]
+        _base, static_paths, protected = pool.get_static_workspace_policy(chat_id)
+        if resolved in {path.resolve() for path in static_paths}:
+            source = "runtime profile" if protected else "users.yaml"
+            await update.message.reply_text(
+                f"That workspace is configured in the {source} and cannot be removed via Telegram."
+            )
+            return
         if resolved in [p.resolve() for p in config.allowed_workspaces]:
             await update.message.reply_text("That workspace is configured globally and cannot be removed via Telegram.")
         else:
@@ -2362,24 +2362,21 @@ async def _handle_workspace_allowed(
     assert update.message is not None
     chat_id = _chat_id(update)
     config: Config = context.bot_data["config"]
-    user_config = config.get_user_config(chat_id)
+    pool = _get_pool(context)
+    profile_base, static_paths, protected = pool.get_static_workspace_policy(chat_id)
 
-    # Resolve workspace_base: users.yaml > env
-    base = user_config.workspace_base if user_config and user_config.workspace_base else config.workspace_base
+    base = profile_base or config.workspace_base
 
     # Build allowed list with source attribution. Avoids calling
     # resolve_workspace_access() + get_allowed_workspaces() which
     # would query the DB twice. Only this handler needs attribution.
     db_paths = await sessions.get_allowed_workspaces(chat_id)
     db_path_set = {p.resolve() for p in db_paths}
-    # Per-user yaml allowed_workspaces tier (#460). Tracked
-    # separately from db_path_set so the source attribution
-    # below can distinguish "your yaml" from "your DB entries".
-    yaml_path_set: set[Path] = set()
-    if user_config and user_config.allowed_workspaces:
-        yaml_path_set = {p.resolve() for p in user_config.allowed_workspaces}
+    # Track the static runtime tier separately so source attribution can
+    # distinguish operator policy from mutable DB entries.
+    static_path_set = {p.resolve() for p in static_paths}
 
-    # Combined list: DB > yaml-per-user > global. Same order as
+    # Combined list: DB > runtime static > global. Same order as
     # resolve_workspace_access so this view matches what name
     # resolution actually traverses.
     seen: set[Path] = set()
@@ -2389,12 +2386,11 @@ async def _handle_workspace_allowed(
         if resolved not in seen:
             seen.add(resolved)
             allowed.append(resolved)
-    if user_config and user_config.allowed_workspaces:
-        for p in user_config.allowed_workspaces:
-            resolved = p.resolve()
-            if resolved not in seen:
-                seen.add(resolved)
-                allowed.append(resolved)
+    for p in static_paths:
+        resolved = p.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            allowed.append(resolved)
     for p in config.allowed_workspaces:
         resolved = p.resolve()
         if resolved not in seen:
@@ -2412,14 +2408,14 @@ async def _handle_workspace_allowed(
         lines.append("Allowed workspaces:")
         for p in allowed:
             # Source attribution priority matches the union order:
-            # DB beats yaml beats global. A path could in principle
+            # DB beats runtime policy beats global. A path could in principle
             # appear in multiple tiers (operator pinned via
             # /workspace allow AND listed in users.yaml); the most
             # specific tier wins the label.
             if p in db_path_set:
                 source = "you"
-            elif p in yaml_path_set:
-                source = "yaml"
+            elif p in static_path_set:
+                source = "profile" if protected else "yaml"
             else:
                 source = "global"
             lines.append(f"  {p} ({source})")
@@ -2434,7 +2430,7 @@ async def _handle_workspace_allowed(
     await update.message.reply_text("\n".join(lines))
 
 
-_NO_BASE_MSG = "No workspace base configured. Set workspace_base in users.yaml or WORKSPACE_BASE in .env."
+_NO_BASE_MSG = "No workspace base configured. Ask the operator to set a runtime workspace base or WORKSPACE_BASE."
 
 
 # Project ids are retrieval-time labels stored in memory rows, so
@@ -2670,12 +2666,10 @@ async def handle_workspace(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     chat_id = _chat_id(update)
     pool = _get_pool(context)
     config: Config = context.bot_data["config"]
-    # Per-user `/workspace home` destination. The user-visible fix for
-    # #353: prior to this, "home" was a shared directory.
-    home = resolve_home_workspace(chat_id, config)
+    home = pool.get_home_workspace(chat_id)
 
     # Resolve per-user workspace access (workspace_base + allowed list)
-    base, allowed = await sessions.resolve_workspace_access(chat_id, config)
+    base, allowed = await pool.resolve_workspace_access(chat_id)
 
     # No args: show current workspace
     if not context.args:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -964,15 +964,17 @@ def _migrated_service_scopes(entry: dict[object, object]) -> list[str]:
     return checked
 
 
-def _migrated_workspace_directory(value: object) -> str | None:
-    """Mirror users.yaml's effective optional workspace directory."""
+def _migrated_workspace_directory(value: object, *, field: str) -> str | None:
+    """Preserve one shape-valid workspace path through policy migration."""
     if value is None:
         return None
     rendered = str(value).strip()
     if not rendered:
         return None
-    path = Path(rendered).expanduser().resolve()
-    return str(path) if path.is_dir() else None
+    path = Path(rendered).expanduser()
+    if not path.is_absolute():
+        raise ValueError(f"users.yaml {field} must be an absolute path before runtime-policy migration")
+    return str(path.resolve())
 
 
 def _migrated_allowed_workspaces(entry: dict[object, object]) -> list[str]:
@@ -982,7 +984,7 @@ def _migrated_allowed_workspaces(entry: dict[object, object]) -> list[str]:
         return []
     checked: list[str] = []
     for raw_path in raw:
-        path = _migrated_workspace_directory(raw_path)
+        path = _migrated_workspace_directory(raw_path, field="allowed_workspaces entry")
         if path is not None and path not in checked:
             checked.append(path)
     return checked
@@ -1070,8 +1072,14 @@ def _build_migrated_runtime_profiles(
             "model": model,
             "timeout_seconds": timeout_seconds,
             "allowed_services": _migrated_service_scopes(entry),
-            "home_workspace": _migrated_workspace_directory(entry.get("home_workspace")),
-            "workspace_base": _migrated_workspace_directory(entry.get("workspace_base")),
+            "home_workspace": _migrated_workspace_directory(
+                entry.get("home_workspace"),
+                field="home_workspace",
+            ),
+            "workspace_base": _migrated_workspace_directory(
+                entry.get("workspace_base"),
+                field="workspace_base",
+            ),
             "allowed_workspaces": _migrated_allowed_workspaces(entry),
         }
         raw_os_user = entry.get("os_user")

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -964,6 +964,30 @@ def _migrated_service_scopes(entry: dict[object, object]) -> list[str]:
     return checked
 
 
+def _migrated_workspace_directory(value: object) -> str | None:
+    """Mirror users.yaml's effective optional workspace directory."""
+    if value is None:
+        return None
+    rendered = str(value).strip()
+    if not rendered:
+        return None
+    path = Path(rendered).expanduser().resolve()
+    return str(path) if path.is_dir() else None
+
+
+def _migrated_allowed_workspaces(entry: dict[object, object]) -> list[str]:
+    """Mirror users.yaml's effective static workspace allowlist."""
+    raw = entry.get("allowed_workspaces", [])
+    if not isinstance(raw, list):
+        return []
+    checked: list[str] = []
+    for raw_path in raw:
+        path = _migrated_workspace_directory(raw_path)
+        if path is not None and path not in checked:
+            checked.append(path)
+    return checked
+
+
 def _build_migrated_runtime_profiles(
     users_yaml_path: Path,
     *,
@@ -1046,6 +1070,9 @@ def _build_migrated_runtime_profiles(
             "model": model,
             "timeout_seconds": timeout_seconds,
             "allowed_services": _migrated_service_scopes(entry),
+            "home_workspace": _migrated_workspace_directory(entry.get("home_workspace")),
+            "workspace_base": _migrated_workspace_directory(entry.get("workspace_base")),
+            "allowed_workspaces": _migrated_allowed_workspaces(entry),
         }
         raw_os_user = entry.get("os_user")
         if raw_os_user is not None and str(raw_os_user).strip():
@@ -1128,6 +1155,15 @@ def _upgrade_runtime_policy_content(
         if "allowed_services" not in profile:
             profile["allowed_services"] = expected["allowed_services"] if isinstance(expected, dict) else []
             changed = True
+        if "home_workspace" not in profile:
+            profile["home_workspace"] = expected["home_workspace"] if isinstance(expected, dict) else None
+            changed = True
+        if "workspace_base" not in profile:
+            profile["workspace_base"] = expected["workspace_base"] if isinstance(expected, dict) else None
+            changed = True
+        if "allowed_workspaces" not in profile:
+            profile["allowed_workspaces"] = expected["allowed_workspaces"] if isinstance(expected, dict) else []
+            changed = True
     if not changed:
         return content, False
     return yaml.safe_dump(document, sort_keys=False, default_flow_style=False), True
@@ -1191,6 +1227,9 @@ def _runtime_policy_apply_plan(
             actual.model,
             actual.timeout_seconds,
             frozenset(actual.allowed_services),
+            actual.home_workspace,
+            actual.workspace_base,
+            frozenset(actual.allowed_workspaces),
         ) != (
             expected.backend,
             expected.provider,
@@ -1198,6 +1237,9 @@ def _runtime_policy_apply_plan(
             expected.model,
             expected.timeout_seconds,
             frozenset(expected.allowed_services),
+            expected.home_workspace,
+            expected.workspace_base,
+            frozenset(expected.allowed_workspaces),
         ):
             raise ValueError(
                 f"Protected runtime profile {actual.profile_id} conflicts with users.yaml fields still required "

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -208,6 +208,55 @@ class SubprocessPool:
         self._in_flight: set[int] = set()  # chat_ids with active send()
         self._eviction_task: asyncio.Task | None = None
 
+    def _protected_profile(self, runtime_config_id: int):
+        """Resolve protected policy while preserving the negative-group bridge."""
+        if self._runtime_profiles is None:
+            return None
+        try:
+            return self._runtime_profiles.for_config_id(runtime_config_id)
+        except WorkshopRuntimeProfileError:
+            if runtime_config_id >= 0:
+                raise
+            return None
+
+    def get_home_workspace(self, runtime_config_id: int) -> Path:
+        """Resolve home through protected profile policy when available."""
+        profile = self._protected_profile(runtime_config_id)
+        if profile is not None:
+            if profile.home_workspace is not None:
+                return profile.home_workspace
+            return resolve_home_workspace(
+                runtime_config_id,
+                self._config,
+                use_user_config=False,
+                provisioned_runtime=True,
+            )
+        return resolve_home_workspace(runtime_config_id, self._config)
+
+    def get_static_workspace_policy(
+        self,
+        runtime_config_id: int,
+    ) -> tuple[Path | None, tuple[Path, ...], bool]:
+        """Return per-runtime base/list policy and whether it is protected."""
+        profile = self._protected_profile(runtime_config_id)
+        if profile is not None:
+            return profile.workspace_base, profile.allowed_workspaces, True
+        user = self._config.get_user_config(runtime_config_id)
+        if user is None:
+            return None, (), False
+        return user.workspace_base, tuple(user.allowed_workspaces), False
+
+    async def resolve_workspace_access(self, runtime_config_id: int) -> tuple[Path | None, list[Path]]:
+        """Resolve mutable and static workspace access through runtime policy."""
+        base, allowed, protected = self.get_static_workspace_policy(runtime_config_id)
+        return await sessions.resolve_workspace_access(
+            runtime_config_id,
+            self._config,
+            use_user_config=not protected,
+            workspace_base=base,
+            static_allowed_workspaces=allowed if protected else (),
+        )
+
     @property
     def internal_api_auth(self) -> InternalAPIAuth:
         """Return the credential store shared with the loopback HTTP server."""
@@ -240,36 +289,22 @@ class SubprocessPool:
         """
         Create an AgentBackend for a specific user.
 
-        Backend selection: per-user backend (from users.yaml)
-        overrides the global config.default_backend. Both share the same
-        ABC interface; pool.py is backend-agnostic after this point.
+        Protected profiles own execution policy. Compatibility callers use
+        the existing UserConfig/global cascade.
 
-        Resolution order for each setting:
-        1. UserConfig from users.yaml (os_user, home_workspace, model,
-           timeout, backend, provider)
-        2. Global config defaults (from .env)
+        Protected profile fields take precedence over compatibility config.
 
         Per-user DB overrides (set via /settings or /model) are applied
         in _apply_user_db_settings() since they require async DB access.
         """
         user = self._config.get_user_config(chat_id)
-        protected_profile = None
-        if self._runtime_profiles is not None:
-            try:
-                protected_profile = self._runtime_profiles.for_config_id(chat_id)
-            except WorkshopRuntimeProfileError:
-                # Interactive Telegram groups and group-owned scheduled jobs
-                # remain on their established negative-chat compatibility
-                # path until group orchestration crosses the canonical runtime
-                # boundary. Positive private/configuration keys fail closed.
-                if chat_id >= 0:
-                    raise
+        protected_profile = self._protected_profile(chat_id)
 
         # Resolve through the single backend.resolve_home_workspace
         # helper: users.yaml override first, else DATA_DIR/home/<principal_id>/.
         # The old global home field on Config was removed by #353 because
         # it pointed every unconfigured user at a shared directory.
-        workspace = resolve_home_workspace(chat_id, self._config)
+        workspace = self.get_home_workspace(chat_id)
 
         ws_config = self._config.get_workspace_config(workspace)
 
@@ -351,7 +386,7 @@ class SubprocessPool:
         # non-home default. The redundant stat/mkdir inside
         # ensure_user_home is cheap (idempotent mkdir + chmod); the
         # clarity of two separate resolution calls is worth it.
-        home_ws = resolve_home_workspace(chat_id, self._config)
+        home_ws = self.get_home_workspace(chat_id)
 
         # os_user for sudo -u isolation. None = run as bot user.
         # Resolved here (rather than inside each branch) because all
@@ -562,8 +597,7 @@ class SubprocessPool:
         """Restore the saved workspace into a live instance.
 
         Reads `settings.workspace:<chat_id>`, validates path existence
-        and per-user workspace access (workspace_base from users.yaml,
-        allowed list from DB + global ALLOWED_WORKSPACES), and switches
+        and effective runtime workspace access, and switches
         the instance into the saved path when valid. Stale rows (path
         gone or no longer allowed) are deleted so an admin removing a
         path does not have users silently bypass the restriction.
@@ -589,7 +623,7 @@ class SubprocessPool:
                 )
                 await sessions.delete_setting(f"workspace:{chat_id}")
             else:
-                base, allowed = await sessions.resolve_workspace_access(chat_id, self._config)
+                base, allowed = await self.resolve_workspace_access(chat_id)
                 if not is_workspace_allowed(ws_path, base, allowed):
                     log.warning(
                         "Saved workspace for user %d is no longer allowed: %s",
@@ -611,7 +645,7 @@ class SubprocessPool:
         self._pending_workspace_restore.discard(chat_id)
         if effective is not None:
             return effective
-        return resolve_home_workspace(chat_id, self._config)
+        return self.get_home_workspace(chat_id)
 
     async def _apply_user_db_settings(self, chat_id: int, instance: AgentBackend) -> None:
         """Apply per-user DB-stored settings to a live instance.
@@ -838,10 +872,10 @@ class SubprocessPool:
         if not saved:
             if instance is not None:
                 self._pending_workspace_restore.discard(chat_id)
-            return resolve_home_workspace(chat_id, self._config)
+            return self.get_home_workspace(chat_id)
 
         ws_path = Path(saved)
-        base, allowed = await sessions.resolve_workspace_access(chat_id, self._config)
+        base, allowed = await self.resolve_workspace_access(chat_id)
         if not ws_path.is_dir() or not is_workspace_allowed(ws_path, base, allowed):
             log.warning(
                 "Saved workspace for user %d invalid; clearing: %s",
@@ -851,7 +885,7 @@ class SubprocessPool:
             await sessions.delete_setting(f"workspace:{chat_id}")
             if instance is not None:
                 self._pending_workspace_restore.discard(chat_id)
-            return resolve_home_workspace(chat_id, self._config)
+            return self.get_home_workspace(chat_id)
 
         # Only now do we materialize an instance. Avoiding instance
         # creation in the no-saved-row and stale-row branches keeps

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -224,6 +224,11 @@ class SubprocessPool:
         profile = self._protected_profile(runtime_config_id)
         if profile is not None:
             if profile.home_workspace is not None:
+                if not profile.home_workspace.is_dir():
+                    raise RuntimeError(
+                        f"Protected runtime {profile.profile_id} home workspace is unavailable: "
+                        f"{profile.home_workspace}. Mount or create it, or update the protected runtime profile."
+                    )
                 return profile.home_workspace
             return resolve_home_workspace(
                 runtime_config_id,

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -1422,37 +1422,47 @@ async def get_allowed_workspaces(chat_id: int) -> list[Path]:
     return [Path(row[0]) for row in rows]
 
 
-async def resolve_workspace_access(chat_id: int, config: Config) -> tuple[Path | None, list[Path]]:
+async def resolve_workspace_access(
+    chat_id: int,
+    config: Config,
+    *,
+    use_user_config: bool = True,
+    workspace_base: Path | None = None,
+    static_allowed_workspaces: tuple[Path, ...] = (),
+) -> tuple[Path | None, list[Path]]:
     """
     Resolve per-user workspace_base and allowed_workspaces.
 
-    Returns (workspace_base, allowed_workspaces) with per-user config
-    applied. The allowed list is the union of:
+    Returns (workspace_base, allowed_workspaces) with the selected static
+    policy applied. The allowed list is the union of:
       1. The per-chat DB `allowed_workspaces` table (set via
          `/workspace allow` from Telegram).
-      2. The per-user `allowed_workspaces` field in users.yaml
-         (admin-set baseline; see issue #460).
+      2. The selected per-runtime static `allowed_workspaces` baseline.
       3. The global `Config.allowed_workspaces` (env var
          ALLOWED_WORKSPACES + workspaces.yaml entries).
     Deduplicated by resolved path; earlier tiers win on collision.
 
     Precedence for workspace_base:
-        1. users.yaml workspace_base (admin-set per user)
+        1. Per-runtime workspace_base
         2. Global WORKSPACE_BASE env var
 
     Precedence for allowed_workspaces:
-        DB > yaml-per-user > global. DB first so user-added
+        DB > per-runtime static > global. DB first so user-added
         workspaces appear at the top of the /workspaces keyboard
-        and /workspace allowed list; yaml-per-user before global
-        because the user-specific tier is more relevant to the
+        and /workspace allowed list; the runtime tier precedes global
+        because the runtime-specific tier is more relevant to the
         user than the bot-wide tier.
     """
-    user_config = config.get_user_config(chat_id)
+    user_config = config.get_user_config(chat_id) if use_user_config else None
 
-    # workspace_base: users.yaml > env
-    base = user_config.workspace_base if user_config and user_config.workspace_base else config.workspace_base
+    # workspace_base: per-runtime static policy > env
+    base = (
+        user_config.workspace_base
+        if user_config and user_config.workspace_base
+        else workspace_base or config.workspace_base
+    )
 
-    # allowed_workspaces: union of DB + yaml-per-user + global,
+    # allowed_workspaces: union of DB + per-runtime static + global,
     # deduplicated. Resolved paths are the dedup key so the same
     # directory expressed two different ways (symlink, relative
     # form) collapses to a single entry.
@@ -1466,17 +1476,19 @@ async def resolve_workspace_access(chat_id: int, config: Config) -> tuple[Path |
             seen.add(resolved)
             combined.append(resolved)
 
-    # Per-user yaml allowed_workspaces (#460). The loader already
-    # resolved each path at load time, but re-resolve here for
-    # symmetry with the other tiers - cheap and protects against
-    # a stale Path object if the loader is ever changed to keep
-    # the raw form.
+    # Compatibility callers still obtain their static tier from UserConfig.
     if user_config and user_config.allowed_workspaces:
         for p in user_config.allowed_workspaces:
             resolved = p.resolve()
             if resolved not in seen:
                 seen.add(resolved)
                 combined.append(resolved)
+
+    for p in static_allowed_workspaces:
+        resolved = p.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            combined.append(resolved)
 
     for p in config.allowed_workspaces:
         resolved = p.resolve()

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -60,6 +60,9 @@ class ProtectedRuntimeProfile:
     model: str
     timeout_seconds: int
     allowed_services: tuple[str, ...]
+    home_workspace: Path | None
+    workspace_base: Path | None
+    allowed_workspaces: tuple[Path, ...]
 
 
 def _compatibility_model(
@@ -129,6 +132,44 @@ def _service_scopes(value: object, *, profile_id: RuntimeProfileId) -> tuple[str
                 f"Runtime profile {profile_id}: allowed service {service!r} is duplicated"
             )
         checked.append(service)
+    return tuple(checked)
+
+
+def _workspace_directory(
+    value: object,
+    *,
+    field: str,
+    profile_id: RuntimeProfileId,
+) -> Path | None:
+    """Validate one optional protected workspace directory."""
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: {field} must be a directory path or null")
+    path = Path(value.strip()).expanduser()
+    if not path.is_absolute():
+        raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: {field} must be an absolute path")
+    resolved = path.resolve()
+    if not resolved.is_dir():
+        raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: {field} is not an existing directory")
+    return resolved
+
+
+def _workspace_directories(value: object, *, profile_id: RuntimeProfileId) -> tuple[Path, ...]:
+    """Validate one explicit unique protected workspace allowlist."""
+    if not isinstance(value, list):
+        raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: allowed_workspaces must be a list")
+    checked: list[Path] = []
+    for raw_path in value:
+        path = _workspace_directory(
+            raw_path,
+            field="allowed_workspaces entry",
+            profile_id=profile_id,
+        )
+        assert path is not None
+        if path in checked:
+            raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: allowed workspace {path} is duplicated")
+        checked.append(path)
     return tuple(checked)
 
 
@@ -224,6 +265,9 @@ class WorkshopRuntimeProfileRegistry:
                     model=_compatibility_model(user, config, backend=backend, provider=provider),
                     timeout_seconds=user.timeout if user.timeout is not None else config.default_timeout,
                     allowed_services=tuple(user.allowed_services),
+                    home_workspace=user.home_workspace,
+                    workspace_base=user.workspace_base,
+                    allowed_workspaces=tuple(user.allowed_workspaces),
                 )
             )
         return cls(tuple(profiles))
@@ -317,6 +361,20 @@ class WorkshopRuntimeProfileRegistry:
                         raw_profile.get("allowed_services"),
                         profile_id=profile_id,
                     ),
+                    home_workspace=_workspace_directory(
+                        raw_profile.get("home_workspace"),
+                        field="home_workspace",
+                        profile_id=profile_id,
+                    ),
+                    workspace_base=_workspace_directory(
+                        raw_profile.get("workspace_base"),
+                        field="workspace_base",
+                        profile_id=profile_id,
+                    ),
+                    allowed_workspaces=_workspace_directories(
+                        raw_profile.get("allowed_workspaces"),
+                        profile_id=profile_id,
+                    ),
                 )
             )
         return cls(tuple(profiles))
@@ -355,9 +413,8 @@ class WorkshopRuntimeProfileRegistry:
         """Fail closed while users.yaml still provisions existing OS identities.
 
         Backend selection is owned by this registry. While users.yaml still
-        provisions the corresponding OS account, models, workspaces, and
-        service grants for migrated profiles, the duplicated backend/provider/
-        OS-user/model/timeout/service-scope fields must agree.
+        provisions the corresponding OS account and compatibility policy for
+        migrated profiles, duplicated execution fields must agree.
         """
         for runtime_config_id, user in config.user_configs.items():
             profile = self.for_config_id(runtime_config_id)
@@ -371,6 +428,9 @@ class WorkshopRuntimeProfileRegistry:
                 profile.model,
                 profile.timeout_seconds,
                 frozenset(profile.allowed_services),
+                profile.home_workspace,
+                profile.workspace_base,
+                frozenset(profile.allowed_workspaces),
             ) != (
                 backend,
                 provider,
@@ -378,6 +438,9 @@ class WorkshopRuntimeProfileRegistry:
                 expected_model,
                 expected_timeout,
                 frozenset(user.allowed_services),
+                user.home_workspace,
+                user.workspace_base,
+                frozenset(user.allowed_workspaces),
             ):
                 raise WorkshopRuntimeProfileError(
                     f"Runtime profile {profile.profile_id} conflicts with the migrated users.yaml execution policy"

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -141,7 +141,12 @@ def _workspace_directory(
     field: str,
     profile_id: RuntimeProfileId,
 ) -> Path | None:
-    """Validate one optional protected workspace directory."""
+    """Validate one optional protected workspace path.
+
+    Availability is deliberately a use-time concern. Retaining an absolute
+    path while its volume is unmounted keeps access restrictive and lets the
+    runtime recover when the path becomes available again.
+    """
     if value is None:
         return None
     if not isinstance(value, str) or not value.strip():
@@ -149,10 +154,7 @@ def _workspace_directory(
     path = Path(value.strip()).expanduser()
     if not path.is_absolute():
         raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: {field} must be an absolute path")
-    resolved = path.resolve()
-    if not resolved.is_dir():
-        raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: {field} is not an existing directory")
-    return resolved
+    return path.resolve()
 
 
 def _workspace_directories(value: object, *, profile_id: RuntimeProfileId) -> tuple[Path, ...]:
@@ -421,6 +423,13 @@ class WorkshopRuntimeProfileRegistry:
             backend, provider = get_user_backend_and_provider(user, config)
             expected_model = _compatibility_model(user, config, backend=backend, provider=provider)
             expected_timeout = user.timeout if user.timeout is not None else config.default_timeout
+            available_home = (
+                profile.home_workspace if profile.home_workspace and profile.home_workspace.is_dir() else None
+            )
+            available_base = (
+                profile.workspace_base if profile.workspace_base and profile.workspace_base.is_dir() else None
+            )
+            available_allowed = frozenset(path for path in profile.allowed_workspaces if path.is_dir())
             if (
                 profile.backend,
                 profile.provider,
@@ -428,9 +437,9 @@ class WorkshopRuntimeProfileRegistry:
                 profile.model,
                 profile.timeout_seconds,
                 frozenset(profile.allowed_services),
-                profile.home_workspace,
-                profile.workspace_base,
-                frozenset(profile.allowed_workspaces),
+                available_home,
+                available_base,
+                available_allowed,
             ) != (
                 backend,
                 provider,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -854,28 +854,29 @@ def _make_context(config=None, claude=None, pool=None, args=None, user_data=None
     # mock subprocess manager. Pool is preferred for new tests.
     mock_pool = pool or claude or _make_mock_claude()
     resolved_config = config or _make_config()
-    mock_pool.get_home_workspace = MagicMock(
-        side_effect=lambda runtime_config_id: resolve_home_workspace(
-            runtime_config_id,
-            resolved_config,
-        )
-    )
-    mock_pool.get_static_workspace_policy = MagicMock(
-        side_effect=lambda runtime_config_id: (
-            (
-                resolved_config.get_user_config(runtime_config_id).workspace_base,
-                tuple(resolved_config.get_user_config(runtime_config_id).allowed_workspaces),
-                False,
+    if pool is None:
+        mock_pool.get_home_workspace = MagicMock(
+            side_effect=lambda runtime_config_id: resolve_home_workspace(
+                runtime_config_id,
+                resolved_config,
             )
-            if resolved_config.get_user_config(runtime_config_id) is not None
-            else (None, (), False)
         )
-    )
+        mock_pool.get_static_workspace_policy = MagicMock(
+            side_effect=lambda runtime_config_id: (
+                (
+                    resolved_config.get_user_config(runtime_config_id).workspace_base,
+                    tuple(resolved_config.get_user_config(runtime_config_id).allowed_workspaces),
+                    False,
+                )
+                if resolved_config.get_user_config(runtime_config_id) is not None
+                else (None, (), False)
+            )
+        )
 
-    async def resolve_access(runtime_config_id):
-        return await sessions.resolve_workspace_access(runtime_config_id, resolved_config)
+        async def resolve_access(runtime_config_id):
+            return await sessions.resolve_workspace_access(runtime_config_id, resolved_config)
 
-    mock_pool.resolve_workspace_access = AsyncMock(side_effect=resolve_access)
+        mock_pool.resolve_workspace_access = AsyncMock(side_effect=resolve_access)
     runtime_config_ids = {
         runtime_config_id
         for runtime_config_id in (

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -19,7 +19,7 @@ import pytest
 from telegram.error import BadRequest
 
 from kai import sessions
-from kai.backend import AgentResponse, StreamEvent
+from kai.backend import AgentResponse, StreamEvent, resolve_home_workspace
 from kai.bot import (
     _QUEUED_MESSAGE_MARKER,
     ResponseDeliveryRoute,
@@ -854,6 +854,28 @@ def _make_context(config=None, claude=None, pool=None, args=None, user_data=None
     # mock subprocess manager. Pool is preferred for new tests.
     mock_pool = pool or claude or _make_mock_claude()
     resolved_config = config or _make_config()
+    mock_pool.get_home_workspace = MagicMock(
+        side_effect=lambda runtime_config_id: resolve_home_workspace(
+            runtime_config_id,
+            resolved_config,
+        )
+    )
+    mock_pool.get_static_workspace_policy = MagicMock(
+        side_effect=lambda runtime_config_id: (
+            (
+                resolved_config.get_user_config(runtime_config_id).workspace_base,
+                tuple(resolved_config.get_user_config(runtime_config_id).allowed_workspaces),
+                False,
+            )
+            if resolved_config.get_user_config(runtime_config_id) is not None
+            else (None, (), False)
+        )
+    )
+
+    async def resolve_access(runtime_config_id):
+        return await sessions.resolve_workspace_access(runtime_config_id, resolved_config)
+
+    mock_pool.resolve_workspace_access = AsyncMock(side_effect=resolve_access)
     runtime_config_ids = {
         runtime_config_id
         for runtime_config_id in (

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8261,6 +8261,49 @@ class TestApplySecretsDryRun:
 
 
 class TestIndependentRuntimePolicy:
+    def test_migration_preserves_effective_workspace_policy(self, tmp_path):
+        home = tmp_path / "home"
+        base = tmp_path / "projects"
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        for path in (home, base, first, second):
+            path.mkdir()
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            yaml.safe_dump(
+                {
+                    "users": [
+                        {
+                            "telegram_id": 101,
+                            "name": "Daniel",
+                            "role": "admin",
+                            "backend": "codex",
+                            "home_workspace": str(home),
+                            "workspace_base": str(base),
+                            "allowed_workspaces": [str(first), str(second), str(first)],
+                        }
+                    ]
+                },
+                sort_keys=False,
+            )
+        )
+
+        rendered = _build_migrated_runtime_profiles(
+            users_yaml,
+            registry_entries={"codex": {"allowed_models": ["gpt-5.5"]}},
+            defaults=kai.install._RuntimePolicyDefaults(
+                backend="codex",
+                provider="openai",
+                model="gpt-5.5",
+                timeout_seconds=120,
+            ),
+        )
+
+        profile = next(iter(yaml.safe_load(rendered)["runtime_profiles"].values()))
+        assert profile["home_workspace"] == str(home.resolve())
+        assert profile["workspace_base"] == str(base.resolve())
+        assert profile["allowed_workspaces"] == [str(first.resolve()), str(second.resolve())]
+
     def test_migration_preserves_existing_profile_ids_and_backend_choices(self, tmp_path, monkeypatch):
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(
@@ -8315,6 +8358,9 @@ class TestIndependentRuntimePolicy:
             "model": "gpt-5.5",
             "timeout_seconds": 120,
             "allowed_services": ["perplexity"],
+            "home_workspace": None,
+            "workspace_base": None,
+            "allowed_workspaces": [],
             "os_user": "daniel",
         }
         assert document["runtime_profiles"][scott_id]["backend"] == "claude"
@@ -8322,6 +8368,9 @@ class TestIndependentRuntimePolicy:
         assert document["runtime_profiles"][scott_id]["model"] == "sonnet"
         assert document["runtime_profiles"][scott_id]["timeout_seconds"] == 120
         assert document["runtime_profiles"][scott_id]["allowed_services"] == []
+        assert document["runtime_profiles"][scott_id]["home_workspace"] is None
+        assert document["runtime_profiles"][scott_id]["workspace_base"] is None
+        assert document["runtime_profiles"][scott_id]["allowed_workspaces"] == []
 
     def test_migration_validates_against_registry_being_installed(self, tmp_path, monkeypatch):
         users_yaml = tmp_path / "users.yaml"
@@ -8383,6 +8432,9 @@ backends:
                             "model": "gpt-5.5",
                             "timeout_seconds": 120,
                             "allowed_services": [],
+                            "home_workspace": None,
+                            "workspace_base": None,
+                            "allowed_workspaces": [],
                         }
                     },
                 }
@@ -8598,6 +8650,9 @@ backends:
                             "model": "gpt-5.5",
                             "timeout_seconds": 120,
                             "allowed_services": ["weather", "perplexity"],
+                            "home_workspace": None,
+                            "workspace_base": None,
+                            "allowed_workspaces": [],
                         }
                     },
                 },

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8304,6 +8304,66 @@ class TestIndependentRuntimePolicy:
         assert profile["workspace_base"] == str(base.resolve())
         assert profile["allowed_workspaces"] == [str(first.resolve()), str(second.resolve())]
 
+    def test_migration_preserves_unavailable_absolute_paths(self, tmp_path):
+        unavailable = (tmp_path / "later-mounted").resolve()
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            yaml.safe_dump(
+                {
+                    "users": [
+                        {
+                            "telegram_id": 101,
+                            "name": "Daniel",
+                            "role": "admin",
+                            "backend": "codex",
+                            "workspace_base": str(unavailable),
+                            "allowed_workspaces": [str(unavailable)],
+                        }
+                    ]
+                },
+                sort_keys=False,
+            )
+        )
+
+        rendered = _build_migrated_runtime_profiles(
+            users_yaml,
+            registry_entries={"codex": {"allowed_models": ["gpt-5.5"]}},
+            defaults=kai.install._RuntimePolicyDefaults(
+                backend="codex",
+                provider="openai",
+                model="gpt-5.5",
+                timeout_seconds=120,
+            ),
+        )
+
+        profile = next(iter(yaml.safe_load(rendered)["runtime_profiles"].values()))
+        assert profile["workspace_base"] == str(unavailable)
+        assert profile["allowed_workspaces"] == [str(unavailable)]
+
+    def test_migration_rejects_relative_workspace_paths(self, tmp_path):
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text(
+            """users:
+  - telegram_id: 101
+    name: Daniel
+    role: admin
+    backend: codex
+    workspace_base: relative/projects
+"""
+        )
+
+        with pytest.raises(ValueError, match="workspace_base must be an absolute path"):
+            _build_migrated_runtime_profiles(
+                users_yaml,
+                registry_entries={"codex": {"allowed_models": ["gpt-5.5"]}},
+                defaults=kai.install._RuntimePolicyDefaults(
+                    backend="codex",
+                    provider="openai",
+                    model="gpt-5.5",
+                    timeout_seconds=120,
+                ),
+            )
+
     def test_migration_preserves_existing_profile_ids_and_backend_choices(self, tmp_path, monkeypatch):
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -48,6 +48,7 @@ class TestRuntimeAssignmentPolicy:
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
                         "allowed_services": [],
+                        "allowed_workspaces": [],
                     }
                 },
             },

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -99,6 +99,9 @@ def test_protected_profile_selects_backend_and_os_user_over_compatibility_config
                 model="gpt-5.6-sol",
                 timeout_seconds=345,
                 allowed_services=(),
+                home_workspace=None,
+                workspace_base=None,
+                allowed_workspaces=(),
             ),
         )
     )
@@ -146,6 +149,9 @@ def test_protected_profile_service_scopes_override_compatibility_config(tmp_path
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
                 allowed_services=("perplexity",),
+                home_workspace=None,
+                workspace_base=None,
+                allowed_workspaces=(),
             ),
         )
     )
@@ -189,6 +195,9 @@ def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, mon
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
                 allowed_services=("perplexity",),
+                home_workspace=None,
+                workspace_base=None,
+                allowed_workspaces=(),
             ),
         )
     )
@@ -203,6 +212,81 @@ def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, mon
     assert principal.chat_id == runtime_config_id
     assert principal.allowed_services == frozenset({"perplexity"})
     assert instance._api_context.services_info == services_info
+    assert instance.workspace == tmp_path / "home" / str(runtime_config_id)
+
+
+async def test_protected_workspace_policy_overrides_compatibility_config(tmp_path, monkeypatch):
+    from kai.pool import SubprocessPool
+
+    protected_home = tmp_path / "protected-home"
+    protected_base = tmp_path / "protected-base"
+    protected_allowed = tmp_path / "protected-allowed"
+    compatibility_home = tmp_path / "compatibility-home"
+    compatibility_base = tmp_path / "compatibility-base"
+    compatibility_allowed = tmp_path / "compatibility-allowed"
+    global_allowed = tmp_path / "global-allowed"
+    db_allowed = tmp_path / "db-allowed"
+    for path in (
+        protected_home,
+        protected_base,
+        protected_allowed,
+        compatibility_home,
+        compatibility_base,
+        compatibility_allowed,
+        global_allowed,
+        db_allowed,
+    ):
+        path.mkdir()
+    monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+    config = Config(
+        telegram_bot_token="test",
+        allowed_user_ids={111},
+        default_backend="codex",
+        default_provider="openai",
+        default_model="gpt-5.6-sol",
+        allowed_workspaces=[global_allowed],
+        user_configs={
+            111: UserConfig(
+                telegram_id=111,
+                name="Alice",
+                home_workspace=compatibility_home,
+                workspace_base=compatibility_base,
+                allowed_workspaces=[compatibility_allowed],
+            )
+        },
+    )
+    profiles = WorkshopRuntimeProfileRegistry(
+        (
+            ProtectedRuntimeProfile(
+                profile_id=RuntimeProfileId("rtp_56565656565656565656565656565656"),
+                runtime_config_id=111,
+                display_name="Protected runtime",
+                os_user=None,
+                backend="codex",
+                provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
+                allowed_services=(),
+                home_workspace=protected_home,
+                workspace_base=protected_base,
+                allowed_workspaces=(protected_allowed,),
+            ),
+        )
+    )
+    pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
+    monkeypatch.setattr(
+        "kai.pool.sessions.get_allowed_workspaces",
+        AsyncMock(return_value=[db_allowed]),
+    )
+
+    instance = pool.get(111)
+    base, allowed = await pool.resolve_workspace_access(111)
+
+    assert instance.workspace == protected_home
+    assert instance.home_workspace == protected_home
+    assert base == protected_base
+    assert allowed == [db_allowed, protected_allowed, global_allowed]
+    assert compatibility_allowed not in allowed
 
 
 def test_unavailable_protected_service_is_denied_with_warning(tmp_path, monkeypatch, caplog):
@@ -230,6 +314,9 @@ def test_unavailable_protected_service_is_denied_with_warning(tmp_path, monkeypa
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
                 allowed_services=("missing",),
+                home_workspace=None,
+                workspace_base=None,
+                allowed_workspaces=(),
             ),
         )
     )
@@ -269,6 +356,9 @@ def test_negative_group_key_retains_legacy_compatibility_runtime(tmp_path, monke
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
                 allowed_services=(),
+                home_workspace=None,
+                workspace_base=None,
+                allowed_workspaces=(),
             ),
         )
     )
@@ -307,6 +397,9 @@ def test_positive_configuration_key_without_profile_fails_closed(tmp_path, monke
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
                 allowed_services=(),
+                home_workspace=None,
+                workspace_base=None,
+                allowed_workspaces=(),
             ),
         )
     )

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -289,6 +289,83 @@ async def test_protected_workspace_policy_overrides_compatibility_config(tmp_pat
     assert compatibility_allowed not in allowed
 
 
+def test_unavailable_explicit_profile_home_fails_only_that_runtime(tmp_path, monkeypatch):
+    from kai.pool import SubprocessPool
+
+    missing_home = tmp_path / "unmounted-home"
+    monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+    config = Config(
+        telegram_bot_token="test",
+        allowed_user_ids=set(),
+        default_backend="codex",
+        default_provider="openai",
+        default_model="gpt-5.6-sol",
+        protected_install=True,
+        user_configs={},
+    )
+    runtime_config_id = 987654321012347
+    profiles = WorkshopRuntimeProfileRegistry(
+        (
+            ProtectedRuntimeProfile(
+                profile_id=RuntimeProfileId("rtp_57575757575757575757575757575757"),
+                runtime_config_id=runtime_config_id,
+                display_name="Browser-only runtime",
+                os_user=None,
+                backend="codex",
+                provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
+                allowed_services=(),
+                home_workspace=missing_home,
+                workspace_base=None,
+                allowed_workspaces=(),
+            ),
+        )
+    )
+    pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
+
+    with pytest.raises(RuntimeError, match="Mount or create it, or update the protected runtime profile"):
+        pool.get(runtime_config_id)
+
+
+def test_profile_only_canonical_home_error_has_actionable_remediation(tmp_path, monkeypatch):
+    from kai.pool import SubprocessPool
+
+    monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
+    config = Config(
+        telegram_bot_token="test",
+        allowed_user_ids=set(),
+        default_backend="codex",
+        default_provider="openai",
+        default_model="gpt-5.6-sol",
+        protected_install=True,
+        user_configs={},
+    )
+    runtime_config_id = 987654321012348
+    profiles = WorkshopRuntimeProfileRegistry(
+        (
+            ProtectedRuntimeProfile(
+                profile_id=RuntimeProfileId("rtp_58585858585858585858585858585858"),
+                runtime_config_id=runtime_config_id,
+                display_name="Browser-only runtime",
+                os_user=None,
+                backend="codex",
+                provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
+                allowed_services=(),
+                home_workspace=None,
+                workspace_base=None,
+                allowed_workspaces=(),
+            ),
+        )
+    )
+    pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
+
+    with pytest.raises(RuntimeError, match="profile-only runtimes require an explicit home_workspace"):
+        pool.get(runtime_config_id)
+
+
 def test_unavailable_protected_service_is_denied_with_warning(tmp_path, monkeypatch, caplog):
     from kai.pool import SubprocessPool
 

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -89,6 +89,9 @@ def test_registry_rejects_duplicate_configuration_authority():
         "gpt-5.6-sol",
         120,
         (),
+        None,
+        None,
+        (),
     )
 
     with pytest.raises(WorkshopRuntimeProfileError, match="Duplicate runtime profile ID"):
@@ -110,6 +113,7 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
                     "model": "gpt-5.6-sol",
                     "timeout_seconds": 240,
                     "allowed_services": ["perplexity", "weather"],
+                    "allowed_workspaces": [],
                 }
             },
         },
@@ -127,6 +131,98 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
     assert profile.allowed_services == ("perplexity", "weather")
 
 
+def test_document_owns_resolved_workspace_policy(tmp_path):
+    home = tmp_path / "home"
+    base = tmp_path / "projects"
+    extra = tmp_path / "external"
+    for path in (home, base, extra):
+        path.mkdir()
+    profile_id = runtime_profile_id_for_config_id(101)
+
+    profile = WorkshopRuntimeProfileRegistry.from_document(
+        {
+            "version": 1,
+            "runtime_profiles": {
+                str(profile_id): {
+                    "display_name": "Daniel coding",
+                    "compatibility_runtime_config_id": 101,
+                    "backend": "codex",
+                    "provider": "openai",
+                    "model": "gpt-5.6-sol",
+                    "timeout_seconds": 120,
+                    "allowed_services": [],
+                    "home_workspace": str(home / "."),
+                    "workspace_base": str(base / "."),
+                    "allowed_workspaces": [str(extra / ".")],
+                }
+            },
+        },
+        backend_registry={"codex": {}},
+    ).resolve(profile_id)
+
+    assert profile.home_workspace == home.resolve()
+    assert profile.workspace_base == base.resolve()
+    assert profile.allowed_workspaces == (extra.resolve(),)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("home_workspace", "relative", "must be an absolute path"),
+        ("workspace_base", "relative", "must be an absolute path"),
+        ("allowed_workspaces", "not-a-list", "must be a list"),
+    ),
+)
+def test_document_rejects_invalid_workspace_policy(field, value, message):
+    profile_id = runtime_profile_id_for_config_id(101)
+    entry = {
+        "display_name": "Daniel coding",
+        "compatibility_runtime_config_id": 101,
+        "backend": "codex",
+        "provider": "openai",
+        "model": "gpt-5.6-sol",
+        "timeout_seconds": 120,
+        "allowed_services": [],
+        "allowed_workspaces": [],
+    }
+    entry[field] = value
+
+    with pytest.raises(WorkshopRuntimeProfileError, match=message):
+        WorkshopRuntimeProfileRegistry.from_document(
+            {
+                "version": 1,
+                "runtime_profiles": {str(profile_id): entry},
+            },
+            backend_registry={"codex": {}},
+        )
+
+
+def test_document_rejects_duplicate_resolved_allowed_workspace(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    profile_id = runtime_profile_id_for_config_id(101)
+
+    with pytest.raises(WorkshopRuntimeProfileError, match="duplicated"):
+        WorkshopRuntimeProfileRegistry.from_document(
+            {
+                "version": 1,
+                "runtime_profiles": {
+                    str(profile_id): {
+                        "display_name": "Daniel coding",
+                        "compatibility_runtime_config_id": 101,
+                        "backend": "codex",
+                        "provider": "openai",
+                        "model": "gpt-5.6-sol",
+                        "timeout_seconds": 120,
+                        "allowed_services": [],
+                        "allowed_workspaces": [str(workspace), str(workspace / ".")],
+                    }
+                },
+            },
+            backend_registry={"codex": {}},
+        )
+
+
 def test_non_telegram_profile_derives_stable_private_compatibility_key():
     profile_id = RuntimeProfileId("rtp_11111111111111111111111111111111")
     first = WorkshopRuntimeProfileRegistry.from_document(
@@ -140,6 +236,7 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
                     "model": "openai-codex/gpt-5.5",
                     "timeout_seconds": 120,
                     "allowed_services": [],
+                    "allowed_workspaces": [],
                 }
             },
         },
@@ -156,6 +253,7 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
                     "model": "openai-codex/gpt-5.5",
                     "timeout_seconds": 120,
                     "allowed_services": [],
+                    "allowed_workspaces": [],
                 }
             },
         },
@@ -191,6 +289,7 @@ def test_document_accepts_each_registered_backend_without_priority(backend, prov
                     "model": model,
                     "timeout_seconds": 120,
                     "allowed_services": [],
+                    "allowed_workspaces": [],
                 }
             },
         },
@@ -215,6 +314,7 @@ def test_document_rejects_backend_absent_from_protected_registry():
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
                         "allowed_services": [],
+                        "allowed_workspaces": [],
                     }
                 },
             },
@@ -238,6 +338,7 @@ def test_document_rejects_provider_not_supported_by_backend(backend):
                         "model": "sonnet",
                         "timeout_seconds": 120,
                         "allowed_services": [],
+                        "allowed_workspaces": [],
                     }
                 },
             },
@@ -261,6 +362,7 @@ def test_single_provider_backend_defaults_only_when_provider_is_omitted(backend,
                     "model": "sonnet" if backend == "claude" else "gpt-5.5",
                     "timeout_seconds": 120,
                     "allowed_services": [],
+                    "allowed_workspaces": [],
                 }
             },
         },
@@ -286,6 +388,7 @@ def test_document_rejects_invalid_os_user():
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
                         "allowed_services": [],
+                        "allowed_workspaces": [],
                     }
                 },
             },
@@ -312,6 +415,7 @@ def test_document_fails_closed_on_invalid_model_or_timeout(field, value, message
         "model": "gpt-5.5",
         "timeout_seconds": 120,
         "allowed_services": [],
+        "allowed_workspaces": [],
     }
     if value is None:
         profile.pop(field)
@@ -378,6 +482,7 @@ def test_document_enforces_loaded_backend_registry_model_ceiling():
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
                         "allowed_services": [],
+                        "allowed_workspaces": [],
                     }
                 },
             },
@@ -400,6 +505,7 @@ def test_document_rejects_unknown_backend_registry_entry_type():
                         "model": "gpt-5.5",
                         "timeout_seconds": 120,
                         "allowed_services": [],
+                        "allowed_workspaces": [],
                     }
                 },
             },
@@ -444,6 +550,7 @@ runtime_profiles:
     model: openai-codex/gpt-5.5
     timeout_seconds: 120
     allowed_services: []
+    allowed_workspaces: []
 """
     )
     monkeypatch.setattr(
@@ -481,6 +588,7 @@ runtime_profiles:
     model: sonnet
     timeout_seconds: 120
     allowed_services: []
+    allowed_workspaces: []
 """
     )
     monkeypatch.setattr(
@@ -507,6 +615,7 @@ runtime_profiles:
     model: gpt-5.5
     timeout_seconds: 999
     allowed_services: []
+    allowed_workspaces: []
 """
     )
     monkeypatch.setattr(
@@ -534,6 +643,7 @@ runtime_profiles:
     timeout_seconds: 120
     allowed_services:
       - perplexity
+    allowed_workspaces: []
 """
     )
     monkeypatch.setattr(
@@ -564,6 +674,7 @@ runtime_profiles:
     allowed_services:
       - weather
       - perplexity
+    allowed_workspaces: []
   {runtime_profile_id_for_config_id(202)}:
     display_name: Scott
     compatibility_runtime_config_id: 202
@@ -573,6 +684,7 @@ runtime_profiles:
     model: sonnet
     timeout_seconds: 120
     allowed_services: []
+    allowed_workspaces: []
 """
     )
     monkeypatch.setattr(

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -223,6 +223,73 @@ def test_document_rejects_duplicate_resolved_allowed_workspace(tmp_path):
         )
 
 
+def test_unavailable_workspace_paths_remain_restrictive_and_do_not_create_false_drift(tmp_path):
+    unavailable = (tmp_path / "later-mounted").resolve()
+    profile_id = runtime_profile_id_for_config_id(101)
+    registry = WorkshopRuntimeProfileRegistry.from_document(
+        {
+            "version": 1,
+            "runtime_profiles": {
+                str(profile_id): {
+                    "display_name": "Daniel",
+                    "compatibility_runtime_config_id": 101,
+                    "os_user": "daniel",
+                    "backend": "codex",
+                    "provider": "openai",
+                    "model": "gpt-5.6-sol",
+                    "timeout_seconds": 120,
+                    "allowed_services": [],
+                    "home_workspace": str(unavailable),
+                    "workspace_base": str(unavailable),
+                    "allowed_workspaces": [str(unavailable)],
+                }
+            },
+        },
+        backend_registry={"codex": {}},
+    )
+    unavailable_profile = registry.resolve(profile_id)
+    assert unavailable_profile.workspace_base == unavailable
+    registry._validate_compatibility_projection(
+        Config(
+            telegram_bot_token="test",
+            allowed_user_ids={101},
+            default_backend="codex",
+            default_provider="openai",
+            default_model="gpt-5.6-sol",
+            user_configs={
+                101: UserConfig(
+                    telegram_id=101,
+                    name="Daniel",
+                    os_user="daniel",
+                    backend="codex",
+                )
+            },
+        )
+    )
+
+    unavailable.mkdir()
+    registry._validate_compatibility_projection(
+        Config(
+            telegram_bot_token="test",
+            allowed_user_ids={101},
+            default_backend="codex",
+            default_provider="openai",
+            default_model="gpt-5.6-sol",
+            user_configs={
+                101: UserConfig(
+                    telegram_id=101,
+                    name="Daniel",
+                    os_user="daniel",
+                    backend="codex",
+                    home_workspace=unavailable,
+                    workspace_base=unavailable,
+                    allowed_workspaces=[unavailable],
+                )
+            },
+        )
+    )
+
+
 def test_non_telegram_profile_derives_stable_private_compatibility_key():
     profile_id = RuntimeProfileId("rtp_11111111111111111111111111111111")
     first = WorkshopRuntimeProfileRegistry.from_document(

--- a/tests/workshop_profiles.py
+++ b/tests/workshop_profiles.py
@@ -26,6 +26,9 @@ def profile_registry(*runtime_config_ids: int) -> WorkshopRuntimeProfileRegistry
                 model="gpt-5.6-sol",
                 timeout_seconds=120,
                 allowed_services=(),
+                home_workspace=None,
+                workspace_base=None,
+                allowed_workspaces=(),
             )
             for runtime_config_id in runtime_config_ids
         )


### PR DESCRIPTION
## Summary

- make protected runtime profiles authoritative for home workspace, workspace base, and static allowed workspaces
- migrate existing `users.yaml` workspace policy into `/etc/kai/runtime-profiles.yaml` without replacing operator-authored profile identities
- route backend startup, saved-workspace restoration, effective-workspace resolution, and Telegram workspace commands through the protected profile boundary
- preserve mutable database grants, global workspace policy, and the temporary negative Telegram-group compatibility bridge

## Security boundary

Positive runtime configuration keys now fail closed when protected policy is present but no matching profile exists. A protected profile cannot be overridden by conflicting workspace fields in `users.yaml`.

The effective access order is:

1. mutable per-runtime database grants
2. protected per-runtime static policy
3. global workspace policy

For migrated profiles, install-time drift validation requires the protected workspace fields to remain consistent with compatibility provisioning data. Independently authored profiles receive canonical defaults during policy enrichment.

Absolute workspace paths remain present in protected policy while temporarily unavailable. This prevents an unmounted base from widening access and allows the runtime to recover when the path returns. An unavailable explicit home fails only that runtime when used; it does not crash policy loading for every runtime.

## Compatibility

- existing profile IDs and compatibility runtime keys are preserved
- existing policy files are enriched in place and become idempotent on the next install
- user-visible `/workspace`, `/workspaces`, allow/deny, and saved-workspace behavior is retained
- negative Telegram group runtimes continue using the compatibility configuration path until group orchestration crosses the canonical boundary
- profile-only runtimes without an installer-provisioned canonical home must temporarily set an explicit `home_workspace` or have the operator provision the canonical directory
- no persistent integer-keyed settings or DB workspace grants are migrated in this change

## Validation

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest tests/ -q` — 5,710 passed, 1 skipped
- focused tests cover path validation, unavailable/remounted paths, deterministic migration, non-Telegram profile homes, protected-policy precedence, compatibility-group behavior, and Telegram workspace handlers

Closes #927
Part of #921
