### PR TITLE
Make protected runtime policy independently authoritative

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pip install -e '.[dev]'
 make config
 ```
 
-`make config` runs without `sudo`. It discovers the supported backend CLIs installed on the machine, requires an explicit installation default when more than one is available, and writes `install.conf` as the configuration artifact for the selected deployment mode. It does not accept user-supplied backend executable paths. Model defaults come from Kai's backend/provider/role model registry; admin-set per-user model baselines belong in the `models:` map in `users.yaml`, while users can change their active conversational model with `/model`.
+`make config` runs without `sudo`. It discovers the supported backend CLIs installed on the machine, requires an explicit installation default when more than one is available, and writes `install.conf` as the configuration artifact for the selected deployment mode. It does not accept user-supplied backend executable paths. Model defaults come from Kai's backend/provider/role model registry. In protected installs, conversational model baselines belong to `runtime-profiles.yaml`; operator-set PR-review and issue-triage baselines remain in each human's `models:` map in `users.yaml`. Users can change their active conversational model with `/model`.
 
 For a `single_user` deployment, `make config` also writes the runtime files under the operator's account. Start Kai from the checkout:
 
@@ -100,6 +100,20 @@ make install-status
 ```
 
 `make install` invokes `sudo` internally and installs source, data, and secrets under separate protected system directories. It also generates the admin-owned `/etc/kai/backends.yaml` registry containing the discovered executable paths, allowed model surfaces, and selected default backend. Runtime configuration names backend identifiers; it cannot redirect a protected backend to an arbitrary executable. After a successful protected install, `install.conf` may be deleted because it can contain secrets; re-run `make config` before a later reconfiguration.
+
+On the first protected install, Kai seeds `/etc/kai/runtime-profiles.yaml`
+from the configured humans. After that file exists, it is the independent
+authority for each Workshop runtime's backend, provider, model baseline,
+timeout, OS execution user, service grants, and workspace policy. Later edits
+to duplicated execution fields in `users.yaml` do not replace or veto the
+protected profile. `users.yaml` remains the Telegram-human bootstrap and
+integration-policy input during the Workshop migration.
+
+Edit an installed runtime profile with `sudoedit`, validate it with
+`make install-status`, then run `make install` to reconcile OS-owned storage
+and restart Kai. The installer preserves explicit profile values and fails
+closed if a configured compatibility identity has lost its profile mapping or
+if the protected policy references an unavailable backend or invalid model.
 
 Workshop remains loopback-only by default. To reach its browser client directly
 from a trusted private network, enter one private IPv4 interface address at the
@@ -126,7 +140,7 @@ Kai has real local authority, so the security model is part of the product rathe
 - **Local execution:** Kai runs on your machine. Conversations do not pass through a Kai-hosted relay.
 - **Path confinement:** File exchange is constrained to allowed workspace and file-storage paths.
 - **Protected backend registry:** Protected installs resolve backend identifiers through admin-owned `/etc/kai/backends.yaml`; executable paths and allowed model surfaces are installation state, not user input.
-- **Service proxy:** Third-party API keys live in server-side config and are injected only for services explicitly allowed to that user in `users.yaml`; keys are never placed in conversation context.
+- **Service proxy:** Third-party API keys live in server-side config and are injected only for services explicitly allowed by the protected runtime profile (or compatibility configuration outside a protected install); keys are never placed in conversation context.
 - **GitHub operation boundary:** PR review and issue triage run only for repositories explicitly authorized to that user in admin-controlled `users.yaml`. Protected installs require the user's stored GitHub token, and notification subscriptions cannot grant operation access.
 - **Per-user isolation:** Users have separate history, files, workspaces, jobs, settings, and agent subprocesses.
 - **Principal-bound internal API:** Agent API credentials resolve to a fixed user and explicit scopes in the outer service; request data cannot select another principal.

--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -419,7 +419,7 @@ No entry may use an indefinite condition such as "keep for compatibility." A gen
 | GitHub and generic webhook paths that route directly to Telegram or the pool | Canonical integration commands/events plus delivery/run services | Existing GitHub group notifications, generic callers, deduplication, and secret separation pass end-to-end tests | Remove direct routing while retaining verified webhook adapters and supported external contracts | Planned |
 | Per-chat settings, files, memory references, and project selection | Principal/channel/agent/project-workspace records and artifact metadata | Existing per-user isolation, context assembly, memory provenance, file delivery, and workspace access remain equivalent | Migrate namespaces and remove Telegram-derived ownership from domain storage; retire recorded compatibility `storage_path` values when an authoritative artifact store replaces local per-chat files | Active (new uploads and staged review artifacts use opaque human `PrincipalId` directories; numeric file directories remain read-compatible for existing uploads; settings, history, home, preferences, memory, and workspace compatibility state remain to migrate) |
 | `users.yaml` values that represent mutable application state | Workshop administration and durable policy records | Workshop administration can safely inspect and change the relevant state, and bootstrap/recovery behavior is proven | Retain only protected installation/bootstrap policy; remove duplicated mutable state and precedence rules | Planned |
