### PR TITLE
Document protected-install sudo requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Requirements:
 - A Telegram bot token from [BotFather](https://t.me/BotFather)
 - Your Telegram user ID from [userinfobot](https://t.me/userinfobot)
 - At least one supported agent backend installed and authenticated
+- Sudo 1.9.3+ for protected multi-user installs (`CWD`/`-D` support)
 
 Install Kai for local development:
 


### PR DESCRIPTION
## Summary

- document sudo 1.9.3+ as a prerequisite for protected multi-user installs
- close the sole actionable documentation gap found by the retrospective review of #933 and #939

## Context

Protected cross-user backend launches use sudo's `-D` option and command-scoped `CWD=*` policy so the target OS user enters a private runtime workspace. Sudo documents those features as requiring version 1.9.3 or newer.

Older versions already fail closed, but the prerequisite was not stated and their parse error would not identify the underlying compatibility requirement.

## Validation

- `make check`
- `git diff --check`

Relates to #917 and #921.
