### PR TITLE
Fix protected cross-user runtime workspaces

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -59,6 +59,7 @@ from kai.backend import (
     sanitize_agent_environment,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
 
 log = logging.getLogger(__name__)
 
@@ -654,7 +655,8 @@ class AcpBackend(AgentBackend):
         # explicit value.
         memory_enabled: bool = False,
         # Optional OS user to run the ACP subprocess as, via
-        # `sudo -H -u <user>`. None = run as the bot's process user.
+        # `sudo -H -D <workspace> -u <user>`. None = run as the bot's
+        # process user.
         # Same per-user isolation contract as claude_user / codex_user
         # on the sibling backends; resolved through resolve_claude_user
         # at spawn time so a value naming the bot's own user collapses
@@ -942,7 +944,7 @@ class AcpBackend(AgentBackend):
         2. session/new - creates a session with backend-specific params
 
         When `os_user` resolves to a non-bot user, the argv is wrapped
-        in `sudo -H -u <target> --preserve-env=<csv> --` so the agent
+        in `sudo -H -D <workspace> -u <target> --preserve-env=<csv> --` so the agent
         runs as that user (per-user OS isolation, same contract as the
         claude and codex backends). `-H` rewrites HOME so the agent
         reads its config and auth state under the target user's home;
@@ -990,16 +992,12 @@ class AcpBackend(AgentBackend):
             # authorizes --preserve-env; the rule pins the absolute
             # agent binary path, so sudo's PATH resolution of the
             # argv head must land on the same file the rule names.
-            preserve = ",".join(self.preserved_env_vars())
-            argv = [
-                "sudo",
-                "-H",
-                "-u",
-                effective_os_user,
-                f"--preserve-env={preserve}",
-                "--",
-                *argv,
-            ]
+            argv = wrap_command_for_target_user(
+                argv,
+                target_user=effective_os_user,
+                working_directory=self.workspace,
+                preserve_env=self.preserved_env_vars(),
+            )
 
         log.info(
             "Starting persistent %s ACP process (model=%s, user=%s)",
@@ -1013,7 +1011,10 @@ class AcpBackend(AgentBackend):
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=str(self.workspace),
+            cwd=subprocess_spawn_cwd(
+                self.workspace,
+                target_user=effective_os_user,
+            ),
             env=env,
             # A single ACP notification line can carry a large payload
             # (a tool result echoed into a chunk, a long final

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -42,6 +42,7 @@ from kai.backend import (
 )
 from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
 
 log = logging.getLogger(__name__)
 
@@ -279,16 +280,19 @@ class ClaudeCodeBackend(AgentBackend):
             # subprocess env below when autocompact_pct > 0; without
             # preservation, env_reset strips it and the per-user
             # claude never sees the configured threshold.
-            cmd = [
-                "sudo",
-                "-H",
-                "-u",
-                effective_claude_user,
-                "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,"
-                "CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL,"
-                "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE",
-                "--",
-            ] + claude_cmd
+            cmd = wrap_command_for_target_user(
+                claude_cmd,
+                target_user=effective_claude_user,
+                working_directory=self.workspace,
+                preserve_env=(
+                    "KAI_WEBHOOK_SECRET",
+                    "TMPDIR",
+                    "CLAUDE_CONFIG_DIR",
+                    "ANTHROPIC_API_KEY",
+                    "ANTHROPIC_BASE_URL",
+                    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE",
+                ),
+            )
         else:
             cmd = claude_cmd
 
@@ -353,7 +357,10 @@ class ClaudeCodeBackend(AgentBackend):
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=str(self.workspace),
+            cwd=subprocess_spawn_cwd(
+                self.workspace,
+                target_user=effective_claude_user,
+            ),
             env=env,
             # A single stream-json line can inline the full text of a
             # large tool result. The asyncio.StreamReader default

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -68,6 +68,7 @@ from kai.backend import (
 )
 from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
 
 log = logging.getLogger(__name__)
 
@@ -267,7 +268,8 @@ class CodexBackend(AgentBackend):
         services_info: list[dict] | None = None,
         workspace_config: WorkspaceConfig | None = None,
         provider: str = "openai",
-        # Optional OS user to run codex as via `sudo -H -u <user>`. When
+        # Optional OS user to run codex as via
+        # `sudo -H -D <workspace> -u <user>`. When
         # set, the codex subprocess runs as <codex_user> and reads its
         # auth token from ~<codex_user>/.codex/auth.json, NOT the kai
         # service user's home. This is the multi-user OAuth-isolation
@@ -489,14 +491,18 @@ class CodexBackend(AgentBackend):
             # CODEX_PROVIDER are deliberately NOT preserved: the
             # authoritative model selection rides the per-turn
             # protocol params, so the env mirrors are informational.
-            argv: list[str] = [
-                "sudo",
-                "-H",
-                "-u",
-                effective_codex_user,
-                "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CODEX_HOME,OPENAI_API_KEY,OPENAI_BASE_URL",
-                "--",
-            ] + codex_argv
+            argv = wrap_command_for_target_user(
+                codex_argv,
+                target_user=effective_codex_user,
+                working_directory=self.workspace,
+                preserve_env=(
+                    "KAI_WEBHOOK_SECRET",
+                    "TMPDIR",
+                    "CODEX_HOME",
+                    "OPENAI_API_KEY",
+                    "OPENAI_BASE_URL",
+                ),
+            )
         else:
             argv = codex_argv
 
@@ -512,7 +518,10 @@ class CodexBackend(AgentBackend):
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=str(self.workspace),
+            cwd=subprocess_spawn_cwd(
+                self.workspace,
+                target_user=effective_codex_user,
+            ),
             env=env,
             # Cross-user mode: new session group so the sudo wrapper
             # is the session leader (PGID == PID). os.killpg later

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3578,6 +3578,15 @@ def _generate_sudoers(
         # `kill -<sig> <pid>` calls we use here. Same anchoring
         # rationale as the claude_bin fix in PR #455.
         kill_bin = "/bin/kill"
+        # CWD=* allows sudo's -D option on the pinned agent commands so
+        # the target OS user, rather than the Kai service user, enters a
+        # private protected workspace. Kai supplies only workspaces that
+        # passed protected runtime policy validation. This does not expand
+        # the practical authority of these rules: every allowed agent is
+        # already an arbitrary-code execution boundary for <target>, as
+        # documented immediately below. The config-read and kill rules do
+        # not receive CWD=*.
+        #
         # SETENV: allows the service user to pass env vars (e.g.,
         # KAI_WEBHOOK_SECRET, provider API keys) through sudo to the
         # agent binaries. Scoped to the agent rules; the kill rule
@@ -3611,11 +3620,11 @@ def _generate_sudoers(
             # delta is zero.
         """)
         for target in target_users:
-            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {claude_bin_resolved}\n"
-            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {codex_bin_resolved}\n"
-            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {opencode_bin_resolved}\n"
-            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {goose_bin_resolved}\n"
-            rules += f"{service_user} ALL=({target}) SETENV: NOPASSWD: {pi_bin_resolved}\n"
+            rules += f"{service_user} ALL=({target}) CWD=* SETENV: NOPASSWD: {claude_bin_resolved}\n"
+            rules += f"{service_user} ALL=({target}) CWD=* SETENV: NOPASSWD: {codex_bin_resolved}\n"
+            rules += f"{service_user} ALL=({target}) CWD=* SETENV: NOPASSWD: {opencode_bin_resolved}\n"
+            rules += f"{service_user} ALL=({target}) CWD=* SETENV: NOPASSWD: {goose_bin_resolved}\n"
+            rules += f"{service_user} ALL=({target}) CWD=* SETENV: NOPASSWD: {pi_bin_resolved}\n"
             rules += f"{service_user} ALL=({target}) NOPASSWD: {kill_bin}\n"
 
     return rules

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -62,6 +62,7 @@ from kai.pi_rpc import (
     require_pi_rpc_response,
 )
 from kai.prompt_utils import make_boundary
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
 
 log = logging.getLogger(__name__)
 
@@ -424,10 +425,11 @@ def _wrap_cmd_for_user(
     target_user: str,
     backend: str,
     *,
+    working_directory: Path,
     preserve_vars: tuple[str, ...] | None = None,
 ) -> list[str]:
     """
-    Prefix `cmd` with `sudo -H -u <target> --preserve-env=<csv> --`.
+    Prefix `cmd` with a target-user sudo wrapper.
 
     `-H` rewrites HOME so the agent reads its config and OAuth state
     under the target user's home. The `--preserve-env=<csv>` clause
@@ -438,18 +440,18 @@ def _wrap_cmd_for_user(
     because the bot user's PATH is already in the subprocess env via
     the per-backend allow-list, and sudo resolves bare commands like
     `claude` / `codex` against that PATH before applying its sudoers
-    check (the sudoers rule pins the resolved absolute path).
+    check (the sudoers rule pins the resolved absolute path). ``-D``
+    enters the selected workspace after sudo assumes the target identity;
+    the Kai service user never needs traversal access to private managed
+    homes.
     """
     preserve = ",".join(preserve_vars if preserve_vars is not None else _preserved_auth_vars_for(backend))
-    wrapped = [
-        "sudo",
-        "-H",
-        "-u",
-        target_user,
-    ]
-    if preserve:
-        wrapped.append(f"--preserve-env={preserve}")
-    return [*wrapped, "--", *cmd]
+    return wrap_command_for_target_user(
+        cmd,
+        target_user=target_user,
+        working_directory=working_directory,
+        preserve_env=preserve.split(",") if preserve else (),
+    )
 
 
 def _os_user_log_field(effective_user: str | None) -> str:
@@ -612,7 +614,8 @@ class ClaudeOneShotReasoner:
                 DATA_DIR. Production callers leave this unset; the
                 reasoner uses `_EXTRACTOR_CWD` and ensures it exists
                 on first call.
-            os_user: Optional OS user to run claude as via `sudo -H -u`.
+            os_user: Optional OS user to run claude as via
+                `sudo -H -D <workspace> -u`.
                 When None or matching the bot process user (the
                 self-sudo-skip case, detected by `resolve_claude_user`),
                 claude spawns directly with no wrap, preserving the
@@ -691,7 +694,12 @@ class ClaudeOneShotReasoner:
         # user os_user keep working without configuration changes.
         effective_user = resolve_claude_user(self._os_user)
         if effective_user is not None:
-            cmd = _wrap_cmd_for_user(cmd, effective_user, "claude")
+            cmd = _wrap_cmd_for_user(
+                cmd,
+                effective_user,
+                "claude",
+                working_directory=self._cwd,
+            )
 
         # Allow-listed env: only forward vars from
         # _SUBPROCESS_ENV_ALLOWLIST that are present in the parent
@@ -709,7 +717,10 @@ class ClaudeOneShotReasoner:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=str(self._cwd),
+            cwd=subprocess_spawn_cwd(
+                self._cwd,
+                target_user=effective_user,
+            ),
             env=subprocess_env,
             # New session on the wrap path so kill -KILL -<pgid> hits
             # every target-user descendant; default semantics on the
@@ -1124,7 +1135,7 @@ class CodexOneShotReasoner:
                 `resolve_claude_user` collapses to the current process
                 user) spawns codex in-process as the bot user - the
                 self-sudo-skip path. A non-bot username wraps the
-                argv in `sudo -H -u <user>` for cross-user isolation.
+                argv in `sudo -H -D <workspace> -u <user>` for cross-user isolation.
                 Operators who want the cross-user separation set
                 `os_user` to a different OS account in users.yaml;
                 operators running kai under their own account leave
@@ -1258,7 +1269,7 @@ class CodexOneShotReasoner:
             schema_path.chmod(0o644)
             cmd.extend(["--output-schema", str(schema_path)])
 
-        # Wrap codex in `sudo -H -u <target>` with the auth preserve
+        # Wrap codex in `sudo -H -D <workspace> -u <target>` with the auth preserve
         # list when running cross-user. When `effective_user is None`
         # (same-user spawn: os_user unset OR matches the bot user),
         # the argv stays direct - codex runs in-process as the bot
@@ -1267,7 +1278,12 @@ class CodexOneShotReasoner:
         # the timeout-escalation branch below already gate on the
         # same predicate so the cross-user path stays unchanged.
         if effective_user is not None:
-            cmd = _wrap_cmd_for_user(cmd, effective_user, "codex")
+            cmd = _wrap_cmd_for_user(
+                cmd,
+                effective_user,
+                "codex",
+                working_directory=self._cwd,
+            )
 
         # Allow-listed env: only forward keys present in the parent
         # env. Defense-in-depth against a future regression that
@@ -1287,7 +1303,10 @@ class CodexOneShotReasoner:
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                cwd=str(self._cwd),
+                cwd=subprocess_spawn_cwd(
+                    self._cwd,
+                    target_user=effective_user,
+                ),
                 env=subprocess_env,
                 start_new_session=bool(effective_user),
             )
@@ -1633,7 +1652,7 @@ class OpenCodeOneShotReasoner:
     Per-OS-user routing: mirrors claude and codex. When
     `os_user is None` or resolves to the bot user, opencode spawns
     directly. A non-bot target wraps the argv in
-    `sudo -H -u <user> --preserve-env=<csv>` carrying the auth vars
+    `sudo -H -D <workspace> -u <user> --preserve-env=<csv>` carrying the auth vars
     from `_preserved_auth_vars_for("opencode")`. The sudoers rule
     emitted by `install._generate_sudoers` for the opencode binary
     authorizes the passthrough; without that rule the wrap path
@@ -1661,7 +1680,7 @@ class OpenCodeOneShotReasoner:
                 process user) spawns opencode in-process as the bot
                 user; the self-sudo-skip path is identical to the
                 no-os_user case. A non-bot username wraps the argv
-                in `sudo -H -u <user>` with the opencode preserve
+                in `sudo -H -D <workspace> -u <user>` with the opencode preserve
                 list.
         """
         self._cwd = cwd if cwd is not None else _EXTRACTOR_CWD
@@ -1707,7 +1726,12 @@ class OpenCodeOneShotReasoner:
         # preserve list.
         effective_user = resolve_claude_user(self._os_user)
         if effective_user is not None:
-            cmd = _wrap_cmd_for_user(cmd, effective_user, "opencode")
+            cmd = _wrap_cmd_for_user(
+                cmd,
+                effective_user,
+                "opencode",
+                working_directory=self._cwd,
+            )
 
         # Allow-listed env: only forward keys present in the parent
         # env. Defense-in-depth against a future regression that tries
@@ -1735,7 +1759,10 @@ class OpenCodeOneShotReasoner:
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                cwd=str(self._cwd),
+                cwd=subprocess_spawn_cwd(
+                    self._cwd,
+                    target_user=effective_user,
+                ),
                 env=subprocess_env,
                 # New session on the wrap path so a future
                 # `_kill_target_user_tree` on this reasoner has a pgid
@@ -2328,7 +2355,7 @@ class GooseOneShotReasoner:
                 other reasoners: None (or a value resolve_claude_user
                 collapses to the current process user) spawns goose
                 in-process; a non-bot username wraps the argv in
-                `sudo -H -u <user>`.
+                `sudo -H -D <workspace> -u <user>`.
             provider: Kai provider key for the `--provider` flag
                 (translated to goose's wire name at argv build).
                 Empty omits the flag so goose falls back to its own
@@ -2380,7 +2407,12 @@ class GooseOneShotReasoner:
         # preserve list.
         effective_user = resolve_claude_user(self._os_user)
         if effective_user is not None:
-            cmd = _wrap_cmd_for_user(cmd, effective_user, "goose")
+            cmd = _wrap_cmd_for_user(
+                cmd,
+                effective_user,
+                "goose",
+                working_directory=self._cwd,
+            )
 
         # Allow-listed env: only forward keys present in the parent
         # env. PATH is allow-listed so sudo can resolve the bare
@@ -2398,7 +2430,10 @@ class GooseOneShotReasoner:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=str(self._cwd),
+            cwd=subprocess_spawn_cwd(
+                self._cwd,
+                target_user=effective_user,
+            ),
             env=subprocess_env,
             start_new_session=bool(effective_user),
         )
@@ -2624,6 +2659,7 @@ class PiOneShotReasoner:
                 cmd,
                 effective_user,
                 "pi",
+                working_directory=self._cwd,
                 preserve_vars=_pi_provider_env_vars(self._provider),
             )
         env_allowlist = (*_PI_ENV_BASE_ALLOWLIST, *_pi_provider_env_vars(self._provider))
@@ -2640,7 +2676,10 @@ class PiOneShotReasoner:
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                cwd=str(self._cwd),
+                cwd=subprocess_spawn_cwd(
+                    self._cwd,
+                    target_user=effective_user,
+                ),
                 env=subprocess_env,
                 limit=PI_RPC_STREAM_LIMIT,
                 start_new_session=bool(effective_user),

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -35,6 +35,7 @@ from kai.pi_rpc import (
     pi_rpc_text_delta,
     require_pi_rpc_response,
 )
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
 
 log = logging.getLogger(__name__)
 
@@ -231,16 +232,12 @@ class PiBackend(AgentBackend):
         argv = self._build_argv()
         env = self._build_env(effective_os_user)
         if effective_os_user:
-            preserve = ",".join(("KAI_WEBHOOK_SECRET", "TMPDIR", *_pi_provider_env_vars(self.provider)))
-            argv = [
-                "sudo",
-                "-H",
-                "-u",
-                effective_os_user,
-                f"--preserve-env={preserve}",
-                "--",
-                *argv,
-            ]
+            argv = wrap_command_for_target_user(
+                argv,
+                target_user=effective_os_user,
+                working_directory=self.workspace,
+                preserve_env=("KAI_WEBHOOK_SECRET", "TMPDIR", *_pi_provider_env_vars(self.provider)),
+            )
 
         log.info(
             "Starting persistent Pi RPC process (model=%s, user=%s)",
@@ -252,7 +249,10 @@ class PiBackend(AgentBackend):
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=str(self.workspace),
+            cwd=subprocess_spawn_cwd(
+                self.workspace,
+                target_user=effective_os_user,
+            ),
             env=env,
             limit=PI_RPC_STREAM_LIMIT,
             start_new_session=bool(effective_os_user),

--- a/src/kai/subprocess_identity.py
+++ b/src/kai/subprocess_identity.py
@@ -1,0 +1,44 @@
+"""Cross-user subprocess launch mechanics for protected agent runtimes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+
+def wrap_command_for_target_user(
+    command: Sequence[str],
+    *,
+    target_user: str,
+    working_directory: Path,
+    preserve_env: Iterable[str] = (),
+) -> list[str]:
+    """Enter a private workspace after sudo changes execution identity.
+
+    ``asyncio.create_subprocess_exec(cwd=...)`` changes directory before it
+    executes sudo, while the child still has the Kai service UID. Canonical
+    managed homes are intentionally private to the target OS user, so the
+    service cannot enter them. ``sudo -D`` performs that transition under the
+    target-user execution policy instead.
+    """
+    preserved = tuple(preserve_env)
+    wrapped = [
+        "sudo",
+        "-H",
+        "-D",
+        str(working_directory),
+        "-u",
+        target_user,
+    ]
+    if preserved:
+        wrapped.append(f"--preserve-env={','.join(preserved)}")
+    return [*wrapped, "--", *command]
+
+
+def subprocess_spawn_cwd(
+    working_directory: Path,
+    *,
+    target_user: str | None,
+) -> str | None:
+    """Return a pre-exec cwd only when no cross-user transition is needed."""
+    return None if target_user is not None else str(working_directory)

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1791,14 +1791,15 @@ class TestOsUserRouting:
             await b._ensure_started()
 
         argv = list(captured["argv"])
-        assert argv[:4] == ["sudo", "-H", "-u", "other-user"]
+        assert argv[:6] == ["sudo", "-H", "-D", "/tmp/test-workspace", "-u", "other-user"]
         # Preserve-env CSV exact contract: the AcpBackend default
         # (webhook callback auth + per-os-user temp anchor). Backends
         # that need more override preserved_env_vars(); see the
         # hook-driven test below.
-        assert argv[4] == "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR"
-        assert argv[5] == "--"
-        assert argv[6] == "fake_acp_binary"
+        assert argv[6] == "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR"
+        assert argv[7] == "--"
+        assert argv[8] == "fake_acp_binary"
+        assert captured["cwd"] is None
         assert captured["start_new_session"] is True
         # _make_mock_proc pins pid=12345; PGID == PID for session
         # leaders, recorded at spawn time.
@@ -1828,7 +1829,7 @@ class TestOsUserRouting:
         ):
             await b._ensure_started()
 
-        assert captured["argv"][4] == "--preserve-env=ALPHA,BETA"
+        assert captured["argv"][6] == "--preserve-env=ALPHA,BETA"
 
     @pytest.mark.asyncio
     async def test_tmpdir_anchored_per_os_user_on_wrap(self):

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -144,7 +144,7 @@ class TestCommandConstruction:
 
     @pytest.mark.asyncio
     async def test_cmd_with_claude_user(self):
-        """With claude_user set, command is prefixed with 'sudo -H -u <user> --'."""
+        """With claude_user set, sudo enters the workspace as that user."""
         claude = _make_claude(claude_user="daniel")
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
@@ -158,16 +158,21 @@ class TestCommandConstruction:
 
             args = mock_exec.call_args
             cmd = args[0]
-            assert cmd[0] == "sudo"
-            assert cmd[1] == "-H"
-            assert cmd[2] == "-u"
-            assert cmd[3] == "daniel"
+            assert cmd[:6] == (
+                "sudo",
+                "-H",
+                "-D",
+                "/tmp/test-workspace",
+                "-u",
+                "daniel",
+            )
             assert (
-                cmd[4]
+                cmd[6]
                 == "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL,CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
             )
-            assert cmd[5] == "--"
-            assert cmd[6] == "claude"
+            assert cmd[7] == "--"
+            assert cmd[8] == "claude"
+            assert args.kwargs["cwd"] is None
 
     @pytest.mark.asyncio
     async def test_start_new_session_true_with_claude_user(self):
@@ -239,15 +244,20 @@ class TestCommandConstruction:
 
             args = mock_exec.call_args
             cmd = args[0]
-            assert cmd[0] == "sudo"
-            assert cmd[1] == "-H"
-            assert cmd[2] == "-u"
-            assert cmd[3] == "some_other_user"
+            assert cmd[:6] == (
+                "sudo",
+                "-H",
+                "-D",
+                "/tmp/test-workspace",
+                "-u",
+                "some_other_user",
+            )
             assert (
-                cmd[4]
+                cmd[6]
                 == "--preserve-env=KAI_WEBHOOK_SECRET,TMPDIR,CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL,CLAUDE_AUTOCOMPACT_PCT_OVERRIDE"
             )
-            assert cmd[5] == "--"
+            assert cmd[7] == "--"
+            assert args.kwargs["cwd"] is None
             assert args[1].get("start_new_session") is True
 
     @pytest.mark.asyncio
@@ -274,7 +284,8 @@ class TestCommandConstruction:
             # Should still wrap with sudo since we can't determine the user.
             assert cmd[0] == "sudo"
             assert cmd[1] == "-H"
-            assert cmd[3] == "container_user"
+            assert cmd[2:6] == ("-D", "/tmp/test-workspace", "-u", "container_user")
+            assert args.kwargs["cwd"] is None
             assert args[1].get("start_new_session") is True
 
     @pytest.mark.asyncio

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1880,7 +1880,7 @@ class TestCodexUserSudoWrap:
     Verify the per-user OAuth isolation lever.
 
     When codex_user is set to a non-self user, the subprocess argv is
-    wrapped in `sudo -H -u <user> --preserve-env=<csv> --`
+    wrapped in `sudo -H -D <workspace> -u <user> --preserve-env=<csv> --`
     so codex runs as <codex_user> and reads
     ~<codex_user>/.codex/auth.json. This is what makes a multi-user
     install (e.g., users.yaml has os_user=daniel for one chat and
@@ -1914,6 +1914,7 @@ class TestCodexUserSudoWrap:
         argv = mock_exec.call_args[0]
         assert argv[0] == "sudo"
         assert "-H" in argv
+        assert argv[argv.index("-D") + 1] == "/tmp/test-workspace"
         i = argv.index("-u")
         assert argv[i + 1] == "ci-fake-user"
         # Exact preserve CSV: the webhook secret and TMPDIR anchor,
@@ -1926,6 +1927,7 @@ class TestCodexUserSudoWrap:
         separator_i = argv.index("--")
         assert argv[separator_i + 1].endswith("/codex") or argv[separator_i + 1] == "codex"
         assert argv[separator_i + 2] == "app-server"
+        assert mock_exec.call_args.kwargs["cwd"] is None
 
     @pytest.mark.asyncio
     async def test_tmpdir_anchored_per_os_user_in_cross_user_mode(self):

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -1314,12 +1314,12 @@ class TestPreservedEnvVars:
             await g._ensure_started()
 
         argv = list(captured["argv"])
-        assert argv[:4] == ["sudo", "-H", "-u", "goose-user"]
-        assert argv[4] == (
+        assert argv[:6] == ["sudo", "-H", "-D", "/tmp/test-workspace", "-u", "goose-user"]
+        assert argv[6] == (
             "--preserve-env=GOOSE_MODEL,GOOSE_PROVIDER,CONTEXT_FILE_NAMES,ANTHROPIC_API_KEY,"
             "OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY,"
             "ANTHROPIC_HOST,OPENAI_HOST,OPENAI_BASE_PATH,OLLAMA_HOST,"
             "KAI_WEBHOOK_SECRET,TMPDIR"
         )
-        assert argv[5] == "--"
-        assert argv[6:] == ["goose", "acp", "--with-builtin", "developer"]
+        assert argv[7] == "--"
+        assert argv[8:] == ["goose", "acp", "--with-builtin", "developer"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -417,7 +417,7 @@ class TestGenerateSudoers:
         """
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
         result = _generate_sudoers("kai", os_users=["alice"])
-        assert "kai ALL=(alice) SETENV: NOPASSWD: /home/kai/.local/bin/claude" in result
+        assert "kai ALL=(alice) CWD=* SETENV: NOPASSWD: /home/kai/.local/bin/claude" in result
 
     def test_claude_bin_ignores_caller_path(self, monkeypatch):
         """
@@ -456,7 +456,7 @@ class TestGenerateSudoers:
 
         result = _generate_sudoers("kai", os_users=["alice"])
 
-        assert "kai ALL=(alice) SETENV: NOPASSWD: /opt/homebrew/bin/claude" in result
+        assert "kai ALL=(alice) CWD=* SETENV: NOPASSWD: /opt/homebrew/bin/claude" in result
         assert "/Users/kai/.local/bin/claude" not in result
 
     def test_claude_bin_arg_overrides_default(self, monkeypatch):
@@ -465,7 +465,7 @@ class TestGenerateSudoers:
         the backend registry."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
         result = _generate_sudoers("kai", os_users=["alice"], claude_bin="/opt/homebrew/bin/claude")
-        assert "kai ALL=(alice) SETENV: NOPASSWD: /opt/homebrew/bin/claude" in result
+        assert "kai ALL=(alice) CWD=* SETENV: NOPASSWD: /opt/homebrew/bin/claude" in result
         assert "/home/kai/.local/bin/claude" not in result
 
     # -- Issue #341: per-user rules from users.yaml -----------------------
@@ -482,16 +482,16 @@ class TestGenerateSudoers:
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
         result = _generate_sudoers("kai", os_users=["sellison"])
         assert result.count("SETENV: NOPASSWD: /home/kai/.local/bin/claude") == 1
-        assert "kai ALL=(sellison) SETENV: NOPASSWD: /home/kai/.local/bin/claude" in result
+        assert "kai ALL=(sellison) CWD=* SETENV: NOPASSWD: /home/kai/.local/bin/claude" in result
 
     def test_multiple_os_users_emit_one_rule_each(self, monkeypatch):
         """Acceptance (c): multiple distinct os_users → one rule each."""
         monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
         result = _generate_sudoers("kai", os_users=["sellison", "bob", "carol"])
         bin_path = "/home/kai/.local/bin/claude"
-        assert f"kai ALL=(sellison) SETENV: NOPASSWD: {bin_path}" in result
-        assert f"kai ALL=(bob) SETENV: NOPASSWD: {bin_path}" in result
-        assert f"kai ALL=(carol) SETENV: NOPASSWD: {bin_path}" in result
+        assert f"kai ALL=(sellison) CWD=* SETENV: NOPASSWD: {bin_path}" in result
+        assert f"kai ALL=(bob) CWD=* SETENV: NOPASSWD: {bin_path}" in result
+        assert f"kai ALL=(carol) CWD=* SETENV: NOPASSWD: {bin_path}" in result
         assert result.count(f"SETENV: NOPASSWD: {bin_path}") == 3
 
     def test_duplicate_os_users_deduped(self, monkeypatch):
@@ -505,8 +505,8 @@ class TestGenerateSudoers:
         # without the kill-rule or codex-rule noise inflating the
         # count.
         claude_bin = "/home/kai/.local/bin/claude"
-        assert result.count(f"kai ALL=(sellison) SETENV: NOPASSWD: {claude_bin}") == 1
-        assert result.count(f"kai ALL=(bob) SETENV: NOPASSWD: {claude_bin}") == 1
+        assert result.count(f"kai ALL=(sellison) CWD=* SETENV: NOPASSWD: {claude_bin}") == 1
+        assert result.count(f"kai ALL=(bob) CWD=* SETENV: NOPASSWD: {claude_bin}") == 1
 
     def test_os_user_matching_service_user_skipped(self, monkeypatch):
         """Acceptance (d): os_user == service_user → no rule (self-sudo path)."""
@@ -516,7 +516,7 @@ class TestGenerateSudoers:
         # resolve_claude_user() short-circuits the sudo wrapper at runtime.
         assert "kai ALL=(kai)" not in result
         bin_path = "/home/kai/.local/bin/claude"
-        assert f"kai ALL=(sellison) SETENV: NOPASSWD: {bin_path}" in result
+        assert f"kai ALL=(sellison) CWD=* SETENV: NOPASSWD: {bin_path}" in result
         assert result.count(f"SETENV: NOPASSWD: {bin_path}") == 1
 
     # -- Codex per-target rule (per-user OAuth isolation) ----------------
@@ -539,8 +539,8 @@ class TestGenerateSudoers:
         # Each target gets exactly one codex SETENV rule. The binary
         # path is not pinned in the assertion (shutil.which is
         # environment-dependent); match on the rule prefix instead.
-        assert "kai ALL=(alice) SETENV: NOPASSWD: " in result
-        assert "kai ALL=(bob) SETENV: NOPASSWD: " in result
+        assert "kai ALL=(alice) CWD=* SETENV: NOPASSWD: " in result
+        assert "kai ALL=(bob) CWD=* SETENV: NOPASSWD: " in result
         # Specifically: a line referencing "codex" appears under each target.
         alice_lines = [line for line in result.splitlines() if "(alice)" in line and "codex" in line]
         bob_lines = [line for line in result.splitlines() if "(bob)" in line and "codex" in line]
@@ -554,8 +554,8 @@ class TestGenerateSudoers:
             pi_bin="/opt/homebrew/bin/pi",
         )
 
-        assert "kai ALL=(alice) SETENV: NOPASSWD: /opt/homebrew/bin/pi" in result
-        assert "kai ALL=(bob) SETENV: NOPASSWD: /opt/homebrew/bin/pi" in result
+        assert "kai ALL=(alice) CWD=* SETENV: NOPASSWD: /opt/homebrew/bin/pi" in result
+        assert "kai ALL=(bob) CWD=* SETENV: NOPASSWD: /opt/homebrew/bin/pi" in result
 
     # -- Issue #456: per-target kill rule for cross-user signal escalation ----
 
@@ -595,10 +595,33 @@ class TestGenerateSudoers:
         kill_lines = [line for line in rule_lines if "kill" in line]
         assert len(kill_lines) == 1
         assert "SETENV" not in kill_lines[0]
+        assert "CWD=*" not in kill_lines[0]
         # The claude rule still has SETENV (unchanged by #456).
         claude_lines = [line for line in rule_lines if "claude" in line]
         assert len(claude_lines) == 1
         assert "SETENV" in claude_lines[0]
+        assert "CWD=*" in claude_lines[0]
+
+    def test_cwd_permission_is_scoped_to_agent_commands(self, monkeypatch):
+        """Only arbitrary-code agent rules may enter protected workspaces."""
+        monkeypatch.setattr("kai.install._user_home", lambda u: f"/home/{u}")
+        result = _generate_sudoers(
+            "kai",
+            os_users=["alice"],
+            claude_bin="/agents/claude",
+            codex_bin="/agents/codex",
+            opencode_bin="/agents/opencode",
+            goose_bin="/agents/goose",
+            pi_bin="/agents/pi",
+        )
+        rule_lines = [line for line in result.splitlines() if line.startswith("kai ALL=")]
+        agent_lines = [line for line in rule_lines if line.startswith("kai ALL=(alice)") and "kill" not in line]
+        assert len(agent_lines) == 5
+        assert all("CWD=* SETENV: NOPASSWD:" in line for line in agent_lines)
+        assert "kai ALL=(alice) NOPASSWD: /bin/kill" in rule_lines
+        config_lines = [line for line in rule_lines if " /etc/kai/" in line]
+        assert config_lines
+        assert all("CWD=*" not in line for line in config_lines)
 
     def test_kill_rule_path_is_hardcoded(self, monkeypatch):
         """
@@ -8832,7 +8855,7 @@ class TestApplyBackendRegistry:
 
         for backend in ("claude", "codex", "opencode", "goose", "pi"):
             command = registry["backends"][backend]["command"]
-            assert f"kai ALL=(alice) SETENV: NOPASSWD: {command}" in sudoers
+            assert f"kai ALL=(alice) CWD=* SETENV: NOPASSWD: {command}" in sudoers
 
     def test_dry_run_prints_registry_write(self, capsys, monkeypatch):
         monkeypatch.setattr(
@@ -11443,7 +11466,7 @@ class TestGenerateSudoersCodexBinArg:
             os_users=["daniel"],
             codex_bin="/Users/daniel/.npm-global/bin/codex",
         )
-        assert "kai ALL=(daniel) SETENV: NOPASSWD: /Users/daniel/.npm-global/bin/codex" in out
+        assert "kai ALL=(daniel) CWD=* SETENV: NOPASSWD: /Users/daniel/.npm-global/bin/codex" in out
         assert "/opt/homebrew/bin/codex" not in out
 
     def test_codex_bin_arg_none_prefers_common_absolute_path(self, monkeypatch):
@@ -11455,7 +11478,7 @@ class TestGenerateSudoersCodexBinArg:
             os_users=["daniel"],
             codex_bin=None,
         )
-        assert "kai ALL=(daniel) SETENV: NOPASSWD: /usr/local/bin/codex" in out
+        assert "kai ALL=(daniel) CWD=* SETENV: NOPASSWD: /usr/local/bin/codex" in out
         assert "/opt/homebrew/bin/codex" not in out
 
     def test_codex_bin_does_not_read_os_environ(self, monkeypatch):
@@ -11486,10 +11509,10 @@ class TestGenerateSudoersBackendPathArgs:
             goose_bin="/pins/goose",
         )
 
-        assert "kai ALL=(daniel) SETENV: NOPASSWD: /pins/claude" in out
-        assert "kai ALL=(daniel) SETENV: NOPASSWD: /pins/codex" in out
-        assert "kai ALL=(daniel) SETENV: NOPASSWD: /pins/opencode" in out
-        assert "kai ALL=(daniel) SETENV: NOPASSWD: /pins/goose" in out
+        assert "kai ALL=(daniel) CWD=* SETENV: NOPASSWD: /pins/claude" in out
+        assert "kai ALL=(daniel) CWD=* SETENV: NOPASSWD: /pins/codex" in out
+        assert "kai ALL=(daniel) CWD=* SETENV: NOPASSWD: /pins/opencode" in out
+        assert "kai ALL=(daniel) CWD=* SETENV: NOPASSWD: /pins/goose" in out
 
     def test_backend_path_args_do_not_read_os_environ(self, monkeypatch):
         monkeypatch.setenv("CLAUDE_BIN", "/env/claude")

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -1469,15 +1469,13 @@ class TestRoutingArgvAndPreserveEnv:
         ):
             await reasoner.run(prompt="p", purpose="fact_extraction")
         cmd = mock_exec.call_args[0]
-        assert cmd[0] == "sudo"
-        assert cmd[1] == "-H"
-        assert cmd[2] == "-u"
-        assert cmd[3] == "other-user"
+        assert cmd[:6] == ("sudo", "-H", "-D", str(tmp_path), "-u", "other-user")
         # Preserve-env CSV exact contract: Claude auth vars only;
         # no HOME (covered by -H), no PATH (covered by allow-list).
-        assert cmd[4] == "--preserve-env=CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL"
-        assert cmd[5] == "--"
-        assert cmd[6] == "claude"
+        assert cmd[6] == "--preserve-env=CLAUDE_CONFIG_DIR,ANTHROPIC_API_KEY,ANTHROPIC_BASE_URL"
+        assert cmd[7] == "--"
+        assert cmd[8] == "claude"
+        assert mock_exec.call_args.kwargs["cwd"] is None
         assert mock_exec.call_args.kwargs["start_new_session"] is True
 
     @pytest.mark.asyncio
@@ -1513,16 +1511,17 @@ class TestRoutingArgvAndPreserveEnv:
         ):
             await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
         cmd = mock_exec.call_args[0]
-        assert cmd[:4] == ("sudo", "-H", "-u", "other-user") or list(cmd[:4]) == ["sudo", "-H", "-u", "other-user"]
-        assert cmd[4] == "--preserve-env=CODEX_HOME,OPENAI_API_KEY,OPENAI_BASE_URL"
-        assert cmd[5] == "--"
+        assert cmd[:6] == ("sudo", "-H", "-D", str(tmp_path), "-u", "other-user")
+        assert cmd[6] == "--preserve-env=CODEX_HOME,OPENAI_API_KEY,OPENAI_BASE_URL"
+        assert cmd[7] == "--"
         # PATH and bare HOME deliberately not in the preserve list
         # (CODEX_HOME is intentional; the substring check splits on
         # the CSV so a future regression that adds bare HOME still
         # fails this assertion).
-        preserved = cmd[4].split("=", 1)[1].split(",")
+        preserved = cmd[6].split("=", 1)[1].split(",")
         assert "PATH" not in preserved
         assert "HOME" not in preserved
+        assert mock_exec.call_args.kwargs["cwd"] is None
         assert mock_exec.call_args.kwargs["start_new_session"] is True
 
 
@@ -3029,21 +3028,19 @@ class TestOpenCodeOneShotReasonerSudoWrap:
             await reasoner.run(prompt="hi", purpose="fact_extraction")
 
         cmd = mock_exec.call_args_list[0][0]
-        assert cmd[0] == "sudo"
-        assert cmd[1] == "-H"
-        assert cmd[2] == "-u"
-        assert cmd[3] == "some_other_user"
-        # preserve-env is the fifth element; the value carries every
+        assert cmd[:6] == ("sudo", "-H", "-D", str(tmp_path), "-u", "some_other_user")
+        # preserve-env follows the sudo identity options; the value carries every
         # _OPENCODE_PRESERVED_AUTH_VARS entry in a comma-separated CSV.
-        assert cmd[4].startswith("--preserve-env=")
-        csv = cmd[4][len("--preserve-env=") :]
+        assert cmd[6].startswith("--preserve-env=")
+        csv = cmd[6][len("--preserve-env=") :]
         preserved = set(csv.split(","))
         assert preserved == set(_OPENCODE_PRESERVED_AUTH_VARS)
         # `--` ends the sudo options; the wrapped argv (opencode acp)
         # follows.
-        assert cmd[5] == "--"
-        assert cmd[6] == "opencode"
-        assert cmd[7] == "acp"
+        assert cmd[7] == "--"
+        assert cmd[8] == "opencode"
+        assert cmd[9] == "acp"
+        assert mock_exec.call_args.kwargs["cwd"] is None
 
     @pytest.mark.asyncio
     async def test_sudo_wrap_uses_start_new_session_true(self, tmp_path):
@@ -3369,11 +3366,12 @@ class TestGooseRouting:
         ):
             await reasoner.run(prompt="p", purpose="fact_extraction", json_schema={"type": "object"})
         cmd = list(mock_exec.call_args[0])
