### PR TITLE
Load cached memory embeddings without Hub requests

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -819,6 +819,30 @@ _config: Config | None = None
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
+def _resolve_cached_embedding_model(model: str) -> tuple[str, bool]:
+    """Prefer an already-cached model snapshot without probing the Hub.
+
+    SentenceTransformer refreshes repository metadata when it receives a Hub
+    model ID, even when every required file is cached. Resolve a complete
+    local snapshot first and pass its filesystem path to Mem0 instead. A cache
+    miss deliberately preserves SentenceTransformer's existing first-run
+    download behavior.
+    """
+    local_path = Path(model).expanduser()
+    if local_path.exists():
+        return str(local_path.resolve()), True
+
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    repo_id = model if "/" in model else f"sentence-transformers/{model}"
+    try:
+        snapshot_path = snapshot_download(repo_id, local_files_only=True)
+    except LocalEntryNotFoundError:
+        return model, False
+    return str(Path(snapshot_path).resolve()), True
+
+
 def _mem0_config(config: Config) -> dict:
     """
     Build Mem0 configuration dict from Kai's config.
@@ -828,13 +852,17 @@ def _mem0_config(config: Config) -> dict:
     """
     qdrant_path = DATA_DIR / "memory" / "qdrant"
     qdrant_path.mkdir(parents=True, exist_ok=True)
+    embedding_model, local_only = _resolve_cached_embedding_model(config.memory_embedding_model)
+    model_kwargs: dict[str, object] = {"device": "cpu"}
+    if local_only:
+        model_kwargs["local_files_only"] = True
 
     return {
         "embedder": {
             "provider": "huggingface",
             "config": {
-                "model": config.memory_embedding_model,
-                "model_kwargs": {"device": "cpu"},
+                "model": embedding_model,
+                "model_kwargs": model_kwargs,
             },
         },
         "vector_store": {
@@ -1275,8 +1303,9 @@ def init_memory(config: Config) -> None:
     Haiku extraction via `add_structured`.
 
     Creates the Qdrant collection if it does not exist. Downloads the
-    embedding model on first run (~80MB, cached in ~/.cache/huggingface/
-    for subsequent runs).
+    embedding model on first run (~80MB, cached in ~/.cache/huggingface/).
+    Subsequent runs resolve that snapshot locally so model loading does not
+    contact Hugging Face merely to refresh repository metadata.
 
     Mem0 v2.0.0 unconditionally creates an LLM client at init time,
     even though we only use infer=False (no LLM extraction). To satisfy

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -16,8 +16,10 @@ import json
 import logging
 import os
 import re
+import sys
 from dataclasses import replace
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -192,6 +194,95 @@ def real_memory_instance(tmp_path_factory):
 
 
 # ── Unit tests (mocked Mem0, fast) ─────────────────────────────────
+
+
+class TestEmbeddingModelResolution:
+    """Cache-first model loading avoids recurring Hub metadata requests."""
+
+    @staticmethod
+    def _fake_hub(snapshot_download):
+        class LocalEntryNotFoundError(Exception):
+            pass
+
+        hub = ModuleType("huggingface_hub")
+        hub.snapshot_download = snapshot_download
+        errors = ModuleType("huggingface_hub.errors")
+        errors.LocalEntryNotFoundError = LocalEntryNotFoundError
+        return {
+            "huggingface_hub": hub,
+            "huggingface_hub.errors": errors,
+        }, LocalEntryNotFoundError
+
+    def test_existing_local_model_path_never_consults_hub(self, tmp_path):
+        from kai.memory import _resolve_cached_embedding_model
+
+        model_dir = tmp_path / "local-model"
+        model_dir.mkdir()
+        model, local_only = _resolve_cached_embedding_model(str(model_dir))
+
+        assert model == str(model_dir.resolve())
+        assert local_only is True
+
+    def test_cached_hub_snapshot_is_resolved_without_network(self, tmp_path):
+        from kai.memory import _resolve_cached_embedding_model
+
+        snapshot = tmp_path / "cached-snapshot"
+        snapshot.mkdir()
+        download = MagicMock(return_value=str(snapshot))
+        modules, _ = self._fake_hub(download)
+        with patch.dict(sys.modules, modules):
+            model, local_only = _resolve_cached_embedding_model("all-MiniLM-L6-v2")
+
+        assert model == str(snapshot.resolve())
+        assert local_only is True
+        download.assert_called_once_with(
+            "sentence-transformers/all-MiniLM-L6-v2",
+            local_files_only=True,
+        )
+
+    def test_cache_miss_preserves_first_run_download_behavior(self, tmp_path):
+        from kai.memory import _mem0_config, _resolve_cached_embedding_model
+
+        download = MagicMock()
+        modules, local_entry_not_found = self._fake_hub(download)
+        download.side_effect = local_entry_not_found("not cached")
+        with patch.dict(sys.modules, modules):
+            model, local_only = _resolve_cached_embedding_model("all-MiniLM-L6-v2")
+
+        assert model == "all-MiniLM-L6-v2"
+        assert local_only is False
+
+        with (
+            patch("kai.memory.DATA_DIR", tmp_path),
+            patch(
+                "kai.memory._resolve_cached_embedding_model",
+                return_value=(model, local_only),
+            ),
+        ):
+            config = _mem0_config(_make_config())
+
+        assert config["embedder"]["config"] == {
+            "model": "all-MiniLM-L6-v2",
+            "model_kwargs": {"device": "cpu"},
+        }
+
+    def test_cached_config_forces_sentence_transformers_local_only(self, tmp_path):
+        from kai.memory import _mem0_config
+
+        snapshot = tmp_path / "cached-snapshot"
+        with (
+            patch("kai.memory.DATA_DIR", tmp_path),
+            patch(
+                "kai.memory._resolve_cached_embedding_model",
+                return_value=(str(snapshot), True),
+            ),
+        ):
+            config = _mem0_config(_make_config())
+
+        assert config["embedder"]["config"] == {
+            "model": str(snapshot),
+            "model_kwargs": {"device": "cpu", "local_files_only": True},
+        }
 
 
 # Third-party warnings scoped to this class: qdrant-client's local


### PR DESCRIPTION
## Summary

Stop normal Kai restarts from contacting Hugging Face merely to refresh
metadata for an embedding model that is already cached.

- resolve the configured sentence-transformer through Hugging Face's local
  cache lookup before Mem0 constructs its embedder
- pass the resolved snapshot filesystem path with `local_files_only=True`
  when a complete cached snapshot exists
- preserve the existing first-run behavior when the model is not cached, so a
  new installation can still download and populate the model cache
- treat an explicitly configured local model path as local-only without
  consulting the Hub

## Why

Passing `all-MiniLM-L6-v2` to `SentenceTransformer` causes a Hub metadata
request even when all model files are present locally. On the installed Mac
mini this added roughly 23 seconds between memory configuration and model
loading and emitted an unauthenticated-Hub warning during every restart.

Kai now asks `snapshot_download(..., local_files_only=True)` only for cache
resolution. A cache hit becomes an absolute snapshot path, so downstream model
construction has no remote repository to probe. A cache miss returns the
original model identifier and deliberately leaves online first-run download
enabled.

## Compatibility and rollback

- No schema, protected configuration, or model-cache migration is required.
- Existing cached models continue to use the same files.
- Fresh installations retain automatic initial model download behavior.
- Explicit local model directories remain supported.
- Reverting this commit restores the previous metadata-refresh behavior.

## Verification

- focused memory suite: 220 passed
- full suite: 5,752 passed, 1 skipped
- repository-wide Ruff lint and formatting checks
- Pyright: 0 errors, 0 warnings
