### PR TITLE
Provision storage from protected runtime profiles

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -71,11 +71,13 @@ from kai.config import (
 from kai.named_access import replace_named_read_access
 from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
+from kai.workshop.bootstrap import bootstrap_human_principal_id
 from kai.workshop.diagnostics import (
     workshop_bootstrap_status,
     workshop_delivery_authority_status,
     workshop_message_parity_status,
 )
+from kai.workshop.domain import WorkshopId
 from kai.workshop.runtime_profiles import (
     WorkshopRuntimeProfileError,
     WorkshopRuntimeProfileRegistry,
@@ -4306,15 +4308,19 @@ class _RuntimeStorageTarget:
     home_workspace: Path | None
 
 
-def _runtime_profile_principal_names(data_path: Path) -> tuple[bool, dict[str, str]]:
+def _runtime_profile_principal_names(
+    data_path: Path,
+) -> tuple[bool, WorkshopId | None, dict[str, str]]:
     """Resolve protected runtime profiles to canonical direct-channel owners.
 
     The boolean distinguishes a database that predates Workshop assignments
     from an initialized database whose missing mappings must fail closed.
     """
     db_path = data_path / "kai.db"
-    if db_path.is_symlink() or not db_path.is_file():
-        return False, {}
+    if db_path.is_symlink():
+        raise RuntimeError(f"Refusing symlinked database during protected runtime storage preflight: {db_path}")
+    if not db_path.is_file():
+        return False, None, {}
     try:
         connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
         try:
@@ -4327,9 +4333,17 @@ def _runtime_profile_principal_names(data_path: Path) -> tuple[bool, dict[str, s
                 "channels",
                 "channel_memberships",
                 "principals",
+                "workshops",
             }
             if not tables >= required:
-                return False, {}
+                return False, None, {}
+            workshop_rows = connection.execute("SELECT id FROM workshops ORDER BY id").fetchall()
+            if len(workshop_rows) != 1:
+                raise RuntimeError("Initialized Workshop storage must contain exactly one Workshop")
+            try:
+                workshop_id = WorkshopId(str(workshop_rows[0][0]))
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError("Initialized Workshop storage contains an invalid Workshop ID") from exc
             rows = connection.execute(
                 "SELECT ra.runtime_profile_id, cm.principal_id "
                 "FROM channel_agent_runtime_assignments ra "
@@ -4349,7 +4363,7 @@ def _runtime_profile_principal_names(data_path: Path) -> tuple[bool, dict[str, s
     ambiguous = sorted(profile_id for profile_id, principal_ids in owners.items() if len(principal_ids) != 1)
     if ambiguous:
         raise RuntimeError("Protected runtime storage ownership is ambiguous for profile(s): " + ", ".join(ambiguous))
-    return True, {profile_id: next(iter(principal_ids)) for profile_id, principal_ids in owners.items()}
+    return True, workshop_id, {profile_id: next(iter(principal_ids)) for profile_id, principal_ids in owners.items()}
 
 
 def _runtime_storage_targets(
@@ -4360,7 +4374,7 @@ def _runtime_storage_targets(
     """Build profile-authoritative provisioning targets before disk mutation."""
     compatibility_order = [chat_id for chat_id, _os_user in _collect_user_memory_owners(users_yaml_path)]
     compatibility_ids = set(compatibility_order)
-    assignments_initialized, principal_names = _runtime_profile_principal_names(data_path)
+    assignments_initialized, workshop_id, principal_names = _runtime_profile_principal_names(data_path)
     compatibility_principal_names = _canonical_principal_storage_names(data_path)
     by_config_id = {profile.runtime_config_id: profile for profile in runtime_profiles.profiles}
     policy_profile_ids = {str(profile.profile_id) for profile in runtime_profiles.profiles}
@@ -4387,14 +4401,27 @@ def _runtime_storage_targets(
                 f"Protected runtime profile {profile.profile_id} conflicts with its canonical compatibility owner"
             )
         if principal_name is None:
-            if assignments_initialized or runtime_config_id not in compatibility_ids:
+            if runtime_config_id not in compatibility_ids:
                 raise RuntimeError(
                     f"Protected runtime profile {profile.profile_id} must map to exactly one canonical human owner"
                 )
-            # A first installation has no Workshop projection yet. Migrated
-            # compatibility users keep their pre-bootstrap numeric slot until
-            # the next install can resolve the canonical principal.
-            principal_name = str(runtime_config_id)
+            if compatibility_principal is not None:
+                principal_name = compatibility_principal
+            elif assignments_initialized:
+                assert workshop_id is not None
+                principal_name = str(
+                    bootstrap_human_principal_id(
+                        workshop_id,
+                        "telegram",
+                        str(runtime_config_id),
+                    )
+                )
+            else:
+                # A first installation has no Workshop namespace from which
+                # to derive the future principal. The initial service start
+                # bootstraps it, and the next install migrates this empty
+                # compatibility slot to the canonical directory.
+                principal_name = str(runtime_config_id)
         if profile.os_user is not None:
             try:
                 pwd.getpwnam(profile.os_user)
@@ -4413,6 +4440,15 @@ def _runtime_storage_targets(
                 home_workspace=profile.home_workspace,
             )
         )
+    storage_owners: dict[str, str] = {}
+    for target in targets:
+        prior_profile = storage_owners.get(target.storage_name)
+        if prior_profile is not None:
+            raise RuntimeError(
+                "Protected runtime profiles resolve to the same canonical human storage owner: "
+                f"{prior_profile}, {target.profile_id}"
+            )
+        storage_owners[target.storage_name] = target.profile_id
     return tuple(targets)
 
 
@@ -7907,34 +7943,55 @@ def _runtime_storage_status(
     managed = 0
     operator_managed = 0
     incomplete = 0
+    issues = {"home": 0, "identity": 0, "memory": 0, "preferences": 0, "temp": 0}
     resolved_data_path = data_path.resolve()
+
+    def owned_private_directory(path: Path, owner: tuple[int, int]) -> bool:
+        try:
+            path_stat = path.stat()
+        except OSError:
+            return False
+        return (
+            path.is_dir()
+            and stat.S_IMODE(path_stat.st_mode) == _PRIVATE_USER_DIR_MODE
+            and (path_stat.st_uid, path_stat.st_gid) == owner
+        )
+
+    def owned_private_file(path: Path, owner: tuple[int, int]) -> bool:
+        try:
+            path_stat = path.stat()
+        except OSError:
+            return False
+        return (
+            path.is_file()
+            and stat.S_IMODE(path_stat.st_mode) == _PRIVATE_USER_FILE_MODE
+            and (path_stat.st_uid, path_stat.st_gid) == owner
+        )
+
     for target in targets:
         try:
             expected_entry = pwd.getpwnam(target.os_user) if target.os_user is not None else service_entry
             expected_owner = (expected_entry.pw_uid, expected_entry.pw_gid)
-            memory_dir = data_path / "memory" / target.storage_name
-            preferences_dir = data_path / "preferences" / target.storage_name
-            supporting_complete = all(
-                path.is_dir()
-                and stat.S_IMODE(path.stat().st_mode) == _PRIVATE_USER_DIR_MODE
-                and (path.stat().st_uid, path.stat().st_gid) == expected_owner
-                for path in (memory_dir, preferences_dir)
-            )
-            supporting_complete = (
-                supporting_complete
-                and (memory_dir / "MEMORY.md").is_file()
-                and (preferences_dir / "PREFERENCES.md").is_file()
-            )
-            if target.os_user is not None:
-                tmp_dir = data_path / "tmp" / target.os_user
-                supporting_complete = (
-                    supporting_complete
-                    and tmp_dir.is_dir()
-                    and stat.S_IMODE(tmp_dir.stat().st_mode) == _PRIVATE_USER_DIR_MODE
-                    and (tmp_dir.stat().st_uid, tmp_dir.stat().st_gid) == expected_owner
-                )
-        except (KeyError, OSError):
-            supporting_complete = False
+        except KeyError:
+            expected_owner = (-1, -1)
+
+        memory_dir = data_path / "memory" / target.storage_name
+        preferences_dir = data_path / "preferences" / target.storage_name
+        memory_complete = owned_private_directory(memory_dir, expected_owner) and owned_private_file(
+            memory_dir / "MEMORY.md",
+            expected_owner,
+        )
+        preferences_complete = owned_private_directory(
+            preferences_dir,
+            expected_owner,
+        ) and owned_private_file(
+            preferences_dir / "PREFERENCES.md",
+            expected_owner,
+        )
+        temp_complete = target.os_user is None or owned_private_directory(
+            data_path / "tmp" / target.os_user,
+            expected_owner,
+        )
 
         if target.home_workspace is None:
             home = data_path / "home" / target.storage_name
@@ -7944,39 +8001,47 @@ def _runtime_storage_status(
             installer_managed = home.is_relative_to(resolved_data_path)
         if not installer_managed:
             operator_managed += 1
-            if not home.is_dir() or not supporting_complete:
-                incomplete += 1
-            continue
-
-        managed += 1
-        try:
-            home_stat = home.stat()
+            home_complete = home.is_dir()
+            identity_complete = True
+        else:
+            managed += 1
+            home_complete = owned_private_directory(home, expected_owner)
             agents_path = home / "AGENTS.md"
             claude_path = home / ".claude" / "CLAUDE.md"
-            complete = (
-                supporting_complete
-                and home.is_dir()
-                and stat.S_IMODE(home_stat.st_mode) == _PRIVATE_USER_DIR_MODE
-                and (home_stat.st_uid, home_stat.st_gid) == expected_owner
-                and agents_path.is_file()
-                and stat.S_IMODE(agents_path.stat().st_mode) == _PRIVATE_USER_FILE_MODE
-                and (agents_path.stat().st_uid, agents_path.stat().st_gid) == expected_owner
-            )
+            identity_complete = owned_private_file(agents_path, expected_owner)
             if target.backend == "claude":
-                complete = complete and claude_path.is_file() and claude_path.read_text() == _CLAUDE_IDENTITY_ADAPTER
+                try:
+                    identity_complete = (
+                        identity_complete
+                        and owned_private_file(claude_path, expected_owner)
+                        and claude_path.read_text() == _CLAUDE_IDENTITY_ADAPTER
+                    )
+                except OSError:
+                    identity_complete = False
             else:
-                complete = complete and not claude_path.exists()
-        except (KeyError, OSError):
+                identity_complete = identity_complete and not claude_path.exists()
+
+        checks = {
+            "home": home_complete,
+            "identity": identity_complete,
+            "memory": memory_complete,
+            "preferences": preferences_complete,
+            "temp": temp_complete,
+        }
+        if not all(checks.values()):
             incomplete += 1
-            continue
-        if not complete:
-            incomplete += 1
+            for category, complete in checks.items():
+                issues[category] += int(not complete)
 
     state = "complete" if incomplete == 0 else "INCOMPLETE"
-    return (
+    result = (
         f"{prefix} {state}; profiles={len(targets)}, managed={managed}, "
         f"operator-managed={operator_managed}, incomplete={incomplete}"
     )
+    if incomplete:
+        issue_summary = ", ".join(f"{category}={count}" for category, count in issues.items())
+        result += f"; issues: {issue_summary}"
+    return result
 
 
 def _webhook_secret_migration_status(env: dict[str, str], *, source: str = "install.conf artifact") -> str:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -4294,6 +4294,128 @@ def _canonical_principal_storage_names(data_path: Path) -> dict[str, str]:
     }
 
 
+@dataclass(frozen=True, slots=True)
+class _RuntimeStorageTarget:
+    """One protected runtime's install-time storage and ownership target."""
+
+    runtime_config_id: int
+    profile_id: str
+    storage_name: str
+    os_user: str | None
+    backend: str
+    home_workspace: Path | None
+
+
+def _runtime_profile_principal_names(data_path: Path) -> tuple[bool, dict[str, str]]:
+    """Resolve protected runtime profiles to canonical direct-channel owners.
+
+    The boolean distinguishes a database that predates Workshop assignments
+    from an initialized database whose missing mappings must fail closed.
+    """
+    db_path = data_path / "kai.db"
+    if db_path.is_symlink() or not db_path.is_file():
+        return False, {}
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            required = {
+                "channel_agent_runtime_assignments",
+                "channels",
+                "channel_memberships",
+                "principals",
+            }
+            if not tables >= required:
+                return False, {}
+            rows = connection.execute(
+                "SELECT ra.runtime_profile_id, cm.principal_id "
+                "FROM channel_agent_runtime_assignments ra "
+                "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+                "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
+                "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+                "ORDER BY ra.runtime_profile_id, cm.principal_id"
+            ).fetchall()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        raise RuntimeError(f"Could not resolve protected runtime storage ownership: {exc}") from exc
+
+    owners: dict[str, set[str]] = {}
+    for raw_profile_id, raw_principal_id in rows:
+        owners.setdefault(str(raw_profile_id), set()).add(str(raw_principal_id))
+    ambiguous = sorted(profile_id for profile_id, principal_ids in owners.items() if len(principal_ids) != 1)
+    if ambiguous:
+        raise RuntimeError("Protected runtime storage ownership is ambiguous for profile(s): " + ", ".join(ambiguous))
+    return True, {profile_id: next(iter(principal_ids)) for profile_id, principal_ids in owners.items()}
+
+
+def _runtime_storage_targets(
+    data_path: Path,
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
+    users_yaml_path: Path,
+) -> tuple[_RuntimeStorageTarget, ...]:
+    """Build profile-authoritative provisioning targets before disk mutation."""
+    compatibility_order = [chat_id for chat_id, _os_user in _collect_user_memory_owners(users_yaml_path)]
+    compatibility_ids = set(compatibility_order)
+    assignments_initialized, principal_names = _runtime_profile_principal_names(data_path)
+    compatibility_principal_names = _canonical_principal_storage_names(data_path)
+    by_config_id = {profile.runtime_config_id: profile for profile in runtime_profiles.profiles}
+    policy_profile_ids = {str(profile.profile_id) for profile in runtime_profiles.profiles}
+    stale_assignments = sorted(set(principal_names) - policy_profile_ids)
+    if stale_assignments:
+        raise RuntimeError(
+            "Canonical runtime storage assignment references profile(s) absent from protected policy: "
+            + ", ".join(stale_assignments)
+        )
+
+    ordered_ids = [runtime_id for runtime_id in compatibility_order if runtime_id in by_config_id]
+    ordered_ids.extend(sorted(runtime_id for runtime_id in by_config_id if runtime_id not in compatibility_ids))
+    targets: list[_RuntimeStorageTarget] = []
+    for runtime_config_id in ordered_ids:
+        profile = by_config_id[runtime_config_id]
+        principal_name = principal_names.get(str(profile.profile_id))
+        compatibility_principal = compatibility_principal_names.get(str(runtime_config_id))
+        if (
+            principal_name is not None
+            and compatibility_principal is not None
+            and principal_name != compatibility_principal
+        ):
+            raise RuntimeError(
+                f"Protected runtime profile {profile.profile_id} conflicts with its canonical compatibility owner"
+            )
+        if principal_name is None:
+            if assignments_initialized or runtime_config_id not in compatibility_ids:
+                raise RuntimeError(
+                    f"Protected runtime profile {profile.profile_id} must map to exactly one canonical human owner"
+                )
+            # A first installation has no Workshop projection yet. Migrated
+            # compatibility users keep their pre-bootstrap numeric slot until
+            # the next install can resolve the canonical principal.
+            principal_name = str(runtime_config_id)
+        if profile.os_user is not None:
+            try:
+                pwd.getpwnam(profile.os_user)
+            except KeyError as exc:
+                raise ValueError(
+                    f"Protected runtime profile {profile.profile_id} names os_user "
+                    f"{profile.os_user!r}, which does not exist on this host"
+                ) from exc
+        targets.append(
+            _RuntimeStorageTarget(
+                runtime_config_id=runtime_config_id,
+                profile_id=str(profile.profile_id),
+                storage_name=principal_name,
+                os_user=profile.os_user,
+                backend=profile.backend,
+                home_workspace=profile.home_workspace,
+            )
+        )
+    return tuple(targets)
+
+
 def _rewrite_managed_home_path(value: str, legacy_home: Path, canonical_home: Path) -> str | None:
     """Rewrite an exact managed-home prefix without resolving symlinks."""
     try:
@@ -4564,6 +4686,7 @@ def _apply_migrate(
     dry_run: bool,
     users_yaml_path: Path | None = None,
     default_backend: str | None = None,
+    runtime_storage_targets: tuple[_RuntimeStorageTarget, ...] | None = None,
 ) -> None:
     """
     Migrate runtime data from the development directory to the data directory.
@@ -4586,6 +4709,9 @@ def _apply_migrate(
             a per-user backend. Production apply always supplies it. ``None``
             is retained for focused helper tests and means the installer must
             preserve, rather than infer, any backend-specific adapter.
+        runtime_storage_targets: Prevalidated protected-profile provisioning
+            targets. Production apply supplies these; ``None`` retains the
+            compatibility helper behavior used by focused migration tests.
     """
     # None resolves to the module-level USERS_YAML at call time rather
     # than in the signature: a def-time default would bake the
@@ -4674,7 +4800,22 @@ def _apply_migrate(
     # the resolved install path (post-_apply_secrets, default
     # /etc/kai/users.yaml) so that all known operators get a seeded
     # directory on the install where this code first lands.
-    memory_owners = _collect_user_memory_owners(users_yaml_path)
+    if runtime_storage_targets is None:
+        memory_owners = _collect_user_memory_owners(users_yaml_path)
+        protected_storage_names: dict[str, str] = {}
+        protected_home_overrides: dict[int, Path] | None = None
+        protected_backends: dict[int, str | None] | None = None
+    else:
+        memory_owners = [(target.runtime_config_id, target.os_user) for target in runtime_storage_targets]
+        protected_storage_names = {
+            str(target.runtime_config_id): target.storage_name for target in runtime_storage_targets
+        }
+        protected_home_overrides = {
+            target.runtime_config_id: target.home_workspace
+            for target in runtime_storage_targets
+            if target.home_workspace is not None
+        }
+        protected_backends = {target.runtime_config_id: target.backend for target in runtime_storage_targets}
     memory_root = data_path / "memory"
     legacy_global = memory_root / "MEMORY.md"
     template = PROJECT_ROOT / "templates" / ".claude" / "MEMORY.md"
@@ -4709,7 +4850,11 @@ def _apply_migrate(
     known_user_dir_names = {str(chat_id) for chat_id, _os_user in memory_owners if chat_id is not None}
     canonical_reader_users = _canonical_storage_reader_users(data_path, reader_users)
     canonical_principal_names = _canonical_principal_storage_names(data_path)
+    canonical_principal_names.update(protected_storage_names)
     reader_users.update(canonical_reader_users)
+    for target in runtime_storage_targets or ():
+        if target.os_user is not None:
+            reader_users[target.storage_name] = target.os_user
     known_user_dir_names.update(canonical_principal_names.values())
     for legacy_name, principal_name in canonical_principal_names.items():
         owner = per_user_ids.get(legacy_name)
@@ -4986,7 +5131,9 @@ def _apply_migrate(
     # Subdirectories whose chat_id has no os_user fall through to the
     # service-owned tier, matching the memory tier-(a) rule above.
     home_root = data_path / "home"
-    home_overrides = _collect_user_home_overrides(users_yaml_path)
+    home_overrides = (
+        _collect_user_home_overrides(users_yaml_path) if protected_home_overrides is None else protected_home_overrides
+    )
     managed_home_migrations: dict[int, tuple[Path, Path]] = {}
     for chat_id, _os_user in memory_owners:
         if chat_id is None or chat_id in home_overrides:
@@ -5099,7 +5246,11 @@ def _apply_migrate(
     # losslessly before compatibility files are changed.
     home_template = PROJECT_ROOT / "templates" / "AGENTS.md"
     home_template_exists = home_template.is_file()
-    effective_backends = _collect_user_effective_backends(users_yaml_path, default_backend)
+    effective_backends = (
+        _collect_user_effective_backends(users_yaml_path, default_backend)
+        if protected_backends is None
+        else protected_backends
+    )
 
     # Validate every managed identity surface before changing any of them.
     # This prevents a conflict for a later user from leaving earlier users
@@ -5503,7 +5654,7 @@ def _cmd_apply() -> None:
     # backward-compatible schema enrichment; absence produces the
     # deterministic one-time users.yaml migration.
     try:
-        runtime_policy_action, runtime_policy_content, _runtime_policy = _runtime_policy_apply_plan(
+        runtime_policy_action, runtime_policy_content, runtime_policy = _runtime_policy_apply_plan(
             service_user,
             env,
             effective_users_yaml,
@@ -5511,6 +5662,17 @@ def _cmd_apply() -> None:
     except ValueError as exc:
         raise SystemExit(
             f"Protected runtime policy preflight failed; no installation changes were made:\n{exc}"
+        ) from exc
+
+    try:
+        runtime_storage_targets = _runtime_storage_targets(
+            Path(data_dir),
+            runtime_policy,
+            effective_users_yaml,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise SystemExit(
+            f"Protected runtime storage preflight failed; no installation changes were made:\n{exc}"
         ) from exc
 
     dry_run = os.environ.get("DRY_RUN", "").strip() in ("1", "true", "yes")
@@ -5632,7 +5794,13 @@ def _cmd_apply() -> None:
         )
 
         # -- Step 6: Deploy installed backend registry --
-        _apply_backend_registry(service_user, env, dry_run, users_yaml_path=effective_users_yaml)
+        _apply_backend_registry(
+            service_user,
+            env,
+            dry_run,
+            users_yaml_path=effective_users_yaml,
+            runtime_profiles=runtime_policy,
+        )
 
         # -- Step 6b: Deploy independent protected runtime policy --
         _apply_runtime_policy(runtime_policy_action, runtime_policy_content, dry_run)
@@ -5649,6 +5817,7 @@ def _cmd_apply() -> None:
             svc_gid,
             dry_run,
             agent_backend=agent_backend,
+            runtime_profiles=runtime_policy,
         )
 
         # -- Step 8: Configure sudoers --
@@ -5656,6 +5825,7 @@ def _cmd_apply() -> None:
             service_user,
             dry_run,
             agent_backend=agent_backend,
+            runtime_profiles=runtime_policy,
         )
 
         # -- Step 9: Migrate runtime data --
@@ -5666,6 +5836,7 @@ def _cmd_apply() -> None:
             svc_gid,
             dry_run,
             default_backend=agent_backend,
+            runtime_storage_targets=runtime_storage_targets,
         )
 
         # -- Step 10: Generate service definition --
@@ -7064,10 +7235,15 @@ def _backend_command_trust_issues(command: str, username: str) -> tuple[str, ...
 
 
 def _backend_command_trust_warnings(
-    commands: dict[str, str], service_user: str, users_yaml_path: str | Path
+    commands: dict[str, str],
+    service_user: str,
+    users_yaml_path: str | Path,
+    runtime_profiles: WorkshopRuntimeProfileRegistry | None = None,
 ) -> tuple[str, ...]:
     """Return warnings for registered commands modifiable by agent identities."""
     target_users = [service_user, *_collect_os_users_from_yaml(users_yaml_path)]
+    if runtime_profiles is not None:
+        target_users.extend(profile.os_user for profile in runtime_profiles.profiles if profile.os_user is not None)
     seen_users: set[str] = set()
     warnings: list[str] = []
     for username in target_users:
@@ -7088,6 +7264,7 @@ def _apply_backend_registry(
     env: dict[str, str],
     dry_run: bool,
     users_yaml_path: str | Path | None = None,
+    runtime_profiles: WorkshopRuntimeProfileRegistry | None = None,
 ) -> None:
     """Write the non-secret installed backend registry."""
     if users_yaml_path is None:
@@ -7100,7 +7277,12 @@ def _apply_backend_registry(
         for backend, entry in raw_backends.items()
         if isinstance(entry, dict) and isinstance(entry.get("command"), str)
     }
-    trust_warnings = _backend_command_trust_warnings(commands, service_user, users_yaml_path)
+    trust_warnings = _backend_command_trust_warnings(
+        commands,
+        service_user,
+        users_yaml_path,
+        runtime_profiles,
+    )
     if trust_warnings:
         print("Warning: local-process backend executable trust is limited:", file=sys.stderr)
         for warning in trust_warnings:
@@ -7128,13 +7310,15 @@ def _apply_goose_config(
     dry_run: bool,
     users_yaml_path: str | Path | None = None,
     agent_backend: str = "",
+    runtime_profiles: WorkshopRuntimeProfileRegistry | None = None,
 ) -> None:
     """
-    Deploy the Goose extension config to every home goose runs from.
+    Deploy the Goose extension config to every home Goose runs from.
 
     Copies config/goose-config.yaml from the install tree to
     `~/.config/goose/config.yaml` for the service user AND for each
-    distinct goose-backed `os_user` in users.yaml, so `goose acp`
+    distinct Goose-backed `os_user` in protected runtime policy (with
+    users.yaml retained for direct helper compatibility), so `goose acp`
     picks up the right extension settings wherever it spawns. The
     service-user copy covers goose-backed users with no os_user (they
     run as the service user); the per-os_user copies cover isolated
@@ -7142,13 +7326,9 @@ def _apply_goose_config(
     config beneath the target user's home. Directories are created if
     missing, with each user's tree owned by that user.
 
-    `agent_backend` is the install's global backend; users.yaml
-    entries without a per-user override inherit it (same contract as
-    `_apply_sudoers`). No-ops when nothing in the install is
-    goose-backed - neither the global backend nor any users.yaml
-    override - so the apply pipeline can call it unconditionally and
-    an install without Goose users is never blocked on the goose
-    template.
+    `agent_backend` and users.yaml remain compatibility inputs for focused
+    helper callers. Production apply supplies the protected runtime registry.
+    The function no-ops when no configured profile uses Goose.
     """
     # None resolves to the module-level USERS_YAML at call time rather
     # than in the signature: a def-time default would bake the
@@ -7161,7 +7341,14 @@ def _apply_goose_config(
     # requirement when some session will spawn `goose acp`. users.yaml
     # is canonical at /etc/kai by this step (the secrets step deploys
     # any staged copy first).
-    if agent_backend != "goose" and "goose" not in _collect_backends_from_yaml(users_yaml_path):
+    profile_backends = (
+        {profile.backend for profile in runtime_profiles.profiles} if runtime_profiles is not None else set()
+    )
+    if (
+        agent_backend != "goose"
+        and "goose" not in _collect_backends_from_yaml(users_yaml_path)
+        and "goose" not in profile_backends
+    ):
         return
 
     src = install_path / "config" / "goose-config.yaml"
@@ -7182,7 +7369,14 @@ def _apply_goose_config(
     targets: list[tuple[Path, int, int]] = [
         (Path(_user_home(service_user)), svc_uid, svc_gid),
     ]
-    for name in _collect_goose_os_users_from_yaml(users_yaml_path, agent_backend):
+    goose_os_users = _collect_goose_os_users_from_yaml(users_yaml_path, agent_backend)
+    if runtime_profiles is not None:
+        goose_os_users.extend(
+            profile.os_user
+            for profile in runtime_profiles.profiles
+            if profile.backend == "goose" and profile.os_user is not None
+        )
+    for name in dict.fromkeys(goose_os_users):
         # An os_user matching the service user is already covered by
         # the unconditional service-user deploy (the runtime self-
         # sudo-skips that case anyway).
@@ -7252,15 +7446,14 @@ def _apply_sudoers(
     opencode_bin: str | None = None,
     goose_bin: str | None = None,
     agent_backend: str = "",
+    runtime_profiles: WorkshopRuntimeProfileRegistry | None = None,
 ) -> None:
     """
     Write sudoers rules for the service user to read protected config.
 
-    Loads `users_yaml_path` (None means the module-level USERS_YAML,
-    resolved at call time) to discover every distinct `os_user` the
-    runtime may target via `sudo -u`, so each gets a matching
-    SETENV: NOPASSWD: rule. Without this, hand-added per-user rules
-    were silently wiped on every `sudo make install`.
+    Production apply discovers every distinct `os_user` from protected runtime
+    policy, so each target of `sudo -u` gets a matching SETENV: NOPASSWD rule.
+    `users_yaml_path` remains a compatibility input for direct helper callers.
 
     Backend command paths are resolved from installer discovery and
     rendered into /etc/kai/backends.yaml. This function reuses the
@@ -7269,9 +7462,9 @@ def _apply_sudoers(
     for direct/dev formatter compatibility; `_cmd_apply` does not feed
     them from install.conf or process environment.
 
-    `agent_backend` is the install's resolved global backend. Together
-    with the per-user backend overrides in users.yaml it scopes the
-    missing-binary backstop below to backends the install actually uses.
+    `runtime_profiles` scopes protected per-profile identities and backend
+    checks. `agent_backend` and users.yaml retain compatibility coverage for
+    the global/default runtime path.
     """
     # None resolves to the module-level USERS_YAML at call time rather
     # than in the signature: a def-time default would bake the
@@ -7286,6 +7479,15 @@ def _apply_sudoers(
     # dry run, since the operator's next step is `sudo make install` which
     # would hit the same error with worse blast radius (partial install).
     os_users = _collect_os_users_from_yaml(users_yaml_path)
+    if runtime_profiles is not None:
+        os_users = list(
+            dict.fromkeys(
+                [
+                    *os_users,
+                    *(profile.os_user for profile in runtime_profiles.profiles if profile.os_user is not None),
+                ]
+            )
+        )
     registry_entries = _backend_registry_entries(service_user, {"DEFAULT_BACKEND": agent_backend}, users_yaml_path)
     registry_commands = {
         backend: str(entry["command"])
@@ -7319,6 +7521,8 @@ def _apply_sudoers(
     # backend switch cannot strand a user without a rule.
     if os_users:
         backends_in_use = {agent_backend} | _collect_backends_from_yaml(users_yaml_path)
+        if runtime_profiles is not None:
+            backends_in_use.update(profile.backend for profile in runtime_profiles.profiles)
         # Each entry's path must resolve to exactly what _generate_sudoers
         # pins for that backend's rule (including the fallbacks); a new
         # backend with a sudoers rule needs an entry in both places.
@@ -7573,6 +7777,7 @@ def _cmd_status() -> None:
     platform = "darwin" if sys.platform == "darwin" else "linux"
     install_dir = _DEFAULT_INSTALL_DIR
     data_dir = _DEFAULT_DATA_DIR
+    service_user = _DEFAULT_SERVICE_USER
     conf_env: dict[str, str] | None = None
     if INSTALL_CONF.exists():
         try:
@@ -7580,6 +7785,7 @@ def _cmd_status() -> None:
             platform = conf.get("platform", platform)
             install_dir = conf.get("install_dir", install_dir)
             data_dir = conf.get("data_dir", data_dir)
+            service_user = conf.get("service_user", service_user)
             raw_env = conf.get("env", {})
             if isinstance(raw_env, dict):
                 conf_env = {str(key): str(value) for key, value in raw_env.items()}
@@ -7602,6 +7808,15 @@ def _cmd_status() -> None:
         print(_webhook_secret_migration_status(conf_env, source="install.conf artifact"))
 
     print(_runtime_policy_status(RUNTIME_PROFILES_YAML, BACKENDS_YAML))
+    print(
+        _runtime_storage_status(
+            Path(data_dir),
+            service_user,
+            RUNTIME_PROFILES_YAML,
+            BACKENDS_YAML,
+            USERS_YAML,
+        )
+    )
 
     expected_humans: int | None = None
     if os.geteuid() == 0:
@@ -7665,6 +7880,103 @@ def _runtime_policy_status(policy_path: Path, backend_registry_path: Path) -> st
         return f"{prefix} INVALID ({type(exc).__name__})"
     backends = ",".join(sorted({profile.backend for profile in profiles.profiles}))
     return f"{prefix} initialized; profiles={len(profiles.profiles)}, backends={backends}"
+
+
+def _runtime_storage_status(
+    data_path: Path,
+    service_user: str,
+    policy_path: Path,
+    backend_registry_path: Path,
+    users_yaml_path: Path,
+) -> str:
+    """Return non-secret protected-profile storage provisioning coverage."""
+    prefix = "Workshop runtime storage:"
+    try:
+        backend_document = yaml.safe_load(backend_registry_path.read_text(encoding="utf-8"))
+        raw_backends = backend_document.get("backends") if isinstance(backend_document, dict) else None
+        backend_ids = raw_backends if isinstance(raw_backends, dict) else {}
+        profiles = WorkshopRuntimeProfileRegistry.from_yaml(
+            policy_path.read_text(encoding="utf-8"),
+            backend_registry=backend_ids,
+        )
+        targets = _runtime_storage_targets(data_path, profiles, users_yaml_path)
+        service_entry = pwd.getpwnam(service_user)
+    except (OSError, KeyError, RuntimeError, ValueError, yaml.YAMLError, WorkshopRuntimeProfileError) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+
+    managed = 0
+    operator_managed = 0
+    incomplete = 0
+    resolved_data_path = data_path.resolve()
+    for target in targets:
+        try:
+            expected_entry = pwd.getpwnam(target.os_user) if target.os_user is not None else service_entry
+            expected_owner = (expected_entry.pw_uid, expected_entry.pw_gid)
+            memory_dir = data_path / "memory" / target.storage_name
+            preferences_dir = data_path / "preferences" / target.storage_name
+            supporting_complete = all(
+                path.is_dir()
+                and stat.S_IMODE(path.stat().st_mode) == _PRIVATE_USER_DIR_MODE
+                and (path.stat().st_uid, path.stat().st_gid) == expected_owner
+                for path in (memory_dir, preferences_dir)
+            )
+            supporting_complete = (
+                supporting_complete
+                and (memory_dir / "MEMORY.md").is_file()
+                and (preferences_dir / "PREFERENCES.md").is_file()
+            )
+            if target.os_user is not None:
+                tmp_dir = data_path / "tmp" / target.os_user
+                supporting_complete = (
+                    supporting_complete
+                    and tmp_dir.is_dir()
+                    and stat.S_IMODE(tmp_dir.stat().st_mode) == _PRIVATE_USER_DIR_MODE
+                    and (tmp_dir.stat().st_uid, tmp_dir.stat().st_gid) == expected_owner
+                )
+        except (KeyError, OSError):
+            supporting_complete = False
+
+        if target.home_workspace is None:
+            home = data_path / "home" / target.storage_name
+            installer_managed = True
+        else:
+            home = target.home_workspace
+            installer_managed = home.is_relative_to(resolved_data_path)
+        if not installer_managed:
+            operator_managed += 1
+            if not home.is_dir() or not supporting_complete:
+                incomplete += 1
+            continue
+
+        managed += 1
+        try:
+            home_stat = home.stat()
+            agents_path = home / "AGENTS.md"
+            claude_path = home / ".claude" / "CLAUDE.md"
+            complete = (
+                supporting_complete
+                and home.is_dir()
+                and stat.S_IMODE(home_stat.st_mode) == _PRIVATE_USER_DIR_MODE
+                and (home_stat.st_uid, home_stat.st_gid) == expected_owner
+                and agents_path.is_file()
+                and stat.S_IMODE(agents_path.stat().st_mode) == _PRIVATE_USER_FILE_MODE
+                and (agents_path.stat().st_uid, agents_path.stat().st_gid) == expected_owner
+            )
+            if target.backend == "claude":
+                complete = complete and claude_path.is_file() and claude_path.read_text() == _CLAUDE_IDENTITY_ADAPTER
+            else:
+                complete = complete and not claude_path.exists()
+        except (KeyError, OSError):
+            incomplete += 1
+            continue
+        if not complete:
+            incomplete += 1
+
+    state = "complete" if incomplete == 0 else "INCOMPLETE"
+    return (
+        f"{prefix} {state}; profiles={len(targets)}, managed={managed}, "
+        f"operator-managed={operator_managed}, incomplete={incomplete}"
+    )
 
 
 def _webhook_secret_migration_status(env: dict[str, str], *, source: str = "install.conf artifact") -> str:

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -92,6 +92,16 @@ def _stable_token(*parts: str) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def bootstrap_human_principal_id(
+    workshop_id: WorkshopId,
+    transport: str,
+    external_subject: str,
+) -> PrincipalId:
+    """Derive the principal ID bootstrap will assign one external human."""
+    token = _stable_token(transport, external_subject)
+    return PrincipalId.derived(workshop_id, f"human:{token}")
+
+
 def _idempotency_key(kind: str, stable_token: str) -> str:
     return f"{_BOOTSTRAP_PREFIX}:{kind}:{stable_token}"
 
@@ -222,7 +232,11 @@ async def bootstrap_default_workshop(
     for human in ordered_humans:
         token = _stable_token(human.transport, human.external_subject)
         channel_token = _stable_token(human.transport, human.external_channel_id)
-        principal_id = PrincipalId.derived(workshop_id, f"human:{token}")
+        principal_id = bootstrap_human_principal_id(
+            workshop_id,
+            human.transport,
+            human.external_subject,
+        )
         external_identity_id = ExternalIdentityId.derived(workshop_id, f"external-identity:{token}")
         membership_id = WorkshopMembershipId.derived(workshop_id, f"membership:human:{token}")
         channel_id = ChannelId.derived(workshop_id, f"direct-channel:{channel_token}")
@@ -370,7 +384,11 @@ async def bootstrap_default_workshop(
         )
         for subject in sorted(notification.member_external_subjects):
             human_token = _stable_token(notification.transport, subject)
-            principal_id = PrincipalId.derived(workshop_id, f"human:{human_token}")
+            principal_id = bootstrap_human_principal_id(
+                workshop_id,
+                notification.transport,
+                subject,
+            )
             membership_id = ChannelMembershipId.derived(
                 workshop_id,
                 f"notification-channel-membership:{channel_token}:human:{human_token}",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -10,6 +10,7 @@ import sqlite3
 import stat
 import subprocess
 import time
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -86,8 +87,12 @@ from kai.install import (
     _webhook_secret_migration_status,
     cli,
 )
-from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
-from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.bootstrap import (
+    BootstrapHuman,
+    bootstrap_default_workshop,
+    bootstrap_human_principal_id,
+)
+from kai.workshop.domain import RuntimeProfileId, WorkshopId
 from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id
@@ -12250,13 +12255,93 @@ class TestProtectedRuntimeStorageProvisioning:
                 users_yaml,
             )
 
+    @pytest.mark.asyncio
+    async def test_new_compatibility_user_uses_future_bootstrap_principal(self, tmp_path):
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        users_yaml = tmp_path / "users.yaml"
+        profile = self._profile("codex")
+        users_yaml.write_text(
+            f"users:\n  - telegram_id: {profile.runtime_config_id}\n    name: New Telegram human\n    role: member\n"
+        )
+        store = await WorkshopEventStore.open(data_path / "kai.db")
+        await bootstrap_default_workshop(
+            store,
+            (BootstrapHuman("Existing", "admin", "telegram", "1", "1", None),),
+        )
+        async with store.connection.execute("SELECT id FROM workshops") as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        workshop_id = WorkshopId(str(row[0]))
+        await store.close()
+
+        targets = _runtime_storage_targets(
+            data_path,
+            WorkshopRuntimeProfileRegistry((profile,)),
+            users_yaml,
+        )
+
+        assert targets[0].storage_name == str(
+            bootstrap_human_principal_id(
+                workshop_id,
+                "telegram",
+                str(profile.runtime_config_id),
+            )
+        )
+        assert targets[0].storage_name != str(profile.runtime_config_id)
+
+    def test_profiles_cannot_share_one_canonical_storage_owner(self, tmp_path, monkeypatch):
+        first = self._profile("codex")
+        second = replace(
+            first,
+            profile_id=RuntimeProfileId("rtp_" + "e" * 32),
+            runtime_config_id=123456789,
+        )
+        shared_principal = "prn_" + "a" * 32
+        monkeypatch.setattr(
+            "kai.install._runtime_profile_principal_names",
+            lambda _data_path: (
+                True,
+                None,
+                {
+                    str(first.profile_id): shared_principal,
+                    str(second.profile_id): shared_principal,
+                },
+            ),
+        )
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users: []\n")
+
+        with pytest.raises(RuntimeError, match="same canonical human storage owner"):
+            _runtime_storage_targets(
+                tmp_path / "data",
+                WorkshopRuntimeProfileRegistry((first, second)),
+                users_yaml,
+            )
+
+    def test_symlinked_database_never_uses_uninitialized_fallback(self, tmp_path):
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        real_db = tmp_path / "real.db"
+        real_db.touch()
+        (data_path / "kai.db").symlink_to(real_db)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users: []\n")
+
+        with pytest.raises(RuntimeError, match="Refusing symlinked database"):
+            _runtime_storage_targets(
+                data_path,
+                WorkshopRuntimeProfileRegistry((self._profile("codex"),)),
+                users_yaml,
+            )
+
     def test_profile_only_missing_os_account_fails_before_provisioning(self, tmp_path, monkeypatch):
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text("users: []\n")
         profile = self._profile("codex", os_user="missing-user")
         monkeypatch.setattr(
             "kai.install._runtime_profile_principal_names",
-            lambda _data_path: (True, {str(profile.profile_id): "prn_" + "a" * 32}),
+            lambda _data_path: (True, None, {str(profile.profile_id): "prn_" + "a" * 32}),
         )
         monkeypatch.setattr(
             "kai.install.pwd.getpwnam",
@@ -12278,7 +12363,7 @@ class TestProtectedRuntimeStorageProvisioning:
         profile = self._profile("codex")
         monkeypatch.setattr(
             "kai.install._runtime_profile_principal_names",
-            lambda _data_path: (True, {str(profile.profile_id): "prn_" + "a" * 32}),
+            lambda _data_path: (True, None, {str(profile.profile_id): "prn_" + "a" * 32}),
         )
         monkeypatch.setattr(
             "kai.install._canonical_principal_storage_names",
@@ -12412,6 +12497,23 @@ class TestProtectedRuntimeStorageProvisioning:
         assert status == ("Workshop runtime storage: complete; profiles=1, managed=1, operator-managed=0, incomplete=0")
         assert str(profile.profile_id) not in status
         assert str(profile.runtime_config_id) not in status
+
+        (home / "AGENTS.md").chmod(0o644)
+        incomplete_status = _runtime_storage_status(
+            data_path,
+            service_user,
+            policy,
+            backends,
+            users_yaml,
+        )
+
+        assert incomplete_status == (
+            "Workshop runtime storage: INCOMPLETE; profiles=1, managed=1, "
+            "operator-managed=0, incomplete=1; issues: home=0, identity=1, "
+            "memory=0, preferences=0, temp=0"
+        )
+        assert str(profile.profile_id) not in incomplete_status
+        assert str(profile.runtime_config_id) not in incomplete_status
 
     def test_profile_only_os_user_is_included_in_sudoers(self, tmp_path, monkeypatch):
         profile = self._profile("codex", os_user="browser-user")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -63,6 +63,8 @@ from kai.install import (
     _retire_install_home_dir,
     _runtime_policy_apply_plan,
     _runtime_policy_status,
+    _runtime_storage_status,
+    _runtime_storage_targets,
     _secure_codex_turn_image_staging,
     _secure_history_directories,
     _secure_upload_directories,
@@ -85,6 +87,8 @@ from kai.install import (
     cli,
 )
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id
 
@@ -12126,3 +12130,351 @@ class TestWizardPerUserBackendsUseRegistry:
         env = self._run(monkeypatch, tmp_path, inputs)
 
         assert "OPENCODE_BIN" not in env
+
+
+class TestProtectedRuntimeStorageProvisioning:
+    @staticmethod
+    def _profile(backend: str, *, os_user: str | None = None) -> ProtectedRuntimeProfile:
+        provider = {
+            "claude": "anthropic",
+            "codex": "openai",
+            "goose": "openai",
+            "opencode": "openai",
+            "pi": "openai",
+        }[backend]
+        model = "sonnet" if backend == "claude" else "gpt-5.5"
+        return ProtectedRuntimeProfile(
+            profile_id=RuntimeProfileId("rtp_" + "f" * 32),
+            runtime_config_id=987654321,
+            display_name="Browser-only human",
+            os_user=os_user,
+            backend=backend,
+            provider=provider,
+            model=model,
+            timeout_seconds=120,
+            allowed_services=(),
+            home_workspace=None,
+            workspace_base=None,
+            allowed_workspaces=(),
+        )
+
+    @staticmethod
+    def _setup_project(tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
+        project = tmp_path / "project"
+        templates = project / "templates"
+        (templates / ".claude").mkdir(parents=True)
+        (templates / "AGENTS.md").write_text("# Canonical identity\n")
+        (templates / ".claude" / "MEMORY.md").write_text("# Memory\n")
+        (templates / ".claude" / "PREFERENCES.md").write_text("# Preferences\n")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", project)
+        monkeypatch.setattr("kai.install.os.chown", lambda *_args: None)
+
+        data_path = tmp_path / "data"
+        for name in ("logs", "memory", "files", "history"):
+            (data_path / name).mkdir(parents=True, exist_ok=True)
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users: []\n")
+        return data_path, users_yaml
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("backend", ["claude", "codex", "goose", "opencode", "pi"])
+    async def test_profile_without_telegram_user_gets_canonical_managed_storage(
+        self,
+        backend,
+        tmp_path,
+        monkeypatch,
+    ):
+        data_path, users_yaml = self._setup_project(tmp_path, monkeypatch)
+        profile = self._profile(backend)
+        registry = WorkshopRuntimeProfileRegistry((profile,))
+        store = await WorkshopEventStore.open(data_path / "kai.db")
+        await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    "Browser human",
+                    "admin",
+                    "workshop",
+                    "browser-human",
+                    "browser-direct",
+                    profile.profile_id,
+                ),
+            ),
+        )
+        await store.close()
+
+        targets = _runtime_storage_targets(data_path, registry, users_yaml)
+        assert len(targets) == 1
+        assert targets[0].storage_name.startswith("prn_")
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=os.getuid(),
+            svc_gid=os.getgid(),
+            dry_run=False,
+            users_yaml_path=users_yaml,
+            runtime_storage_targets=targets,
+        )
+
+        principal_name = targets[0].storage_name
+        home = data_path / "home" / principal_name
+        assert (home / "AGENTS.md").read_text() == "# Canonical identity\n"
+        assert (data_path / "memory" / principal_name / "MEMORY.md").is_file()
+        assert (data_path / "preferences" / principal_name / "PREFERENCES.md").is_file()
+        claude_adapter = home / ".claude" / "CLAUDE.md"
+        if backend == "claude":
+            assert claude_adapter.read_text() == "@../AGENTS.md\n"
+        else:
+            assert not claude_adapter.exists()
+        assert not (data_path / "home" / str(profile.runtime_config_id)).exists()
+
+    @pytest.mark.asyncio
+    async def test_initialized_assignments_fail_closed_for_unmapped_profile(self, tmp_path):
+        data_path = tmp_path / "data"
+        data_path.mkdir()
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users: []\n")
+        profile = self._profile("codex")
+        store = await WorkshopEventStore.open(data_path / "kai.db")
+        await bootstrap_default_workshop(
+            store,
+            (BootstrapHuman("Other", "admin", "workshop", "other", "other-direct", None),),
+        )
+        await store.close()
+
+        with pytest.raises(RuntimeError, match="exactly one canonical human owner"):
+            _runtime_storage_targets(
+                data_path,
+                WorkshopRuntimeProfileRegistry((profile,)),
+                users_yaml,
+            )
+
+    def test_profile_only_missing_os_account_fails_before_provisioning(self, tmp_path, monkeypatch):
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users: []\n")
+        profile = self._profile("codex", os_user="missing-user")
+        monkeypatch.setattr(
+            "kai.install._runtime_profile_principal_names",
+            lambda _data_path: (True, {str(profile.profile_id): "prn_" + "a" * 32}),
+        )
+        monkeypatch.setattr(
+            "kai.install.pwd.getpwnam",
+            lambda name: (_ for _ in ()).throw(KeyError(name)),
+        )
+
+        with pytest.raises(ValueError, match="does not exist on this host"):
+            _runtime_storage_targets(
+                tmp_path / "data",
+                WorkshopRuntimeProfileRegistry((profile,)),
+                users_yaml,
+            )
+
+        assert not (tmp_path / "data").exists()
+
+    def test_migrated_profile_conflicting_canonical_owner_fails_closed(self, tmp_path, monkeypatch):
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users:\n  - telegram_id: 987654321\n    name: Existing human\n    role: admin\n")
+        profile = self._profile("codex")
+        monkeypatch.setattr(
+            "kai.install._runtime_profile_principal_names",
+            lambda _data_path: (True, {str(profile.profile_id): "prn_" + "a" * 32}),
+        )
+        monkeypatch.setattr(
+            "kai.install._canonical_principal_storage_names",
+            lambda _data_path: {str(profile.runtime_config_id): "prn_" + "b" * 32},
+        )
+
+        with pytest.raises(RuntimeError, match="conflicts with its canonical compatibility owner"):
+            _runtime_storage_targets(
+                tmp_path / "data",
+                WorkshopRuntimeProfileRegistry((profile,)),
+                users_yaml,
+            )
+
+    @pytest.mark.asyncio
+    async def test_profile_driven_dry_run_describes_canonical_home_without_writing(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        data_path, users_yaml = self._setup_project(tmp_path, monkeypatch)
+        profile = self._profile("codex")
+        registry = WorkshopRuntimeProfileRegistry((profile,))
+        store = await WorkshopEventStore.open(data_path / "kai.db")
+        await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    "Browser human",
+                    "admin",
+                    "workshop",
+                    "browser-human",
+                    "browser-direct",
+                    profile.profile_id,
+                ),
+            ),
+        )
+        await store.close()
+        targets = _runtime_storage_targets(data_path, registry, users_yaml)
+
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=os.getuid(),
+            svc_gid=os.getgid(),
+            dry_run=True,
+            users_yaml_path=users_yaml,
+            runtime_storage_targets=targets,
+        )
+
+        canonical_home = data_path / "home" / targets[0].storage_name
+        assert f"Would create {canonical_home}" in capsys.readouterr().out
+        assert not canonical_home.exists()
+        assert not (data_path / "memory" / targets[0].storage_name).exists()
+
+    @pytest.mark.asyncio
+    async def test_status_reports_profile_storage_coverage_without_identifiers(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        data_path, users_yaml = self._setup_project(tmp_path, monkeypatch)
+        profile = self._profile("codex")
+        store = await WorkshopEventStore.open(data_path / "kai.db")
+        await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    "Browser human",
+                    "admin",
+                    "workshop",
+                    "browser-human",
+                    "browser-direct",
+                    profile.profile_id,
+                ),
+            ),
+        )
+        await store.close()
+        targets = _runtime_storage_targets(
+            data_path,
+            WorkshopRuntimeProfileRegistry((profile,)),
+            users_yaml,
+        )
+        _apply_migrate(
+            data_path,
+            tmp_path / "install",
+            svc_uid=os.getuid(),
+            svc_gid=os.getgid(),
+            dry_run=False,
+            users_yaml_path=users_yaml,
+            runtime_storage_targets=targets,
+        )
+
+        policy = tmp_path / "runtime-profiles.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "version": 1,
+                    "runtime_profiles": {
+                        str(profile.profile_id): {
+                            "display_name": profile.display_name,
+                            "compatibility_runtime_config_id": profile.runtime_config_id,
+                            "backend": profile.backend,
+                            "provider": profile.provider,
+                            "model": profile.model,
+                            "timeout_seconds": profile.timeout_seconds,
+                            "allowed_services": [],
+                            "home_workspace": None,
+                            "workspace_base": None,
+                            "allowed_workspaces": [],
+                        }
+                    },
+                }
+            )
+        )
+        backends = tmp_path / "backends.yaml"
+        backends.write_text("version: 1\nbackends:\n  codex: {}\n")
+        service_user = pwd.getpwuid(os.getuid()).pw_name
+        home = data_path / "home" / targets[0].storage_name
+        service_entry = MagicMock(pw_uid=home.stat().st_uid, pw_gid=home.stat().st_gid)
+        monkeypatch.setattr("kai.install.pwd.getpwnam", lambda _name: service_entry)
+
+        status = _runtime_storage_status(
+            data_path,
+            service_user,
+            policy,
+            backends,
+            users_yaml,
+        )
+
+        assert status == ("Workshop runtime storage: complete; profiles=1, managed=1, operator-managed=0, incomplete=0")
+        assert str(profile.profile_id) not in status
+        assert str(profile.runtime_config_id) not in status
+
+    def test_profile_only_os_user_is_included_in_sudoers(self, tmp_path, monkeypatch):
+        profile = self._profile("codex", os_user="browser-user")
+        registry = WorkshopRuntimeProfileRegistry((profile,))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users: []\n")
+        observed_users: list[str] = []
+
+        def fake_generate_sudoers(_service_user, os_users, **_kwargs):
+            observed_users.extend(os_users)
+            return "# test sudoers\n"
+
+        monkeypatch.setattr("kai.install._generate_sudoers", fake_generate_sudoers)
+        monkeypatch.setattr(
+            "kai.install._backend_registry_entries",
+            lambda *_args, **_kwargs: {"codex": {"command": str(tmp_path / "codex")}},
+        )
+
+        _apply_sudoers(
+            "kai",
+            dry_run=True,
+            users_yaml_path=users_yaml,
+            agent_backend="codex",
+            runtime_profiles=registry,
+        )
+
+        assert observed_users == ["browser-user"]
+
+    def test_profile_only_goose_os_user_receives_config(self, tmp_path, monkeypatch):
+        import types
+
+        profile = self._profile("goose", os_user="browser-user")
+        registry = WorkshopRuntimeProfileRegistry((profile,))
+        users_yaml = tmp_path / "users.yaml"
+        users_yaml.write_text("users: []\n")
+        install_path = tmp_path / "install"
+        (install_path / "config").mkdir(parents=True)
+        (install_path / "config" / "goose-config.yaml").write_text("extensions: {}\n")
+        service_home = tmp_path / "home" / "kai"
+        browser_home = tmp_path / "home" / "browser-user"
+        service_home.mkdir(parents=True)
+        browser_home.mkdir(parents=True)
+        monkeypatch.setattr("kai.install._user_home", lambda _name: str(service_home))
+        monkeypatch.setattr("kai.install.shutil.which", lambda _name: "/usr/local/bin/goose")
+        monkeypatch.setattr(
+            "kai.install.pwd.getpwnam",
+            lambda _name: types.SimpleNamespace(
+                pw_dir=str(browser_home),
+                pw_uid=os.getuid(),
+                pw_gid=os.getgid(),
+            ),
+        )
+        monkeypatch.setattr("kai.install._set_ownership", lambda *_args, **_kwargs: None)
+
+        _apply_goose_config(
+            "kai",
+            install_path,
+            os.getuid(),
+            os.getgid(),
+            dry_run=False,
+            users_yaml_path=users_yaml,
+            agent_backend="codex",
+            runtime_profiles=registry,
+        )
+
+        assert (browser_home / ".config" / "goose" / "config.yaml").is_file()


### PR DESCRIPTION
## Summary

Make protected Workshop runtime profiles the installation authority for runtime-owned storage and OS execution support.

This closes the gap where a canonical Workshop human/profile without a Telegram-derived `users.yaml` record could be valid protected policy yet remain unusable because `make install` never created its managed home, identity files, memory/preferences storage, temp namespace, sudoers target, or Goose configuration.

Closes #929
Parent milestone: #921

## What changed

### Profile-authoritative provisioning plan

- Build an immutable install-time target for every protected runtime profile.
- Resolve each profile through its canonical direct-channel human owner in the Workshop projection.
- Derive the exact future canonical principal for a newly staged Telegram compatibility user when Workshop is already initialized, so one install both provisions the correct storage and enables bootstrap.
- Preserve numeric first-install compatibility only when no Workshop namespace exists yet.
- Refuse profiles with no canonical owner after Workshop initialization.
- Refuse ambiguous ownership, assignments absent from protected policy, and disagreement between a migrated compatibility owner and the protected profile assignment.
- Refuse multiple protected profiles that resolve to one mutable canonical storage owner; shared-home semantics must be explicit rather than order-dependent.
- Refuse a symlinked Workshop database during storage preflight instead of treating it as an uninitialized installation.
- Validate every protected `os_user` against the host account database before the service is stopped or disk state is changed.

### Managed runtime storage

For every protected profile, including profiles absent from `users.yaml`, installation now provisions or reconciles:

- canonical `home/<principal-id>` directories;
- canonical `memory/<principal-id>/MEMORY.md`;
- canonical `preferences/<principal-id>/PREFERENCES.md`;
- canonical upload/history ownership mappings;
- private per-OS-user temporary directories;
- `AGENTS.md` as the backend-neutral managed identity;
- `.claude/CLAUDE.md` only when the protected profile backend is Claude.

Explicit `home_workspace` paths keep their existing contract: paths outside Kai's data tree remain operator-managed and are not chowned or populated by the installer.

### Execution support

- Generate sudoers target-user coverage from protected profiles, not only `users.yaml`.
- Include protected profile OS identities in executable trust warnings.
- Deploy Goose configuration for profile-only Goose OS users.
- Include profile backends in the missing-binary diagnostic scope.

### Diagnostics

`make install-status` now reports a non-secret Workshop runtime-storage line with:

- total protected profiles;
- installer-managed homes;
- operator-managed homes;
- incomplete profiles.

Completeness checks cover canonical ownership and private modes, managed identity files, memory, preferences, temporary storage, and backend-specific Claude adapter state. No profile IDs, compatibility keys, paths, display names, or policy values are printed.

When storage is incomplete, the diagnostic also reports aggregate issue counts for home, identity, memory, preferences, and temporary storage without disclosing identifiers.

## Safety and compatibility

- Existing Daniel/Scott compatibility profiles retain their opaque runtime-profile IDs and canonical principal directories.
- Existing numeric directories remain rollback archives; this does not delete compatibility state.
- The old direct `_apply_migrate` helper behavior remains available to focused/dev callers that do not supply protected targets.
- This does not migrate integer-keyed sessions/settings, remove Telegram adapter code, alter delivery behavior, or change backend selection.
- All five supported backend drivers use the same provisioning contract; no backend is assumed as a fallback.

## Tests

- `make check`
- `make typecheck`
- `python -m pytest tests/test_install.py -q`
  - 592 passed
- `python -m pytest -q`
  - 5,725 passed, 1 skipped

New coverage includes:

- browser-only canonical human/profile provisioning with no `users.yaml` entry;
- Claude, Codex, Goose, OpenCode, and Pi identity behavior;
- dry-run with no filesystem mutation;
- missing and ambiguous canonical mappings;
- staged compatibility-user onboarding into the deterministic future canonical principal;
- duplicate profile-to-storage-owner rejection;
- symlinked database rejection;
- stale protected-policy assignments;
- migrated-owner conflict rejection;
- missing OS account rejection before mutation;
- profile-only sudoers coverage;
- profile-only Goose configuration;
- non-secret installed status.
- category-specific incomplete-storage status without identifiers.

## Review focus

Please challenge:

- whether any Telegram-derived record remains an execution authority;
- whether first-install compatibility can become a silent fallback after Workshop initialization;
- canonical owner ambiguity or cross-human storage disclosure;
- missing OS-user/sudoers/Goose support for profile-only runtimes;
- backend fallback or Claude-specific assumptions;
- dry-run and failure-before-mutation behavior;
- rollback preservation without dual runtime authority.

## Installed qualification after merge

1. Run `make DRY_RUN=1 install` and confirm the new runtime-storage actions are profile/principal keyed.
2. Run `make install`.
3. Run `make install-status` and confirm `Workshop runtime storage: complete`.
4. Confirm Daniel and Scott still respond through their existing configured backends.
5. Provision and exercise one canonical Workshop human/profile with no `users.yaml` entry.