-        assert cmd[:4] == ["sudo", "-H", "-u", "other-user"]
-        assert cmd[4] == (
+        assert cmd[:6] == ["sudo", "-H", "-D", str(tmp_path), "-u", "other-user"]
+        assert cmd[6] == (
             "--preserve-env=ANTHROPIC_API_KEY,OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY,"
             "ANTHROPIC_HOST,OPENAI_HOST,OPENAI_BASE_PATH,OLLAMA_HOST"
         )
-        assert cmd[5] == "--"
-        assert cmd[6] == "goose"
+        assert cmd[7] == "--"
+        assert cmd[8] == "goose"
+        assert mock_exec.call_args.kwargs["cwd"] is None
         assert mock_exec.call_args.kwargs["start_new_session"] is True

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -874,11 +874,11 @@ class TestPreservedEnvVars:
             await b._ensure_started()
 
         argv = list(captured["argv"])
-        assert argv[:4] == ["sudo", "-H", "-u", "oc-user"]
-        assert argv[4] == (
+        assert argv[:6] == ["sudo", "-H", "-D", "/tmp/test-workspace", "-u", "oc-user"]
+        assert argv[6] == (
             "--preserve-env=OPENCODE_CONFIG_CONTENT,OPENCODE_DISABLE_CLAUDE_CODE_PROMPT,ANTHROPIC_API_KEY,"
             "OPENAI_API_KEY,GOOGLE_API_KEY,OPENROUTER_API_KEY,DEEPSEEK_API_KEY,"
             "KAI_WEBHOOK_SECRET,TMPDIR"
         )
-        assert argv[5] == "--"
-        assert argv[6:] == ["opencode", "acp"]
+        assert argv[7] == "--"
+        assert argv[8:] == ["opencode", "acp"]

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -169,10 +169,11 @@ class TestPiStartup:
         await backend._ensure_started()
 
         argv = spawn.await_args.args
-        assert argv[:4] == ("sudo", "-H", "-u", "daniel")
-        assert argv[4].startswith("--preserve-env=")
-        assert "ANTHROPIC_API_KEY" in argv[4]
-        assert argv[5:7] == ("--", "/opt/homebrew/bin/pi")
+        assert argv[:6] == ("sudo", "-H", "-D", str(tmp_path), "-u", "daniel")
+        assert argv[6].startswith("--preserve-env=")
+        assert "ANTHROPIC_API_KEY" in argv[6]
+        assert argv[7:9] == ("--", "/opt/homebrew/bin/pi")
+        assert spawn.await_args.kwargs["cwd"] is None
         assert backend.session_id == "session-1"
         assert backend._supports_image_input is True
         assert transport.sent == [{"id": "kai-get_state-1", "type": "get_state"}]

--- a/tests/test_pi_oneshot.py
+++ b/tests/test_pi_oneshot.py
@@ -199,11 +199,12 @@ async def test_pi_oneshot_cross_user_wrap_preserves_only_pi_auth(tmp_path, monke
     process = FakeProcess([state_response(), prompt_response(), completed_message("ok"), {"type": "agent_settled"}])
     _, spawn = await run_with_process(tmp_path, monkeypatch, process, os_user="daniel")
     argv = spawn.await_args_list[0].args
-    assert argv[:4] == ("sudo", "-H", "-u", "daniel")
-    assert "ANTHROPIC_API_KEY" in argv[4]
-    assert "OPENAI_API_KEY" not in argv[4]
-    assert "GEMINI_API_KEY" not in argv[4]
-    assert "KAI_WEBHOOK_SECRET" not in argv[4]
+    assert argv[:6] == ("sudo", "-H", "-D", str(tmp_path), "-u", "daniel")
+    assert "ANTHROPIC_API_KEY" in argv[6]
+    assert "OPENAI_API_KEY" not in argv[6]
+    assert "GEMINI_API_KEY" not in argv[6]
+    assert "KAI_WEBHOOK_SECRET" not in argv[6]
+    assert spawn.await_args_list[0].kwargs["cwd"] is None
     assert spawn.await_args_list[0].kwargs["start_new_session"] is True
 
 
@@ -237,9 +238,10 @@ async def test_pi_subscription_wrap_needs_no_environment_credentials(tmp_path, m
     )
 
     argv = spawn.await_args_list[0].args
-    assert argv[:4] == ("sudo", "-H", "-u", "daniel")
-    assert argv[4:6] == ("--", "/opt/homebrew/bin/pi")
+    assert argv[:6] == ("sudo", "-H", "-D", str(tmp_path), "-u", "daniel")
+    assert argv[6:8] == ("--", "/opt/homebrew/bin/pi")
     assert not any(str(part).startswith("--preserve-env=") for part in argv)
+    assert spawn.await_args_list[0].kwargs["cwd"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_subprocess_identity.py
+++ b/tests/test_subprocess_identity.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
+
+
+def test_cross_user_wrapper_enters_workspace_after_identity_change():
+    workspace = Path("/var/lib/kai/home/prn_test")
+
+    command = wrap_command_for_target_user(
+        ["/usr/local/bin/codex", "app-server"],
+        target_user="daniel",
+        working_directory=workspace,
+        preserve_env=("CODEX_HOME", "OPENAI_API_KEY"),
+    )
+
+    assert command == [
+        "sudo",
+        "-H",
+        "-D",
+        str(workspace),
+        "-u",
+        "daniel",
+        "--preserve-env=CODEX_HOME,OPENAI_API_KEY",
+        "--",
+        "/usr/local/bin/codex",
+        "app-server",
+    ]
+
+
+def test_cross_user_wrapper_omits_empty_preserve_option():
+    command = wrap_command_for_target_user(
+        ["agent"],
+        target_user="alice",
+        working_directory=Path("/private/workspace"),
+    )
+
+    assert command == [
+        "sudo",
+        "-H",
+        "-D",
+        "/private/workspace",
+        "-u",
+        "alice",
+        "--",
+        "agent",
+    ]
+
+
+def test_cross_user_spawn_does_not_pre_enter_private_workspace():
+    workspace = Path("/var/lib/kai/home/prn_test")
+
+    assert subprocess_spawn_cwd(workspace, target_user="daniel") is None
+
+
+def test_direct_spawn_keeps_requested_workspace():
+    workspace = Path("/workspace")
+
+    assert subprocess_spawn_cwd(workspace, target_user=None) == str(workspace)


### PR DESCRIPTION
## Summary

- enter protected runtime workspaces only after sudo has changed to the assigned OS user
- give the five pinned backend commands narrowly scoped `CWD=*` sudoers authority while leaving config-read and kill rules unchanged
- use one shared launch helper across persistent Claude, Codex, Goose, OpenCode, and Pi backends and all corresponding one-shot reasoners

## Problem

The consolidated Milestone 1 installed qualification provisioned a Workshop-only human with a canonical managed home at `/var/lib/kai/home/<principal-id>`. That home is intentionally owned by the assigned OS user with mode `0700`.

Every protected backend launch failed before the backend started. Python's `create_subprocess_exec(cwd=...)` changes directory while the child still has the Kai service identity, before executing the `sudo -u <target>` wrapper. The service account therefore could not traverse the target user's private canonical home.

Existing Telegram-derived profiles masked this defect when they had a saved, service-traversable project workspace.

## Change

Cross-user launches now use:

```text
sudo -H -D <validated-workspace> -u <target> ... -- <pinned-agent-command>
```

Python leaves `cwd` unset for that path, allowing sudo to enter the directory under the target-user execution policy. Direct same-user launches retain the existing subprocess `cwd` behavior.

The installer grants `CWD=*` only on the five backend rules. It does not grant it to protected configuration reads or `/bin/kill`. Kai continues to select the workspace through protected runtime policy; operators do not supply arbitrary backend commands or paths at request time.

This does not broaden the practical execution authority of an agent rule: each pinned coding-agent binary is already an arbitrary-code execution boundary for its target OS user. It does make the intended private workspace usable without weakening its filesystem permissions.

## Coverage

- shared wrapper and spawn-cwd unit tests
- persistent Claude, Codex, Goose, OpenCode, and Pi launch tests
- all corresponding one-shot reasoner tests
- installer contract tests proving `CWD=*` is present on agent rules and absent from config-read and kill rules
- generated sudoers validated by macOS `visudo`

## Validation

- `make check`
- `5741 passed, 1 skipped`
- generated sudoers: `parsed OK`

Relates to #917 and #921.
