### PR TITLE
Fix Workshop-only history namespace startup

### DIFF
--- a/src/kai/workshop/storage_namespaces.py
+++ b/src/kai/workshop/storage_namespaces.py
@@ -115,11 +115,20 @@ class WorkshopChannelHistoryRegistry:
             channel_by_profile[profile_id] = channel_id
 
         runtime_aliases: dict[int, ChannelId] = {}
+        namespace_channels = {namespace.channel_id for namespace in namespaces}
         for profile in runtime_profiles.profiles:
             channel_id = channel_by_profile.get(profile.profile_id)
             if channel_id is None:
                 raise WorkshopStorageNamespaceError("Protected runtime profile has no canonical history channel")
             runtime_aliases[profile.runtime_config_id] = channel_id
+            if channel_id not in namespace_channels:
+                namespaces.append(
+                    WorkshopChannelHistoryNamespace(
+                        channel_id,
+                        profile.runtime_config_id,
+                    )
+                )
+                namespace_channels.add(channel_id)
         return cls(tuple(namespaces), runtime_aliases=runtime_aliases)
 
     @property

--- a/tests/test_workshop_storage_namespaces.py
+++ b/tests/test_workshop_storage_namespaces.py
@@ -9,6 +9,8 @@ import pytest
 from kai.install import _canonical_storage_reader_users
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.domain import ChannelId, PrincipalId
+from kai.workshop.human_provisioning import WorkshopHumanProvisioner
+from kai.workshop.runtime_assignments import WorkshopRuntimeAssignmentService
 from kai.workshop.storage_namespaces import (
     WorkshopChannelHistoryNamespace,
     WorkshopChannelHistoryRegistry,
@@ -168,6 +170,41 @@ class TestWorkshopChannelHistoryRegistry:
             assert namespace.channel_id == expected_channel
             assert namespace.history_directory(tmp_path) == (tmp_path / "history" / str(expected_channel))
             assert namespace.legacy_history_directory(tmp_path) == (tmp_path / "history" / "101")
+        finally:
+            await store.close()
+
+    async def test_resolves_workshop_only_runtime_to_canonical_channel(
+        self,
+        tmp_path: Path,
+    ):
+        store = await _store(tmp_path / "kai.db")
+        profiles = profile_registry(101, 202, 303)
+        try:
+            human = await WorkshopHumanProvisioner(store).provision(
+                "workshop-only-human",
+                "Workshop-only human",
+                "member",
+            )
+            await WorkshopRuntimeAssignmentService(store, profiles).assign(
+                human.principal_id,
+                human.channel_id,
+                profile_id(303),
+            )
+
+            registry = await WorkshopChannelHistoryRegistry.from_store(
+                store,
+                profiles,
+            )
+            namespace = registry.for_compatibility_chat_id(303)
+
+            assert namespace.channel_id == human.channel_id
+            assert namespace.history_directory(tmp_path) == (tmp_path / "history" / str(human.channel_id))
+            assert namespace.legacy_history_directory(tmp_path) == (tmp_path / "history" / "303")
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_bindings WHERE channel_id = ?",
+                (human.channel_id,),
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
         finally:
             await store.close()
 


### PR DESCRIPTION
## Summary

- create canonical history namespaces for protected runtime assignments whose
  channels do not have Telegram bindings
- retain Telegram channel IDs as legacy aliases when a binding exists
- use the protected runtime compatibility ID only as the transitional archive
  alias for a Workshop-only channel

## Problem

The Milestone 1 installed qualification added a third protected runtime profile
owned by a canonical Workshop human with no Telegram identity or channel
binding. The install preflight accepted that topology, but Kai then failed at
startup with:

```text
WorkshopStorageNamespaceError: Runtime history alias references an unknown channel
```

The channel-history registry built namespaces exclusively from Telegram
bindings before resolving protected runtime assignments. A valid
Workshop-only direct channel therefore could not acquire a history namespace.

## Fix

The registry still imports Telegram bindings as compatibility aliases, then
adds a namespace for every protected runtime's assigned canonical channel that
does not already have one. This keeps canonical channel IDs authoritative while
allowing the compatibility runtime to address the history during migration.
Ambiguous compatibility IDs continue to fail closed in the registry
constructor.

## Validation

- regression test provisions a human with no external identity, assigns an
  independent protected runtime profile, and resolves its canonical history
  namespace
- focused storage/history/runtime/bootstrap/install tests: 685 passed
- full test suite: 5,736 passed, 1 skipped
- `make lint`: passed

This defect was found by the consolidated installed qualification for epic
#917 Milestone 1. The qualification remains open until this fix is installed
and the Workshop-only execution and existing-user continuity checks complete.
