### PR TITLE
Introduce a transport-neutral Kai application host

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -419,6 +419,7 @@ No entry may use an indefinite condition such as "keep for compatibility." A gen
 | GitHub and generic webhook paths that route directly to Telegram or the pool | Canonical integration commands/events plus delivery/run services | Existing GitHub group notifications, generic callers, deduplication, and secret separation pass end-to-end tests | Remove direct routing while retaining verified webhook adapters and supported external contracts | Planned |
 | Per-chat settings, files, memory references, and project selection | Principal/channel/agent/project-workspace records and artifact metadata | Existing per-user isolation, context assembly, memory provenance, file delivery, and workspace access remain equivalent | Migrate namespaces and remove Telegram-derived ownership from domain storage; retire recorded compatibility `storage_path` values when an authoritative artifact store replaces local per-chat files | Active (new uploads and staged review artifacts use opaque human `PrincipalId` directories; numeric file directories remain read-compatible for existing uploads; settings, history, home, preferences, memory, and workspace compatibility state remain to migrate) |
 | `users.yaml` values that represent mutable application state | Workshop administration and durable policy records | Workshop administration can safely inspect and change the relevant state, and bootstrap/recovery behavior is proven | Retain only protected installation/bootstrap policy; remove duplicated mutable state and precedence rules | Planned |
+| Core services mirrored into Telegram `bot_data` for compatibility handlers | Typed core host plus explicit adapter dependency injection | Core lifecycle tests run without Telegram; HTTP uses direct typed dependencies; each remaining Telegram handler family receives its required service without dictionary lookup; hybrid installed behavior passes | Remove `pool`, `workshop_runtime_pool`, `workshop_conversation_run_service`, `workshop_private_text_execution`, and `workshop_principal_storage` mirrors from `create_bot()` after handler injection is complete | Active (construction, startup, delivery-authority activation, supervision, browser-command executor, client store, readiness, and shutdown are core-owned; existing Telegram handlers temporarily retain adapter-local mirrors) |
 | One-time `users.yaml` projection into protected `runtime-profiles.yaml`, plus private integer `compatibility_runtime_config_id` values | Independently authored runtime profiles and profile-keyed runtime/state stores | Existing profile IDs and state continuity survive migration; a profile with no Telegram identity can be assigned and executed; installer/status diagnostics pass; all five backends remain equivalent | Remove the migration renderer and `from_config` development projection; remove `compatibility_runtime_config_id`, `for_config_id`, and integer conversion in `WorkshopRuntimePool` after pool and persistent state are profile-keyed | Active (#921; protected fields are independently authoritative after their one-time seed and are no longer compared with `users.yaml`; the explicitly named integer pool/storage bridge and bootstrap-coverage check remain) |
 | Backend-specific execution orchestration embedded in the control plane | Equal Harness Driver contracts and a Runtime Backend boundary | Capability and lifecycle tests cover Claude, Codex, Goose, OpenCode, and Pi without privileging one driver | Delete duplicated process orchestration only after the shared contracts carry the required evidence | Planned |
 | Trusted-host `local_process` execution and its executable-trust warnings | Isolated Workshop workers | Worker identity, filesystem grants, credentials, networking, artifacts, cancellation, upgrade, and recovery are verified for all five harnesses | Retire trusted-host mode or explicitly reclassify it as a supported development mode; remove production mitigations that it alone requires | Planned |
@@ -2020,6 +2021,36 @@ The remaining Milestone 1 debt is the deliberately named integer bridge, not
 execution-policy precedence. Removing it requires profile-keyed subprocess and
 persistent-state namespaces; it does not require another round of field-by-
 field authority migration.
+
+## 43. Transport-neutral core application host foundation
+
+**Implementation date:** 2026-08-14
+
+Kai now constructs and supervises the subprocess pool, protected runtime
+facade, canonical conversation-run service, durable private-text executor,
+Workshop browser command executor, and browser-facing event store through a
+typed `KaiApplicationHost`. The host imports no Telegram package and exposes a
+non-sensitive readiness snapshot for runtime, executor, client API, and store
+components. Its shutdown order drains browser commands before closing stores,
+execution recovery, and backend processes.
+
+The host also resumes or creates the durable conversation-delivery authority
+epoch before private-text recovery begins. Terminal recovery can therefore
+create correctly fenced delivery work even when the prior epoch was inactive.
+The Telegram conversation worker receives and validates that core-owned epoch;
+it no longer activates delivery authority as a transport startup side effect.
+
+The Telegram factory no longer constructs runtime or Workshop execution
+services. The mixed HTTP server receives its core dependencies explicitly and
+no longer discovers them through Telegram `bot_data`; it also no longer owns
+the browser executor or its canonical store. Telegram conversation and
+notification delivery workers remain adapter-owned, as intended.
+
+Existing Telegram handlers still receive temporary adapter-local service
+mirrors because their command and media orchestration has not yet moved behind
+typed feature services. The retirement ledger names those exact keys and their
+removal gate. This is a bounded compatibility surface, not a second lifecycle
+owner.
 
 ## Canonical notification feed activation
 

--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -1,0 +1,215 @@
+"""Transport-neutral construction and lifecycle for Kai core services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from kai import sessions
+from kai.config import Config
+from kai.pool import SubprocessPool
+from kai.workshop.client_commands import WorkshopClientCommandExecutor
+from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
+from kai.workshop.conversation_runs import WorkshopConversationRunService
+from kai.workshop.delivery_authority import (
+    DeliveryAuthorityEpoch,
+    WorkshopConversationDeliveryAuthority,
+)
+from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
+from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
+from kai.workshop.store import WorkshopEventStore
+
+
+class KaiApplicationState(StrEnum):
+    """Observable lifecycle state for the transport-neutral application host."""
+
+    NEW = "new"
+    STARTING = "starting"
+    READY = "ready"
+    DRAINING = "draining"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class KaiCoreReadiness:
+    """Non-sensitive component readiness exposed to operators and adapters."""
+
+    state: KaiApplicationState
+    runtime: bool
+    executor: bool
+    client_api: bool
+    store: bool
+
+    @property
+    def ready(self) -> bool:
+        return self.state == KaiApplicationState.READY and all(
+            (self.runtime, self.executor, self.client_api, self.store)
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "status": self.state.value,
+            "ready": self.ready,
+            "components": {
+                "runtime": self.runtime,
+                "executor": self.executor,
+                "client_api": self.client_api,
+                "store": self.store,
+            },
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class KaiCoreServices:
+    """Typed dependencies shared by client and transport adapters."""
+
+    subprocess_pool: SubprocessPool
+    runtime_profiles: WorkshopRuntimeProfileRegistry
+    runtime_pool: WorkshopRuntimePool
+    conversation_runs: WorkshopConversationRunService
+    private_text_execution: WorkshopPrivateTextExecutionService
+    client_commands: WorkshopClientCommandExecutor
+    client_store: WorkshopEventStore
+    principal_storage: WorkshopPrincipalStorageRegistry
+    delivery_authority_epoch: DeliveryAuthorityEpoch
+
+
+class KaiApplicationHost:
+    """Own core service construction, supervision, readiness, and shutdown.
+
+    This module deliberately imports no Telegram package and accepts no
+    Telegram object. Adapters receive :attr:`services` after startup and cannot
+    become the owner of runtime or Workshop execution lifecycle.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        runtime_profiles: WorkshopRuntimeProfileRegistry,
+        principal_storage: WorkshopPrincipalStorageRegistry,
+        services_info: list[dict],
+        registered_backend_ids: frozenset[str],
+    ) -> None:
+        self._config = config
+        self._runtime_profiles = runtime_profiles
+        self._principal_storage = principal_storage
+        self._services_info = services_info
+        self._registered_backend_ids = registered_backend_ids
+        self._state = KaiApplicationState.NEW
+        self._services: KaiCoreServices | None = None
+
+    @property
+    def services(self) -> KaiCoreServices:
+        services = self._services
+        if services is None:
+            raise RuntimeError("Kai core services are not started")
+        return services
+
+    @property
+    def readiness(self) -> KaiCoreReadiness:
+        services = self._services
+        return KaiCoreReadiness(
+            state=self._state,
+            runtime=services is not None and self._state == KaiApplicationState.READY,
+            executor=services is not None and services.private_text_execution.ready,
+            client_api=services is not None and services.client_commands.ready,
+            store=services is not None,
+        )
+
+    async def start(self) -> KaiCoreServices:
+        if self._state != KaiApplicationState.NEW:
+            raise RuntimeError(f"Kai application host cannot start from {self._state.value}")
+        self._state = KaiApplicationState.STARTING
+
+        subprocess_pool: SubprocessPool | None = None
+        private_execution: WorkshopPrivateTextExecutionService | None = None
+        client_store: WorkshopEventStore | None = None
+        client_commands: WorkshopClientCommandExecutor | None = None
+        try:
+            subprocess_pool = SubprocessPool(
+                config=self._config,
+                services_info=self._services_info,
+                runtime_profiles=self._runtime_profiles,
+            )
+            runtime_pool = WorkshopRuntimePool(subprocess_pool, self._runtime_profiles)
+            conversation_runs = WorkshopConversationRunService(
+                runtime_pool,
+                sessions.resolve_workshop_conversation_run,
+            )
+
+            subprocess_pool.start()
+            # Terminal run recovery atomically creates delivery work stamped
+            # with the active authority epoch. Resume or create that durable,
+            # transport-neutral authority before either recovery owner starts.
+            client_store = await WorkshopEventStore.open(Path(self._config.session_db_path))
+            delivery_authority_epoch = (await WorkshopConversationDeliveryAuthority(client_store).activate()).epoch
+            private_execution = await WorkshopPrivateTextExecutionService.open_and_start(
+                Path(self._config.session_db_path),
+                runtime_pool,
+                registered_backend_ids=self._registered_backend_ids,
+            )
+            client_commands = WorkshopClientCommandExecutor(
+                private_execution,
+                WorkshopCompatibilityStateWriter(self._config, runtime_pool),
+            )
+            await client_commands.start()
+
+            self._services = KaiCoreServices(
+                subprocess_pool=subprocess_pool,
+                runtime_profiles=self._runtime_profiles,
+                runtime_pool=runtime_pool,
+                conversation_runs=conversation_runs,
+                private_text_execution=private_execution,
+                client_commands=client_commands,
+                client_store=client_store,
+                principal_storage=self._principal_storage,
+                delivery_authority_epoch=delivery_authority_epoch,
+            )
+            self._state = KaiApplicationState.READY
+            return self._services
+        except BaseException:
+            self._state = KaiApplicationState.FAILED
+            if client_commands is not None:
+                await client_commands.stop()
+            if client_store is not None:
+                await client_store.close()
+            if private_execution is not None:
+                await private_execution.stop()
+            if subprocess_pool is not None:
+                await subprocess_pool.shutdown()
+            raise
+
+    async def wait(self) -> None:
+        """Expose failure of a required supervised core worker."""
+        await self.services.private_text_execution.wait()
+
+    async def stop(self) -> None:
+        if self._state in {KaiApplicationState.NEW, KaiApplicationState.STOPPED}:
+            self._state = KaiApplicationState.STOPPED
+            return
+        services = self._services
+        self._state = KaiApplicationState.DRAINING
+        if services is None:
+            self._state = KaiApplicationState.STOPPED
+            return
+
+        errors: list[Exception] = []
+        for operation in (
+            services.client_commands.stop,
+            services.client_store.close,
+            services.private_text_execution.stop,
+            services.subprocess_pool.shutdown,
+        ):
+            try:
+                await operation()
+            except Exception as exc:
+                errors.append(exc)
+        self._services = None
+        self._state = KaiApplicationState.STOPPED
+        if errors:
+            raise ExceptionGroup("Kai core shutdown failed", errors)

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -58,8 +58,9 @@ from telegram.ext import (
     filters,
 )
 
