### PR TITLE
refactor: establish Telegram adapter lifecycle

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -419,7 +419,7 @@ No entry may use an indefinite condition such as "keep for compatibility." A gen
 | GitHub and generic webhook paths that route directly to Telegram or the pool | Canonical integration commands/events plus delivery/run services | Existing GitHub group notifications, generic callers, deduplication, and secret separation pass end-to-end tests | Remove direct routing while retaining verified webhook adapters and supported external contracts | Planned |
 | Per-chat settings, files, memory references, and project selection | Principal/channel/agent/project-workspace records and artifact metadata | Existing per-user isolation, context assembly, memory provenance, file delivery, and workspace access remain equivalent | Migrate namespaces and remove Telegram-derived ownership from domain storage; retire recorded compatibility `storage_path` values when an authoritative artifact store replaces local per-chat files | Active (new uploads and staged review artifacts use opaque human `PrincipalId` directories; numeric file directories remain read-compatible for existing uploads; settings, history, home, preferences, memory, and workspace compatibility state remain to migrate) |
 | `users.yaml` values that represent mutable application state | Workshop administration and durable policy records | Workshop administration can safely inspect and change the relevant state, and bootstrap/recovery behavior is proven | Retain only protected installation/bootstrap policy; remove duplicated mutable state and precedence rules | Planned |
-| Core services mirrored into Telegram `bot_data` for compatibility handlers | Typed core host plus explicit adapter dependency injection | Core lifecycle tests run without Telegram; HTTP uses direct typed dependencies; each remaining Telegram handler family receives its required service without dictionary lookup; hybrid installed behavior passes | Remove `pool`, `workshop_runtime_pool`, `workshop_conversation_run_service`, `workshop_private_text_execution`, and `workshop_principal_storage` mirrors from `create_bot()` after handler injection is complete | Active (construction, startup, delivery-authority activation, supervision, browser-command executor, client store, readiness, and shutdown are core-owned; existing Telegram handlers temporarily retain adapter-local mirrors) |
+| Core services mirrored into Telegram `bot_data` for compatibility handlers | Typed core host plus explicit adapter dependency injection | Core lifecycle tests run without Telegram; HTTP uses direct typed dependencies; each remaining Telegram handler family receives its required service without dictionary lookup; hybrid installed behavior passes | Remove `pool`, `workshop_runtime_pool`, `workshop_conversation_run_service`, `workshop_private_text_execution`, and `workshop_principal_storage` mirrors from `create_bot()` after handler injection is complete | Implemented; awaiting installed hybrid qualification before closing this ledger row (typed application access now covers ordinary handlers, media, memory commands, and scheduled callbacks; source contains none of the five bot-data mirrors) |
 | One-time `users.yaml` projection into protected `runtime-profiles.yaml`, plus private integer `compatibility_runtime_config_id` values | Independently authored runtime profiles and profile-keyed runtime/state stores | Existing profile IDs and state continuity survive migration; a profile with no Telegram identity can be assigned and executed; installer/status diagnostics pass; all five backends remain equivalent | Remove the migration renderer and `from_config` development projection; remove `compatibility_runtime_config_id`, `for_config_id`, and integer conversion in `WorkshopRuntimePool` after pool and persistent state are profile-keyed | Active (#921; protected fields are independently authoritative after their one-time seed and are no longer compared with `users.yaml`; the explicitly named integer pool/storage bridge and bootstrap-coverage check remain) |
 | Backend-specific execution orchestration embedded in the control plane | Equal Harness Driver contracts and a Runtime Backend boundary | Capability and lifecycle tests cover Claude, Codex, Goose, OpenCode, and Pi without privileging one driver | Delete duplicated process orchestration only after the shared contracts carry the required evidence | Planned |
 | Trusted-host `local_process` execution and its executable-trust warnings | Isolated Workshop workers | Worker identity, filesystem grants, credentials, networking, artifacts, cancellation, upgrade, and recovery are verified for all five harnesses | Retire trusted-host mode or explicitly reclassify it as a supported development mode; remove production mitigations that it alone requires | Planned |
@@ -2046,11 +2046,22 @@ no longer discovers them through Telegram `bot_data`; it also no longer owns
 the browser executor or its canonical store. Telegram conversation and
 notification delivery workers remain adapter-owned, as intended.
 
-Existing Telegram handlers still receive temporary adapter-local service
-mirrors because their command and media orchestration has not yet moved behind
-typed feature services. The retirement ledger names those exact keys and their
-removal gate. This is a bounded compatibility surface, not a second lifecycle
-owner.
+The next Milestone 2 slice introduced an explicit `TelegramAdapter` supervised
+by the core host. It owns Telegram application initialization, command-menu and
+compatibility-scheduler registration, polling ingress, conversation and
+notification delivery workers, readiness, failure propagation, and reverse-
+order cleanup. The HTTP webhook registration remains HTTP-adapter-owned until
+adapter enablement becomes explicit, but the host now supervises the required
+Telegram worker boundary and reports its component readiness separately from
+core readiness.
+
+Telegram callbacks now receive core services through a typed application
+boundary. The subprocess pool, runtime facade, conversation-run service,
+private-text executor, and principal-storage registry are no longer mirrored
+through Telegram `bot_data`; ordinary handlers, memory commands, and scheduled
+callbacks use the same typed boundary. Remaining bot-data recorders are
+separate canonical-shadow transition mechanisms covered by their own ledger
+entry, not core lifecycle dependencies.
 
 ## Canonical notification feed activation
 

--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
+from typing import Protocol
 
 from kai import sessions
 from kai.config import Config
@@ -32,6 +34,25 @@ class KaiApplicationState(StrEnum):
     DRAINING = "draining"
     STOPPED = "stopped"
     FAILED = "failed"
+
+
+class KaiAdapterReadiness(Protocol):
+    """JSON-safe readiness contract for one external adapter."""
+
+    def as_dict(self) -> dict[str, object]: ...
+
+
+class KaiApplicationAdapter(Protocol):
+    """Lifecycle contract for one configured external adapter."""
+
+    @property
+    def readiness(self) -> KaiAdapterReadiness: ...
+
+    async def start(self) -> None: ...
+
+    async def wait(self) -> None: ...
+
+    async def stop(self) -> None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,6 +123,7 @@ class KaiApplicationHost:
         self._registered_backend_ids = registered_backend_ids
         self._state = KaiApplicationState.NEW
         self._services: KaiCoreServices | None = None
+        self._adapters: dict[str, KaiApplicationAdapter] = {}
 
     @property
     def services(self) -> KaiCoreServices:
@@ -120,6 +142,11 @@ class KaiApplicationHost:
             client_api=services is not None and services.client_commands.ready,
             store=services is not None,
         )
+
+    @property
+    def adapter_readiness(self) -> dict[str, object]:
+        """Return non-sensitive readiness reported by attached adapters."""
+        return {name: adapter.readiness.as_dict() for name, adapter in self._adapters.items()}
 
     async def start(self) -> KaiCoreServices:
         if self._state != KaiApplicationState.NEW:
@@ -184,9 +211,31 @@ class KaiApplicationHost:
                 await subprocess_pool.shutdown()
             raise
 
+    async def attach_adapter(self, name: str, adapter: KaiApplicationAdapter) -> None:
+        """Start and supervise an adapter after the core is ready."""
+        if self._state != KaiApplicationState.READY:
+            raise RuntimeError(f"Kai adapter cannot start while core is {self._state.value}")
+        if not name:
+            raise RuntimeError("Kai adapter name cannot be empty")
+        if name in self._adapters:
+            raise RuntimeError(f"Kai adapter {name!r} is already attached")
+        try:
+            await adapter.start()
+        except BaseException:
+            self._state = KaiApplicationState.FAILED
+            try:
+                await adapter.stop()
+            except Exception:
+                pass
+            raise
+        self._adapters[name] = adapter
+
     async def wait(self) -> None:
         """Expose failure of a required supervised core worker."""