-| One-time `users.yaml` projection into protected `runtime-profiles.yaml`, plus private integer `compatibility_runtime_config_id` values | Independently authored runtime profiles and profile-keyed runtime/state stores | Existing profile IDs and state continuity survive migration; a profile with no Telegram identity can be assigned and executed; installer/status diagnostics pass; all five backends remain equivalent | Remove the migration renderer and `from_config` development projection; remove `compatibility_runtime_config_id`, `for_config_id`, and integer conversion in `WorkshopRuntimePool` after pool and persistent state are profile-keyed | Active (#921; protected startup now loads the independent document, while pool/state execution still uses the explicitly named integer bridge) |
+| One-time `users.yaml` projection into protected `runtime-profiles.yaml`, plus private integer `compatibility_runtime_config_id` values | Independently authored runtime profiles and profile-keyed runtime/state stores | Existing profile IDs and state continuity survive migration; a profile with no Telegram identity can be assigned and executed; installer/status diagnostics pass; all five backends remain equivalent | Remove the migration renderer and `from_config` development projection; remove `compatibility_runtime_config_id`, `for_config_id`, and integer conversion in `WorkshopRuntimePool` after pool and persistent state are profile-keyed | Active (#921; protected fields are independently authoritative after their one-time seed and are no longer compared with `users.yaml`; the explicitly named integer pool/storage bridge and bootstrap-coverage check remain) |
 | Backend-specific execution orchestration embedded in the control plane | Equal Harness Driver contracts and a Runtime Backend boundary | Capability and lifecycle tests cover Claude, Codex, Goose, OpenCode, and Pi without privileging one driver | Delete duplicated process orchestration only after the shared contracts carry the required evidence | Planned |
 | Trusted-host `local_process` execution and its executable-trust warnings | Isolated Workshop workers | Worker identity, filesystem grants, credentials, networking, artifacts, cancellation, upgrade, and recovery are verified for all five harnesses | Retire trusted-host mode or explicitly reclassify it as a supported development mode; remove production mitigations that it alone requires | Planned |
 | Preliminary static Workshop browser shell | React Workshop client at the same `/workshop/` route | The React client proves enrollment, tab-scoped session handling, canonical timeline history, authenticated resumable live updates, channel correction, session revocation, and equivalent security headers against the installed API | Replace the packaged `static/index.html`, `static/app.css`, and `static/app.js`; delete tests specific to the preliminary asset implementation while retaining transport-neutral API and browser-boundary contract tests; do not retain a second UI or compatibility route | Replacement implemented and installed parity qualified; authenticated canonical command submission is now implemented for the first browser conversation path |
@@ -1988,6 +1988,38 @@ The next coherent boundary is event-driven run progress and inspection. It can
 replace status polling with canonical lifecycle events and expose useful agent
 activity without coupling the browser to backend processes or compatibility
 storage.
+
+## 42. Independent protected runtime-policy authority
+
+**Implementation date:** 2026-08-14
+
+An existing protected `/etc/kai/runtime-profiles.yaml` now owns its execution
+fields without a second authority in `users.yaml`. Installed startup and
+install reconciliation validate the protected document against the backend
+registry, but no longer reject an intentional difference in backend, provider,
+OS execution user, model baseline, timeout, service grants, or workspace
+policy. `users.yaml` supplies those values only for the one-time seed and for
+uninstalled compatibility operation.
+
+The temporary configured-user mapping remains explicit and fail-closed. During
+installation, every configured compatibility identity must still map to a
+preserved protected profile because the physical subprocess pool and some
+persistent namespaces remain integer-keyed. This coverage check does not copy
+or compare execution policy. Independently provisioned protected profiles may
+exist without a Telegram identity.
+
+Runtime-facing compatibility surfaces now resolve through the protected pool:
+model and timeout display/reset, model validation, backend-aware memory
+extraction messaging, upload-reader ownership, actionable authentication
+failures, and compatibility history/memory writes all use the selected profile
+rather than rereading duplicated fields. Tests exercise independent selection
+for Claude, Codex, Goose, OpenCode, and Pi and pin invalid user model overrides
+to the protected backend/provider boundary.
+
+The remaining Milestone 1 debt is the deliberately named integer bridge, not
+execution-policy precedence. Removing it requires profile-keyed subprocess and
+persistent-state namespaces; it does not require another round of field-by-
+field authority migration.
 
 ## Canonical notification feed activation
 

--- a/src/kai/agent_failure.py
+++ b/src/kai/agent_failure.py
@@ -165,6 +165,8 @@ def render_agent_failure(
     error: str | None,
     config: Config,
     chat_id: int,
+    *,
+    runtime_route: tuple[str, str, str | None] | None = None,
 ) -> str:
     """Render a safe, actionable error for a failed backend turn.
 
@@ -179,9 +181,12 @@ def render_agent_failure(
         return f"Error: {detail}"
 
     user_config = config.get_user_config(chat_id)
-    backend, provider = get_user_backend_and_provider(user_config, config)
+    if runtime_route is None:
+        backend, provider = get_user_backend_and_provider(user_config, config)
+        os_user = user_config.os_user if user_config else None
+    else:
+        backend, provider, os_user = runtime_route
     route = _agent_route_display(backend, provider)
-    os_user = user_config.os_user if user_config else None
 
     if kind in {AgentFailureKind.AUTHENTICATION_EXPIRED, AgentFailureKind.AUTHENTICATION_REQUIRED}:
         state = "has expired" if kind is AgentFailureKind.AUTHENTICATION_EXPIRED else "is required"

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -60,7 +60,6 @@ from telegram.ext import (
 
 from kai import github_api, memory_command, review, services, sessions, webhook
 from kai.agent_failure import render_agent_failure
-from kai.backend import require_backend_name
 from kai.config import (
     DATA_DIR,
     ONESHOT_REASONER_BACKENDS,
@@ -69,10 +68,9 @@ from kai.config import (
     Config,
     ModelRole,
     WorkspaceConfig,
+    canonicalize_model_for_backend,
     get_effective_provider,
-    get_user_backend_and_provider,
     models_for_backend,
-    resolve_user_model,
     validate_model_for_backend,
 )
 from kai.conversation_compatibility import (
@@ -894,24 +892,15 @@ async def handle_new(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
 # ── Model selection ──────────────────────────────────────────────────
 
 
-def _backend_name_for_instance(instance: object) -> str:
-    """Return a live instance's validated config-key backend name."""
-    return require_backend_name(instance)
-
-
 def _get_user_backend_provider(pool: SubprocessPool, chat_id: int, config: Config) -> tuple[str, str]:
     """Derive the effective (backend, provider) for a user without creating an instance.
 
-    Checks the running instance first; falls back to the canonical
-    get_user_backend_and_provider helper so read-only commands avoid
-    spawning a subprocess. The pair drives both the model-keyboard
-    listing and model validation, so they cannot drift.
+    Protected runtime policy owns the route when present. Compatibility
+    runtimes retain the existing live-instance/config cascade. The pair drives
+    both the model keyboard and model validation, so they cannot drift.
     """
-    instance = pool.get_if_exists(chat_id)
-    if instance:
-        return _backend_name_for_instance(instance), instance.provider
-    user_config = config.get_user_config(chat_id)
-    return get_user_backend_and_provider(user_config, config)
+    del config
+    return pool.get_backend_provider(chat_id)
 
 
 def _get_user_provider(pool: SubprocessPool, chat_id: int, config: Config) -> str:
@@ -1190,8 +1179,10 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
     assert update.message is not None
     db_settings = await sessions.get_user_settings(chat_id)
     user_config = config.get_user_config(chat_id)
+    pool = _get_pool(context)
+    profile = pool.get_runtime_profile(chat_id)
 
-    def _resolve(db_key: str, yaml_val: object, global_val: object, fmt: object) -> tuple[str, str]:
+    def _resolve(db_key: str, baseline: object, baseline_source: str, fmt: object) -> tuple[str, str]:
         """Resolve effective value and source for a setting."""
         # Wrap fmt in try/except so a corrupt DB row doesn't crash the
         # display command. Matches the defensive parsing in _restore_workspace.
@@ -1199,24 +1190,41 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
             try:
                 return fmt(db_settings[db_key]), "user override"  # type: ignore[operator]
             except (ValueError, TypeError):
-                pass  # fall through to yaml/global
-        if yaml_val is not None:
-            return fmt(yaml_val), "users.yaml"  # type: ignore[operator]
-        return fmt(global_val), "global default"  # type: ignore[operator]
+                pass  # fall through to protected/compatibility baseline
+        return fmt(baseline), baseline_source  # type: ignore[operator]
 
-    # Model
-    yaml_model = user_config.model if user_config else None
-    model, model_src = _resolve("model", yaml_model, config.default_model, str)
-
-    # Timeout
-    yaml_timeout = user_config.timeout if user_config else None
-    timeout, timeout_src = _resolve("timeout", yaml_timeout, config.default_timeout, lambda v: f"{int(v)}s")
+    if profile is not None:
+        baseline_model = profile.model
+        baseline_timeout = profile.timeout_seconds
+        model_baseline_source = timeout_baseline_source = "runtime policy"
+    else:
+        baseline_model = user_config.model if user_config and user_config.model else config.default_model
+        baseline_timeout = (
+            user_config.timeout if user_config and user_config.timeout is not None else config.default_timeout
+        )
+        model_baseline_source = "users.yaml" if user_config is not None and user_config.model else "global default"
+        timeout_baseline_source = (
+            "users.yaml" if user_config is not None and user_config.timeout is not None else "global default"
+        )
+    if profile is not None and (raw_model := db_settings.get("model", "").strip()):
+        candidate = canonicalize_model_for_backend(raw_model, profile.backend)
+        if validate_model_for_backend(candidate, profile.backend, profile.provider):
+            model, model_src = candidate, "user override"
+        else:
+            model, model_src = profile.model, "runtime policy"
+    else:
+        model, model_src = _resolve("model", baseline_model, model_baseline_source, str)
+    timeout, timeout_src = _resolve(
+        "timeout",
+        baseline_timeout,
+        timeout_baseline_source,
+        lambda value: f"{int(value)}s",
+    )
 
     # Provider info - always show so users know their configuration.
     # Uses the shared helper that checks the running instance first,
     # falling back to config cascade so new users see their provider
     # before any session starts.
-    pool = _get_pool(context)
     provider = _get_user_provider(pool, chat_id, config)
     provider_line = f"\n  Provider: {provider}"
 
@@ -1228,18 +1236,21 @@ async def _show_settings(update: Update, context: ContextTypes.DEFAULT_TYPE, cha
 def _revert_instance_field(pool: SubprocessPool, chat_id: int, field: str, config: Config) -> None:
     """
     Write the resolved default value for a single field back onto the
-    live ClaudeCodeBackend instance.
+    live backend instance.
 
     Called before restart so that stale in-memory overrides don't
     persist after a DB entry is deleted. Resolution order mirrors
-    _create_instance(): users.yaml > global config.
+    _create_instance(): runtime policy > compatibility configuration.
     """
     instance = pool.get_if_exists(chat_id)
     if not instance:
         return
+    profile = pool.get_runtime_profile(chat_id)
     user = config.get_user_config(chat_id)
     if field == "model":
-        if user and user.model:
+        if profile is not None:
+            instance.model = profile.model
+        elif user and user.model:
             instance.model = user.model
         else:
             # Fall back to provider default, not necessarily config.default_model.
@@ -1262,7 +1273,13 @@ def _revert_instance_field(pool: SubprocessPool, chat_id: int, field: str, confi
                     fallback = config.default_model
                 instance.model = fallback
     elif field == "timeout":
-        instance.timeout_seconds = user.timeout if user and user.timeout is not None else config.default_timeout
+        instance.timeout_seconds = (
+            profile.timeout_seconds
+            if profile is not None
+            else user.timeout
+            if user and user.timeout is not None
+            else config.default_timeout
+        )
 
 
 async def _handle_settings_reset(
@@ -1839,7 +1856,7 @@ async def _handle_workspace_config(
 
     # /workspace config - show current settings
     if field is None:
-        await _show_workspace_config(update, workspace, config)
+        await _show_workspace_config(update, context, workspace, config)
         return
 
     # /workspace config reset [field]
@@ -1914,6 +1931,7 @@ async def _handle_workspace_config(
 
 async def _show_workspace_config(
     update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
     workspace: Path,
     config: Config,
 ) -> None:
@@ -1925,28 +1943,31 @@ async def _show_workspace_config(
 
     # Fetch user-level settings so the display reflects the full
     # precedence chain: workspace DB > workspaces.yaml > user DB >
-    # users.yaml > global default. Without these, fields that the user
+    # runtime policy > compatibility defaults. Without these, fields that the user
     # set via /settings or /model would show "global default" instead
     # of the actual effective value.
     user_settings = await sessions.get_user_settings(chat_id)
     user_config = config.get_user_config(chat_id)
+    profile = _get_pool(context).get_runtime_profile(chat_id)
 
     lines = [f"Config for {workspace.name}:"]
 
-    # Model: workspace DB > workspaces.yaml > user DB > users.yaml > global
+    # Model: workspace DB > workspaces.yaml > user DB > runtime/compatibility baseline
     if "model" in db_settings:
         model, model_src = db_settings["model"], "workspace override"
     elif yaml_config and yaml_config.model:
         model, model_src = yaml_config.model, "workspaces.yaml"
     elif "model" in user_settings:
         model, model_src = user_settings["model"], "user setting"
+    elif profile is not None:
+        model, model_src = profile.model, "runtime policy"
     elif user_config and user_config.model:
         model, model_src = user_config.model, "users.yaml"
     else:
         model, model_src = config.default_model, "global default"
     lines.append(f"  Model: {model} ({model_src})")
 
-    # Timeout: workspace DB > workspaces.yaml > user DB > users.yaml > global
+    # Timeout: workspace DB > workspaces.yaml > user DB > runtime/compatibility baseline
     try:
         if "timeout" in db_settings:
             timeout, timeout_src = int(db_settings["timeout"]), "workspace override"
@@ -1954,6 +1975,8 @@ async def _show_workspace_config(
             timeout, timeout_src = yaml_config.timeout, "workspaces.yaml"
         elif "timeout" in user_settings:
             timeout, timeout_src = int(user_settings["timeout"]), "user setting"
+        elif profile is not None:
+            timeout, timeout_src = profile.timeout_seconds, "runtime policy"
         elif user_config and user_config.timeout is not None:
             timeout, timeout_src = user_config.timeout, "users.yaml"
         else:
@@ -3610,15 +3633,12 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
         )
         return
 
-    # Per-user backend / provider / claude-user / model-override
-    # resolution. Use the shared `get_user_backend_and_provider`
-    # helper so a manual /review picks up exactly the same effective
-    # backend the rest of the bot uses for this user; hand-rolling
-    # the fallback would drift if config.py's resolution rules ever
-    # change.
-    claude_user = user_config.os_user if user_config and user_config.os_user else None
-    agent_backend, provider = get_user_backend_and_provider(user_config, config)
-    model_override = resolve_user_model(ModelRole.PR_REVIEW, user_config, config)
+    # Execution identity comes from the protected runtime profile. GitHub
+    # authorization and optional per-role model overrides remain operator
+    # policy on the human bootstrap record during this migration.
+    claude_user = pool.get_os_user(actor_id)
+    agent_backend, provider = pool.get_backend_provider(actor_id)
+    model_override = pool.get_role_model(actor_id, ModelRole.PR_REVIEW)
     github_token = await sessions.get_setting(f"github_token:{actor_id}")
     if getattr(config, "protected_install", False) is True and not github_token:
         await update.message.reply_text(
@@ -3846,10 +3866,8 @@ def _grant_upload_read_access(path: Path, reader_user: str) -> None:
 
 
 def _upload_reader_user(context: ContextTypes.DEFAULT_TYPE, chat_id: int) -> str | None:
-    """Return the configured target OS user that must read uploaded files."""
-    config: Config = context.bot_data["config"]
-    user_config = config.get_user_config(chat_id)
-    return user_config.os_user if user_config and user_config.os_user else None
+    """Return the policy-selected OS user that must read uploaded files."""
+    return _get_pool(context).get_os_user(chat_id)
 
 
 def _upload_principal_id(
@@ -4744,6 +4762,7 @@ async def _handle_workshop_private_text(
             user_log=user_log,
             assistant_log=assistant_log,
             reasoner_backends=ONESHOT_REASONER_BACKENDS,
+            effective_backend=_get_pool(context).get_backend_provider(chat_id)[0],
         )
 
 
@@ -4943,7 +4962,7 @@ async def _handle_response(
         context: Telegram callback context.
         chat_id: The Telegram chat ID.
         prompt: Text string or list of content blocks to send to Claude.
-        claude: The ClaudeCodeBackend instance.
+        pool: The runtime pool used for this response.
         model: Current model name (for session tracking).
     """
     assert update.message is not None
@@ -4951,7 +4970,7 @@ async def _handle_response(
         raise ValueError("delivery_route must be a ResponseDeliveryRoute")
     # Check voice mode before starting
     config: Config = context.bot_data["config"]
-    reader_user = _upload_reader_user(context, chat_id)
+    reader_user = pool.get_os_user(chat_id)
     voice_mode = "off"
     if config.tts_enabled:
         voice_mode = await sessions.get_setting(f"voice_mode:{chat_id}") or "off"
@@ -5127,7 +5146,14 @@ async def _handle_response(
         # suspenders against a future change that re-introduces None,
         # so the literal "Error: None" string can't reappear via this
         # surface even on a regression.
-        error_text = render_agent_failure(final_response.failure_kind, final_response.error, config, chat_id)
+        backend, provider = pool.get_backend_provider(chat_id)
+        error_text = render_agent_failure(
+            final_response.failure_kind,
+            final_response.error,
+            config,
+            chat_id,
+            runtime_route=(backend, provider, pool.get_os_user(chat_id)),
+        )
         visible_error = error_text.removeprefix("Error: ")
         log_message(
             direction="assistant",

--- a/src/kai/conversation_compatibility.py
+++ b/src/kai/conversation_compatibility.py
@@ -30,6 +30,7 @@ def schedule_memory_ingestion(
     user_log: LogEntry | None,
     assistant_log: LogEntry | None,
     reasoner_backends: frozenset[str] = ONESHOT_REASONER_BACKENDS,
+    effective_backend: str | None = None,
 ) -> None:
     """Preserve the existing fire-and-forget semantic-memory write path."""
     from kai.memory import is_enabled as memory_is_enabled
@@ -50,10 +51,10 @@ def schedule_memory_ingestion(
                 if not user_text:
                     return
                 user_config = config.get_user_config(chat_id)
-                effective_backend = (
+                backend = effective_backend or (
                     user_config.backend if user_config and user_config.backend else config.default_backend
                 )
-                if config.memory_extraction_enabled and effective_backend in reasoner_backends:
+                if config.memory_extraction_enabled and backend in reasoner_backends:
                     prior_pairs: list[tuple[str, str]] = []
                     if config.episode_classifier_context_turns > 0:
                         from kai.history import get_recent_pairs

--- a/src/kai/cron.py
+++ b/src/kai/cron.py
@@ -50,8 +50,13 @@ _CONDITION_NOT_MET_PREFIX = (
 
 def _history_reader_user(context: ContextTypes.DEFAULT_TYPE, chat_id: int) -> str | None:
     """Resolve the OS user allowed to search one scheduled chat's history."""
+    pool = context.bot_data.get("pool")
+    if pool is not None:
+        return pool.get_os_user(chat_id)
     config = context.bot_data.get("config")
     if config is None:
+        return None
+    if getattr(config, "protected_install", False) is True:
         return None
     user_config = config.get_user_config(chat_id)
     return user_config.os_user if user_config and user_config.os_user else None

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -1219,42 +1219,6 @@ def _runtime_policy_apply_plan(
         raise ValueError(
             f"Protected runtime policy has no preserved profile for configured compatibility key(s): {rendered}"
         )
-    expected_profiles = WorkshopRuntimeProfileRegistry.from_yaml(
-        migrated_content,
-        backend_registry=registry_entries,
-    )
-    for expected in expected_profiles.profiles:
-        try:
-            actual = profiles.for_config_id(expected.runtime_config_id)
-        except WorkshopRuntimeProfileError as exc:
-            raise ValueError(
-                "Protected runtime policy lost a required compatibility profile during validation"
-            ) from exc
-        if (
-            actual.backend,
-            actual.provider,
-            actual.os_user,
-            actual.model,
-            actual.timeout_seconds,
-            frozenset(actual.allowed_services),
-            actual.home_workspace,
-            actual.workspace_base,
-            frozenset(actual.allowed_workspaces),
-        ) != (
-            expected.backend,
-            expected.provider,
-            expected.os_user,
-            expected.model,
-            expected.timeout_seconds,
-            frozenset(expected.allowed_services),
-            expected.home_workspace,
-            expected.workspace_base,
-            frozenset(expected.allowed_workspaces),
-        ):
-            raise ValueError(
-                f"Protected runtime profile {actual.profile_id} conflicts with users.yaml fields still required "
-                "for compatibility provisioning; update both protected documents together"
-            )
     return action, content, profiles
 
 

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -1901,8 +1901,12 @@ async def _send_dashboard(
     # sharpest. The per-user fall-through matches the extraction
     # gate's backend resolution in bot.py.
     config: Config = context.bot_data["config"]
-    user_config = config.get_user_config(chat_id)
-    effective_backend = user_config.backend if user_config and user_config.backend else config.default_backend
+    pool: SubprocessPool | None = context.bot_data.get("pool")
+    if pool is not None:
+        effective_backend = pool.get_backend_provider(chat_id)[0]
+    else:
+        user_config = config.get_user_config(chat_id)
+        effective_backend = user_config.backend if user_config and user_config.backend else config.default_backend
     if effective_backend not in ONESHOT_REASONER_BACKENDS:
         text += (
             f"\n\nNote: memory extraction is not available on the {effective_backend} "

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -8,9 +8,9 @@ Provides functionality to:
 4. Evict idle subprocesses to reclaim memory on resource-constrained machines
 5. Restore per-user saved workspaces on first interaction
 
-Each user gets their own backend instance with full conversation isolation,
-independent lifecycle, and OS-level enforcement via sudo -u when os_user is
-configured in users.yaml.
+Each runtime gets its own backend instance with full conversation isolation,
+independent lifecycle, and OS-level enforcement via sudo -u when an OS user is
+selected by protected runtime policy (or compatibility config outside it).
 """
 
 from __future__ import annotations
@@ -30,11 +30,14 @@ from kai.config import (
     OPEN_ENDED_PROVIDERS,
     VALID_BACKENDS,
     Config,
+    ModelRole,
     WorkspaceConfig,
     canonicalize_model_for_backend,
     get_default_model_for_backend,
     get_effective_provider,
+    get_model_for,
     get_user_backend_and_provider,
+    resolve_user_model,
     validate_model_for_backend,
 )
 from kai.goose import GooseBackend
@@ -43,7 +46,7 @@ from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError
 from kai.workspace_utils import is_workspace_allowed
 
 if TYPE_CHECKING:
-    from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+    from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
 
 log = logging.getLogger(__name__)
 
@@ -218,6 +221,58 @@ class SubprocessPool:
             if runtime_config_id >= 0:
                 raise
             return None
+
+    def get_runtime_profile(self, runtime_config_id: int) -> ProtectedRuntimeProfile | None:
+        """Return protected policy for one runtime, when that boundary applies."""
+        return self._protected_profile(runtime_config_id)
+
+    def get_backend_provider(self, runtime_config_id: int) -> tuple[str, str]:
+        """Resolve the active route without creating a backend process."""
+        profile = self._protected_profile(runtime_config_id)
+        if profile is not None:
+            return profile.backend, profile.provider
+        instance = self.get_if_exists(runtime_config_id)
+        if instance is not None:
+            return require_backend_name(instance), instance.provider
+        return get_user_backend_and_provider(
+            self._config.get_user_config(runtime_config_id),
+            self._config,
+        )
+
+    def get_os_user(self, runtime_config_id: int) -> str | None:
+        """Resolve the OS execution identity from protected policy when present."""
+        profile = self._protected_profile(runtime_config_id)
+        if profile is not None:
+            return profile.os_user
+        user = self._config.get_user_config(runtime_config_id)
+        return user.os_user if user is not None else None
+
+    def get_role_model(self, runtime_config_id: int, role: ModelRole) -> str:
+        """Resolve an operator role model against the policy-selected route."""
+        backend, provider = self.get_backend_provider(runtime_config_id)
+        model = canonicalize_model_for_backend(
+            resolve_user_model(
+                role,
+                self._config.get_user_config(runtime_config_id),
+                self._config,
+                backend=backend,
+                provider=provider,
+            ),
+            backend,
+        )
+        if validate_model_for_backend(model, backend, provider):
+            return model
+        fallback = get_model_for(role, backend, provider)
+        log.warning(
+            "Ignoring %s model %r for runtime %d because it is invalid for %s/%s; using %r",
+            role.value,
+            model,
+            runtime_config_id,
+            backend,
+            provider,
+            fallback,
+        )
+        return fallback
 
     def get_home_workspace(self, runtime_config_id: int) -> Path:
         """Resolve home through protected profile policy when available."""
@@ -656,8 +711,8 @@ class SubprocessPool:
         """Apply per-user DB-stored settings to a live instance.
 
         Covers the model and timeout overrides set via /settings or
-        /model. _create_instance() already applied the users.yaml
-        baselines, so this layer only handles the DB tier. Workspace
+        /model. _create_instance() already applied the protected policy or
+        compatibility baseline, so this layer only handles the DB tier. Workspace
         config takes precedence over user settings (more specific
         wins).
 
@@ -809,18 +864,19 @@ class SubprocessPool:
     # ── Per-user property accessors ─────────────────────────────────
 
     def get_model(self, chat_id: int) -> str:
-        """Get the active model for a user (or global default if no instance)."""
+        """Get the active model without bypassing protected runtime policy."""
         instance = self.get_if_exists(chat_id)
-        return instance.model if instance else self._config.default_model
+        if instance is not None:
+            return instance.model
+        profile = self._protected_profile(chat_id)
+        return profile.model if profile is not None else self._config.default_model
 
     async def get_effective_model(self, chat_id: int) -> str:
         """Get the effective model, checking persisted settings if no instance exists.
 
-        Unlike get_model() which returns the global default when no
-        subprocess instance exists (e.g., after a service restart before
-        the first message), this method resolves the model from the DB
-        using the same precedence chain as resolve_user_defaults():
-        user settings DB > users.yaml > global default.
+        Protected runtimes use the user settings DB over their protected
+        profile baseline. Compatibility runtimes retain the existing
+        users.yaml/global cascade through ``resolve_user_defaults``.
 
         Use this in command handlers that display the current model
         (like /models) where accuracy matters more than speed.
@@ -828,8 +884,18 @@ class SubprocessPool:
         instance = self.get_if_exists(chat_id)
         if instance:
             return instance.model
-        defaults = await sessions.resolve_user_defaults(chat_id, self._config)
-        return defaults["model"]
+        profile = self._protected_profile(chat_id)
+        if profile is None:
+            defaults = await sessions.resolve_user_defaults(chat_id, self._config)
+            return defaults["model"]
+        db_settings = await sessions.get_user_settings(chat_id)
+        raw_model = db_settings.get("model", "").strip()
+        if not raw_model:
+            return profile.model
+        model = canonicalize_model_for_backend(raw_model, profile.backend)
+        if validate_model_for_backend(model, profile.backend, profile.provider):
+            return model
+        return profile.model
 
     def set_model(self, chat_id: int, model: str) -> None:
         """Set the model for a user's subprocess."""

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -64,7 +64,15 @@ from telegram import Bot, Update
 from telegram.ext import Application
 
 from kai import cron, memory, review, services, sessions, triage
-from kai.config import DATA_DIR, IMAGE_EXTENSIONS, Config, ModelRole, UserConfig, resolve_user_model
+from kai.config import (
+    DATA_DIR,
+    IMAGE_EXTENSIONS,
+    Config,
+    ModelRole,
+    UserConfig,
+    get_user_backend_and_provider,
+    resolve_user_model,
+)
 from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, InternalAPIScope
 from kai.job_types import CANONICAL_JOB_TYPES, normalize_job_type
 from kai.telegram_utils import chunk_text
@@ -970,37 +978,38 @@ async def _process_github_event_for_user(
     github_token = await sessions.get_setting(f"github_token:{chat_id}")
     protected_install = getattr(config, "protected_install", False) is True
 
-    # Resolve per-user os_user for subprocess isolation. None falls
-    # back to "run as the bot's own OS user" inside the agent backend.
     user_config = config.get_user_config(chat_id)
-    claude_user = user_config.os_user if user_config and user_config.os_user else None
     repo_full_name = payload.get("repository", {}).get("full_name", "")
     github_operations_authorized = bool(user_config and user_config.authorizes_github_repo(repo_full_name))
 
-    # Resolve per-user backend/provider for the review/triage agents.
-    # Same resolution logic as pool.py _create_instance: per-user
-    # config overrides global config.
-    if user_config and user_config.backend:
-        agent_backend = user_config.backend
+    # Review and triage subprocess identity follows protected runtime policy.
+    # Development callers without a protected pool retain compatibility config;
+    # a protected install never falls back when the pool boundary is absent.
+    pool = request.app.get(POOL_KEY)
+    if pool is not None:
+        claude_user = pool.get_os_user(chat_id)
+        agent_backend, provider = pool.get_backend_provider(chat_id)
+        pr_review_model_override = pool.get_role_model(chat_id, ModelRole.PR_REVIEW)
+        issue_triage_model_override = pool.get_role_model(chat_id, ModelRole.ISSUE_TRIAGE)
+    elif protected_install:
+        raise RuntimeError("Protected runtime pool is unavailable for GitHub agent execution")
     else:
-        agent_backend = config.default_backend
-
-    if user_config and user_config.provider:
-        provider = user_config.provider
-    else:
-        provider = config.default_provider
-
-    # Per-role model overrides for review and triage. `resolve_user_model`
-    # implements the full precedence chain: per-user `models:` from
-    # users.yaml > Config.default_models from DEFAULT_MODELS_JSON >
-    # MODEL_REGISTRY's (backend, provider, role) default. review.py /
-    # triage.py treat the empty string as "fall through to the registry
-    # default" via the model_override parameter; the resolver always
-    # returns a concrete model string, so the override path here is
-    # load-bearing only when the resolved value differs from the
-    # registry default (which is exactly when it should fire).
-    pr_review_model_override = resolve_user_model(ModelRole.PR_REVIEW, user_config, config)
-    issue_triage_model_override = resolve_user_model(ModelRole.ISSUE_TRIAGE, user_config, config)
+        claude_user = user_config.os_user if user_config and user_config.os_user else None
+        agent_backend, provider = get_user_backend_and_provider(user_config, config)
+        pr_review_model_override = resolve_user_model(
+            ModelRole.PR_REVIEW,
+            user_config,
+            config,
+            backend=agent_backend,
+            provider=provider,
+        )
+        issue_triage_model_override = resolve_user_model(
+            ModelRole.ISSUE_TRIAGE,
+            user_config,
+            config,
+            backend=agent_backend,
+            provider=provider,
+        )
 
     # ── PR review routing ────────────────────────────────────────
     # When PR review is enabled for this user, reviewable PR events

--- a/src/kai/workshop/compatibility_state.py
+++ b/src/kai/workshop/compatibility_state.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 
 from kai import sessions
 from kai.config import Config
-from kai.conversation_compatibility import reader_user, schedule_memory_ingestion
+from kai.conversation_compatibility import schedule_memory_ingestion
 from kai.history import LogEntry, log_message
 from kai.workshop.domain import RuntimeProfileId
 from kai.workshop.runtime_pool import WorkshopRuntimePool
@@ -24,6 +24,7 @@ class WorkshopProfileCompatibilityState:
     _runtime_config_id: int = field(repr=False)
     _config: Config = field(repr=False)
     _reader_user: str | None = field(repr=False)
+    _backend: str = field(repr=False)
 
     def append_history(self, *, direction: str, text: str) -> LogEntry | None:
         return log_message(
@@ -55,6 +56,7 @@ class WorkshopProfileCompatibilityState:
             workspace=workspace,
             user_log=user_log,
             assistant_log=assistant_log,
+            effective_backend=self._backend,
         )
 
 
@@ -73,9 +75,10 @@ class WorkshopCompatibilityStateWriter:
         self,
         runtime_profile_id: str | RuntimeProfileId,
     ) -> WorkshopProfileCompatibilityState:
-        runtime_config_id = self._runtime_pool.compatibility_runtime_config_id(runtime_profile_id)
+        profile = self._runtime_pool.runtime_profile(runtime_profile_id)
         return WorkshopProfileCompatibilityState(
-            runtime_config_id,
+            profile.runtime_config_id,
             self._config,
-            reader_user(self._config, runtime_config_id),
+            profile.os_user,
+            profile.backend,
         )

--- a/src/kai/workshop/runtime_pool.py
+++ b/src/kai/workshop/runtime_pool.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from kai.backend import StreamEvent
 from kai.pool import PreparedBackendExecution, SubprocessPool
 from kai.workshop.domain import RuntimeProfileId
-from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
 
 type AgentPrompt = str | list[dict[str, str]]
 
@@ -35,6 +35,13 @@ class WorkshopRuntimePool:
     ) -> int:
         """Return the private compatibility key for non-pool migrations."""
         return self._profiles.resolve(runtime_profile_id).runtime_config_id
+
+    def runtime_profile(
+        self,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> ProtectedRuntimeProfile:
+        """Resolve the protected profile without exposing compatibility lookup."""
+        return self._profiles.resolve(runtime_profile_id)
 
     async def prepare_execution(
         self,

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -407,53 +407,7 @@ class WorkshopRuntimeProfileRegistry:
         protected = bool(os.environ.get(INSTALL_DIR_ENV, "").strip())
         if not explicit and not protected:
             return cls.from_config(config)
-        registry = cls.from_yaml(_policy_text(policy_path), backend_registry=load_backend_registry())
-        registry._validate_compatibility_projection(config)
-        return registry
-
-    def _validate_compatibility_projection(self, config: Config) -> None:
-        """Fail closed while users.yaml still provisions existing OS identities.
-
-        Backend selection is owned by this registry. While users.yaml still
-        provisions the corresponding OS account and compatibility policy for
-        migrated profiles, duplicated execution fields must agree.
-        """
-        for runtime_config_id, user in config.user_configs.items():
-            profile = self.for_config_id(runtime_config_id)
-            backend, provider = get_user_backend_and_provider(user, config)
-            expected_model = _compatibility_model(user, config, backend=backend, provider=provider)
-            expected_timeout = user.timeout if user.timeout is not None else config.default_timeout
-            available_home = (
-                profile.home_workspace if profile.home_workspace and profile.home_workspace.is_dir() else None
-            )
-            available_base = (
-                profile.workspace_base if profile.workspace_base and profile.workspace_base.is_dir() else None
-            )
-            available_allowed = frozenset(path for path in profile.allowed_workspaces if path.is_dir())
-            if (
-                profile.backend,
-                profile.provider,
-                profile.os_user,
-                profile.model,
-                profile.timeout_seconds,
-                frozenset(profile.allowed_services),
-                available_home,
-                available_base,
-                available_allowed,
-            ) != (
-                backend,
-                provider,
-                user.os_user,
-                expected_model,
-                expected_timeout,
-                frozenset(user.allowed_services),
-                user.home_workspace,
-                user.workspace_base,
-                frozenset(user.allowed_workspaces),
-            ):
-                raise WorkshopRuntimeProfileError(
-                    f"Runtime profile {profile.profile_id} conflicts with the migrated users.yaml execution policy"
-                )
+        return cls.from_yaml(_policy_text(policy_path), backend_registry=load_backend_registry())
 
     @property
     def profiles(self) -> tuple[ProtectedRuntimeProfile, ...]:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -24,7 +24,6 @@ from kai.bot import (
     _QUEUED_MESSAGE_MARKER,
     ResponseDeliveryRoute,
     _acquire_lock_or_kill,
-    _backend_name_for_instance,
     _clear_responding,
     _do_switch_workspace,
     _edit_message_safe,
@@ -78,7 +77,15 @@ from kai.bot import (
     handle_workspace_callback,
     handle_workspaces,
 )
-from kai.config import PROVIDER_MODELS, Config, UserConfig, get_default_model_for_backend
+from kai.config import (
+    PROVIDER_MODELS,
+    Config,
+    ModelRole,
+    UserConfig,
+    get_default_model_for_backend,
+    get_user_backend_and_provider,
+    resolve_user_model,
+)
 from kai.review import CollectionWarning, PRReviewResult
 from kai.tts import DEFAULT_VOICE, VOICES
 from kai.workshop.artifacts import InboundArtifact
@@ -100,78 +107,6 @@ from kai.workshop.storage_namespaces import (
 from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
 from kai.workspace_utils import is_workspace_allowed
 from tests.workshop_profiles import profile_id, profile_registry
-
-# ── _backend_name_for_instance ───────────────────────────────────────
-
-
-class TestBackendNameForInstance:
-    """
-    Verify the bot-side runtime backend dispatch reads `backend_name`
-    off the instance rather than inspecting the concrete class name.
-
-    Real backends each set the attribute to their canonical identifier
-    (claude.py: "claude"; goose.py: "goose"; codex.py: "codex").
-    Missing or invalid identities are rejected so model validation
-    cannot silently use another backend's policy.
-    """
-
-    def test_claude_backend_returns_class_attribute(self):
-        """ClaudeCodeBackend.backend_name is "claude"."""
-        from kai.claude import ClaudeCodeBackend
-
-        instance = MagicMock(spec=ClaudeCodeBackend)
-        instance.backend_name = ClaudeCodeBackend.backend_name
-        assert _backend_name_for_instance(instance) == "claude"
-
-    def test_goose_backend_returns_goose(self):
-        """GooseBackend.backend_name is "goose"."""
-        from kai.goose import GooseBackend
-
-        instance = MagicMock(spec=GooseBackend)
-        instance.backend_name = GooseBackend.backend_name
-        assert _backend_name_for_instance(instance) == "goose"
-
-    def test_codex_backend_returns_codex(self):
-        """CodexBackend.backend_name is "codex"."""
-        from kai.codex import CodexBackend
-
-        instance = MagicMock(spec=CodexBackend)
-        instance.backend_name = CodexBackend.backend_name
-        assert _backend_name_for_instance(instance) == "codex"
-
-    def test_opencode_backend_returns_opencode(self):
-        """OpenCodeBackend.backend_name is "opencode"."""
-        from kai.opencode import OpenCodeBackend
-
-        instance = MagicMock(spec=OpenCodeBackend)
-        instance.backend_name = OpenCodeBackend.backend_name
-        assert _backend_name_for_instance(instance) == "opencode"
-
-    def test_falsy_backend_name_is_rejected(self):
-        """A stub with an empty backend identity fails closed."""
-        stub = MagicMock()
-        stub.backend_name = ""
-
-        with pytest.raises(RuntimeError, match="invalid backend_name"):
-            _backend_name_for_instance(stub)
-
-    def test_missing_backend_name_attribute_is_rejected(self):
-        """A stub without a backend identity fails closed."""
-
-        class _Stub:
-            pass
-
-        with pytest.raises(RuntimeError, match="invalid backend_name"):
-            _backend_name_for_instance(_Stub())
-
-    def test_unknown_backend_name_is_rejected(self):
-        """A non-canonical backend identity cannot reach model routing."""
-        stub = MagicMock()
-        stub.backend_name = "unknown"
-
-        with pytest.raises(RuntimeError, match="invalid backend_name"):
-            _backend_name_for_instance(stub)
-
 
 # ── _get_user_models warning suppression ─────────────────────────────
 
@@ -204,6 +139,7 @@ class TestGetUserModelsWarningSuppression:
         config.get_user_config = MagicMock(return_value=None)
         pool = MagicMock(spec=SubprocessPool)
         pool.get_if_exists = MagicMock(return_value=None)
+        pool.get_backend_provider = MagicMock(return_value=("opencode", ""))
 
         with caplog.at_level(logging.WARNING, logger="kai.bot"):
             result = _get_user_models(pool, 111, config)
@@ -225,6 +161,7 @@ class TestGetUserModelsWarningSuppression:
         config.get_user_config = MagicMock(return_value=None)
         pool = MagicMock(spec=SubprocessPool)
         pool.get_if_exists = MagicMock(return_value=None)
+        pool.get_backend_provider = MagicMock(return_value=("codex", ""))
 
         with caplog.at_level(logging.WARNING, logger="kai.bot"):
             _get_user_models(pool, 111, config)
@@ -830,6 +767,10 @@ def _make_mock_claude(model="sonnet", workspace=None, is_alive=True, provider="a
     pool.get_effective_workspace = AsyncMock(return_value=ws)
     pool.is_alive = MagicMock(return_value=is_alive)
     pool.get_session_id = MagicMock(return_value=None)
+    pool.get_runtime_profile = MagicMock(return_value=None)
+    pool.get_backend_provider = MagicMock(return_value=("claude", provider))
+    pool.get_os_user = MagicMock(return_value=None)
+    pool.get_role_model = MagicMock(return_value=model)
     pool.restart = AsyncMock()
     pool.change_workspace = AsyncMock()
     pool.force_kill = AsyncMock()
@@ -852,8 +793,24 @@ def _make_context(config=None, claude=None, pool=None, args=None, user_data=None
     ctx = MagicMock()
     # Accept either pool (Phase 3) or claude (legacy test compat) as the
     # mock subprocess manager. Pool is preferred for new tests.
+    created_pool = pool is None and claude is None
     mock_pool = pool or claude or _make_mock_claude()
     resolved_config = config or _make_config()
+    if created_pool:
+        mock_pool.get_backend_provider.side_effect = lambda runtime_config_id: get_user_backend_and_provider(
+            resolved_config.get_user_config(runtime_config_id),
+            resolved_config,
+        )
+        mock_pool.get_os_user.side_effect = lambda runtime_config_id: (
+            user.os_user if (user := resolved_config.get_user_config(runtime_config_id)) is not None else None
+        )
+        mock_pool.get_role_model.side_effect = lambda runtime_config_id, role: resolve_user_model(
+            role,
+            resolved_config.get_user_config(runtime_config_id),
+            resolved_config,
+            backend=mock_pool.get_backend_provider(runtime_config_id)[0],
+            provider=mock_pool.get_backend_provider(runtime_config_id)[1],
+        )
     if pool is None:
         mock_pool.get_home_workspace = MagicMock(
             side_effect=lambda runtime_config_id: resolve_home_workspace(
@@ -5886,6 +5843,25 @@ class TestHandleSettings:
         assert "global default" in reply
         assert "anthropic" in reply.lower()
 
+    @pytest.mark.asyncio
+    async def test_show_settings_ignores_invalid_protected_model_override(self):
+        """The display matches the model that protected execution will use."""
+        update = _make_update(text="/settings")
+        config = _make_config(protected_install=True)
+        pool = _make_mock_claude()
+        pool.get_runtime_profile.return_value = profile_registry(12345).for_config_id(12345)
+        pool.get_backend_provider.return_value = ("codex", "openai")
+        ctx = _make_context(config=config, pool=pool)
+        mock_sessions = self._mock_sessions({"model": "opus"})
+
+        with self._patches(mock_sessions):
+            await _show_settings(update, ctx, 12345, config)
+
+        reply = update.message.reply_text.call_args[0][0]
+        assert "gpt-5.6-sol (runtime policy)" in reply
+        assert "opus (user override)" not in reply
+        assert "openai" in reply.lower()
+
     # ── 2. Set model ───────────────────────────────────────────────
 
     @pytest.mark.asyncio
@@ -7869,6 +7845,57 @@ class TestHandleReviewCommand:
         # And the inferred repo is the operator's sole configured
         # repo, not empty.
         assert mock_generate.call_args.args == ("dcellison/kai", 681)
+
+    @pytest.mark.asyncio
+    async def test_protected_review_uses_pool_execution_policy(self, tmp_path, monkeypatch):
+        """Compatibility fields cannot select the protected review subprocess."""
+        monkeypatch.setattr("kai.bot.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
+        update = _make_update(user_id=1)
+        config = _make_config(
+            protected_install=True,
+            allowed_user_ids={1},
+            user_configs={
+                1: UserConfig(
+                    telegram_id=1,
+                    name="operator",
+                    github_repos=["dcellison/kai"],
+                    backend="claude",
+                    provider="anthropic",
+                    os_user="compatibility-user",
+                    models={"pr_review": "opus"},
+                )
+            },
+        )
+        pool = _make_mock_claude()
+        pool.get_os_user.return_value = "policy-user"
+        pool.get_backend_provider.return_value = ("codex", "openai")
+        pool.get_role_model.return_value = "gpt-5.5"
+        ctx = _make_context(
+            config=config,
+            pool=pool,
+            args=["dcellison/kai", "681"],
+        )
+        ctx.bot.send_document = AsyncMock()
+
+        with (
+            patch("kai.bot._check_totp", new=AsyncMock(return_value=True)),
+            patch("kai.bot.sessions.get_setting", new=AsyncMock(return_value="ghp_user")),
+            patch(
+                "kai.bot.review.generate_pr_review",
+                new=AsyncMock(return_value=_review_result()),
+            ) as mock_generate,
+        ):
+            await handle_review_command(update, ctx)
+
+        kwargs = mock_generate.call_args.kwargs
+        assert kwargs["claude_user"] == "policy-user"
+        assert kwargs["agent_backend"] == "codex"
+        assert kwargs["provider"] == "openai"
+        assert kwargs["model_override"] == "gpt-5.5"
+        pool.get_os_user.assert_called_once_with(1)
+        pool.get_backend_provider.assert_called_once_with(1)
+        pool.get_role_model.assert_called_once_with(1, ModelRole.PR_REVIEW)
 
     @pytest.mark.asyncio
     async def test_upload_failure_is_surfaced_in_reply(self, tmp_path, monkeypatch):

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -19,6 +19,7 @@ from telegram.error import Forbidden
 
 from kai.cron import (
     _ensure_utc,
+    _history_reader_user,
     _job_callback,
     _register_job,
     _register_new_jobs,
@@ -119,6 +120,31 @@ def _make_agent_mock(text="The response", success=True, error=None):
 
     mock_agent.send = fake_send
     return mock_agent
+
+
+class TestHistoryReaderUser:
+    def test_pool_identity_is_authoritative(self):
+        context = MagicMock()
+        pool = MagicMock()
+        pool.get_os_user.return_value = "policy-user"
+        config = MagicMock()
+        config.get_user_config.return_value = MagicMock(os_user="compatibility-user")
+        context.bot_data = {"pool": pool, "config": config}
+
+        assert _history_reader_user(context, 12345) == "policy-user"
+        pool.get_os_user.assert_called_once_with(12345)
+        config.get_user_config.assert_not_called()
+
+    def test_explicit_pool_none_does_not_fall_back_to_config(self):
+        context = MagicMock()
+        pool = MagicMock()
+        pool.get_os_user.return_value = None
+        config = MagicMock()
+        config.get_user_config.return_value = MagicMock(os_user="compatibility-user")
+        context.bot_data = {"pool": pool, "config": config}
+
+        assert _history_reader_user(context, 12345) is None
+        config.get_user_config.assert_not_called()
 
 
 # ── _ensure_utc ──────────────────────────────────────────────────────

--- a/tests/test_error_recovery.py
+++ b/tests/test_error_recovery.py
@@ -183,7 +183,13 @@ class TestErrorMessageLifecycle:
     internal `reply_text` call, so a future refactor of `_reply_safe`
     cannot silently void these tests."""
 
-    def _make_pool_text_then_error(self, error_text: str | None = "API connection lost"):
+    def _make_pool_text_then_error(
+        self,
+        error_text: str | None = "API connection lost",
+        *,
+        backend: str = "codex",
+        provider: str = "openai",
+    ):
         """Mock pool whose .send() yields a text event followed by a
         done StreamEvent with the given error string. The text event
         triggers live_msg creation in the streaming loop, so the
@@ -208,6 +214,8 @@ class TestErrorMessageLifecycle:
 
         pool = MagicMock()
         pool.send = MagicMock(side_effect=_fake_stream)
+        pool.get_os_user.return_value = "daniel"
+        pool.get_backend_provider.return_value = (backend, provider)
         return pool
 
     def _make_update_with_live_msg(self):
@@ -372,7 +380,9 @@ class TestErrorMessageLifecycle:
         update, _live_msg = self._make_update_with_live_msg()
         ctx = self._make_context(backend="claude", provider="anthropic")
         pool = self._make_pool_text_then_error(
-            "Failed to authenticate: OAuth session expired and could not be refreshed"
+            "Failed to authenticate: OAuth session expired and could not be refreshed",
+            backend="claude",
+            provider="anthropic",
         )
 
         with (

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8690,7 +8690,11 @@ backends:
                 users_yaml,
             )
 
-    def test_existing_policy_accepts_migrated_service_scope_reordering(self, tmp_path, monkeypatch):
+    def test_existing_policy_remains_authoritative_when_users_yaml_execution_fields_drift(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
         users_yaml = tmp_path / "users.yaml"
         users_yaml.write_text(
             """users:
@@ -8712,13 +8716,14 @@ backends:
                     "version": 1,
                     "runtime_profiles": {
                         profile_id: {
-                            "display_name": "Daniel",
+                            "display_name": "Protected Daniel runtime",
                             "compatibility_runtime_config_id": 101,
-                            "backend": "codex",
-                            "provider": "openai",
-                            "model": "gpt-5.5",
-                            "timeout_seconds": 120,
-                            "allowed_services": ["weather", "perplexity"],
+                            "os_user": "protected-daniel",
+                            "backend": "claude",
+                            "provider": "anthropic",
+                            "model": "opus",
+                            "timeout_seconds": 999,
+                            "allowed_services": ["weather"],
                             "home_workspace": None,
                             "workspace_base": None,
                             "allowed_workspaces": [],
@@ -8731,7 +8736,10 @@ backends:
         monkeypatch.setattr("kai.install.RUNTIME_PROFILES_YAML", policy)
         monkeypatch.setattr(
             "kai.install._backend_registry_entries",
-            lambda *args: {"codex": {"allowed_models": ["gpt-5.5"]}},
+            lambda *args: {
+                "claude": {"allowed_models": ["opus"]},
+                "codex": {"allowed_models": ["gpt-5.5"]},
+            },
         )
 
         action, content, profiles = _runtime_policy_apply_plan(
@@ -8747,7 +8755,13 @@ backends:
 
         assert action == "preserve"
         assert content == policy.read_text()
-        assert profiles.resolve(profile_id).allowed_services == ("weather", "perplexity")
+        profile = profiles.resolve(profile_id)
+        assert profile.display_name == "Protected Daniel runtime"
+        assert profile.os_user == "protected-daniel"
+        assert (profile.backend, profile.provider) == ("claude", "anthropic")
+        assert profile.model == "opus"
+        assert profile.timeout_seconds == 999
+        assert profile.allowed_services == ("weather",)
 
 
 class TestApplyBackendRegistry:

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -2427,6 +2427,26 @@ class TestDashboardBackendNote:
         sent_text = upd.effective_chat.send_message.call_args.kwargs["text"]
         assert "memory extraction is not available on the goose backend" in sent_text
 
+    @pytest.mark.asyncio
+    async def test_protected_pool_route_drives_note(self, monkeypatch, update_factory, context_factory):
+        monkeypatch.setattr(memory_command, "ONESHOT_REASONER_BACKENDS", frozenset({"claude"}))
+        monkeypatch.setattr(memory_command.memory, "is_enabled", lambda: True)
+        monkeypatch.setattr(
+            memory_command.memory,
+            "get_stats",
+            lambda *, user_id: _stats(extracted_count=3),
+        )
+        upd = update_factory()
+        ctx = context_factory(args=[])
+        pool = MagicMock()
+        pool.get_backend_provider.return_value = ("codex", "openai")
+        ctx.bot_data["pool"] = pool
+
+        await memory_command.handle_memory_command(upd, ctx)
+
+        sent_text = upd.effective_chat.send_message.call_args.kwargs["text"]
+        assert "memory extraction is not available on the codex backend" in sent_text
+
 
 # ── Cache TTL ──────────────────────────────────────────────────────
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -18,10 +18,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kai.config import Config, UserConfig, WorkspaceConfig
+from kai.config import Config, ModelRole, UserConfig, WorkspaceConfig, get_model_for
 from kai.goose import GooseBackend
 from kai.internal_api_auth import InternalAPIScope
 from kai.pool import SubprocessPool
+from tests.workshop_profiles import profile_registry
 
 
 def _make_config(**overrides) -> Config:
@@ -586,6 +587,105 @@ class TestPerUserActions:
 
 
 class TestPropertyAccessors:
+    def test_protected_policy_owns_route_identity_and_model_without_starting_process(self):
+        config = _make_config(
+            default_backend="claude",
+            default_provider="anthropic",
+            default_model="sonnet",
+            user_configs={
+                111: UserConfig(
+                    telegram_id=111,
+                    name="Compatibility Daniel",
+                    os_user="compatibility-user",
+                    backend="claude",
+                    provider="anthropic",
+                    model="opus",
+                )
+            },
+        )
+        profiles = profile_registry(111)
+        pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
+
+        assert pool.get_runtime_profile(111) == profiles.for_config_id(111)
+        assert pool.get_backend_provider(111) == ("codex", "openai")
+        assert pool.get_os_user(111) is None
+        assert pool.get_model(111) == "gpt-5.6-sol"
+        assert pool.get_if_exists(111) is None
+
+    def test_role_model_uses_protected_route_with_compatible_override(self):
+        config = _make_config(
+            user_configs={
+                111: UserConfig(
+                    telegram_id=111,
+                    name="Compatibility Daniel",
+                    backend="claude",
+                    provider="anthropic",
+                    models={"pr_review": "gpt-5.5"},
+                )
+            }
+        )
+        pool = SubprocessPool(
+            config=config,
+            services_info=[],
+            runtime_profiles=profile_registry(111),
+        )
+
+        assert pool.get_role_model(111, ModelRole.PR_REVIEW) == "gpt-5.5"
+        assert pool.get_if_exists(111) is None
+
+    def test_invalid_role_model_falls_back_within_protected_route(self, caplog):
+        config = _make_config(
+            user_configs={
+                111: UserConfig(
+                    telegram_id=111,
+                    name="Compatibility Daniel",
+                    backend="claude",
+                    provider="anthropic",
+                    models={"pr_review": "opus"},
+                )
+            }
+        )
+        pool = SubprocessPool(
+            config=config,
+            services_info=[],
+            runtime_profiles=profile_registry(111),
+        )
+
+        expected = get_model_for(ModelRole.PR_REVIEW, "codex", "openai")
+        assert pool.get_role_model(111, ModelRole.PR_REVIEW) == expected
+        assert "invalid for codex/openai" in caplog.text
+        assert pool.get_if_exists(111) is None
+
+    @pytest.mark.asyncio
+    async def test_protected_policy_is_effective_model_baseline(self):
+        pool = SubprocessPool(
+            config=_make_config(default_model="sonnet"),
+            services_info=[],
+            runtime_profiles=profile_registry(111),
+        )
+
+        with patch(
+            "kai.pool.sessions.get_user_settings",
+            new_callable=AsyncMock,
+            return_value={},
+        ):
+            assert await pool.get_effective_model(111) == "gpt-5.6-sol"
+
+    @pytest.mark.asyncio
+    async def test_invalid_model_override_cannot_escape_protected_route(self):
+        pool = SubprocessPool(
+            config=_make_config(default_model="sonnet"),
+            services_info=[],
+            runtime_profiles=profile_registry(111),
+        )
+
+        with patch(
+            "kai.pool.sessions.get_user_settings",
+            new_callable=AsyncMock,
+            return_value={"model": "opus"},
+        ):
+            assert await pool.get_effective_model(111) == "gpt-5.6-sol"
+
     def test_get_model_existing_instance(self):
         """get_model returns the instance's model when it exists."""
         pool = SubprocessPool(config=_make_config(), services_info=[])

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -21,6 +21,7 @@ from kai.webhook import (
     GITHUB_WEBHOOK_SECRET_KEY,
     INTERNAL_API_AUTH_KEY,
     NOTIFICATION_CHAT_IDS_KEY,
+    POOL_KEY,
     PR_REVIEW_COOLDOWN_KEY,
     PR_REVIEW_TIMEOUT_S_KEY,
     SPEC_DIR_KEY,
@@ -432,6 +433,7 @@ def _default_github_token_lookup():
 def _build_test_app(
     cooldown: int = 300,
     config: object | None = None,
+    pool: object | None = None,
 ) -> web.Application:
     """Build a minimal aiohttp app with _handle_github wired up.
 
@@ -499,8 +501,27 @@ def _build_test_app(
         app[CONFIG_KEY] = mock_config
     else:
         app[CONFIG_KEY] = config
+    if pool is not None:
+        app[POOL_KEY] = pool
     app.router.add_post("/webhook/github", _handle_github)
     return app
+
+
+def _protected_pool(
+    *,
+    os_user: str | None = "policy-user",
+    backend: str = "codex",
+    provider: str = "openai",
+    pr_review_model: str = "gpt-5.5",
+    issue_triage_model: str = "gpt-5.5",
+) -> MagicMock:
+    pool = MagicMock()
+    pool.get_os_user.return_value = os_user
+    pool.get_backend_provider.return_value = (backend, provider)
+    pool.get_role_model.side_effect = lambda _runtime_config_id, role: (
+        pr_review_model if role.value == "pr_review" else issue_triage_model
+    )
+    return pool
 
 
 @pytest.fixture
@@ -2215,12 +2236,69 @@ class TestPerUserRouting:
             assert mock_review.call_args[1]["provider"] == "openai"
 
     @pytest.mark.asyncio
+    async def test_protected_review_uses_pool_execution_policy(
+        self,
+        _clear_cooldowns,
+        _mock_resolve_repo,
+    ):
+        """Webhook review cannot execute with divergent compatibility fields."""
+        base = self._make_user_config(111, repos=["owner/repo"])
+        user = dataclasses.replace(
+            base,
+            backend="claude",
+            provider="anthropic",
+            os_user="compatibility-user",
+            models={"pr_review": "opus"},
+        )
+        config = self._make_config_with_users([user])
+        config.protected_install = True
+        pool = _protected_pool(
+            os_user="policy-user",
+            backend="codex",
+            provider="openai",
+            pr_review_model="gpt-5.5",
+        )
+        app = _build_test_app(config=config, pool=pool)
+        payload = _make_pr_payload("opened")
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        with (
+            _mock_settings(pr_review=True, notify_chat_id=111),
+            patch(
+                "kai.webhook.sessions.get_setting",
+                new_callable=AsyncMock,
+                return_value="ghp_user",
+            ),
+            patch("kai.webhook.review.review_pr", new_callable=AsyncMock) as mock_review,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/webhook/github",
+                    data=body,
+                    headers={
+                        "X-GitHub-Event": "pull_request",
+                        "X-Hub-Signature-256": sig,
+                    },
+                )
+                assert resp.status == 200
+
+            await asyncio.sleep(0.01)
+            kwargs = mock_review.call_args.kwargs
+            assert kwargs["claude_user"] == "policy-user"
+            assert kwargs["agent_backend"] == "codex"
+            assert kwargs["provider"] == "openai"
+            assert kwargs["model_override"] == "gpt-5.5"
+            pool.get_os_user.assert_called_once_with(111)
+            pool.get_backend_provider.assert_called_once_with(111)
+
+    @pytest.mark.asyncio
     async def test_protected_review_requires_user_github_token(self, _clear_cooldowns, _mock_resolve_repo):
         """Protected installs do not fall back to the daemon gh identity for PR review."""
         user = self._make_user_config(111, repos=["owner/repo"])
         config = self._make_config_with_users([user])
         config.protected_install = True
-        app = _build_test_app(config=config)
+        app = _build_test_app(config=config, pool=_protected_pool())
         payload = _make_pr_payload("opened")
         body = json.dumps(payload).encode()
         sig = _sign_payload(payload)
@@ -2288,12 +2366,63 @@ class TestPerUserRouting:
             assert mock_triage.call_args[1]["allowed_triage_projects"] == ["Sprint 1"]
 
     @pytest.mark.asyncio
+    async def test_protected_triage_uses_pool_execution_policy(self, _clear_cooldowns):
+        """Webhook triage cannot execute with divergent compatibility fields."""
+        base = self._make_user_config(111, repos=["owner/repo"])
+        user = dataclasses.replace(
+            base,
+            backend="claude",
+            provider="anthropic",
+            os_user="compatibility-user",
+            models={"issue_triage": "opus"},
+        )
+        config = self._make_config_with_users([user])
+        config.protected_install = True
+        pool = _protected_pool(
+            os_user="policy-user",
+            backend="codex",
+            provider="openai",
+            issue_triage_model="gpt-5.4",
+        )
+        app = _build_test_app(config=config, pool=pool)
+        payload = _make_issue_payload("opened")
+        body = json.dumps(payload).encode()
+        sig = _sign_payload(payload)
+
+        with (
+            _mock_settings(issue_triage=True, notify_chat_id=111),
+            patch(
+                "kai.webhook.sessions.get_setting",
+                new_callable=AsyncMock,
+                return_value="ghp_user",
+            ),
+            patch("kai.webhook.triage.triage_issue", new_callable=AsyncMock) as mock_triage,
+        ):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post(
+                    "/webhook/github",
+                    data=body,
+                    headers={
+                        "X-GitHub-Event": "issues",
+                        "X-Hub-Signature-256": sig,
+                    },
+                )
+                assert resp.status == 200
+
+            await asyncio.sleep(0.01)
+            kwargs = mock_triage.call_args.kwargs
+            assert kwargs["claude_user"] == "policy-user"
+            assert kwargs["agent_backend"] == "codex"
+            assert kwargs["provider"] == "openai"
+            assert kwargs["model_override"] == "gpt-5.4"
+
+    @pytest.mark.asyncio
     async def test_protected_triage_requires_user_github_token(self, _clear_cooldowns):
         """Protected installs do not fall back to the daemon gh identity for issue triage."""
         user = self._make_user_config(111, repos=["owner/repo"])
         config = self._make_config_with_users([user])
         config.protected_install = True
-        app = _build_test_app(config=config)
+        app = _build_test_app(config=config, pool=_protected_pool())
         payload = _make_issue_payload("opened")
         body = json.dumps(payload).encode()
         sig = _sign_payload(payload)

--- a/tests/test_workshop_compatibility_state.py
+++ b/tests/test_workshop_compatibility_state.py
@@ -13,7 +13,15 @@ async def test_profile_state_preserves_existing_storage_keys(monkeypatch):
             SimpleNamespace(os_user="daniel") if runtime_config_id == 101 else None
         )
     )
-    runtime_pool = SimpleNamespace(compatibility_runtime_config_id=Mock(return_value=101))
+    runtime_pool = SimpleNamespace(
+        runtime_profile=Mock(
+            return_value=SimpleNamespace(
+                runtime_config_id=101,
+                os_user="daniel",
+                backend="codex",
+            )
+        )
+    )
     log = Mock(side_effect=["user-log", "assistant-log"])
     save_session = AsyncMock()
     schedule = Mock()
@@ -40,7 +48,7 @@ async def test_profile_state_preserves_existing_storage_keys(monkeypatch):
         assistant_log=assistant_log,
     )
 
-    runtime_pool.compatibility_runtime_config_id.assert_called_once_with(profile_id(101))
+    runtime_pool.runtime_profile.assert_called_once_with(profile_id(101))
     assert log.call_args_list == [
         call(
             direction="user",
@@ -65,4 +73,5 @@ async def test_profile_state_preserves_existing_storage_keys(monkeypatch):
         workspace="/workspace/project",
         user_log="user-log",
         assistant_log="assistant-log",
+        effective_backend="codex",
     )

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 
 from kai.backend_registry import BackendRegistryEntry
 from kai.config import Config, UserConfig
@@ -223,7 +224,7 @@ def test_document_rejects_duplicate_resolved_allowed_workspace(tmp_path):
         )
 
 
-def test_unavailable_workspace_paths_remain_restrictive_and_do_not_create_false_drift(tmp_path):
+def test_unavailable_workspace_paths_remain_in_protected_policy(tmp_path):
     unavailable = (tmp_path / "later-mounted").resolve()
     profile_id = runtime_profile_id_for_config_id(101)
     registry = WorkshopRuntimeProfileRegistry.from_document(
@@ -249,45 +250,9 @@ def test_unavailable_workspace_paths_remain_restrictive_and_do_not_create_false_
     )
     unavailable_profile = registry.resolve(profile_id)
     assert unavailable_profile.workspace_base == unavailable
-    registry._validate_compatibility_projection(
-        Config(
-            telegram_bot_token="test",
-            allowed_user_ids={101},
-            default_backend="codex",
-            default_provider="openai",
-            default_model="gpt-5.6-sol",
-            user_configs={
-                101: UserConfig(
-                    telegram_id=101,
-                    name="Daniel",
-                    os_user="daniel",
-                    backend="codex",
-                )
-            },
-        )
-    )
 
     unavailable.mkdir()
-    registry._validate_compatibility_projection(
-        Config(
-            telegram_bot_token="test",
-            allowed_user_ids={101},
-            default_backend="codex",
-            default_provider="openai",
-            default_model="gpt-5.6-sol",
-            user_configs={
-                101: UserConfig(
-                    telegram_id=101,
-                    name="Daniel",
-                    os_user="daniel",
-                    backend="codex",
-                    home_workspace=unavailable,
-                    workspace_base=unavailable,
-                    allowed_workspaces=[unavailable],
-                )
-            },
-        )
-    )
+    assert registry.resolve(profile_id).allowed_workspaces == (unavailable,)
 
 
 def test_non_telegram_profile_derives_stable_private_compatibility_key():
@@ -640,7 +605,7 @@ runtime_profiles:
         registry.resolve(runtime_profile_id_for_config_id(101))
 
 
-def test_loaded_policy_fails_when_migrated_execution_fields_drift(tmp_path, monkeypatch):
+def test_loaded_policy_owns_execution_fields_independently_of_users_yaml(tmp_path, monkeypatch):
     profile_id = runtime_profile_id_for_config_id(101)
     policy = tmp_path / "runtime-profiles.yaml"
     policy.write_text(
@@ -663,11 +628,16 @@ runtime_profiles:
         lambda: {"claude": {}, "codex": {}},
     )
 
-    with pytest.raises(WorkshopRuntimeProfileError, match=r"conflicts with the migrated users\.yaml"):
-        WorkshopRuntimeProfileRegistry.load(_config(), path=policy)
+    profile = WorkshopRuntimeProfileRegistry.load(_config(), path=policy).resolve(profile_id)
+
+    assert (profile.backend, profile.provider, profile.os_user) == (
+        "claude",
+        "anthropic",
+        "daniel",
+    )
 
 
-def test_loaded_policy_fails_when_migrated_model_or_timeout_drifts(tmp_path, monkeypatch):
+def test_loaded_policy_owns_model_and_timeout_independently_of_users_yaml(tmp_path, monkeypatch):
     profile_id = runtime_profile_id_for_config_id(101)
     policy = tmp_path / "runtime-profiles.yaml"
     policy.write_text(
@@ -690,11 +660,13 @@ runtime_profiles:
         lambda: {"codex": {}, "claude": {}},
     )
 
-    with pytest.raises(WorkshopRuntimeProfileError, match=r"conflicts with the migrated users\.yaml"):
-        WorkshopRuntimeProfileRegistry.load(_config(), path=policy)
+    profile = WorkshopRuntimeProfileRegistry.load(_config(), path=policy).resolve(profile_id)
+
+    assert profile.model == "gpt-5.5"
+    assert profile.timeout_seconds == 999
 
 
-def test_loaded_policy_fails_when_migrated_service_scopes_drift(tmp_path, monkeypatch):
+def test_loaded_policy_owns_service_scopes_independently_of_users_yaml(tmp_path, monkeypatch):
     profile_id = runtime_profile_id_for_config_id(101)
     policy = tmp_path / "runtime-profiles.yaml"
     policy.write_text(
@@ -718,8 +690,61 @@ runtime_profiles:
         lambda: {"codex": {}, "claude": {}},
     )
 
-    with pytest.raises(WorkshopRuntimeProfileError, match=r"conflicts with the migrated users\.yaml"):
-        WorkshopRuntimeProfileRegistry.load(_config(), path=policy)
+    profile = WorkshopRuntimeProfileRegistry.load(_config(), path=policy).resolve(profile_id)
+
+    assert profile.allowed_services == ("perplexity",)
+
+
+@pytest.mark.parametrize(
+    ("backend", "provider", "model"),
+    (
+        ("claude", "anthropic", "sonnet"),
+        ("codex", "openai", "gpt-5.6-sol"),
+        ("goose", "openai", "gpt-5.5-pro"),
+        ("opencode", "anthropic", "anthropic/claude-sonnet-4-6"),
+        ("pi", "openai", "openai/gpt-5.6-sol:xhigh"),
+    ),
+)
+def test_every_backend_can_be_selected_only_by_protected_policy(
+    tmp_path,
+    monkeypatch,
+    backend,
+    provider,
+    model,
+):
+    profile_id = runtime_profile_id_for_config_id(101)
+    policy = tmp_path / "runtime-profiles.yaml"
+    policy.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "runtime_profiles": {
+                    str(profile_id): {
+                        "display_name": f"{backend} runtime",
+                        "compatibility_runtime_config_id": 101,
+                        "os_user": f"{backend}-operator",
+                        "backend": backend,
+                        "provider": provider,
+                        "model": model,
+                        "timeout_seconds": 321,
+                        "allowed_services": [],
+                        "allowed_workspaces": [],
+                    }
+                },
+            },
+            sort_keys=False,
+        )
+    )
+    monkeypatch.setattr(
+        "kai.workshop.runtime_profiles.load_backend_registry",
+        lambda: {backend: {}},
+    )
+
+    profile = WorkshopRuntimeProfileRegistry.load(_config(), path=policy).resolve(profile_id)
+
+    assert (profile.backend, profile.provider, profile.model) == (backend, provider, model)
+    assert profile.os_user == f"{backend}-operator"
+    assert profile.timeout_seconds == 321
 
 
 def test_loaded_policy_accepts_migrated_service_scope_reordering(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #931
Part of #921
Parent epic: #917

## Summary

Complete the protected runtime-policy authority cutover as one cohesive
Milestone 1 slice. Once `runtime-profiles.yaml` exists, its execution fields
are authoritative; duplicated values in `users.yaml` can no longer replace or
veto them.

This intentionally leaves only the named integer pool/storage bridge and its
bootstrap-coverage check. That bridge is migration debt for later profile-keyed
storage work, not a second execution-policy authority.

## What changes

### Independent protected policy

- Stop comparing installed runtime profiles with the one-time `users.yaml`
  migration projection during startup.
- Stop rejecting intentional protected-policy differences during install
  reconciliation.
- Continue validating the protected document against the root-owned backend
  registry.
- Continue requiring every configured compatibility identity to retain an
  explicit profile mapping while integer-keyed pool/state storage remains.
- Preserve explicit protected profile values verbatim during repeat installs.

### Runtime-facing consumers

- Add policy-aware pool accessors for the protected profile,
  backend/provider route, and OS execution user.
- Make model and timeout settings displays/resets use the protected profile as
  their baseline.
- Make workspace-config display use protected model/timeout baselines.
- Keep persisted user model overrides, but validate them against the protected
  backend/provider and fail back to the protected model when invalid.
- Resolve upload-reader ownership and actionable backend authentication errors
  through the protected route.
- Resolve compatibility history and memory ingestion from the selected runtime
  profile rather than rereading `users.yaml` backend/OS-user fields.
- Make the memory dashboard's extraction-capability note use the policy-aware
  backend route.

### Operator contract and transition ledger

- Document the first-install seed versus post-install protected authority.
- Document the `sudoedit` / status / install reconciliation workflow.
- Correct the service-proxy documentation to name protected runtime grants.
- Update the Workshop transition ledger and implementation record with the
  exact remaining bridge and retirement condition.

## Security and compatibility properties

- Protected installs still fail closed for missing policy, unknown profiles,
  unavailable backends, invalid providers/models, duplicate mappings, and
  missing compatibility coverage.
- A caller cannot select a backend, provider, OS user, service scope, or
  workspace policy through Telegram identity or request data.
- All five backends remain equal policy choices; tests cover Claude, Codex,
  Goose, OpenCode, and Pi.
- Existing uninstalled/development compatibility behavior remains available.
- Telegram delivery, Workshop browser behavior, schedules, GitHub/generic
  webhook routing, and non-text orchestration are unchanged.
- No legacy fallback backend is introduced.

## Tests

- `ruff format --check .`
- `ruff check .`
- `make typecheck` — 0 errors, 0 warnings
- focused runtime/install/bot/memory suite — 1,334 passed
- full repository suite — 5,727 passed, 1 skipped

## Review gate

Per #921, this implementation requires independent review by a different model
family after tests pass and before operator merge. The review should challenge:

- whether any Workshop execution decision can still be vetoed by duplicated
  `users.yaml` fields;
- whether the retained integer mapping is clearly compatibility storage rather
  than policy authority;
- whether invalid persisted model overrides can cross backend boundaries;
- whether install preservation and missing-profile failure behavior remain
  fail-closed;
- whether all five backends have equivalent coverage.

No external model was invoked while preparing this PR; the operator will supply
the independent review separately.

## Post-merge qualification

Run `make install`, then confirm:

- `make install-status` reports complete runtime policy/storage;
- Daniel and Scott retain their protected backend/model/OS-user/workspace
  behavior;
- one Workshop command and one Telegram command succeed after restart.