-from kai import github_api, memory_command, review, services, sessions, webhook
+from kai import github_api, memory_command, review, sessions, webhook
 from kai.agent_failure import render_agent_failure
+from kai.application_host import KaiCoreServices
 from kai.config import (
     DATA_DIR,
     ONESHOT_REASONER_BACKENDS,
@@ -97,8 +98,6 @@ from kai.workshop.execution_coordinator import (
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
-from kai.workshop.runtime_pool import WorkshopRuntimePool
-from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageRegistry,
     WorkshopStorageNamespaceError,
@@ -5382,7 +5381,7 @@ async def _handle_response(
 def create_bot(
     config: Config,
     *,
-    runtime_profiles: WorkshopRuntimeProfileRegistry,
+    core_services: KaiCoreServices,
     use_webhook: bool = True,
 ) -> Application:
     """
@@ -5400,7 +5399,7 @@ def create_bot(
 
     Args:
         config: The application Config instance.
-        runtime_profiles: Protected runtime policy constructed by startup.
+        core_services: Transport-neutral services constructed by the core host.
         use_webhook: If True, suppress the default Updater (updates arrive via
             webhook POST). If False, keep the Updater for long-polling mode.
 
@@ -5423,21 +5422,13 @@ def create_bot(
     app.bot_data["workshop_delivery_recorder"] = sessions.record_workshop_delivery_observation
     app.bot_data["workshop_streaming_preview_recorder"] = sessions.record_workshop_streaming_preview
     app.bot_data["workshop_streaming_finalizer"] = sessions.record_workshop_streaming_finalization
-    pool = SubprocessPool(
-        config=config,
-        services_info=services.get_available_services(),
-        runtime_profiles=runtime_profiles,
-    )
-    app.bot_data["pool"] = pool
-    workshop_runtime_pool = WorkshopRuntimePool(
-        pool,
-        runtime_profiles,
-    )
-    app.bot_data["workshop_runtime_pool"] = workshop_runtime_pool
-    app.bot_data["workshop_conversation_run_service"] = WorkshopConversationRunService(
-        workshop_runtime_pool,
-        sessions.resolve_workshop_conversation_run,
-    )
+    # Handlers still receive adapter-local mirrors while they migrate to typed
+    # services. Construction and lifecycle belong exclusively to the core host.
+    app.bot_data["pool"] = core_services.subprocess_pool
+    app.bot_data["workshop_runtime_pool"] = core_services.runtime_pool
+    app.bot_data["workshop_conversation_run_service"] = core_services.conversation_runs
+    app.bot_data["workshop_private_text_execution"] = core_services.private_text_execution
+    app.bot_data["workshop_principal_storage"] = core_services.principal_storage
 
     # Default every recognized command to sensitive. `/start` and `/help`
     # disclose no user state and remain available so an authorized operator can

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -1,10 +1,10 @@
 """
-Application entry point - initializes all subsystems and runs the Telegram bot.
+Application entry point for the Kai core host and configured adapters.
 
 Provides functionality to:
 1. Configure logging with daily rotation and terminal output
 2. Load configuration and validate environment
-3. Initialize the database, Telegram bot, scheduled jobs, and webhook server
+3. Initialize the database, transport-neutral core, adapters, jobs, and HTTP server
 4. Restore workspace from previous session
 5. Start the Telegram transport (webhook or polling, depending on config)
 6. Notify the user if a previous response was interrupted by a crash
@@ -18,18 +18,19 @@ Telegram transport mode is determined by TELEGRAM_WEBHOOK_URL in .env:
 The startup sequence is:
     1. Load config from .env
     2. Initialize SQLite database
-    3. Create the Telegram bot application (with or without Updater)
-    4. Restore previous workspace (if saved in settings table)
-    5. Initialize the Telegram bot and register slash commands
-    6. Load scheduled jobs from database into APScheduler
-    7. Start the webhook HTTP server (always runs for scheduling API, GitHub webhooks, etc.)
-    8. In webhook mode: register Telegram webhook with the API
+    3. Start the transport-neutral runtime and Workshop execution host
+    4. Create the Telegram adapter application (with or without Updater)
+    5. Restore previous workspace (if saved in settings table)
+    6. Initialize the Telegram adapter and register slash commands
+    7. Load scheduled jobs from database into APScheduler
+    8. Start the webhook HTTP server (always runs for scheduling API, GitHub webhooks, etc.)
+    9. In webhook mode: register Telegram webhook with the API
        In polling mode: start the Updater's polling loop
-    9. Check for interrupted-response flag file
-    10. Block forever on asyncio.Event().wait()
+    10. Check for interrupted-response flag file
+    11. Supervise required core and delivery workers until shutdown
 
 The shutdown sequence (in the finally block) reverses this order:
-    webhook server -> polling updater (if active) -> bot -> Claude process -> Telegram app -> database
+    HTTP ingress -> Telegram ingress/delivery -> Telegram app -> core host -> database
 """
 
 import asyncio
@@ -43,11 +44,11 @@ from telegram import BotCommand
 from telegram.error import NetworkError
 
 from kai import cron, services, sessions, webhook
+from kai.application_host import KaiApplicationHost
 from kai.backend_registry import load_backend_registry
 from kai.bot import create_bot
 from kai.config import DATA_DIR, PROJECT_ROOT, _read_protected_file, load_config
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
-from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 from kai.workshop.telegram_delivery_runtime import (
     WorkshopTelegramConversationDeliveryService,
@@ -345,15 +346,10 @@ def _start() -> None:
 
         load_db_registry(await sessions.get_memory_project_rows())
 
-        app = create_bot(
-            config,
-            use_webhook=use_webhook,
-            runtime_profiles=runtime_profiles,
-        )
-        app.bot_data["workshop_principal_storage"] = principal_storage
         conversation_delivery: WorkshopTelegramConversationDeliveryService | None = None
         notification_delivery: WorkshopTelegramNotificationService | None = None
-        private_text_execution: WorkshopPrivateTextExecutionService | None = None
+        core_host: KaiApplicationHost | None = None
+        app = None
 
         # Determine the default user (admin or first user) for per-user
         # data migrations and workspace restoration. users.yaml is
@@ -401,6 +397,22 @@ def _start() -> None:
             logging.warning("Could not initialize semantic memory", exc_info=True)
 
         try:
+            core_host = KaiApplicationHost(
+                config=config,
+                runtime_profiles=runtime_profiles,
+                principal_storage=principal_storage,
+                services_info=services.get_available_services(),
+                registered_backend_ids=_workshop_registered_backend_ids(config),
+            )
+            core_services = await core_host.start()
+            logging.info("Kai core application host is ready")
+
+            app = create_bot(
+                config,
+                use_webhook=use_webhook,
+                core_services=core_services,
+            )
+
             # Retry initialization if the network isn't ready yet (e.g. after a
             # power outage where DNS may take a while to come back).
             for attempt in range(1, 13):
@@ -452,12 +464,13 @@ def _start() -> None:
             # Reload scheduled jobs from the database into APScheduler
             await cron.init_jobs(app)
 
-            # Activate exactly one durable authority epoch and recover its
-            # conversation-finalization work on a dedicated SQLite connection
-            # before either webhook or polling ingress can accept updates.
+            # Validate the core-owned durable authority epoch and recover its
+            # Telegram conversation-finalization work on dedicated SQLite
+            # connections before webhook or polling ingress accepts updates.
             conversation_delivery = await WorkshopTelegramConversationDeliveryService.open_and_start(
                 config.session_db_path,
                 app.bot,
+                authority_epoch_id=core_services.delivery_authority_epoch.epoch_id,
             )
             logging.info("Workshop Telegram conversation delivery is ready")
 
@@ -465,27 +478,21 @@ def _start() -> None:
                 config.session_db_path,
                 app.bot,
             )
-            app.bot_data["workshop_github_notifications"] = notification_delivery
             logging.info("Workshop Telegram notification delivery is ready")
-
-            private_text_execution = await WorkshopPrivateTextExecutionService.open_and_start(
-                config.session_db_path,
-                app.bot_data["workshop_runtime_pool"],
-                registered_backend_ids=_workshop_registered_backend_ids(config),
-            )
-            app.bot_data["workshop_private_text_execution"] = private_text_execution
-            logging.info("Workshop private-text execution is ready")
 
             # Start the HTTP server (always runs - serves scheduling API, GitHub
             # webhooks, file exchange, and health check regardless of transport mode).
             # In webhook mode, this also registers the Telegram webhook with the API.
-            await webhook.start(app, config)
+            await webhook.start(
+                app,
+                config,
+                core_host=core_host,
+                core_services=core_services,
+                github_notifications=notification_delivery,
+            )
             # Phase 3: per-user file confinement is handled at request
             # time via pool.get_effective_workspace(chat_id) in
             # webhook.py. No global workspace sync needed at startup.
-
-            # Start the subprocess pool's idle eviction task.
-            app.bot_data["pool"].start()
 
             # Start periodic file cleanup if a retention policy is configured.
             if config.file_retention_days > 0:
@@ -551,23 +558,16 @@ def _start() -> None:
             await asyncio.gather(
                 conversation_delivery.wait(),
                 notification_delivery.wait(),
-                private_text_execution.wait(),
+                core_host.wait(),
             )
         finally:
             # Shutdown in reverse order of startup
             await webhook.stop()
             # Stop the polling Updater if it was running (no-op in webhook mode
             # since the Updater was suppressed at build time)
-            if not use_webhook and app.updater:
+            if app is not None and not use_webhook and app.updater:
                 await app.updater.stop()
-            if private_text_execution is not None:
-                app.bot_data.pop("workshop_private_text_execution", None)
-                try:
-                    await private_text_execution.stop()
-                except Exception:
-                    logging.exception("Workshop private-text execution stopped with an error")
             if notification_delivery is not None:
-                app.bot_data.pop("workshop_github_notifications", None)
                 try:
                     await notification_delivery.stop()
                 except Exception:
@@ -579,9 +579,14 @@ def _start() -> None:
                     # If wait() already exposed a worker failure, retain that
                     # original exception while still completing shutdown.
                     logging.exception("Workshop Telegram conversation delivery stopped with an error")
-            await app.stop()
-            await app.bot_data["pool"].shutdown()
-            await app.shutdown()
+            if app is not None:
+                await app.stop()
+                await app.shutdown()
+            if core_host is not None:
+                try:
+                    await core_host.stop()
+                except Exception:
+                    logging.exception("Kai core application host stopped with an error")
             await sessions.close_db()
 
     try:

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -64,6 +64,7 @@ from telegram import Bot, Update
 from telegram.ext import Application
 
 from kai import cron, memory, review, services, sessions, triage
+from kai.application_host import KaiApplicationHost, KaiCoreServices
 from kai.config import (
     DATA_DIR,
     IMAGE_EXTENSIONS,
@@ -84,14 +85,12 @@ from kai.workshop.client_api import (
     register_workshop_enrollment_routes,
     register_workshop_read_routes,
 )
-from kai.workshop.client_commands import WorkshopClientCommandExecutor
 from kai.workshop.client_sessions import (
     WorkshopBearerSessionAuthenticator,
     WorkshopClientEnrollmentManager,
     WorkshopClientSessionManager,
 )
 from kai.workshop.client_shell import register_workshop_shell_routes
-from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.github_notifications import GitHubNotification
 from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageRegistry,
@@ -123,6 +122,7 @@ ALLOWED_USER_IDS_KEY: web.AppKey[set[int]] = web.AppKey("allowed_user_ids", set)
 ALLOWED_WORKSPACES_KEY: web.AppKey[list[str]] = web.AppKey("allowed_workspaces", list)
 CHAT_ID_KEY: web.AppKey[int] = web.AppKey("chat_id", int)
 CONFIG_KEY: web.AppKey[Config] = web.AppKey("config", Config)
+CORE_HOST_KEY: web.AppKey[KaiApplicationHost] = web.AppKey("core_host", KaiApplicationHost)
 GENERIC_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("generic_webhook_secret", str)
 GITHUB_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("github_webhook_secret", str)
 INTERNAL_API_AUTH_KEY: web.AppKey[InternalAPIAuth] = web.AppKey("internal_api_auth", InternalAPIAuth)
@@ -152,8 +152,6 @@ class UnauthorizedChatIdError(Exception):
 _app: web.Application | None = None
 _runner: web.AppRunner | None = None
 _workshop_lan_runner: web.AppRunner | None = None
-_workshop_client_store: WorkshopEventStore | None = None
-_workshop_client_command_executor: WorkshopClientCommandExecutor | None = None
 # Tracks whether we registered a Telegram webhook with the API, so stop()
 # knows whether to call delete_webhook(). Only True in webhook mode.
 _webhook_registered: bool = False
@@ -715,8 +713,15 @@ def _verify_github_signature(secret: str, body: bytes, signature: str) -> bool:
 
 
 async def _handle_health(request: web.Request) -> web.Response:
-    """Return liveness plus the non-sensitive memory feature mode."""
-    return web.json_response({"status": "ok", "memory_enabled": memory.is_enabled()})
+    """Return liveness plus non-sensitive core component readiness."""
+    response: dict[str, object] = {
+        "status": "ok",
+        "memory_enabled": memory.is_enabled(),
+    }
+    host = request.app.get(CORE_HOST_KEY)
+    if host is not None:
+        response["core"] = host.readiness.as_dict()
+    return web.json_response(response)
 
 
 async def _handle_telegram_update(request: web.Request) -> web.Response:
@@ -2498,11 +2503,11 @@ def _register_routes(app: web.Application, config: Config) -> None:
 
 async def _register_workshop_client_api(
     app: web.Application,
-    database: Path,
+    store: WorkshopEventStore,
     *,
     command_submitter: WorkshopClientCommandSubmitter | None = None,
 ) -> Callable[[web.Application], None]:
-    """Open one client-state connection and return its route registrar.
+    """Register the client API against the core-owned canonical store.
 
     The returned registrar deliberately contains only the Workshop browser
     shell and authenticated client API.  It can therefore be applied to the
@@ -2511,52 +2516,49 @@ async def _register_workshop_client_api(
     Shared locks and rate limiters keep both listeners inside one security
     boundary rather than giving each listener an independent allowance.
     """
-    global _workshop_client_store
-    if _workshop_client_store is not None:
-        raise RuntimeError("Workshop client API store is already open")
+    request_lock = asyncio.Lock()
+    sessions_manager = WorkshopClientSessionManager(store)
+    enrollment_manager = WorkshopClientEnrollmentManager(store)
+    authenticator = WorkshopBearerSessionAuthenticator(sessions_manager)
+    enrollment_rate_limiter = WorkshopEnrollmentRateLimiter()
+    event_stream_limiter = WorkshopEventStreamLimiter()
 
-    store = await WorkshopEventStore.open(database)
-    try:
-        request_lock = asyncio.Lock()
-        sessions_manager = WorkshopClientSessionManager(store)
-        enrollment_manager = WorkshopClientEnrollmentManager(store)
-        authenticator = WorkshopBearerSessionAuthenticator(sessions_manager)
-        enrollment_rate_limiter = WorkshopEnrollmentRateLimiter()
-        event_stream_limiter = WorkshopEventStreamLimiter()
-
-        def register(target: web.Application) -> None:
-            register_workshop_enrollment_routes(
-                target,
-                enrollment_manager=enrollment_manager,
-                rate_limiter=enrollment_rate_limiter,
-                request_lock=request_lock,
-            )
-            register_workshop_read_routes(
+    def register(target: web.Application) -> None:
+        register_workshop_enrollment_routes(
+            target,
+            enrollment_manager=enrollment_manager,
+            rate_limiter=enrollment_rate_limiter,
+            request_lock=request_lock,
+        )
+        register_workshop_read_routes(
+            target,
+            store=store,
+            authenticator=authenticator,
+            request_lock=request_lock,
+            event_stream_limiter=event_stream_limiter,
+        )
+        if command_submitter is not None:
+            register_workshop_command_routes(
                 target,
                 store=store,
                 authenticator=authenticator,
+                submitter=command_submitter,
                 request_lock=request_lock,
-                event_stream_limiter=event_stream_limiter,
             )
-            if command_submitter is not None:
-                register_workshop_command_routes(
-                    target,
-                    store=store,
-                    authenticator=authenticator,
-                    submitter=command_submitter,
-                    request_lock=request_lock,
-                )
-            register_workshop_shell_routes(target)
+        register_workshop_shell_routes(target)
 
-        register(app)
-    except Exception:
-        await store.close()
-        raise
-    _workshop_client_store = store
+    register(app)
     return register
 
 
-async def start(telegram_app, config) -> None:
+async def start(
+    telegram_app: Application,
+    config: Config,
+    *,
+    core_host: KaiApplicationHost,
+    core_services: KaiCoreServices,
+    github_notifications: WorkshopTelegramNotificationService,
+) -> None:
     """
     Start the HTTP server and optionally register the Telegram webhook.
 
@@ -2571,15 +2573,18 @@ async def start(telegram_app, config) -> None:
     Args:
         telegram_app: The python-telegram-bot Application instance.
         config: The application Config instance.
+        core_host: Core lifecycle owner used for health/readiness reporting.
+        core_services: Typed core dependencies required by HTTP routes.
+        github_notifications: Telegram adapter for the configured notification feed.
     """
     global _app, _runner, _workshop_lan_runner, _webhook_registered, _health_monitor_task
-    global _workshop_client_command_executor
 
     _app = web.Application()
+    _app[CORE_HOST_KEY] = core_host
     _app[TELEGRAM_APP_KEY] = telegram_app
     _app[TELEGRAM_BOT_KEY] = telegram_app.bot
 
-    pool = telegram_app.bot_data.get("pool")
+    pool = core_services.subprocess_pool
     internal_api_auth = getattr(pool, "internal_api_auth", None)
     if not isinstance(internal_api_auth, InternalAPIAuth):
         raise RuntimeError("Subprocess pool did not provide an internal API credential store")
@@ -2650,30 +2655,12 @@ async def start(telegram_app, config) -> None:
                     val,
                 )
     _register_routes(_app, config)
-    private_text_execution = telegram_app.bot_data.get("workshop_private_text_execution")
-    if private_text_execution is None:
-        raise RuntimeError("Workshop private-text execution service is unavailable")
-    workshop_runtime_pool = telegram_app.bot_data.get("workshop_runtime_pool")
-    if workshop_runtime_pool is None:
-        raise RuntimeError("Workshop runtime pool is unavailable")
-    principal_storage = telegram_app.bot_data.get("workshop_principal_storage")
-    if not isinstance(principal_storage, WorkshopPrincipalStorageRegistry):
-        raise RuntimeError("Workshop principal storage registry is unavailable")
-    _app[WORKSHOP_PRINCIPAL_STORAGE_KEY] = principal_storage
-    github_notifications = telegram_app.bot_data.get("workshop_github_notifications")
-    if not isinstance(github_notifications, WorkshopTelegramNotificationService):
-        raise RuntimeError("Workshop GitHub notification service is unavailable")
+    _app[WORKSHOP_PRINCIPAL_STORAGE_KEY] = core_services.principal_storage
     _app[WORKSHOP_GITHUB_NOTIFICATIONS_KEY] = github_notifications
-    client_command_executor = WorkshopClientCommandExecutor(
-        private_text_execution,
-        WorkshopCompatibilityStateWriter(config, workshop_runtime_pool),
-    )
-    await client_command_executor.start()
-    _workshop_client_command_executor = client_command_executor
     register_workshop_routes = await _register_workshop_client_api(
         _app,
-        Path(config.session_db_path),
-        command_submitter=client_command_executor,
+        core_services.client_store,
+        command_submitter=core_services.client_commands,
     )
 
     _runner = web.AppRunner(_app, access_log=None)
@@ -2768,7 +2755,6 @@ async def stop() -> None:
     stale webhook on the next set_webhook call at startup.
     """
     global _app, _runner, _workshop_lan_runner, _webhook_registered, _health_monitor_task
-    global _workshop_client_store, _workshop_client_command_executor
     # Cancel the webhook health monitor before tearing down the server
     if _health_monitor_task is not None:
         _health_monitor_task.cancel()
@@ -2800,12 +2786,6 @@ async def stop() -> None:
         _workshop_lan_runner = None
         _runner = None
         _app = None
-        if _workshop_client_command_executor is not None:
-            await _workshop_client_command_executor.stop()
-            _workshop_client_command_executor = None
-        if _workshop_client_store is not None:
-            await _workshop_client_store.close()
-            _workshop_client_store = None
 
 
 def is_running() -> bool:

--- a/src/kai/workshop/telegram_delivery_runtime.py
+++ b/src/kai/workshop/telegram_delivery_runtime.py
@@ -17,6 +17,7 @@ from kai.workshop.delivery_outbox import (
     DeliveryRecoveryResult,
     WorkshopDeliveryOutbox,
 )
+from kai.workshop.domain import DeliveryAuthorityEpochId
 from kai.workshop.github_notifications import (
     GitHubNotification,
     GitHubNotificationRecord,
@@ -221,7 +222,7 @@ class WorkshopTelegramDeliveryRuntime:
 
 
 class WorkshopTelegramConversationDeliveryService:
-    """Own the active authority epoch, dedicated store, and worker runtime."""
+    """Own dedicated Telegram stores and workers for one core-owned epoch."""
 
     def __init__(
         self,
@@ -242,15 +243,18 @@ class WorkshopTelegramConversationDeliveryService:
         database_path: Path,
         bot: Bot,
         *,
+        authority_epoch_id: DeliveryAuthorityEpochId,
         worker_id: str = "kai-telegram-conversation-finalization",
     ) -> WorkshopTelegramConversationDeliveryService:
-        """Activate authority and recover work before returning ready."""
+        """Validate core authority and recover Telegram work before ready."""
         store = await WorkshopEventStore.open(database_path)
         client_store: WorkshopEventStore | None = None
         client_runtime: WorkshopTelegramDeliveryRuntime | None = None
         try:
             client_store = await WorkshopEventStore.open(database_path)
-            epoch = (await WorkshopConversationDeliveryAuthority(store).activate()).epoch
+            epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch()
+            if epoch.epoch_id != authority_epoch_id:
+                raise RuntimeError("Telegram delivery epoch does not match core authority")
             outbox = WorkshopDeliveryOutbox(store)
             fragments = WorkshopDeliveryFragments(store)
             client_worker = WorkshopTelegramDeliveryWorker(

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -1,0 +1,360 @@
+"""Transport-neutral construction and lifecycle tests for Kai's core host."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import kai.application_host as host_module
+from kai.application_host import KaiApplicationHost, KaiApplicationState
+from kai.config import Config
+from kai.workshop.bootstrap import (
+    BootstrapHuman,
+    bootstrap_default_workshop,
+    bootstrap_human_principal_id,
+)
+from kai.workshop.conversation_commands import WorkshopConversationCommandService
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.domain import PrincipalId, RunExecutionOwnerId
+from kai.workshop.inbound import InboundMessage
+from kai.workshop.run_execution_authority import (
+    RunAttemptStatus,
+    RunExecutionSelection,
+    WorkshopRunExecutionAuthority,
+)
+from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
+from kai.workshop.storage_namespaces import (
+    WorkshopPrincipalStorageNamespace,
+    WorkshopPrincipalStorageRegistry,
+)
+from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
+
+
+class _FakePool:
+    def __init__(self, *, events: list[str], **_kwargs) -> None:
+        self.events = events
+
+    def start(self) -> None:
+        self.events.append("pool:start")
+
+    async def shutdown(self) -> None:
+        self.events.append("pool:stop")
+
+
+class _FakeExecution:
+    ready = True
+
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def wait(self) -> None:
+        self.events.append("execution:wait")
+
+    async def stop(self) -> None:
+        self.events.append("execution:stop")
+
+
+class _FakeExecutionFactory:
+    events: list[str]
+
+    @classmethod
+    async def open_and_start(cls, *_args, **_kwargs):
+        cls.events.append("execution:start")
+        return _FakeExecution(cls.events)
+
+
+class _FakeDeliveryAuthority:
+    def __init__(self, _store) -> None:
+        self.events = _FakeExecutionFactory.events
+
+    async def activate(self):
+        self.events.append("authority:activate")
+        return SimpleNamespace(epoch=SimpleNamespace(epoch_id="dae_" + "1" * 32))
+
+
+class _FakeStore:
+    events: list[str]
+
+    @classmethod
+    async def open(cls, _path: Path):
+        cls.events.append("store:open")
+        return cls(cls.events)
+
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def close(self) -> None:
+        self.events.append("store:close")
+
+
+class _FakeClientCommands:
+    ready = False
+
+    def __init__(self, _execution, _compatibility) -> None:
+        self.events = _FakeExecutionFactory.events
+
+    async def start(self) -> None:
+        self.events.append("client:start")
+        self.ready = True
+
+    async def stop(self) -> None:
+        self.events.append("client:stop")
+        self.ready = False
+
+
+@pytest.fixture
+def host_dependencies(monkeypatch):
+    events: list[str] = []
+    _FakeExecutionFactory.events = events
+    _FakeStore.events = events
+    monkeypatch.setattr(
+        host_module,
+        "SubprocessPool",
+        lambda **kwargs: _FakePool(events=events, **kwargs),
+    )
+    monkeypatch.setattr(host_module, "WorkshopRuntimePool", lambda pool, profiles: (pool, profiles))
+    monkeypatch.setattr(host_module, "WorkshopConversationRunService", lambda pool, resolver: (pool, resolver))
+    monkeypatch.setattr(host_module, "WorkshopPrivateTextExecutionService", _FakeExecutionFactory)
+    monkeypatch.setattr(host_module, "WorkshopEventStore", _FakeStore)
+    monkeypatch.setattr(host_module, "WorkshopConversationDeliveryAuthority", _FakeDeliveryAuthority)
+    monkeypatch.setattr(host_module, "WorkshopClientCommandExecutor", _FakeClientCommands)
+    monkeypatch.setattr(host_module, "WorkshopCompatibilityStateWriter", lambda config, pool: (config, pool))
+    return events
+
+
+def _host() -> KaiApplicationHost:
+    return KaiApplicationHost(
+        config=SimpleNamespace(session_db_path=Path("/tmp/kai-test.db")),  # type: ignore[arg-type]
+        runtime_profiles=SimpleNamespace(),  # type: ignore[arg-type]
+        principal_storage=SimpleNamespace(),  # type: ignore[arg-type]
+        services_info=[],
+        registered_backend_ids=frozenset({"codex"}),
+    )
+
+
+async def test_core_starts_and_stops_without_a_telegram_application(host_dependencies) -> None:
+    host = _host()
+
+    services = await host.start()
+
+    assert host.readiness.ready is True
+    assert host.readiness.as_dict() == {
+        "status": "ready",
+        "ready": True,
+        "components": {
+            "runtime": True,
+            "executor": True,
+            "client_api": True,
+            "store": True,
+        },
+    }
+    assert services.subprocess_pool is not None
+    assert host_dependencies == [
+        "pool:start",
+        "store:open",
+        "authority:activate",
+        "execution:start",
+        "client:start",
+    ]
+
+    await host.wait()
+    await host.stop()
+
+    assert host.readiness.state == KaiApplicationState.STOPPED
+    assert host.readiness.ready is False
+    assert host_dependencies[-5:] == [
+        "execution:wait",
+        "client:stop",
+        "store:close",
+        "execution:stop",
+        "pool:stop",
+    ]
+
+
+def test_core_host_module_has_no_telegram_dependency() -> None:
+    source = Path(host_module.__file__).read_text(encoding="utf-8")
+
+    assert "from telegram" not in source
+    assert "import telegram" not in source
+
+
+async def test_core_rejects_double_start(host_dependencies) -> None:
+    host = _host()
+    await host.start()
+
+    with pytest.raises(RuntimeError, match="cannot start from ready"):
+        await host.start()
+
+    await host.stop()
+
+
+async def test_real_core_lifecycle_uses_workshop_identity_without_telegram_application(tmp_path) -> None:
+    database = tmp_path / "kai.db"
+    profiles = profile_registry(101)
+    store = await WorkshopEventStore.open(database)
+    try:
+        bootstrap = await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    display_name="Browser Human",
+                    role="admin",
+                    transport="workshop",
+                    external_subject="browser-human",
+                    external_channel_id="browser-direct",
+                    runtime_profile_id=profile_id(101),
+                ),
+            ),
+        )
+        principal_id = bootstrap_human_principal_id(
+            bootstrap.workshop_id,
+            "workshop",
+            "browser-human",
+        )
+    finally:
+        await store.close()
+
+    config = Config(
+        telegram_bot_token="unused-by-core-host",
+        allowed_user_ids=set(),
+        session_db_path=database,
+        agent_idle_timeout=0,
+        default_backend="codex",
+        default_model="gpt-5.6-sol",
+    )
+    principal_storage = WorkshopPrincipalStorageRegistry(
+        (
+            WorkshopPrincipalStorageNamespace(
+                PrincipalId(str(principal_id)),
+                profile_id(101),
+                101,
+            ),
+        )
+    )
+    host = KaiApplicationHost(
+        config=config,
+        runtime_profiles=profiles,
+        principal_storage=principal_storage,
+        services_info=[],
+        registered_backend_ids=frozenset({"codex"}),
+    )
+
+    services = await host.start()
+    try:
+        assert host.readiness.ready is True
+        assert services.runtime_pool.runtime_profile(profile_id(101)).backend == "codex"
+        assert services.client_commands.ready is True
+        assert services.private_text_execution.ready is True
+    finally:
+        await host.stop()
+
+    assert host.readiness.state == KaiApplicationState.STOPPED
+
+
+async def test_core_activates_delivery_authority_before_recovering_expired_started_run(tmp_path) -> None:
+    database = tmp_path / "kai.db"
+    profiles = profile_registry(101)
+    store = await WorkshopEventStore.open(database)
+    now = datetime.now(UTC)
+    try:
+        bootstrap = await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    display_name="Browser Human",
+                    role="admin",
+                    transport="telegram",
+                    external_subject="101",
+                    external_channel_id="101",
+                    runtime_profile_id=profile_id(101),
+                ),
+            ),
+        )
+        principal_id = bootstrap_human_principal_id(
+            bootstrap.workshop_id,
+            "telegram",
+            "101",
+        )
+        accepted = await WorkshopConversationCommandService(store).accept(
+            InboundMessage(
+                transport="telegram",
+                update_id="expired-run-command",
+                message_id="expired-run-message",
+                sender_subject="101",
+                channel_subject="101",
+                body="Recover me after restart",
+                occurred_at=now - timedelta(minutes=10),
+            )
+        )
+        delivery_authority = WorkshopConversationDeliveryAuthority(store)
+        old_epoch = (await delivery_authority.activate()).epoch
+        await delivery_authority.deactivate()
+
+        selection = RunExecutionSelection("codex", "gpt-5.6-sol", "openai")
+        run_authority = WorkshopRunExecutionAuthority(
+            store,
+            selection_resolver=lambda _run: selection,
+            registered_backend_ids=frozenset({"codex"}),
+        )
+        granted = await run_authority.grant(
+            accepted.run.run_id,
+            owner_id=RunExecutionOwnerId.new(),
+            occurred_at=now - timedelta(minutes=9),
+            lease_expires_at=now - timedelta(minutes=8),
+        )
+        await run_authority.start(
+            granted.claim,
+            occurred_at=now - timedelta(minutes=8, seconds=30),
+        )
+    finally:
+        await store.close()
+
+    host = KaiApplicationHost(
+        config=Config(
+            telegram_bot_token="unused-by-core-host",
+            allowed_user_ids=set(),
+            session_db_path=database,
+            agent_idle_timeout=0,
+            default_backend="codex",
+            default_model="gpt-5.6-sol",
+        ),
+        runtime_profiles=profiles,
+        principal_storage=WorkshopPrincipalStorageRegistry(
+            (
+                WorkshopPrincipalStorageNamespace(
+                    PrincipalId(str(principal_id)),
+                    profile_id(101),
+                    101,
+                ),
+            )
+        ),
+        services_info=[],
+        registered_backend_ids=frozenset({"codex"}),
+    )
+
+    services = await host.start()
+    try:
+        assert services.delivery_authority_epoch.epoch_id != old_epoch.epoch_id
+        inspection = services.client_store
+        recovered_run = await WorkshopRunLifecycle(inspection).state(accepted.run.run_id)
+        recovered_attempt = await WorkshopRunExecutionAuthority(
+            inspection,
+            selection_resolver=lambda _run: selection,
+            registered_backend_ids=frozenset({"codex"}),
+        ).attempt(granted.claim.attempt_id)
+        assert recovered_run.status == RunStatus.FAILED
+        assert recovered_attempt is not None
+        assert recovered_attempt.status == RunAttemptStatus.INTERRUPTED
+        async with inspection.connection.execute(
+            "SELECT d.authority_epoch_id FROM delivery_outbox d "
+            "JOIN messages m ON m.id = d.message_id "
+            "WHERE m.reply_to_message_id = ?",
+            (recovered_run.inbound_message_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        assert str(row[0]) == str(services.delivery_authority_epoch.epoch_id)
+    finally:
+        await host.stop()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -13,6 +13,7 @@ import logging
 import stat
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
@@ -669,6 +670,39 @@ class TestIsWorkspaceAllowed:
 # ── create_bot transport mode ──────────────────────────────────────
 
 
+def _bot_core_services(config):
+    """Build unstarted typed core dependencies for Telegram factory tests."""
+    from kai import services
+    from kai.pool import SubprocessPool
+
+    profiles = profile_registry(1)
+    pool = SubprocessPool(
+        config=config,
+        services_info=services.get_available_services(),
+        runtime_profiles=profiles,
+    )
+    runtime_pool = WorkshopRuntimePool(pool, profiles)
+    principal_storage = WorkshopPrincipalStorageRegistry(
+        (
+            WorkshopPrincipalStorageNamespace(
+                PrincipalId("prn_" + "1" * 32),
+                profile_id(1),
+                1,
+            ),
+        )
+    )
+    return SimpleNamespace(
+        subprocess_pool=pool,
+        runtime_pool=runtime_pool,
+        conversation_runs=WorkshopConversationRunService(
+            runtime_pool,
+            sessions.resolve_workshop_conversation_run,
+        ),
+        private_text_execution=MagicMock(),
+        principal_storage=principal_storage,
+    )
+
+
 class TestCreateBotTransportMode:
     @pytest.fixture(autouse=True)
     def _init_services(self, tmp_path):
@@ -685,17 +719,18 @@ class TestCreateBotTransportMode:
     def test_webhook_mode_suppresses_updater(self):
         """In webhook mode, the Updater is suppressed (None)."""
         config = _make_config()
-        app = create_bot(config, use_webhook=True, runtime_profiles=profile_registry(1))
+        app = create_bot(config, use_webhook=True, core_services=_bot_core_services(config))
         assert app.updater is None
 
     def test_polling_mode_keeps_updater(self):
         """In polling mode, the Updater is present for start_polling()."""
         config = _make_config()
-        app = create_bot(config, use_webhook=False, runtime_profiles=profile_registry(1))
+        app = create_bot(config, use_webhook=False, core_services=_bot_core_services(config))
         assert app.updater is not None
 
     def test_installs_workshop_shadow_recorder(self):
-        app = create_bot(_make_config(), runtime_profiles=profile_registry(1))
+        config = _make_config()
+        app = create_bot(config, core_services=_bot_core_services(config))
 
         assert app.bot_data["workshop_inbound_recorder"] is sessions.record_workshop_inbound_message
         assert app.bot_data["workshop_artifact_recorder"] is sessions.record_workshop_inbound_artifact
@@ -707,7 +742,8 @@ class TestCreateBotTransportMode:
         assert isinstance(app.bot_data["workshop_conversation_run_service"], WorkshopConversationRunService)
 
     def test_does_not_register_durable_run_lifecycle_before_cutover(self):
-        app = create_bot(_make_config(), runtime_profiles=profile_registry(1))
+        config = _make_config()
+        app = create_bot(config, core_services=_bot_core_services(config))
 
         # The durable lifecycle remains deliberately unregistered until the
         # run-authority cutover gates in the Workshop map are satisfied.
@@ -6752,7 +6788,7 @@ class TestCommandMenu:
         from telegram.ext import CommandHandler as CH
 
         config = _make_config()
-        app = create_bot(config, runtime_profiles=profile_registry(1))
+        app = create_bot(config, core_services=_bot_core_services(config))
 
         # Collect all command names from registered CommandHandlers
         registered: set[str] = set()
@@ -6768,7 +6804,8 @@ class TestCommandMenu:
         """Every command except the narrow recovery set defaults to TOTP."""
         from telegram.ext import CommandHandler as CH
 
-        app = create_bot(_make_config(), runtime_profiles=profile_registry(1))
+        config = _make_config()
+        app = create_bot(config, core_services=_bot_core_services(config))
         callbacks: dict[str, object] = {}
         for group_handlers in app.handlers.values():
             for handler in group_handlers:
@@ -6787,7 +6824,8 @@ class TestCommandMenu:
         """Model, voice, workspace, and memory buttons cannot bypass TOTP."""
         from telegram.ext import CallbackQueryHandler as CQH
 
-        app = create_bot(_make_config(), runtime_profiles=profile_registry(1))
+        config = _make_config()
+        app = create_bot(config, core_services=_bot_core_services(config))
         callbacks = [
             handler.callback
             for group_handlers in app.handlers.values()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -5,6 +5,7 @@ import dataclasses
 import hashlib
 import hmac
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -52,6 +53,7 @@ from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageNamespace,
     WorkshopPrincipalStorageRegistry,
 )
+from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery_runtime import WorkshopTelegramNotificationService
 from tests.workshop_profiles import profile_id
 
@@ -2527,13 +2529,14 @@ class TestNotificationChatIdMutations:
         private_execution.recoverable_client_runs = AsyncMock(return_value=())
         telegram_app = MagicMock()
         telegram_app.bot = AsyncMock()
-        telegram_app.bot_data = {
-            "pool": MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
-            "workshop_private_text_execution": private_execution,
-            "workshop_runtime_pool": MagicMock(),
-            "workshop_principal_storage": _principal_storage_registry(),
-            "workshop_github_notifications": MagicMock(spec=WorkshopTelegramNotificationService),
-        }
+        core_services = SimpleNamespace(
+            subprocess_pool=MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
+            principal_storage=_principal_storage_registry(),
+            client_store=MagicMock(),
+            client_commands=MagicMock(),
+        )
+        core_host = MagicMock()
+        github_notifications = MagicMock(spec=WorkshopTelegramNotificationService)
 
         fake_runner = MagicMock()
         fake_runner.setup = AsyncMock()
@@ -2550,7 +2553,13 @@ class TestNotificationChatIdMutations:
                 patch("kai.webhook.web.AppRunner", return_value=fake_runner),
                 patch("kai.webhook.web.TCPSite", return_value=fake_site),
             ):
-                await wh.start(telegram_app, config)
+                await wh.start(
+                    telegram_app,
+                    config,
+                    core_host=core_host,
+                    core_services=core_services,
+                    github_notifications=github_notifications,
+                )
 
             assert wh._app[ALLOWED_USER_IDS_KEY] == {111}
             assert wh._app[NOTIFICATION_CHAT_IDS_KEY] == {-100111, -100222}
@@ -2590,13 +2599,15 @@ class TestNotificationChatIdMutations:
         private_execution.recoverable_client_runs = AsyncMock(return_value=())
         telegram_app = MagicMock()
         telegram_app.bot = AsyncMock()
-        telegram_app.bot_data = {
-            "pool": MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
-            "workshop_private_text_execution": private_execution,
-            "workshop_runtime_pool": MagicMock(),
-            "workshop_principal_storage": _principal_storage_registry(),
-            "workshop_github_notifications": MagicMock(spec=WorkshopTelegramNotificationService),
-        }
+        core_store = await WorkshopEventStore.open(config.session_db_path)
+        core_services = SimpleNamespace(
+            subprocess_pool=MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
+            principal_storage=_principal_storage_registry(),
+            client_store=core_store,
+            client_commands=MagicMock(),
+        )
+        core_host = MagicMock()
+        github_notifications = MagicMock(spec=WorkshopTelegramNotificationService)
 
         apps: list[web.Application] = []
         runners: list[MagicMock] = []
@@ -2620,7 +2631,13 @@ class TestNotificationChatIdMutations:
         monkeypatch.setattr("kai.webhook.web.TCPSite", fake_site)
         monkeypatch.setattr("kai.webhook.sessions.get_setting", AsyncMock(return_value=None))
 
-        await wh.start(telegram_app, config)
+        await wh.start(
+            telegram_app,
+            config,
+            core_host=core_host,
+            core_services=core_services,
+            github_notifications=github_notifications,
+        )
         try:
             assert [(host, port) for _, host, port in sites] == [
                 ("127.0.0.1", 8080),
@@ -2645,6 +2662,7 @@ class TestNotificationChatIdMutations:
             assert not any(path.startswith("/webhook") for path in lan_paths)
         finally:
             await wh.stop()
+            await core_store.close()
 
     def test_add_notification_chat_id(self):
         """add_notification_chat_id adds a chat_id to the outbound registry."""

--- a/tests/test_webhook_routes.py
+++ b/tests/test_webhook_routes.py
@@ -1,11 +1,12 @@
 """Route-registration tests for separated external and internal credentials."""
 
 import json
+from types import SimpleNamespace
 
 from aiohttp import web
 
 from kai.config import Config
-from kai.webhook import _handle_health, _register_routes
+from kai.webhook import CORE_HOST_KEY, _handle_health, _register_routes
 
 
 def _config(**overrides: object) -> Config:
@@ -69,6 +70,33 @@ def test_telegram_route_is_independent_of_other_webhooks() -> None:
 async def test_health_reports_non_sensitive_memory_mode(monkeypatch) -> None:
     monkeypatch.setattr("kai.webhook.memory.is_enabled", lambda: True)
 
-    response = await _handle_health(None)  # type: ignore[arg-type]
+    request = SimpleNamespace(app=web.Application())
+    response = await _handle_health(request)  # type: ignore[arg-type]
 
     assert json.loads(response.body) == {"status": "ok", "memory_enabled": True}
+
+
+async def test_health_reports_typed_core_component_readiness(monkeypatch) -> None:
+    monkeypatch.setattr("kai.webhook.memory.is_enabled", lambda: False)
+    app = web.Application()
+    app[CORE_HOST_KEY] = SimpleNamespace(
+        readiness=SimpleNamespace(
+            as_dict=lambda: {
+                "status": "ready",
+                "ready": True,
+                "components": {"runtime": True, "executor": True},
+            }
+        )
+    )
+
+    response = await _handle_health(SimpleNamespace(app=app))  # type: ignore[arg-type]
+
+    assert json.loads(response.body) == {
+        "status": "ok",
+        "memory_enabled": False,
+        "core": {
+            "status": "ready",
+            "ready": True,
+            "components": {"runtime": True, "executor": True},
+        },
+    }

--- a/tests/test_workshop_client_access.py
+++ b/tests/test_workshop_client_access.py
@@ -327,11 +327,10 @@ class TestWorkshopClientProductionRegistration:
     async def test_runtime_wires_operator_grant_to_authenticated_timeline_read(self, tmp_path: Path):
         database = tmp_path / "kai.db"
         store = await _store(database)
-        await store.close()
         app = web.Application()
         client: TestClient | None = None
         try:
-            await webhook._register_workshop_client_api(app, database)
+            await webhook._register_workshop_client_api(app, store)
             routes = {(route.method, route.resource.canonical) for route in app.router.routes()}
 
             assert ("POST", "/v1/client/enrollment/redeem") in routes
@@ -381,4 +380,4 @@ class TestWorkshopClientProductionRegistration:
         finally:
             if client is not None:
                 await client.close()
-            await webhook.stop()
+            await store.close()

--- a/tests/test_workshop_direct_text_cutover.py
+++ b/tests/test_workshop_direct_text_cutover.py
@@ -10,9 +10,11 @@ from unittest.mock import AsyncMock
 
 from kai import sessions
 from kai.workshop.bootstrap import BootstrapHuman
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.domain import MessageId
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import OutboundMessage
+from kai.workshop.store import WorkshopEventStore
 from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
 from kai.workshop.telegram_delivery_runtime import WorkshopTelegramConversationDeliveryService
 
@@ -41,7 +43,16 @@ async def test_shared_finalizer_and_dedicated_worker_finalize_one_preview_withou
 
         bot = AsyncMock()
         bot.edit_message_text.return_value = SimpleNamespace(message_id=7001)
-        service = await WorkshopTelegramConversationDeliveryService.open_and_start(database, bot)
+        authority_store = await WorkshopEventStore.open(database)
+        try:
+            epoch = (await WorkshopConversationDeliveryAuthority(authority_store).activate()).epoch
+        finally:
+            await authority_store.close()
+        service = await WorkshopTelegramConversationDeliveryService.open_and_start(
+            database,
+            bot,
+            authority_epoch_id=epoch.epoch_id,
+        )
         await sessions.record_workshop_streaming_preview(
             ConfirmedTelegramStreamingPreview(
                 inbound_message_id=inbound_id,

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -152,8 +152,10 @@ class TestProtectedExecutionPreparation:
     def test_service_is_registered_only_through_private_text_runtime_owner(self):
         source_root = Path(__file__).parents[1] / "src" / "kai"
         main_source = (source_root / "main.py").read_text(encoding="utf-8")
+        host_source = (source_root / "application_host.py").read_text(encoding="utf-8")
         owner_source = (source_root / "workshop" / "private_text_execution.py").read_text(encoding="utf-8")
-        assert "WorkshopPrivateTextExecutionService.open_and_start" in main_source
+        assert "WorkshopPrivateTextExecutionService.open_and_start" in host_source
+        assert "WorkshopPrivateTextExecutionService.open_and_start" not in main_source
         assert "WorkshopProtectedExecutionPreparationService" in owner_source
         assert "WorkshopProtectedExecutionPreparationService" not in (source_root / "bot.py").read_text(
             encoding="utf-8"

--- a/tests/test_workshop_telegram_delivery_runtime.py
+++ b/tests/test_workshop_telegram_delivery_runtime.py
@@ -215,18 +215,31 @@ async def test_recovery_failure_prevents_readiness_and_worker_creation():
     assert runtime.state == TelegramDeliveryRuntimeState.STOPPED
 
 
-async def test_conversation_service_activates_once_and_reuses_epoch_after_restart(tmp_path: Path):
+async def test_conversation_service_uses_core_epoch_after_restart(tmp_path: Path):
     database = tmp_path / "kai.db"
     bot = AsyncMock()
+    authority_store = await WorkshopEventStore.open(database)
+    try:
+        core_epoch = (await WorkshopConversationDeliveryAuthority(authority_store).activate()).epoch
+    finally:
+        await authority_store.close()
 
-    first_service = await WorkshopTelegramConversationDeliveryService.open_and_start(database, bot)
+    first_service = await WorkshopTelegramConversationDeliveryService.open_and_start(
+        database,
+        bot,
+        authority_epoch_id=core_epoch.epoch_id,
+    )
     assert first_service.ready
     observer = await WorkshopEventStore.open(database)
     first_epoch = await WorkshopConversationDeliveryAuthority(observer).active_epoch()
     await observer.close()
     await first_service.stop()
 
-    second_service = await WorkshopTelegramConversationDeliveryService.open_and_start(database, bot)
+    second_service = await WorkshopTelegramConversationDeliveryService.open_and_start(
+        database,
+        bot,
+        authority_epoch_id=core_epoch.epoch_id,
+    )
     assert second_service.ready
     observer = await WorkshopEventStore.open(database)
     second_epoch = await WorkshopConversationDeliveryAuthority(observer).active_epoch()
@@ -234,6 +247,24 @@ async def test_conversation_service_activates_once_and_reuses_epoch_after_restar
     await second_service.stop()
 
     assert second_epoch.epoch_id == first_epoch.epoch_id
+
+
+async def test_conversation_service_rejects_epoch_other_than_active_core_authority(tmp_path: Path):
+    from kai.workshop.domain import DeliveryAuthorityEpochId
+
+    database = tmp_path / "kai.db"
+    authority_store = await WorkshopEventStore.open(database)
+    try:
+        await WorkshopConversationDeliveryAuthority(authority_store).activate()
+    finally:
+        await authority_store.close()
+
+    with pytest.raises(RuntimeError, match="does not match core authority"):
+        await WorkshopTelegramConversationDeliveryService.open_and_start(
+            database,
+            AsyncMock(),
+            authority_epoch_id=DeliveryAuthorityEpochId.new(),
+        )
 
 
 async def test_notification_service_owns_a_dedicated_ready_worker(tmp_path: Path):


### PR DESCRIPTION
## Summary

Begin Milestone 2 of #917 with a production-used transport-neutral application
host rather than a scaffolding-only abstraction.

- add a typed `KaiApplicationHost` and `KaiCoreServices` boundary that imports
  no Telegram package and owns core construction, startup, supervision,
  readiness, and shutdown
- move the subprocess pool, protected runtime facade, canonical conversation
  run service, durable private-text executor, Workshop browser command executor,
  browser-facing event store, and durable delivery-authority activation under
  that host
- make the Telegram factory consume already-constructed core services instead
  of creating runtime policy and processes
- make the HTTP server receive typed core dependencies directly instead of
  discovering them through Telegram `bot_data`
- remove HTTP ownership of the Workshop command executor and canonical client
  store
- expose non-sensitive core component readiness through `/health`
- preserve the existing Telegram conversation and notification delivery
  workers as adapter-owned lifecycle components

## Architectural effect

Before this change, Telegram constructed the runtime and canonical run service,
while HTTP constructed the browser executor and opened its store. Core
ownership was therefore split across two transports and coupled through
`Application.bot_data`.

After this change, one transport-neutral host owns those live services and both
adapters receive explicit dependencies. A real integration test starts the
core with a Workshop identity and protected runtime without constructing or
mocking a Telegram `Application`.

The core host also resumes or creates the durable conversation-delivery epoch
before interrupted-run recovery begins. Telegram delivery validates and uses
that core-owned epoch rather than activating authority as a transport startup
side effect. A restart regression covers an inactive prior epoch plus an
expired started run and verifies that recovery reaches a correctly fenced
delivery request.

This does not claim Milestone 2 is complete. Existing Telegram handlers still
receive five adapter-local `bot_data` mirrors until their command/media service
dependencies are injected. The transition ledger names those keys and their
removal gate. Scheduler ownership, full adapter readiness/degradation, and
separation of the mixed HTTP/Telegram listener remain subsequent coherent
Milestone 2 cutovers.

## Lifecycle and rollback

Startup now orders core runtime, delivery authority, and durable execution
before adapter ingress. Shutdown stops HTTP ingress and Telegram delivery
first, then the Telegram application, browser commands, the client store,
private execution recovery, and backend processes.

No schema or protected configuration changes are included. Rolling back the
commit restores the prior construction locations without a data migration.

## Compatibility

- Telegram private interaction is unchanged.
- Workshop browser command acceptance, recovery, and output remain on the same
  canonical services.
- Telegram notification-group delivery remains adapter-owned and unchanged.
- Backend command selection continues through the root-owned backend registry
  and protected runtime profiles.
- Claude, Codex, Goose, OpenCode, and Pi continue through the same shared
  subprocess/runtime facade.

## Verification

- repository-wide Ruff lint and formatting checks
- Pyright: 0 errors, 0 warnings
- focused host, delivery-runtime, and direct-text cutover tests: 17 passed
- full suite: 5,748 passed, 1 skipped

Part of #917.