-        await self.services.private_text_execution.wait()
+        await asyncio.gather(
+            self.services.private_text_execution.wait(),
+            *(adapter.wait() for adapter in self._adapters.values()),
+        )
 
     async def stop(self) -> None:
         if self._state in {KaiApplicationState.NEW, KaiApplicationState.STOPPED}:
@@ -199,6 +248,12 @@ class KaiApplicationHost:
             return
 
         errors: list[Exception] = []
+        for adapter in reversed(tuple(self._adapters.values())):
+            try:
+                await adapter.stop()
+            except Exception as exc:
+                errors.append(exc)
+        self._adapters.clear()
         for operation in (
             services.client_commands.stop,
             services.client_store.close,

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -84,12 +84,13 @@ from kai.history import LogEntry, log_message
 from kai.locks import get_lock, get_stop_event
 from kai.pool import SubprocessPool
 from kai.sessions import WorkshopFinalizationCommitUncertainError
+from kai.telegram_context import KaiTelegramApplication, get_core_services
 from kai.telegram_utils import chunk_text
 from kai.transcribe import TranscriptionError, transcribe_voice
 from kai.tts import DEFAULT_VOICE, VOICES, TTSError, synthesize_speech
 from kai.workshop.artifacts import InboundArtifact
 from kai.workshop.conversation_commands import ConversationCommandDisposition
-from kai.workshop.conversation_runs import PreparedConversationRun, WorkshopConversationRunService
+from kai.workshop.conversation_runs import PreparedConversationRun
 from kai.workshop.domain import MessageId, PrincipalId, RunId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
@@ -97,16 +98,13 @@ from kai.workshop.execution_coordinator import (
 )
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
-from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
-from kai.workshop.storage_namespaces import (
-    WorkshopPrincipalStorageRegistry,
-    WorkshopStorageNamespaceError,
-)
+from kai.workshop.storage_namespaces import WorkshopStorageNamespaceError
 from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
 from kai.workspace_utils import is_workspace_allowed
 
 _UPLOAD_ROOT_MODE = 0o711
 _UPLOAD_FILE_MODE = 0o600
+
 
 # TOTP is optional for single-user development (requires pip install
 # -e '.[totp]'). A missing extra may disable the gate only when neither
@@ -844,8 +842,13 @@ async def _send_response(update: Update, text: str) -> None:
 
 
 def _get_pool(context: ContextTypes.DEFAULT_TYPE) -> "SubprocessPool":
-    """Retrieve the SubprocessPool from bot_data."""
-    return context.bot_data["pool"]
+    """Retrieve the core-owned pool through the typed adapter boundary."""
+    return _get_core_services(context).subprocess_pool
+
+
+def _get_core_services(context: ContextTypes.DEFAULT_TYPE) -> KaiCoreServices:
+    """Resolve core services without using Telegram's untyped bot_data map."""
+    return get_core_services(context)
 
 
 # ── Basic command handlers ───────────────────────────────────────────
@@ -1618,7 +1621,7 @@ async def handle_stop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     """
     assert update.message is not None
     chat_id = _chat_id(update)
-    execution: WorkshopPrivateTextExecutionService | None = context.bot_data.get("workshop_private_text_execution")
+    execution = _get_core_services(context).private_text_execution
     if execution is not None and chat_id == _user_id(update):
         disposition = await execution.request_cancellation(
             telegram_user_id=_user_id(update),
@@ -3874,9 +3877,7 @@ def _upload_principal_id(
     runtime_config_id: int,
 ) -> PrincipalId:
     """Resolve upload ownership through canonical Workshop identity."""
-    registry = context.bot_data.get("workshop_principal_storage")
-    if not isinstance(registry, WorkshopPrincipalStorageRegistry):
-        raise WorkshopStorageNamespaceError("Workshop principal storage registry is unavailable")
+    registry = _get_core_services(context).principal_storage
     return registry.for_runtime_config_id(runtime_config_id).principal_id
 
 
@@ -4689,7 +4690,7 @@ async def _handle_workshop_private_text(
     """Render streaming previews while Workshop owns execution and final delivery."""
     assert update.message is not None
     source_message = update.message
-    execution: WorkshopPrivateTextExecutionService = context.bot_data["workshop_private_text_execution"]
+    execution = _get_core_services(context).private_text_execution
     config: Config = context.bot_data["config"]
     live_msg = None
     last_edit_time = 0.0
@@ -4802,9 +4803,9 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     workshop_run_id: RunId | None = None
     acceptance_disposition: ConversationCommandDisposition | None = None
     if private_text_activation:
-        execution: WorkshopPrivateTextExecutionService | None = context.bot_data.get("workshop_private_text_execution")
+        execution = _get_core_services(context).private_text_execution
         if execution is None:
-            log.error("Workshop private-text execution service is unavailable; refusing legacy backend fallback")
+            log.error("Workshop private-text execution service is unavailable")
             await _reply_safe(update.message, "Kai's durable execution service is unavailable. Please try again.")
             return
         try:
@@ -4886,7 +4887,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     workshop_run: PreparedConversationRun | None = None
     if chat_id == _user_id(update) and workshop_inbound_message_id is not None:
         delivery_route = ResponseDeliveryRoute.WORKSHOP_PRIVATE_TEXT
-        run_service: WorkshopConversationRunService | None = context.bot_data.get("workshop_conversation_run_service")
+        run_service = _get_core_services(context).conversation_runs
         if run_service is not None:
             try:
                 workshop_run = await run_service.prepare(workshop_inbound_message_id)
@@ -5387,9 +5388,9 @@ def create_bot(
     """
     Build and configure the Telegram Application with all handlers.
 
-    Creates the python-telegram-bot Application, initializes the ClaudeCodeBackend
-    subprocess manager, stores both in bot_data, and registers all command,
-    callback, and message handlers.
+    Creates the python-telegram-bot Application, binds the typed core-service
+    boundary on the application object, and registers all command, callback,
+    and message handlers. Runtime services are never mirrored into bot_data.
 
     concurrent_updates=True is required so /stop can be processed while a
     message handler is blocked waiting on Claude's response.
@@ -5406,7 +5407,15 @@ def create_bot(
     Returns:
         A fully configured Telegram Application ready to be started.
     """
-    builder = Application.builder().token(config.telegram_bot_token).concurrent_updates(True)
+    builder = (
+        Application.builder()
+        .application_class(
+            KaiTelegramApplication,
+            kwargs={"core_services": core_services},
+        )
+        .token(config.telegram_bot_token)
+        .concurrent_updates(True)
+    )
 
     # PTB's ApplicationBuilder creates an Updater by default. In webhook mode,
     # updates arrive via HTTP POST so the Updater is dead weight - suppress it.
@@ -5422,13 +5431,6 @@ def create_bot(
     app.bot_data["workshop_delivery_recorder"] = sessions.record_workshop_delivery_observation
     app.bot_data["workshop_streaming_preview_recorder"] = sessions.record_workshop_streaming_preview
     app.bot_data["workshop_streaming_finalizer"] = sessions.record_workshop_streaming_finalization
-    # Handlers still receive adapter-local mirrors while they migrate to typed
-    # services. Construction and lifecycle belong exclusively to the core host.
-    app.bot_data["pool"] = core_services.subprocess_pool
-    app.bot_data["workshop_runtime_pool"] = core_services.runtime_pool
-    app.bot_data["workshop_conversation_run_service"] = core_services.conversation_runs
-    app.bot_data["workshop_private_text_execution"] = core_services.private_text_execution
-    app.bot_data["workshop_principal_storage"] = core_services.principal_storage
 
     # Default every recognized command to sensitive. `/start` and `/help`
     # disclose no user state and remain available so an authorized operator can

--- a/src/kai/cron.py
+++ b/src/kai/cron.py
@@ -35,6 +35,7 @@ from kai import sessions
 from kai.history import log_message
 from kai.job_types import JOB_TYPE_AGENT, JOB_TYPE_REMINDER, normalize_job_type
 from kai.locks import get_lock
+from kai.telegram_context import get_core_services
 from kai.telegram_utils import chunk_text
 
 log = logging.getLogger(__name__)
@@ -50,16 +51,8 @@ _CONDITION_NOT_MET_PREFIX = (
 
 def _history_reader_user(context: ContextTypes.DEFAULT_TYPE, chat_id: int) -> str | None:
     """Resolve the OS user allowed to search one scheduled chat's history."""
-    pool = context.bot_data.get("pool")
-    if pool is not None:
-        return pool.get_os_user(chat_id)
-    config = context.bot_data.get("config")
-    if config is None:
-        return None
-    if getattr(config, "protected_install", False) is True:
-        return None
-    user_config = config.get_user_config(chat_id)
-    return user_config.os_user if user_config and user_config.os_user else None
+    pool = get_core_services(context).subprocess_pool
+    return pool.get_os_user(chat_id) if pool is not None else None
 
 
 async def _send_chunked(bot: ExtBot, chat_id: int, text: str) -> None:
@@ -309,8 +302,8 @@ async def _job_callback(context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     # ── Agent jobs: send prompt through the subprocess pool ──
-    pool = context.bot_data.get("pool")
-    if not pool:
+    pool = get_core_services(context).subprocess_pool
+    if pool is None:
         log.error("No subprocess pool available for job %d", job_id)
         return
 

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -19,10 +19,10 @@ The startup sequence is:
     1. Load config from .env
     2. Initialize SQLite database
     3. Start the transport-neutral runtime and Workshop execution host
-    4. Create the Telegram adapter application (with or without Updater)
+    4. Attach the explicit Telegram adapter to the core host
     5. Restore previous workspace (if saved in settings table)
-    6. Initialize the Telegram adapter and register slash commands
-    7. Load scheduled jobs from database into APScheduler
+    6. Let the adapter initialize Telegram, register commands, and load jobs
+    7. Start adapter-owned conversation and notification delivery workers
     8. Start the webhook HTTP server (always runs for scheduling API, GitHub webhooks, etc.)
     9. In webhook mode: register Telegram webhook with the API
        In polling mode: start the Updater's polling loop
@@ -30,7 +30,7 @@ The startup sequence is:
     11. Supervise required core and delivery workers until shutdown
 
 The shutdown sequence (in the finally block) reverses this order:
-    HTTP ingress -> Telegram ingress/delivery -> Telegram app -> core host -> database
+    HTTP ingress -> core-supervised adapters -> core services -> database
 """
 
 import asyncio
@@ -40,20 +40,13 @@ from datetime import UTC, datetime, timedelta
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
-from telegram import BotCommand
-from telegram.error import NetworkError
-
-from kai import cron, services, sessions, webhook
+from kai import services, sessions, webhook
 from kai.application_host import KaiApplicationHost
 from kai.backend_registry import load_backend_registry
-from kai.bot import create_bot
 from kai.config import DATA_DIR, PROJECT_ROOT, _read_protected_file, load_config
+from kai.telegram_adapter import TelegramAdapter
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
-from kai.workshop.telegram_delivery_runtime import (
-    WorkshopTelegramConversationDeliveryService,
-    WorkshopTelegramNotificationService,
-)
 
 
 def _workshop_bootstrap_humans(
@@ -346,10 +339,9 @@ def _start() -> None:
 
         load_db_registry(await sessions.get_memory_project_rows())
 
-        conversation_delivery: WorkshopTelegramConversationDeliveryService | None = None
-        notification_delivery: WorkshopTelegramNotificationService | None = None
         core_host: KaiApplicationHost | None = None
-        app = None
+        telegram_adapter: TelegramAdapter | None = None
+        cleanup_task: asyncio.Task[None] | None = None
 
         # Determine the default user (admin or first user) for per-user
         # data migrations and workspace restoration. users.yaml is
@@ -407,89 +399,24 @@ def _start() -> None:
             core_services = await core_host.start()
             logging.info("Kai core application host is ready")
 
-            app = create_bot(
+            telegram_adapter = TelegramAdapter(
                 config,
+                core_services,
                 use_webhook=use_webhook,
-                core_services=core_services,
             )
-
-            # Retry initialization if the network isn't ready yet (e.g. after a
-            # power outage where DNS may take a while to come back).
-            for attempt in range(1, 13):
-                try:
-                    await app.initialize()
-                    break
-                except NetworkError:
-                    if attempt == 12:
-                        raise
-                    wait = min(30, 2**attempt)
-                    logging.warning(
-                        "Network not ready (attempt %d/12), retrying in %ds…",
-                        attempt,
-                        wait,
-                    )
-                    await asyncio.sleep(wait)
-
-            await app.start()
-
-            # Register slash command menu in Telegram's bot command list
-            await app.bot.set_my_commands(
-                [
-                    # Session
-                    BotCommand("stop", "Interrupt current response"),
-                    BotCommand("new", "Start a fresh session"),
-                    # Model
-                    BotCommand("models", "Choose a model"),
-                    BotCommand("model", "Switch model directly"),
-                    # Settings
-                    BotCommand("settings", "Show or change your settings"),
-                    # Memory
-                    BotCommand("memory", "Browse, search, and manage remembered facts"),
-                    # Workspace
-                    BotCommand("workspace", "Switch working directory"),
-                    BotCommand("workspaces", "List recent workspaces"),
-                    # GitHub
-                    BotCommand("github", "Show GitHub settings"),
-                    # Voice
-                    BotCommand("voice", "Toggle voice or set voice name"),
-                    BotCommand("voices", "Choose a voice"),
-                    # Info
-                    BotCommand("stats", "Show session info and cost"),
-                    BotCommand("job", "Manage scheduled jobs"),
-                    BotCommand("webhooks", "Show webhook server status"),
-                    BotCommand("help", "Show available commands"),
-                ]
-            )
-
-            # Reload scheduled jobs from the database into APScheduler
-            await cron.init_jobs(app)
-
-            # Validate the core-owned durable authority epoch and recover its
-            # Telegram conversation-finalization work on dedicated SQLite
-            # connections before webhook or polling ingress accepts updates.
-            conversation_delivery = await WorkshopTelegramConversationDeliveryService.open_and_start(
-                config.session_db_path,
-                app.bot,
-                authority_epoch_id=core_services.delivery_authority_epoch.epoch_id,
-            )
-            logging.info("Workshop Telegram conversation delivery is ready")
-
-            notification_delivery = await WorkshopTelegramNotificationService.open_and_start(
-                config.session_db_path,
-                app.bot,
-            )
-            logging.info("Workshop Telegram notification delivery is ready")
+            await core_host.attach_adapter("telegram", telegram_adapter)
 
             # Start the HTTP server (always runs - serves scheduling API, GitHub
             # webhooks, file exchange, and health check regardless of transport mode).
             # In webhook mode, this also registers the Telegram webhook with the API.
             await webhook.start(
-                app,
+                telegram_adapter.application,
                 config,
                 core_host=core_host,
                 core_services=core_services,
-                github_notifications=notification_delivery,
+                github_notifications=telegram_adapter.notification_delivery,
             )
+            await telegram_adapter.activate_ingress()
             # Phase 3: per-user file confinement is handled at request
             # time via pool.get_effective_workspace(chat_id) in
             # webhook.py. No global workspace sync needed at startup.
@@ -497,18 +424,6 @@ def _start() -> None:
             # Start periodic file cleanup if a retention policy is configured.
             if config.file_retention_days > 0:
                 cleanup_task = asyncio.create_task(_file_cleanup_loop(config.file_retention_days))
-                # Store reference to prevent GC; task self-cancels on loop shutdown
-                app.bot_data["cleanup_task"] = cleanup_task
-
-            # In polling mode, start the Updater's long-polling loop. PTB's
-            # start_polling() automatically calls delete_webhook() first, which
-            # cleans up any stale webhook from a previous webhook-mode run.
-            if not use_webhook:
-                assert app.updater is not None
-                await app.updater.start_polling(
-                    allowed_updates=["message", "callback_query"],
-                )
-                logging.info("Polling started")
 
             # Check for interrupted responses from a crash/restart.
             # Phase 2: check all files in the .responding directory (per-user
@@ -525,7 +440,7 @@ def _start() -> None:
                 flag.unlink(missing_ok=True)
                 try:
                     interrupted_chat_id = int(flag.name)
-                    await app.bot.send_message(
+                    await telegram_adapter.bot.send_message(
                         interrupted_chat_id,
                         "Sorry, my previous response was interrupted. Please resend your last message.",
                     )
@@ -542,7 +457,7 @@ def _start() -> None:
                     old_content = old_flag.read_text().strip()
                     old_flag.unlink(missing_ok=True)
                     old_chat_id = int(old_content)
-                    await app.bot.send_message(
+                    await telegram_adapter.bot.send_message(
                         old_chat_id,
                         "Sorry, my previous response was interrupted. Please resend your last message.",
                     )
@@ -552,36 +467,13 @@ def _start() -> None:
                     old_flag.unlink(missing_ok=True)
 
             logging.info("Kai is running. Press Ctrl+C to stop.")
-            # The delivery worker is part of service health. Unexpected worker
-            # exit reaches the top-level crash path instead of leaving a loaded
-            # Kai process that can accept replies it cannot deliver.
-            await asyncio.gather(
-                conversation_delivery.wait(),
-                notification_delivery.wait(),
-                core_host.wait(),
-            )
+            await core_host.wait()
         finally:
             # Shutdown in reverse order of startup
             await webhook.stop()
-            # Stop the polling Updater if it was running (no-op in webhook mode
-            # since the Updater was suppressed at build time)
-            if app is not None and not use_webhook and app.updater:
-                await app.updater.stop()
-            if notification_delivery is not None:
-                try:
-                    await notification_delivery.stop()
-                except Exception:
-                    logging.exception("Workshop Telegram notification delivery stopped with an error")
-            if conversation_delivery is not None:
-                try:
-                    await conversation_delivery.stop()
-                except Exception:
-                    # If wait() already exposed a worker failure, retain that
-                    # original exception while still completing shutdown.
-                    logging.exception("Workshop Telegram conversation delivery stopped with an error")
-            if app is not None:
-                await app.stop()
-                await app.shutdown()
+            if cleanup_task is not None:
+                cleanup_task.cancel()
+                await asyncio.gather(cleanup_task, return_exceptions=True)
             if core_host is not None:
                 try:
                     await core_host.stop()

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -78,6 +78,7 @@ from kai.memory import (
     read_transcript_provenance,
 )
 from kai.memory_projects import ActiveMemoryProject, detect_active_memory_project, merged_registry
+from kai.telegram_context import get_core_services
 
 if TYPE_CHECKING:
     # Only used for type hints; importing at runtime would create a
@@ -536,7 +537,7 @@ async def _scope_inputs(
     """
     config: Config = context.bot_data["config"]
     registry = merged_registry(config.memory_projects)
-    pool: SubprocessPool | None = context.bot_data.get("pool")
+    pool: SubprocessPool | None = get_core_services(context).subprocess_pool
     if pool is None:
         return registry, None
     workspace = await pool.get_effective_workspace(chat_id)
@@ -1901,7 +1902,7 @@ async def _send_dashboard(
     # sharpest. The per-user fall-through matches the extraction
     # gate's backend resolution in bot.py.
     config: Config = context.bot_data["config"]
-    pool: SubprocessPool | None = context.bot_data.get("pool")
+    pool: SubprocessPool | None = get_core_services(context).subprocess_pool
     if pool is not None:
         effective_backend = pool.get_backend_provider(chat_id)[0]
     else:

--- a/src/kai/telegram_adapter.py
+++ b/src/kai/telegram_adapter.py
@@ -1,0 +1,274 @@
+"""Explicit lifecycle boundary for Kai's Telegram adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+
+from telegram import Bot, BotCommand
+from telegram.error import NetworkError
+
+from kai import cron
+from kai.application_host import KaiCoreServices
+from kai.bot import create_bot
+from kai.config import Config
+from kai.telegram_context import KaiTelegramApplication
+from kai.workshop.telegram_delivery_runtime import (
+    WorkshopTelegramConversationDeliveryService,
+    WorkshopTelegramNotificationService,
+)
+
+log = logging.getLogger(__name__)
+
+
+class TelegramAdapterState(StrEnum):
+    """Observable lifecycle state for the Telegram adapter."""
+
+    NEW = "new"
+    STARTING = "starting"
+    READY = "ready"
+    DRAINING = "draining"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramAdapterReadiness:
+    """Non-sensitive readiness for Telegram-owned components."""
+
+    state: TelegramAdapterState
+    application: bool
+    ingress: bool
+    conversation_delivery: bool
+    notification_delivery: bool
+
+    @property
+    def ready(self) -> bool:
+        return self.state == TelegramAdapterState.READY and all(
+            (
+                self.application,
+                self.ingress,
+                self.conversation_delivery,
+                self.notification_delivery,
+            )
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "status": self.state.value,
+            "ready": self.ready,
+            "components": {
+                "application": self.application,
+                "ingress": self.ingress,
+                "conversation_delivery": self.conversation_delivery,
+                "notification_delivery": self.notification_delivery,
+            },
+        }
+
+
+_TELEGRAM_COMMANDS = (
+    BotCommand("stop", "Interrupt current response"),
+    BotCommand("new", "Start a fresh session"),
+    BotCommand("models", "Choose a model"),
+    BotCommand("model", "Switch model directly"),
+    BotCommand("settings", "Show or change your settings"),
+    BotCommand("memory", "Browse, search, and manage remembered facts"),
+    BotCommand("workspace", "Switch working directory"),
+    BotCommand("workspaces", "List recent workspaces"),
+    BotCommand("github", "Show GitHub settings"),
+    BotCommand("voice", "Toggle voice or set voice name"),
+    BotCommand("voices", "Choose a voice"),
+    BotCommand("stats", "Show session info and cost"),
+    BotCommand("job", "Manage scheduled jobs"),
+    BotCommand("webhooks", "Show webhook server status"),
+    BotCommand("help", "Show available commands"),
+)
+
+
+class TelegramAdapter:
+    """Own Telegram application, polling, scheduler bridge, and delivery workers.
+
+    HTTP webhook registration remains in the HTTP adapter during this
+    milestone. The core host starts, supervises, reports, and stops this
+    boundary without importing a Telegram package itself.
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        core_services: KaiCoreServices,
+        *,
+        use_webhook: bool,
+    ) -> None:
+        self._config = config
+        self._core_services = core_services
+        self._use_webhook = use_webhook
+        self._state = TelegramAdapterState.NEW
+        self._application: KaiTelegramApplication | None = None
+        self._application_initialized = False
+        self._application_started = False
+        self._ingress_started = False
+        self._conversation_delivery: WorkshopTelegramConversationDeliveryService | None = None
+        self._notification_delivery: WorkshopTelegramNotificationService | None = None
+
+    @property
+    def application(self) -> KaiTelegramApplication:
+        application = self._application
+        if application is None:
+            raise RuntimeError("Telegram application is not started")
+        return application
+
+    @property
+    def bot(self) -> Bot:
+        return self.application.bot
+
+    @property
+    def notification_delivery(self) -> WorkshopTelegramNotificationService:
+        service = self._notification_delivery
+        if service is None:
+            raise RuntimeError("Telegram notification delivery is not started")
+        return service
+
+    @property
+    def readiness(self) -> TelegramAdapterReadiness:
+        return TelegramAdapterReadiness(
+            state=self._state,
+            application=self._application_started,
+            ingress=self._ingress_started,
+            conversation_delivery=(self._conversation_delivery is not None and self._conversation_delivery.ready),
+            notification_delivery=(self._notification_delivery is not None and self._notification_delivery.ready),
+        )
+
+    async def start(self) -> None:
+        if self._state != TelegramAdapterState.NEW:
+            raise RuntimeError(f"Telegram adapter cannot start from {self._state.value}")
+        self._state = TelegramAdapterState.STARTING
+        try:
+            application = create_bot(
+                self._config,
+                use_webhook=self._use_webhook,
+                core_services=self._core_services,
+            )
+            if not isinstance(application, KaiTelegramApplication):
+                raise RuntimeError("Telegram factory returned an untyped application")
+            self._application = application
+
+            for attempt in range(1, 13):
+                try:
+                    await application.initialize()
+                    self._application_initialized = True
+                    break
+                except NetworkError:
+                    if attempt == 12:
+                        raise
+                    wait = min(30, 2**attempt)
+                    log.warning(
+                        "Telegram network not ready (attempt %d/12), retrying in %ds…",
+                        attempt,
+                        wait,
+                    )
+                    await asyncio.sleep(wait)
+
+            await application.start()
+            self._application_started = True
+            await application.bot.set_my_commands(_TELEGRAM_COMMANDS)
+            await cron.init_jobs(application)
+
+            self._conversation_delivery = await WorkshopTelegramConversationDeliveryService.open_and_start(
+                self._config.session_db_path,
+                application.bot,
+                authority_epoch_id=self._core_services.delivery_authority_epoch.epoch_id,
+            )
+            log.info("Workshop Telegram conversation delivery is ready")
+            self._notification_delivery = await WorkshopTelegramNotificationService.open_and_start(
+                self._config.session_db_path,
+                application.bot,
+            )
+            log.info("Workshop Telegram notification delivery is ready")
+        except BaseException:
+            self._state = TelegramAdapterState.FAILED
+            await self._stop_components()
+            raise
+
+    async def activate_ingress(self) -> None:
+        """Mark webhook ingress ready or start the polling updater.
+
+        In webhook mode the HTTP adapter has already registered Telegram's URL
+        before calling this method. The adapter therefore remains STARTING for
+        the brief handoff between confirmed registration and this readiness
+        transition, even though Telegram may begin delivering during it.
+        """
+        if self._state != TelegramAdapterState.STARTING:
+            raise RuntimeError(f"Telegram ingress cannot start while {self._state.value}")
+        try:
+            if not self._use_webhook:
+                updater = self.application.updater
+                if updater is None:
+                    raise RuntimeError("Telegram polling mode has no updater")
+                await updater.start_polling(allowed_updates=["message", "callback_query"])
+                log.info("Telegram polling started")
+            self._ingress_started = True
+            self._state = TelegramAdapterState.READY
+        except BaseException:
+            self._state = TelegramAdapterState.FAILED
+            raise
+
+    async def wait(self) -> None:
+        if self._state != TelegramAdapterState.READY:
+            raise RuntimeError(f"Telegram adapter cannot be supervised while {self._state.value}")
+        conversation_delivery = self._conversation_delivery
+        notification_delivery = self._notification_delivery
+        if conversation_delivery is None or notification_delivery is None:
+            raise RuntimeError("Telegram delivery services are unavailable")
+        await asyncio.gather(
+            conversation_delivery.wait(),
+            notification_delivery.wait(),
+        )
+
+    async def stop(self) -> None:
+        if self._state in {TelegramAdapterState.NEW, TelegramAdapterState.STOPPED}:
+            self._state = TelegramAdapterState.STOPPED
+            return
+        self._state = TelegramAdapterState.DRAINING
+        errors = await self._stop_components()
+        self._state = TelegramAdapterState.STOPPED
+        if errors:
+            raise ExceptionGroup("Telegram adapter shutdown failed", errors)
+
+    async def _stop_components(self) -> list[Exception]:
+        errors: list[Exception] = []
+        application = self._application
+        if self._ingress_started and not self._use_webhook and application is not None:
+            updater = application.updater
+            if updater is not None:
+                try:
+                    await updater.stop()
+                except Exception as exc:
+                    errors.append(exc)
+        self._ingress_started = False
+
+        for service in (self._notification_delivery, self._conversation_delivery):
+            if service is not None:
+                try:
+                    await service.stop()
+                except Exception as exc:
+                    errors.append(exc)
+        self._notification_delivery = None
+        self._conversation_delivery = None
+
+        if application is not None and self._application_started:
+            try:
+                await application.stop()
+            except Exception as exc:
+                errors.append(exc)
+        self._application_started = False
+        if application is not None and self._application_initialized:
+            try:
+                await application.shutdown()
+            except Exception as exc:
+                errors.append(exc)
+        self._application_initialized = False
+        self._application = None
+        return errors

--- a/src/kai/telegram_context.py
+++ b/src/kai/telegram_context.py
@@ -1,0 +1,27 @@
+"""Typed dependency access for Telegram adapter callbacks."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from telegram.ext import Application, ContextTypes
+
+from kai.application_host import KaiCoreServices
+
+
+class KaiTelegramApplication(Application):
+    """Telegram application carrying an explicit typed core boundary."""
+
+    __slots__ = ("core_services",)
+
+    def __init__(self, *, core_services: KaiCoreServices, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.core_services = core_services
+
+
+def get_core_services(context: ContextTypes.DEFAULT_TYPE) -> KaiCoreServices:
+    """Resolve core services without Telegram's untyped bot_data map."""
+    application = context.application
+    if not isinstance(application, KaiTelegramApplication):
+        raise RuntimeError("Telegram adapter core services are unavailable")
+    return cast(KaiCoreServices, application.core_services)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -721,6 +721,7 @@ async def _handle_health(request: web.Request) -> web.Response:
     host = request.app.get(CORE_HOST_KEY)
     if host is not None:
         response["core"] = host.readiness.as_dict()
+        response["adapters"] = host.adapter_readiness
     return web.json_response(response)
 
 

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -104,6 +104,31 @@ class _FakeClientCommands:
         self.ready = False
 
 
+class _FakeAdapterReadiness:
+    def __init__(self, *, ready: bool) -> None:
+        self.ready = ready
+
+    def as_dict(self) -> dict[str, object]:
+        return {"status": "ready" if self.ready else "starting", "ready": self.ready}
+
+
+class _FakeAdapter:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.readiness = _FakeAdapterReadiness(ready=False)
+
+    async def start(self) -> None:
+        self.events.append("adapter:start")
+        self.readiness = _FakeAdapterReadiness(ready=True)
+
+    async def wait(self) -> None:
+        self.events.append("adapter:wait")
+
+    async def stop(self) -> None:
+        self.events.append("adapter:stop")
+        self.readiness = _FakeAdapterReadiness(ready=False)
+
+
 @pytest.fixture
 def host_dependencies(monkeypatch):
     events: list[str] = []
@@ -171,6 +196,37 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
         "execution:stop",
         "pool:stop",
     ]
+
+
+async def test_core_host_starts_supervises_reports_and_stops_attached_adapter(
+    host_dependencies,
+) -> None:
+    host = _host()
+    await host.start()
+    adapter = _FakeAdapter(host_dependencies)
+
+    await host.attach_adapter("telegram", adapter)
+
+    assert host.adapter_readiness == {
+        "telegram": {"status": "ready", "ready": True},
+    }
+    await host.wait()
+    await host.stop()
+
+    assert "adapter:start" in host_dependencies
+    assert "adapter:wait" in host_dependencies
+    assert host_dependencies.index("adapter:stop") < host_dependencies.index("client:stop")
+
+
+async def test_core_host_rejects_empty_adapter_name(host_dependencies) -> None:
+    host = _host()
+    await host.start()
+
+    with pytest.raises(RuntimeError, match="name cannot be empty"):
+        await host.attach_adapter("", _FakeAdapter(host_dependencies))
+
+    assert "adapter:start" not in host_dependencies
+    await host.stop()
 
 
 def test_core_host_module_has_no_telegram_dependency() -> None:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -23,6 +23,7 @@ from kai import sessions
 from kai.backend import AgentResponse, StreamEvent, resolve_home_workspace
 from kai.bot import (
     _QUEUED_MESSAGE_MARKER,
+    KaiTelegramApplication,
     ResponseDeliveryRoute,
     _acquire_lock_or_kill,
     _clear_responding,
@@ -738,8 +739,17 @@ class TestCreateBotTransportMode:
         assert app.bot_data["workshop_delivery_recorder"] is sessions.record_workshop_delivery_observation
         assert app.bot_data["workshop_streaming_preview_recorder"] is sessions.record_workshop_streaming_preview
         assert app.bot_data["workshop_streaming_finalizer"] is sessions.record_workshop_streaming_finalization
-        assert isinstance(app.bot_data["workshop_runtime_pool"], WorkshopRuntimePool)
-        assert isinstance(app.bot_data["workshop_conversation_run_service"], WorkshopConversationRunService)
+        assert isinstance(app, KaiTelegramApplication)
+        assert isinstance(app.core_services.runtime_pool, WorkshopRuntimePool)
+        assert isinstance(app.core_services.conversation_runs, WorkshopConversationRunService)
+        for removed_key in (
+            "pool",
+            "workshop_runtime_pool",
+            "workshop_conversation_run_service",
+            "workshop_private_text_execution",
+            "workshop_principal_storage",
+        ):
+            assert removed_key not in app.bot_data
 
     def test_does_not_register_durable_run_lifecycle_before_cutover(self):
         config = _make_config()
@@ -889,9 +899,15 @@ def _make_context(config=None, claude=None, pool=None, args=None, user_data=None
     )
     ctx.bot_data = {
         "config": resolved_config,
-        "pool": mock_pool,
-        "workshop_principal_storage": principal_storage,
     }
+    application = MagicMock(spec=KaiTelegramApplication)
+    application.core_services = SimpleNamespace(
+        subprocess_pool=mock_pool,
+        private_text_execution=None,
+        conversation_runs=None,
+        principal_storage=principal_storage,
+    )
+    ctx.application = application
     ctx.args = args or []
     ctx.user_data = user_data if user_data is not None else {}
     ctx.bot.send_chat_action = AsyncMock()
@@ -1251,7 +1267,7 @@ class TestHandleStop:
         ctx = _make_context(claude=pool, config=_make_config(allowed_user_ids={1}))
         execution = MagicMock()
         execution.request_cancellation = AsyncMock(return_value=CanonicalCancellationDisposition.REQUESTED)
-        ctx.bot_data["workshop_private_text_execution"] = execution
+        ctx.application.core_services.private_text_execution = execution
 
         await handle_stop(update, ctx)
 
@@ -2861,7 +2877,7 @@ class TestHandleMessage:
         execution.accept.return_value.message.event.envelope.aggregate_id = inbound_id
         execution.accept.return_value.run.run_id = run_id
         execution.accept.return_value.disposition = ConversationCommandDisposition.NEWLY_ACCEPTED
-        ctx.bot_data["workshop_private_text_execution"] = execution
+        ctx.application.core_services.private_text_execution = execution
         with (
             patch("kai.bot.is_totp_configured", return_value=False),
             patch("kai.bot._handle_workshop_private_text", new_callable=AsyncMock) as response,
@@ -2913,7 +2929,7 @@ class TestHandleMessage:
         )
         execution.accept.return_value.run.run_id = RunId("run_00000000000000000000000000000001")
         execution.accept.return_value.disposition = ConversationCommandDisposition.TERMINAL_REPLAY
-        ctx.bot_data["workshop_private_text_execution"] = execution
+        ctx.application.core_services.private_text_execution = execution
 
         with (
             patch("kai.bot.is_totp_configured", return_value=False),
@@ -3024,7 +3040,7 @@ class TestHandlePhoto:
         ):
             await handle_photo(update, ctx)
 
-        namespace = ctx.bot_data["workshop_principal_storage"].for_runtime_config_id(1)
+        namespace = ctx.application.core_services.principal_storage.for_runtime_config_id(1)
         files = list(namespace.files_directory(tmp_path).iterdir())
         assert len(files) == 1
         assert not (tmp_path / "files" / "-100999").exists()
@@ -6837,27 +6853,10 @@ class TestCommandMenu:
         assert all(getattr(callback, "_kai_totp_sensitive", False) for callback in callbacks)
 
     def test_menu_matches_expected_set(self):
-        """The set_my_commands list in main.py matches EXPECTED_MENU_COMMANDS.
+        """The adapter-owned Telegram command menu matches the contract."""
+        from kai.telegram_adapter import _TELEGRAM_COMMANDS
 
-        Parses the actual source to extract BotCommand names from inside the
-        set_my_commands() call specifically, so the test breaks if someone
-        adds/removes a menu entry without updating the expected set.
-        """
-        import re
-
-        main_py = Path(__file__).parent.parent / "src" / "kai" / "main.py"
-        source = main_py.read_text()
-
-        # Scope to the set_my_commands(...) block so BotCommand references
-        # elsewhere in main.py (future defaults, comments, etc.) don't
-        # cause false positives.
-        match = re.search(
-            r"set_my_commands\(\s*\[(.+?)\]\s*\)",
-            source,
-            re.DOTALL,
-        )
-        assert match, "Could not find set_my_commands() call in main.py"
-        menu_commands = set(re.findall(r'BotCommand\("(\w+)"', match.group(1)))
+        menu_commands = {command.command for command in _TELEGRAM_COMMANDS}
 
         assert menu_commands == EXPECTED_MENU_COMMANDS, (
             f"Menu drift detected. "
@@ -7660,7 +7659,7 @@ class TestHandleReviewCommand:
         ):
             await handle_review_command(update, ctx)
 
-        namespace = ctx.bot_data["workshop_principal_storage"].for_runtime_config_id(1)
+        namespace = ctx.application.core_services.principal_storage.for_runtime_config_id(1)
         staged_dir = namespace.files_directory(tmp_path)
         assert staged_dir.is_dir()
         staged = list(staged_dir.glob("*_pr-681-review.md"))
@@ -7691,7 +7690,7 @@ class TestHandleReviewCommand:
         ):
             await handle_review_command(update, ctx)
 
-        namespace = ctx.bot_data["workshop_principal_storage"].for_runtime_config_id(1)
+        namespace = ctx.application.core_services.principal_storage.for_runtime_config_id(1)
         staged = list(namespace.files_directory(tmp_path).glob("*_pr-681-review.md"))
         assert len(staged) == 1
         assert not (tmp_path / "files" / "-100999").exists()

--- a/tests/test_bot_totp.py
+++ b/tests/test_bot_totp.py
@@ -26,6 +26,7 @@ from kai.bot import (
     handle_voice,
 )
 from kai.totp import TotpStateError
+from kai.workshop.domain import PrincipalId
 
 # ── Test helpers ──────────────────────────────────────────────────────────
 
@@ -433,6 +434,10 @@ async def test_photo_passes_with_valid_totp():
         # log_message MUST be patched to avoid writing test data (chat_id
         # 12345, MagicMock paths) to the real production history files.
         patch("kai.bot._get_pool"),
+        patch(
+            "kai.bot._upload_principal_id",
+            return_value=PrincipalId("prn_00000000000000000000000000000001"),
+        ),
         patch("kai.bot.log_message"),
         patch("kai.bot._notify_if_queued", new_callable=AsyncMock, return_value=False),
         patch("kai.bot._acquire_lock_or_kill", new_callable=AsyncMock, return_value=None),

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -12,11 +12,13 @@ Covers:
 
 import json
 from datetime import UTC, datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from telegram.error import Forbidden
 
+from kai.bot import KaiTelegramApplication
 from kai.cron import (
     _ensure_utc,
     _history_reader_user,
@@ -81,6 +83,15 @@ def _make_job(
 def mock_context():
     """Build a mock Telegram callback context with job data for _job_callback."""
     ctx = AsyncMock()
+    application = MagicMock(spec=KaiTelegramApplication)
+
+    class CoreServices:
+        @property
+        def subprocess_pool(self):
+            return ctx.bot_data.get("pool")
+
+    application.core_services = CoreServices()
+    ctx.application = application
     ctx.bot = AsyncMock()
     ctx.bot.send_message = AsyncMock()
     ctx.bot.send_chat_action = AsyncMock()
@@ -130,6 +141,8 @@ class TestHistoryReaderUser:
         config = MagicMock()
         config.get_user_config.return_value = MagicMock(os_user="compatibility-user")
         context.bot_data = {"pool": pool, "config": config}
+        context.application = MagicMock(spec=KaiTelegramApplication)
+        context.application.core_services = SimpleNamespace(subprocess_pool=pool)
 
         assert _history_reader_user(context, 12345) == "policy-user"
         pool.get_os_user.assert_called_once_with(12345)
@@ -142,6 +155,8 @@ class TestHistoryReaderUser:
         config = MagicMock()
         config.get_user_config.return_value = MagicMock(os_user="compatibility-user")
         context.bot_data = {"pool": pool, "config": config}
+        context.application = MagicMock(spec=KaiTelegramApplication)
+        context.application.core_services = SimpleNamespace(subprocess_pool=pool)
 
         assert _history_reader_user(context, 12345) is None
         config.get_user_config.assert_not_called()
@@ -412,10 +427,9 @@ class TestJobCallbackReminder:
     @pytest.mark.asyncio()
     async def test_logs_message_to_history(self, mock_context):
         """Reminder delivery is recorded in message history."""
-        user_config = MagicMock(os_user="daniel")
-        config = MagicMock()
-        config.get_user_config.return_value = user_config
-        mock_context.bot_data["config"] = config
+        pool = MagicMock()
+        pool.get_os_user.return_value = "daniel"
+        mock_context.bot_data["pool"] = pool
         with patch("kai.cron.log_message") as mock_log:
             await _job_callback(mock_context)
         mock_log.assert_called_once()

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -31,6 +32,7 @@ from kai import memory, memory_command
 from kai.config import MemoryProjectConfig
 from kai.memory import MemoryResult, MemoryStats
 from kai.memory_projects import ActiveMemoryProject
+from kai.telegram_context import KaiTelegramApplication
 
 # ── Fixture builders ────────────────────────────────────────────────
 
@@ -2148,6 +2150,9 @@ def context_factory(auth_config):
         ctx = MagicMock()
         ctx.bot_data = {"config": auth_config}
         ctx.args = args or []
+        application = MagicMock(spec=KaiTelegramApplication)
+        application.core_services = SimpleNamespace(subprocess_pool=None)
+        ctx.application = application
         return ctx
 
     return make
@@ -2440,7 +2445,7 @@ class TestDashboardBackendNote:
         ctx = context_factory(args=[])
         pool = MagicMock()
         pool.get_backend_provider.return_value = ("codex", "openai")
-        ctx.bot_data["pool"] = pool
+        ctx.application.core_services.subprocess_pool = pool
 
         await memory_command.handle_memory_command(upd, ctx)
 
@@ -3460,7 +3465,7 @@ class TestScopeInputs:
         ctx.bot_data["config"].memory_projects = {"kai": cfg}
         pool = MagicMock()
         pool.get_effective_workspace = AsyncMock(return_value=root)
-        ctx.bot_data["pool"] = pool
+        ctx.application.core_services.subprocess_pool = pool
         _registry, active = await memory_command._scope_inputs(ctx, 100)
         assert active is not None and active.project_id == "kai"
         pool.get_effective_workspace.assert_awaited_once_with(100)

--- a/tests/test_telegram_adapter.py
+++ b/tests/test_telegram_adapter.py
@@ -1,0 +1,179 @@
+"""Lifecycle contracts for the explicit Telegram adapter boundary."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import kai.telegram_adapter as adapter_module
+from kai.telegram_adapter import TelegramAdapter, TelegramAdapterState
+
+
+class _FakeBot:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def set_my_commands(self, _commands) -> None:
+        self.events.append("commands:set")
+
+
+class _FakeUpdater:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def start_polling(self, *, allowed_updates) -> None:
+        assert allowed_updates == ["message", "callback_query"]
+        self.events.append("polling:start")
+
+    async def stop(self) -> None:
+        self.events.append("polling:stop")
+
+
+class _FakeApplication:
+    def __init__(self, events: list[str], *, polling: bool) -> None:
+        self.events = events
+        self.bot = _FakeBot(events)
+        self.updater = _FakeUpdater(events) if polling else None
+
+    async def initialize(self) -> None:
+        self.events.append("application:initialize")
+
+    async def start(self) -> None:
+        self.events.append("application:start")
+
+    async def stop(self) -> None:
+        self.events.append("application:stop")
+
+    async def shutdown(self) -> None:
+        self.events.append("application:shutdown")
+
+
+class _FakeDelivery:
+    def __init__(self, events: list[str], name: str) -> None:
+        self.events = events
+        self.name = name
+        self.ready = True
+
+    async def wait(self) -> None:
+        self.events.append(f"{self.name}:wait")
+
+    async def stop(self) -> None:
+        self.events.append(f"{self.name}:stop")
+        self.ready = False
+
+
+@pytest.fixture
+def adapter_dependencies(monkeypatch):
+    events: list[str] = []
+    application: _FakeApplication | None = None
+
+    def fake_create_bot(_config, *, use_webhook, core_services):
+        nonlocal application
+        assert core_services is not None
+        events.append("application:create")
+        application = _FakeApplication(events, polling=not use_webhook)
+        return application
+
+    class FakeConversationDelivery:
+        @classmethod
+        async def open_and_start(cls, _path, _bot, *, authority_epoch_id):
+            assert authority_epoch_id == "dae_test"
+            events.append("conversation:start")
+            return _FakeDelivery(events, "conversation")
+
+    class FakeNotificationDelivery:
+        @classmethod
+        async def open_and_start(cls, _path, _bot):
+            events.append("notification:start")
+            return _FakeDelivery(events, "notification")
+
+    async def fake_init_jobs(app) -> None:
+        assert app is application
+        events.append("jobs:start")
+
+    monkeypatch.setattr(adapter_module, "KaiTelegramApplication", _FakeApplication)
+    monkeypatch.setattr(adapter_module, "create_bot", fake_create_bot)
+    monkeypatch.setattr(
+        adapter_module,
+        "WorkshopTelegramConversationDeliveryService",
+        FakeConversationDelivery,
+    )
+    monkeypatch.setattr(
+        adapter_module,
+        "WorkshopTelegramNotificationService",
+        FakeNotificationDelivery,
+    )
+    monkeypatch.setattr(adapter_module.cron, "init_jobs", fake_init_jobs)
+    return events
+
+
+def _adapter(*, use_webhook: bool) -> TelegramAdapter:
+    config = SimpleNamespace(session_db_path="/tmp/kai.db")
+    core_services = SimpleNamespace(delivery_authority_epoch=SimpleNamespace(epoch_id="dae_test"))
+    return TelegramAdapter(  # type: ignore[arg-type]
+        config,
+        core_services,
+        use_webhook=use_webhook,
+    )
+
+
+async def test_webhook_adapter_owns_application_and_delivery_lifecycle(
+    adapter_dependencies,
+) -> None:
+    adapter = _adapter(use_webhook=True)
+
+    await adapter.start()
+    assert adapter.readiness.state == TelegramAdapterState.STARTING
+    assert adapter.readiness.ready is False
+    assert adapter.readiness.application is True
+    assert adapter.readiness.ingress is False
+
+    await adapter.activate_ingress()
+    assert adapter.readiness.as_dict() == {
+        "status": "ready",
+        "ready": True,
+        "components": {
+            "application": True,
+            "ingress": True,
+            "conversation_delivery": True,
+            "notification_delivery": True,
+        },
+    }
+
+    await adapter.stop()
+    assert adapter.readiness.state == TelegramAdapterState.STOPPED
+    assert adapter_dependencies == [
+        "application:create",
+        "application:initialize",
+        "application:start",
+        "commands:set",
+        "jobs:start",
+        "conversation:start",
+        "notification:start",
+        "notification:stop",
+        "conversation:stop",
+        "application:stop",
+        "application:shutdown",
+    ]
+
+
+async def test_polling_ingress_is_started_and_stopped_inside_adapter(
+    adapter_dependencies,
+) -> None:
+    adapter = _adapter(use_webhook=False)
+
+    await adapter.start()
+    await adapter.activate_ingress()
+    await adapter.stop()
+
+    assert "polling:start" in adapter_dependencies
+    assert adapter_dependencies.index("polling:stop") < adapter_dependencies.index("notification:stop")
+
+
+async def test_adapter_rejects_supervision_before_ingress(adapter_dependencies) -> None:
+    adapter = _adapter(use_webhook=True)
+    await adapter.start()
+
+    with pytest.raises(RuntimeError, match="cannot be supervised while starting"):
+        await adapter.wait()
+
+    await adapter.stop()

--- a/tests/test_webhook_routes.py
+++ b/tests/test_webhook_routes.py
@@ -86,7 +86,14 @@ async def test_health_reports_typed_core_component_readiness(monkeypatch) -> Non
                 "ready": True,
                 "components": {"runtime": True, "executor": True},
             }
-        )
+        ),
+        adapter_readiness={
+            "telegram": {
+                "status": "ready",
+                "ready": True,
+                "components": {"ingress": True, "conversation_delivery": True},
+            }
+        },
     )
 
     response = await _handle_health(SimpleNamespace(app=app))  # type: ignore[arg-type]
@@ -98,5 +105,12 @@ async def test_health_reports_typed_core_component_readiness(monkeypatch) -> Non
             "status": "ready",
             "ready": True,
             "components": {"runtime": True, "executor": True},
+        },
+        "adapters": {
+            "telegram": {
+                "status": "ready",
+                "ready": True,
+                "components": {"ingress": True, "conversation_delivery": True},
+            }
         },
     }


### PR DESCRIPTION
## Summary

This is the next consolidated Milestone 2 slice for #917. It turns Telegram
from lifecycle code embedded in `main.py` into an explicit adapter supervised
by the transport-neutral application host, and removes the remaining five
core-service mirrors from Telegram's untyped `bot_data` map.

## What changed

### Explicit Telegram adapter lifecycle

- Add `TelegramAdapter` as the owner of:
  - Telegram application construction, initialization, and startup
  - retrying initialization while the network is unavailable
  - Telegram command-menu registration
  - compatibility scheduler registration
  - polling ingress activation and shutdown
  - Workshop conversation-delivery and notification-delivery workers
  - component readiness, worker supervision, and reverse-order cleanup
- Keep Telegram webhook registration in the HTTP adapter for this milestone;
  the ownership boundary is documented rather than silently moved.
- Reduce `main.py` to orchestration: start the core, attach Telegram, start HTTP
  ingress, activate Telegram ingress, and supervise the host.

### Core-host adapter supervision

- Add a small adapter lifecycle protocol to `KaiApplicationHost`.
- Start adapters only after core readiness.
- Include adapter workers in host supervision.
- Stop adapters before core services.
- Surface non-sensitive adapter component readiness through `/health` alongside
  existing core readiness.

### Typed Telegram dependency boundary

- Add `KaiTelegramApplication`, which carries `KaiCoreServices` as a typed
  application dependency.
- Route ordinary handlers, cancellation, media uploads, memory commands, and
  scheduled callbacks through that typed boundary.
- Remove these core mirrors from `bot_data`:
  - `pool`
  - `workshop_runtime_pool`
  - `workshop_conversation_run_service`
  - `workshop_private_text_execution`
  - `workshop_principal_storage`
- Retain only non-core compatibility recorders and Telegram-local configuration
  in `bot_data`; those belong to separate retirement-ledger entries.

### Documentation and contracts

- Update the Workshop implementation map with the explicit adapter boundary,
  its deliberately retained HTTP-webhook ownership, and the installed
  qualification gate for closing the core-mirror ledger row.
- Add lifecycle tests for webhook and polling modes, readiness, supervision,
  shutdown order, typed handler access, removed mirrors, and health output.

## Compatibility

- Telegram remains enabled and required exactly as before in current protected
  installs; optional adapter enablement belongs to Milestone 3.
- Telegram command names and descriptions are unchanged.
- Polling and webhook modes retain their existing behavior.
- Scheduled Telegram jobs continue to use the compatibility scheduler, now
  through typed core-service access.
- GitHub notification-group delivery continues through the same Workshop
  notification worker, now owned by `TelegramAdapter`.

## Verification

- `5757 passed, 1 skipped`
- `make check`
- `make typecheck` (`0 errors, 0 warnings`)
- `git diff --check`
- Source audit confirms none of the five retired core-service keys remain in
  `src/kai` as Telegram `bot_data` lookups or mirrors.

## Post-merge installed qualification

After installation, qualify the hybrid boundary with:

1. Telegram private-message PING/PONG.
2. A Workshop browser request and response.
3. `/health` showing both core readiness and `adapters.telegram` readiness.
4. One configured GitHub notification-group delivery.
5. `make install-status` remaining healthy.

Refs #917
