### PR TITLE
Support Workshop-only deployment mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,23 @@
 [![License](https://img.shields.io/github/license/dcellison/kai)](LICENSE)
 [![Version](https://img.shields.io/github/v/tag/dcellison/kai?label=version)](https://github.com/dcellison/kai/releases)
 
-Kai is a local, Telegram-first personal engineering system: a persistent AI collaborator with repo-aware coding, memory, scheduling, PR review, and multi-backend operation.
+Kai is a local, multi-client personal engineering system: a persistent AI collaborator with repo-aware coding, memory, scheduling, PR review, and multi-backend operation.
 
-Run Kai on your own machine, reach it from Telegram, and give it real access to your local workspaces. Kai can inspect repositories, run shell commands, write code, review pull requests, triage issues, remember durable context, handle files, and run scheduled jobs while staying under your control. Your machine, your data, your rules.
+Run Kai on your own machine, reach it through the Workshop browser or Telegram, and give it real access to your local workspaces. Kai can inspect repositories, run shell commands, write code, review pull requests, triage issues, remember durable context, handle files, and run scheduled jobs while staying under your control. Your machine, your data, your rules.
 
 For full setup and operations guides, see the [Kai Wiki](https://github.com/dcellison/kai/wiki).
 
 ## Why Kai Exists
 
-Most AI coding tools are either interactive terminals or hosted chat surfaces. Kai is built for a different operating model: a long-running local service that keeps an agent available wherever Telegram works.
+Most AI coding tools are either interactive terminals or hosted chat surfaces. Kai is built for a different operating model: a long-running local service available through authenticated client adapters.
 
 - **Local-first authority:** Kai runs on hardware you control and works against your local filesystem, shell, git repos, and tools.
-- **Telegram as the control surface:** You can send messages, files, voice notes, GitHub events, and scheduling requests without opening a terminal.
+- **Multiple client surfaces:** Workshop provides the native browser experience; Telegram remains an optional mobile client with files, voice notes, commands, and notifications.
 - **Persistent agent sessions:** Each user gets a lazily-created subprocess with durable context and idle eviction.
 - **Memory across sessions:** Kai preserves identity, personal memory, and conversation history so useful context survives restarts and workspace switches.
 - **Background engineering workflows:** PR review, issue triage, webhooks, reminders, and condition-monitoring jobs run outside the active chat session.
 - **Multi-backend operation:** Each user can run through any installed supported backend, with an explicit installation default and optional per-user overrides.
-- **Multi-user isolation:** One Kai instance can serve multiple Telegram users with isolated history, files, settings, and optional OS-level process separation.
+- **Multi-user isolation:** One Kai instance can serve multiple Workshop humans and optional Telegram identities with isolated history, files, settings, and OS-level process separation.
 
 ## Core Capabilities
 
@@ -34,20 +34,19 @@ Most AI coding tools are either interactive terminals or hosted chat surfaces. K
 | GitHub automation | Reviews PRs, triages issues, routes notifications, and reacts to webhook events. |
 | File exchange | Accepts files from Telegram, exposes their local paths to the agent, and can send files back. |
 | Voice | Supports local voice transcription and optional text-to-speech responses. |
-| Multi-user operation | Isolates users by chat ID, workspace, files, history, jobs, settings, and optionally OS account. |
+| Multi-user operation | Isolates canonical principals, runtime profiles, workspaces, files, history, jobs, settings, and OS accounts. |
 
 ## How It Works
 
 ```text
-Telegram
-  -> Kai service
-    -> per-user agent backend
-      -> local workspace, shell, git, files, web, services
+Workshop browser --\
+                    -> Kai service -> per-user agent backend
+Telegram (optional)-/                    -> local workspace, shell, git, files, web, services
 ```
 
-Kai has two layers. The outer Python service handles Telegram, HTTP, scheduling, authentication, persistence, webhooks, file exchange, and per-user routing. The inner agent backend does the thinking and acting inside a local workspace. Backend subprocesses are created lazily per user and evicted after an idle timeout, so resource use follows active users rather than registered users.
+Kai has two layers. The outer Python service owns client adapters, HTTP, scheduling, authentication, persistence, webhooks, file exchange, and per-user routing. The inner agent backend does the thinking and acting inside a local workspace. Backend subprocesses are created lazily per user and evicted after an idle timeout, so resource use follows active users rather than registered users.
 
-This is not an API relay bot. The inner backend is a full coding-agent runtime with local tools and project context. Kai gives that runtime a durable home, a Telegram control surface, scheduled execution, event-driven inputs, memory, and a security model designed around the fact that it can take real action.
+This is not an API relay bot. The inner backend is a full coding-agent runtime with local tools and project context. Kai gives that runtime a durable home, authenticated client surfaces, scheduled execution, event-driven inputs, memory, and a security model designed around the fact that it can take real action.
 
 ## Backend Options
 
@@ -68,8 +67,7 @@ Kai does not require every supported backend to exist on every machine. Every ba
 Requirements:
 
 - Python 3.13+
-- A Telegram bot token from [BotFather](https://t.me/BotFather)
-- Your Telegram user ID from [userinfobot](https://t.me/userinfobot)
+- A Telegram bot token and Telegram user ID only if enabling the optional Telegram client
 - At least one supported agent backend installed and authenticated
 - Sudo 1.9.3+ for protected multi-user installs (`CWD`/`-D` support)
 
@@ -84,7 +82,17 @@ pip install -e '.[dev]'
 make config
 ```
 
-`make config` runs without `sudo`. It discovers the supported backend CLIs installed on the machine, requires an explicit installation default when more than one is available, and writes `install.conf` as the configuration artifact for the selected deployment mode. It does not accept user-supplied backend executable paths. Model defaults come from Kai's backend/provider/role model registry. In protected installs, conversational model baselines belong to `runtime-profiles.yaml`; operator-set PR-review and issue-triage baselines remain in each human's `models:` map in `users.yaml`. Users can change their active conversational model with `/model`.
+`make config` runs without `sudo`. It discovers the supported backend CLIs installed on the machine, requires an explicit installation default when more than one is available, and writes `install.conf` as the configuration artifact for the selected deployment and client modes. It does not accept user-supplied backend executable paths. Model defaults come from Kai's backend/provider/role model registry. In protected installs, conversational model baselines belong to `runtime-profiles.yaml`; operator-set PR-review and issue-triage baselines remain in each human's `models:` map in `users.yaml`. Users can change their active conversational model with `/model`.
+
+The client-mode choices are explicit and reversible:
+
+- `hybrid` enables Workshop and Telegram and is the upgrade-safe default;
+- `workshop-only` switches an existing protected installation with canonical humans and runtime profiles to the browser client without constructing a Telegram application, contacting Telegram, or retaining a bot token;
+- `telegram-only` runs Telegram without publishing Workshop client routes.
+
+Re-run `make config`, select a different client mode, and apply the installation to change modes. Existing configurations without an explicit client-mode setting remain hybrid. `make install-status` reports both the deployed policy and the current `install.conf` artifact without exposing the Telegram token.
+
+The initial Workshop-only qualification is deliberately an installed-mode switch, not a fresh-host bootstrap path. Fresh protected and single-user Workshop-only provisioning still needs a canonical administration flow for creating the first human and runtime assignment; the wizard refuses those incomplete combinations instead of generating a configuration that cannot start.
 
 For a `single_user` deployment, `make config` also writes the runtime files under the operator's account. Start Kai from the checkout:
 
@@ -124,9 +132,9 @@ event-stream, and authenticated command-submission routes; internal agent APIs
 and webhook ingress remain bound to loopback. This direct listener uses HTTP,
 so use a trusted LAN or put a trusted TLS terminator in front of it.
 
-Protected mode requires every Telegram user to have a unique `os_user` that differs from the Kai service account; this keeps persistent agents from inheriting the daemon's protected-config capabilities. Single-user mode runs the agent as the operator account.
+Protected mode requires every configured Telegram user to have a unique `os_user` that differs from the Kai service account; this keeps persistent agents from inheriting the daemon's protected-config capabilities. Single-user mode runs the agent as the operator account.
 
-Kai-managed per-user identity has one editable source: `<DATA_DIR>/home/<chat_id>/AGENTS.md`. Codex, Goose, OpenCode, and Pi consume that file directly. Claude Code receives a generated `.claude/CLAUDE.md` adapter containing only `@../AGENTS.md`. On upgrade, `make install` migrates existing customized Claude identity content into `AGENTS.md`; if both files contain different customizations, installation stops without choosing or overwriting either one. Instruction files owned by individual project repositories remain independent.
+Kai-managed per-user identity has one editable source: `<DATA_DIR>/home/<principal_id>/AGENTS.md`. Codex, Goose, OpenCode, and Pi consume that file directly. Claude Code receives a generated `.claude/CLAUDE.md` adapter containing only `@../AGENTS.md`. On upgrade, `make install` migrates existing customized Claude identity content into `AGENTS.md`; if both files contain different customizations, installation stops without choosing or overwriting either one. Instruction files owned by individual project repositories remain independent.
 
 Protected Linux installations that use Codex image input also require `setfacl` (normally provided by the distribution's `acl` package). Kai uses a read-only named ACL so an image can remain private to the service and its intended `os_user`; if ACL support is unavailable, that image is dropped with a user-visible notice instead of being made world-readable.
 

--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -2073,8 +2073,41 @@ Telegram components through the common adapter-readiness contract.
 The mixed HTTP application still contains Telegram webhook and compatibility
 integration routes, so the current `HttpAdapter` explicitly receives the
 already-started Telegram adapter. This is a visible transition boundary, not
-an implied core dependency: Milestone 3 will make that binding optional while
+an implied core dependency: Milestone 3 makes that binding optional while
 preserving the existing hybrid configuration.
+
+## 44. Explicit client-adapter deployment policy
+
+**Implementation date:** 2026-08-14
+
+Kai now records the enabled human-facing clients as explicit installation
+policy. `hybrid`, `workshop-only`, and `telegram-only` wizard choices become a
+validated `KAI_ENABLED_ADAPTERS` set. An older installation without the key
+continues in hybrid mode; the compatibility default can be removed after
+installed configurations have been regenerated.
+
+Workshop-only startup does not require a Telegram token, construct a Telegram
+application, attach a Telegram adapter, activate Telegram ingress, publish
+Telegram webhook routes, or start Telegram delivery workers. The HTTP adapter
+accepts no Telegram dependency and still publishes health, protected internal
+services, and authenticated Workshop client routes. Telegram-only startup
+keeps the HTTP health/internal surface but does not publish Workshop client or
+LAN routes. Hybrid remains behavior-compatible with the qualified installed
+system.
+
+This first qualification is a mode switch for an existing protected
+installation whose canonical humans, assignments, and runtime profiles have
+already been provisioned. The wizard rejects fresh-host and single-user
+Workshop-only bootstrap until canonical administration can create that initial
+authority without a transport identity.
+
+Routes whose implementation still owns Telegram scheduling or delivery are
+absent when Telegram is disabled rather than being silently redirected.
+Canonical scheduling and integration migration remains owned by the later
+epic milestones. Installed qualification must switch to Workshop-only with no
+stored bot token, prove browser enrollment, execution, activity,
+cancellation, restart continuity, health, and absence of Telegram contact,
+then restore hybrid mode and re-qualify both clients.
 
 ## Canonical notification feed activation
 

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -5407,13 +5407,16 @@ def create_bot(
     Returns:
         A fully configured Telegram Application ready to be started.
     """
+    token = config.telegram_bot_token
+    if not token:
+        raise RuntimeError("Telegram adapter cannot start without TELEGRAM_BOT_TOKEN")
     builder = (
         Application.builder()
         .application_class(
             KaiTelegramApplication,
             kwargs={"core_services": core_services},
         )
-        .token(config.telegram_bot_token)
+        .token(token)
         .concurrent_updates(True)
     )
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -88,6 +88,33 @@ DATA_DIR = Path(os.environ.get("KAI_DATA_DIR") or str(PROJECT_ROOT))
 # between load_config() and install.py.
 VALID_BACKENDS = {"claude", "goose", "codex", "opencode", "pi"}
 
+# External client adapters are explicit protected policy.  HTTP remains a
+# host-owned listener for health, internal APIs, and configured integrations;
+# these names control the human-facing client surfaces attached to that host.
+# Absence of KAI_ENABLED_ADAPTERS deliberately preserves the historic hybrid
+# deployment so upgrades do not silently disable Telegram.
+VALID_CLIENT_ADAPTERS: frozenset[str] = frozenset({"telegram", "workshop"})
+DEFAULT_CLIENT_ADAPTERS: frozenset[str] = VALID_CLIENT_ADAPTERS
+
+
+def parse_enabled_adapters(value: str | None) -> frozenset[str]:
+    """Parse explicit client-adapter policy, defaulting legacy installs to hybrid."""
+    if value is None:
+        return DEFAULT_CLIENT_ADAPTERS
+    if not value.strip():
+        raise ValueError("must enable at least one client adapter")
+    adapters = frozenset(part.strip().lower() for part in value.split(",") if part.strip())
+    if not adapters:
+        raise ValueError("must enable at least one client adapter")
+    unknown = sorted(adapters - VALID_CLIENT_ADAPTERS)
+    if unknown:
+        raise ValueError(
+            f"contains unsupported adapter(s): {', '.join(unknown)}; "
+            f"expected: {', '.join(sorted(VALID_CLIENT_ADAPTERS))}"
+        )
+    return adapters
+
+
 # Backends that ship a `OneShotReasoner` implementation in
 # `src/kai/oneshot.py`. Every site that gates on "does this backend
 # support one-shot agent dispatch" - memory extraction eligibility,
@@ -1384,14 +1411,16 @@ class Config:
     Optional fields have sensible defaults for single-user local deployment.
 
     Attributes:
-        telegram_bot_token: Bot token from @BotFather (required)
+        telegram_bot_token: Bot token from @BotFather. Required only when the
+            Telegram adapter is enabled.
         telegram_webhook_url: Public URL where Telegram pushes updates via webhook.
             When set, Kai runs in webhook mode (Telegram POSTs updates here).
             When None, Kai falls back to long-polling (Kai pulls updates from Telegram).
         telegram_webhook_secret: Secret token for validating incoming Telegram updates.
             Sent by Telegram as X-Telegram-Bot-Api-Secret-Token header on each update.
             Only used in webhook mode. Generated for the process when not explicitly set.
-        allowed_user_ids: Set of Telegram user IDs permitted to interact with the bot (required)
+        allowed_user_ids: Telegram user IDs permitted to interact with the bot;
+            empty when the Telegram adapter is disabled and no users file exists.
         default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.5-pro, gemini-2.5-pro)
         default_timeout: Seconds before an agent response is considered timed
             out, on every backend
@@ -1413,9 +1442,13 @@ class Config:
             without being under WORKSPACE_BASE. Non-existent paths are skipped at startup.
     """
 
-    # Required fields - no defaults, must be provided
-    telegram_bot_token: str
+    # Telegram credentials are optional for Workshop-only deployments.
+    telegram_bot_token: str | None
     allowed_user_ids: set[int]
+
+    # Explicit human-facing adapter policy. The default preserves the client
+    # surfaces used by installations created before this policy existed.
+    enabled_adapters: frozenset[str] = field(default_factory=lambda: DEFAULT_CLIENT_ADAPTERS)
 
     # Telegram transport mode: set telegram_webhook_url to use webhook mode,
     # leave as None to fall back to long-polling. The secret is only needed
@@ -1557,13 +1590,19 @@ class Config:
     # 0 = no cleanup (default). Cleanup runs once every 24 hours.
     file_retention_days: int = 0
 
-    # Per-user configuration from users.yaml, keyed by telegram_id.
-    # users.yaml is mandatory: _load_user_configs raises SystemExit
-    # if the file is missing, malformed, or has no valid entries, so
-    # this field is always a populated dict at runtime. The default
-    # factory is for tests that construct Config directly; production
-    # code goes through load_config.
+    # Telegram identity and compatibility policy from users.yaml, keyed by
+    # telegram_id. It is required and non-empty when Telegram is enabled. A
+    # Workshop-only runtime may have no users.yaml and instead use canonical
+    # humans plus protected runtime profiles.
     user_configs: dict[int, UserConfig] = field(default_factory=dict)
+
+    @property
+    def telegram_enabled(self) -> bool:
+        return "telegram" in self.enabled_adapters
+
+    @property
+    def workshop_enabled(self) -> bool:
+        return "workshop" in self.enabled_adapters
 
     # TOTP two-factor authentication timing (only relevant when TOTP is enabled)
     totp_session_minutes: int = 30
@@ -3035,10 +3074,21 @@ def load_config() -> Config:
     else:
         load_dotenv(PROJECT_ROOT / ".env")
 
-    # Validate required: Telegram bot token
-    token = os.environ.get("TELEGRAM_BOT_TOKEN")
-    if not token:
-        raise SystemExit("TELEGRAM_BOT_TOKEN is required in .env")
+    try:
+        enabled_adapters = parse_enabled_adapters(os.environ.get("KAI_ENABLED_ADAPTERS"))
+    except ValueError as exc:
+        raise SystemExit(f"KAI_ENABLED_ADAPTERS {exc}") from None
+
+    # Telegram credentials are adapter configuration, not host credentials.
+    # Keeping a token in protected storage while the adapter is disabled must
+    # not construct a client or contact Telegram; the wizard normally removes
+    # it so Workshop-only qualification can also prove token absence.
+    telegram_enabled = "telegram" in enabled_adapters
+    workshop_enabled = "workshop" in enabled_adapters
+    stored_token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip() or None
+    token = stored_token if telegram_enabled else None
+    if telegram_enabled and token is None:
+        raise SystemExit("TELEGRAM_BOT_TOKEN is required when the Telegram adapter is enabled")
 
     # Telegram transport mode: if TELEGRAM_WEBHOOK_URL is set, use webhook mode
     # (Telegram POSTs updates to this URL). If unset, fall back to long-polling
@@ -3047,7 +3097,7 @@ def load_config() -> Config:
     telegram_webhook_url: str | None = None
     telegram_webhook_secret: str | None = None
     raw_webhook_url = os.environ.get("TELEGRAM_WEBHOOK_URL", "").strip()
-    if raw_webhook_url:
+    if telegram_enabled and raw_webhook_url:
         telegram_webhook_url = raw_webhook_url
 
         # Webhook secret: validates incoming updates from Telegram. A fresh
@@ -3058,8 +3108,10 @@ def load_config() -> Config:
         if not telegram_webhook_secret:
             telegram_webhook_secret = secrets.token_urlsafe(32)
         log.info("Telegram transport: webhook (%s)", telegram_webhook_url)
-    else:
+    elif telegram_enabled:
         log.info("Telegram transport: polling (TELEGRAM_WEBHOOK_URL not set)")
+    else:
+        log.info("Telegram adapter disabled by KAI_ENABLED_ADAPTERS")
 
     # Validate optional: workspace base directory (must exist if provided)
     workspace_base = None
@@ -3142,6 +3194,8 @@ def load_config() -> Config:
         )
     except ValueError as exc:
         raise SystemExit(f"WORKSHOP_LAN_HOST {exc}") from None
+    if workshop_lan_host and not workshop_enabled:
+        raise SystemExit("WORKSHOP_LAN_HOST requires the Workshop adapter to be enabled")
     try:
         file_retention_days = int(os.environ.get("FILE_RETENTION_DAYS", "0"))
     except ValueError:
@@ -3445,13 +3499,10 @@ def load_config() -> Config:
     # workspaces the user is otherwise allowed to enter.
     memory_projects = _load_memory_project_configs()
 
-    # Per-user configuration. users.yaml is mandatory; the loader
-    # raises SystemExit on any failure with a path-naming message
-    # (and a one-line ALLOWED_USER_IDS migration hint when that env
-    # var is set on a missing-file install). The legacy env-var
-    # fallback is gone: a malformed users file used to silently
-    # degrade to ALLOWED_USER_IDS, which the wizard and the loader
-    # then disagreed about; fail-closed is the contract now.
+    # Telegram identity and compatibility configuration. users.yaml is
+    # mandatory while Telegram is enabled; a missing file is permitted in a
+    # Workshop-only runtime, while a present malformed file always fails
+    # closed. The legacy ALLOWED_USER_IDS authorization fallback is gone.
     #
     # The path resolves based on whether `/etc/kai/env` had readable
     # content at the top of this load_config call (protected install)
@@ -3460,8 +3511,18 @@ def load_config() -> Config:
     # explicit override for tests and ad-hoc development; the operator
     # path is always one of the two resolved defaults.
     users_yaml_path = _resolve_users_yaml_path(bool(protected_env))
-    user_configs = _load_user_configs(default_backend, default_provider, users_yaml_path)
-    if protected_env:
+    if telegram_enabled or protected_env:
+        user_configs = _load_user_configs(default_backend, default_provider, users_yaml_path)
+    else:
+        # Direct development can omit Telegram identities when the adapter is
+        # disabled. Protected installs retain their existing, real identity
+        # mappings during this installed qualification slice.
+        raw_users = _read_users_yaml(users_yaml_path)
+        if raw_users is None:
+            user_configs = {}
+        else:
+            user_configs = _load_user_configs(default_backend, default_provider, users_yaml_path)
+    if protected_env and user_configs:
         # A protected install gives the outer service account narrowly
         # scoped sudo access to root-owned Kai configuration.  A persistent
         # conversational agent running as that same account would inherit
@@ -3691,6 +3752,7 @@ def load_config() -> Config:
         telegram_webhook_url=telegram_webhook_url,
         telegram_webhook_secret=telegram_webhook_secret,
         allowed_user_ids=allowed_ids,
+        enabled_adapters=enabled_adapters,
         default_model=default_model,
         default_models=default_models,
         default_timeout=default_timeout,

--- a/src/kai/http_adapter.py
+++ b/src/kai/http_adapter.py
@@ -54,10 +54,9 @@ class HttpAdapterReadiness:
 class HttpAdapter:
     """Own HTTP listener startup, readiness, supervision, and shutdown.
 
-    The current mixed HTTP application still hosts Telegram webhook and
-    compatibility integration routes, so this Milestone 2 adapter receives the
-    already-started Telegram adapter explicitly. Making that dependency
-    optional is the configuration and route-separation cutover in Milestone 3.
+    Telegram-owned routes and dependencies are installed only when a started
+    Telegram adapter is supplied.  The loopback host and Workshop client can
+    therefore run without constructing any Telegram application.
     """
 
     def __init__(
@@ -65,7 +64,7 @@ class HttpAdapter:
         config: Config,
         core_host: KaiApplicationHost,
         core_services: KaiCoreServices,
-        telegram_adapter: TelegramAdapter,
+        telegram_adapter: TelegramAdapter | None,
     ) -> None:
         self._config = config
         self._core_host = core_host
@@ -89,11 +88,12 @@ class HttpAdapter:
         self._state = HttpAdapterState.STARTING
         try:
             await webhook.start(
-                self._telegram_adapter.application,
+                self._telegram_adapter.application if self._telegram_adapter else None,
                 self._config,
                 core_host=self._core_host,
                 core_services=self._core_services,
-                github_notifications=self._telegram_adapter.notification_delivery,
+                github_notifications=(self._telegram_adapter.notification_delivery if self._telegram_adapter else None),
+                workshop_enabled=self._config.workshop_enabled,
             )
         except BaseException:
             self._state = HttpAdapterState.FAILED

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -65,6 +65,7 @@ from kai.config import (
     get_effective_provider,
     models_for_backend,
     normalize_workshop_lan_host,
+    parse_enabled_adapters,
     validate_model_for_backend,
     validate_model_for_backend_policy,
 )
@@ -1424,6 +1425,37 @@ def _cmd_config() -> None:
     )
     print()
 
+    # -- Client mode --
+    # Existing configurations without KAI_ENABLED_ADAPTERS are hybrid by
+    # definition.  Persisting the selected mode makes adapter construction an
+    # explicit protected policy decision rather than an inference from whether
+    # a token happens to be present.
+    try:
+        existing_adapters = parse_enabled_adapters(existing_env.get("KAI_ENABLED_ADAPTERS"))
+    except ValueError as exc:
+        raise SystemExit(f"install.conf KAI_ENABLED_ADAPTERS {exc}") from None
+    existing_client_mode = {
+        frozenset({"telegram", "workshop"}): "hybrid",
+        frozenset({"workshop"}): "workshop-only",
+        frozenset({"telegram"}): "telegram-only",
+    }[existing_adapters]
+    print("-- Client mode --")
+    client_mode = _prompt_choice(
+        "Enabled clients",
+        ["hybrid", "workshop-only", "telegram-only"],
+        existing_client_mode,
+    )
+    telegram_enabled = client_mode in {"hybrid", "telegram-only"}
+    workshop_enabled = client_mode in {"hybrid", "workshop-only"}
+    enabled_adapters = {
+        "hybrid": "telegram,workshop",
+        "workshop-only": "workshop",
+        "telegram-only": "telegram",
+    }[client_mode]
+    if not telegram_enabled:
+        print("  Telegram is disabled; the bot token will be omitted from the generated configuration.")
+    print()
+
     # Migration safety: if the operator picks single_user but a
     # readable `/etc/kai/env` exists from a previous protected install,
     # the runtime predicate in `config._resolve_users_yaml_path` will
@@ -1493,12 +1525,14 @@ def _cmd_config() -> None:
         platform = detected_platform
 
     # -- Telegram --
-    print("-- Telegram --")
-    bot_token = _prompt(
-        "Telegram bot token",
-        existing_env.get("TELEGRAM_BOT_TOKEN", ""),
-        required=True,
-    )
+    bot_token = ""
+    if telegram_enabled:
+        print("-- Telegram --")
+        bot_token = _prompt(
+            "Telegram bot token",
+            existing_env.get("TELEGRAM_BOT_TOKEN", ""),
+            required=True,
+        )
 
     # -- User setup --
     # `/etc/kai/users.yaml` is the only canonical source for the wizard.
@@ -1527,6 +1561,19 @@ def _cmd_config() -> None:
     else:
         users_yaml_path = _xdg_users_yaml_path()
     users_yaml_exists = users_yaml_path.exists()
+    if not telegram_enabled:
+        if deployment_mode == "single_user":
+            raise SystemExit(
+                "Workshop-only single-user bootstrap is not available yet. "
+                "Use a protected installation with existing canonical runtime policy, "
+                "or keep Telegram enabled for single-user setup."
+            )
+        if not users_yaml_exists or not RUNTIME_PROFILES_YAML.is_file():
+            raise SystemExit(
+                "Workshop-only mode currently requires an existing protected installation "
+                "with users.yaml and runtime-profiles.yaml. Start from the qualified hybrid "
+                "installation path before switching modes."
+            )
     stray_note = (
         f"  Note: {stray_project_users_yaml} is no longer used. Move it to {users_yaml_path} or remove it."
         if stray_project_users_yaml.exists()
@@ -1536,9 +1583,9 @@ def _cmd_config() -> None:
     # do: a first-time install (the admin prompts below run) or a stray
     # leftover to warn about. When the canonical users.yaml already
     # exists the wizard leaves it untouched, so it prints no bare header.
-    if not users_yaml_exists or stray_note:
+    if telegram_enabled and (not users_yaml_exists or stray_note):
         print("-- User setup --")
-    if stray_note:
+    if telegram_enabled and stray_note:
         print(stray_note)
 
     # Admin os_user captured by the advanced-mode prompt block below.
@@ -1568,7 +1615,7 @@ def _cmd_config() -> None:
 
     # First-time install only: collect the admin identity and stage a
     # users.yaml. An existing canonical file is left untouched.
-    if not users_yaml_exists:
+    if telegram_enabled and not users_yaml_exists:
         while True:
             admin_telegram_id = _prompt(
                 "Admin Telegram ID",
@@ -1655,7 +1702,7 @@ def _cmd_config() -> None:
             os.chmod(users_yaml_path, 0o600)
         print(f"  Generated {users_yaml_path}")
 
-    if deployment_mode == "protected":
+    if deployment_mode == "protected" and telegram_enabled:
         try:
             _validate_protected_users_yaml(
                 users_yaml_path,
@@ -1669,7 +1716,7 @@ def _cmd_config() -> None:
     # gated on the same condition as its header. On a re-run with an
     # existing users.yaml the section is silent, so this would otherwise
     # be an orphaned blank line before the transport prompt.
-    if not users_yaml_exists or stray_note:
+    if telegram_enabled and (not users_yaml_exists or stray_note):
         print()
 
     protected_yaml_staging_paths = _stage_optional_protected_yaml_configs(deployment_mode)
@@ -1678,15 +1725,17 @@ def _cmd_config() -> None:
         print(f"Staged protected YAML config for install: {staged_names}")
         print()
 
-    transport = _prompt_choice(
-        "Telegram transport",
-        ["polling", "webhook"],
-        existing_env.get("TELEGRAM_TRANSPORT", "polling"),
-    )
+    transport = existing_env.get("TELEGRAM_TRANSPORT", "polling")
+    if telegram_enabled:
+        transport = _prompt_choice(
+            "Telegram transport",
+            ["polling", "webhook"],
+            existing_env.get("TELEGRAM_TRANSPORT", "polling"),
+        )
 
-    webhook_url = ""
-    tg_webhook_secret = ""
-    if transport == "webhook":
+    webhook_url = existing_env.get("TELEGRAM_WEBHOOK_URL", "")
+    tg_webhook_secret = existing_env.get("TELEGRAM_WEBHOOK_SECRET", "")
+    if telegram_enabled and transport == "webhook":
         webhook_url = _prompt(
             "Telegram webhook URL",
             existing_env.get("TELEGRAM_WEBHOOK_URL", ""),
@@ -1696,7 +1745,8 @@ def _cmd_config() -> None:
             "Telegram webhook secret",
             existing_env.get("TELEGRAM_WEBHOOK_SECRET", ""),
         )
-    print()
+    if telegram_enabled:
+        print()
 
     # -- Default backend --
     print("-- Default backend --")
@@ -2090,16 +2140,18 @@ def _cmd_config() -> None:
             break
         print("  Must be a valid port number (1-65535).")
 
-    while True:
-        workshop_lan_host_input = _prompt(
-            "Workshop LAN address (optional; client routes only)",
-            existing_env.get("WORKSHOP_LAN_HOST", ""),
-        )
-        try:
-            workshop_lan_host = normalize_workshop_lan_host(workshop_lan_host_input)
-            break
-        except ValueError as exc:
-            print(f"  Workshop LAN address {exc}.")
+    workshop_lan_host = ""
+    if workshop_enabled:
+        while True:
+            workshop_lan_host_input = _prompt(
+                "Workshop LAN address (optional; client routes only)",
+                existing_env.get("WORKSHOP_LAN_HOST", ""),
+            )
+            try:
+                workshop_lan_host = normalize_workshop_lan_host(workshop_lan_host_input)
+                break
+            except ValueError as exc:
+                print(f"  Workshop LAN address {exc}.")
     if workshop_lan_host:
         print(
             "  Warning: Workshop bearer sessions will use plain HTTP on this "
@@ -2187,14 +2239,17 @@ def _cmd_config() -> None:
 
     # -- Optional features --
     print("-- Optional features --")
-    voice_enabled = _prompt_bool(
-        "Voice transcription",
-        existing_env.get("VOICE_ENABLED", "false").lower() in ("1", "true", "yes"),
-    )
-    tts_enabled = _prompt_bool(
-        "Text-to-speech",
-        existing_env.get("TTS_ENABLED", "false").lower() in ("1", "true", "yes"),
-    )
+    voice_enabled = existing_env.get("VOICE_ENABLED", "false").lower() in ("1", "true", "yes")
+    tts_enabled = existing_env.get("TTS_ENABLED", "false").lower() in ("1", "true", "yes")
+    if telegram_enabled:
+        voice_enabled = _prompt_bool(
+            "Voice transcription",
+            existing_env.get("VOICE_ENABLED", "false").lower() in ("1", "true", "yes"),
+        )
+        tts_enabled = _prompt_bool(
+            "Text-to-speech",
+            existing_env.get("TTS_ENABLED", "false").lower() in ("1", "true", "yes"),
+        )
 
     # Per-user OS isolation lives in users.yaml `os_user` (admin-set
     # baseline) and is no longer mirrored to a global env var. The
@@ -2425,13 +2480,15 @@ def _cmd_config() -> None:
     # Build the env dict (only include non-empty values).
     # Truly global vars are always written regardless of users.yaml.
     env: dict[str, str] = {
-        "TELEGRAM_BOT_TOKEN": bot_token,
+        "KAI_ENABLED_ADAPTERS": enabled_adapters,
         "WEBHOOK_PORT": port,
         "GITHUB_WEBHOOK_SECRET": github_webhook_secret,
         "GENERIC_WEBHOOK_SECRET": generic_webhook_secret,
         "VOICE_ENABLED": str(voice_enabled).lower(),
         "TTS_ENABLED": str(tts_enabled).lower(),
     }
+    if telegram_enabled:
+        env["TELEGRAM_BOT_TOKEN"] = bot_token
     if workshop_lan_host:
         env["WORKSHOP_LAN_HOST"] = workshop_lan_host
     # DEFAULT_BACKEND is the global default backend; users.yaml entries
@@ -5668,7 +5725,12 @@ def _cmd_apply() -> None:
             env,
             effective_users_yaml,
         )
-    except ValueError as exc:
+        runtime_policy.validate_protected_os_users(
+            service_user,
+            account_uid=lambda name: pwd.getpwnam(name).pw_uid,
+            service_uid=svc_uid,
+        )
+    except (ValueError, WorkshopRuntimeProfileError) as exc:
         raise SystemExit(
             f"Protected runtime policy preflight failed; no installation changes were made:\n{exc}"
         ) from exc
@@ -7810,6 +7872,17 @@ def _cmd_status() -> None:
     print(_check_path(RUNTIME_PROFILES_YAML, "Runtime profiles"))
     print(_check_path(Path("/etc/sudoers.d/kai"), "Sudoers"))
     print(_check_service_status(platform))
+    print(_deployed_adapter_policy_status(_DEPLOYED_ENV_FILE))
+    schedule_status = _dormant_compatibility_schedule_status(
+        Path(data_dir) / "kai.db",
+        _DEPLOYED_ENV_FILE,
+    )
+    if schedule_status is not None:
+        print(schedule_status)
+    if conf_env is None:
+        print("Client adapters (install.conf artifact): unavailable")
+    else:
+        print(_adapter_policy_status(conf_env, source="install.conf artifact"))
     print(_deployed_webhook_secret_migration_status(_DEPLOYED_ENV_FILE))
     if conf_env is None:
         print("Webhook secret migration (install.conf artifact): unavailable")
@@ -8026,6 +8099,82 @@ def _webhook_secret_migration_status(env: dict[str, str], *, source: str = "inst
         return f"{prefix} named GitHub/generic secrets configured; unsupported WEBHOOK_SECRET absent"
     missing = [key for key in ("GITHUB_WEBHOOK_SECRET", "GENERIC_WEBHOOK_SECRET") if not env.get(key, "").strip()]
     return f"{prefix} unsupported WEBHOOK_SECRET absent; missing named secret(s): {', '.join(missing)}"
+
+
+def _adapter_policy_status(env: dict[str, str], *, source: str) -> str:
+    """Report configured client adapters without exposing token content."""
+    raw = env.get("KAI_ENABLED_ADAPTERS")
+    try:
+        adapters = parse_enabled_adapters(raw)
+    except ValueError as exc:
+        return f"Client adapters ({source}): INVALID ({exc})"
+    names = ",".join(sorted(adapters))
+    telegram_enabled = "telegram" in adapters
+    token_present = bool(env.get("TELEGRAM_BOT_TOKEN", "").strip())
+    if telegram_enabled:
+        token_state = "token configured" if token_present else "TOKEN MISSING"
+    else:
+        token_state = "no token configured" if not token_present else "stored token ignored"
+    legacy = "; legacy hybrid default" if raw is None or not raw.strip() else ""
+    return (
+        f"Client adapters ({source}): {names}; Telegram "
+        f"{'enabled' if telegram_enabled else 'disabled'}, {token_state}{legacy}"
+    )
+
+
+def _deployed_adapter_policy_status(env_path: Path) -> str:
+    """Inspect deployed adapter names and token presence, never token content."""
+    source = f"deployed {env_path}"
+    try:
+        configured = _read_deployed_adapter_configuration(env_path)
+    except FileNotFoundError:
+        return f"Client adapters ({source}): deployed environment file not found"
+    except ProtectedConfigError as exc:
+        return f"Client adapters ({source}): NOT VERIFIED ({exc})"
+    except PermissionError:
+        return f"Client adapters ({source}): NOT VERIFIED (permission denied; run `make install-status`)"
+    except (OSError, UnicodeError) as exc:
+        return f"Client adapters ({source}): NOT VERIFIED (could not read deployed environment: {exc})"
+    return _adapter_policy_status(configured, source=source)
+
+
+def _read_deployed_adapter_configuration(env_path: Path) -> dict[str, str]:
+    """Read only adapter policy and token presence from protected environment."""
+    validate_protected_file_metadata(env_path, max_mode=0o600, require_root_owner=True)
+    configured: dict[str, str] = {}
+    with env_path.open(encoding="utf-8") as env_file:
+        for line in env_file:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            key, separator, raw_value = stripped.partition("=")
+            key = key.strip()
+            if not separator or key not in {"KAI_ENABLED_ADAPTERS", "TELEGRAM_BOT_TOKEN"}:
+                continue
+            value = raw_value.strip().strip("\"'")
+            configured[key] = value if key == "KAI_ENABLED_ADAPTERS" else ("configured" if value else "")
+    return configured
+
+
+def _dormant_compatibility_schedule_status(db_path: Path, env_path: Path) -> str | None:
+    """Report active Telegram-owned jobs that cannot fire without the adapter."""
+    try:
+        configured = _read_deployed_adapter_configuration(env_path)
+        adapters = parse_enabled_adapters(configured.get("KAI_ENABLED_ADAPTERS"))
+    except (FileNotFoundError, OSError, UnicodeError, ProtectedConfigError, ValueError):
+        return None
+    if "telegram" in adapters or not db_path.is_file():
+        return None
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            row = connection.execute("SELECT COUNT(*) FROM jobs WHERE active = 1").fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        return f"Compatibility schedules: NOT VERIFIED ({exc})"
+    count = int(row[0]) if row else 0
+    return f"Compatibility schedules: {count} active job(s) dormant; Telegram adapter disabled"
 
 
 def _deployed_webhook_secret_migration_status(env_path: Path) -> str:

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -6,12 +6,12 @@ Provides functionality to:
 2. Load configuration and validate environment
 3. Initialize the database, transport-neutral core, adapters, jobs, and HTTP server
 4. Restore workspace from previous session
-5. Start the Telegram transport (webhook or polling, depending on config)
+5. Start the optional Telegram transport when configured
 6. Notify the user if a previous response was interrupted by a crash
 7. Run the event loop until shutdown (Ctrl+C or SIGTERM)
 8. Clean up all resources in the correct order on exit
 
-Telegram transport mode is determined by TELEGRAM_WEBHOOK_URL in .env:
+When Telegram is enabled, transport mode is determined by TELEGRAM_WEBHOOK_URL:
     - Set: webhook mode (Telegram POSTs updates to Kai's HTTP server)
     - Unset: polling mode (Kai pulls updates from Telegram's servers)
 
@@ -19,10 +19,10 @@ The startup sequence is:
     1. Load config from .env
     2. Initialize SQLite database
     3. Start the transport-neutral runtime and Workshop execution host
-    4. Attach the explicit Telegram adapter to the core host
+    4. Attach the explicit Telegram adapter when enabled
     5. Restore previous workspace (if saved in settings table)
-    6. Let the adapter initialize Telegram, register commands, and load jobs
-    7. Start adapter-owned conversation and notification delivery workers
+    6. Let an enabled adapter initialize Telegram, register commands, and load jobs
+    7. Start enabled adapter-owned conversation and notification delivery workers
     8. Attach the HTTP adapter for Workshop, integrations, and webhook ingress
     9. In webhook mode: register Telegram webhook with the API
        In polling mode: start the Updater's polling loop
@@ -48,6 +48,20 @@ from kai.http_adapter import HttpAdapter
 from kai.telegram_adapter import TelegramAdapter
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+
+
+async def _warn_if_compatibility_jobs_are_dormant(config) -> int:
+    """Warn when disabling Telegram also pauses its compatibility scheduler."""
+    if config.telegram_enabled:
+        return 0
+    active_jobs = await sessions.get_all_active_jobs()
+    count = len(active_jobs)
+    if count:
+        logging.warning(
+            "Telegram adapter is disabled; %d active compatibility scheduled job(s) are dormant",
+            count,
+        )
+    return count
 
 
 def _workshop_bootstrap_humans(
@@ -292,10 +306,11 @@ def _start() -> None:
         restores previous state, and blocks until shutdown. The finally
         block ensures all resources are cleaned up in reverse order.
         """
-        # Derive transport mode from config: webhook if URL is set, polling otherwise
-        use_webhook = config.telegram_webhook_url is not None
+        # Derive Telegram transport only when that optional adapter is enabled.
+        use_webhook = config.telegram_enabled and config.telegram_webhook_url is not None
 
         await sessions.init_db(config.session_db_path)
+        await _warn_if_compatibility_jobs_are_dormant(config)
 
         # Seed the non-authoritative Workshop identity/channel projection.
         # Notification groups are outbound-only channels: they share existing
@@ -344,15 +359,16 @@ def _start() -> None:
         telegram_adapter: TelegramAdapter | None = None
         cleanup_task: asyncio.Task[None] | None = None
 
-        # Determine the default user (admin or first user) for per-user
-        # data migrations and workspace restoration. users.yaml is
-        # mandatory so user_configs is always non-empty; the admin
-        # branch is preferred, otherwise the first entry wins.
+        # Determine the default compatibility user (admin or first user) for
+        # legacy per-user migrations. Workshop-only installations may have no
+        # users.yaml entries, in which case these migrations are unnecessary.
         admins = config.get_admins()
         if admins:
             default_chat_id: int | None = admins[0].telegram_id
-        else:
+        elif config.user_configs:
             default_chat_id = next(iter(config.user_configs))
+        else:
+            default_chat_id = None
 
         # One-time migration: rename global "workspace" setting to
         # "workspace:{chat_id}" for per-user namespacing (Phase 2).
@@ -400,12 +416,13 @@ def _start() -> None:
             core_services = await core_host.start()
             logging.info("Kai core application host is ready")
 
-            telegram_adapter = TelegramAdapter(
-                config,
-                core_services,
-                use_webhook=use_webhook,
-            )
-            await core_host.attach_adapter("telegram", telegram_adapter)
+            if config.telegram_enabled:
+                telegram_adapter = TelegramAdapter(
+                    config,
+                    core_services,
+                    use_webhook=use_webhook,
+                )
+                await core_host.attach_adapter("telegram", telegram_adapter)
 
             http_adapter = HttpAdapter(
                 config,
@@ -414,7 +431,8 @@ def _start() -> None:
                 telegram_adapter,
             )
             await core_host.attach_adapter("http", http_adapter)
-            await telegram_adapter.activate_ingress()
+            if telegram_adapter is not None:
+                await telegram_adapter.activate_ingress()
             # Phase 3: per-user file confinement is handled at request
             # time via pool.get_effective_workspace(chat_id) in
             # webhook.py. No global workspace sync needed at startup.
@@ -427,30 +445,30 @@ def _start() -> None:
             # Phase 2: check all files in the .responding directory (per-user
             # flags) instead of the old single .responding_to file.
             responding_dir = DATA_DIR / ".responding"
-            try:
-                flags = list(responding_dir.iterdir()) if responding_dir.is_dir() else []
-            except OSError:
-                flags = []
-            for flag in flags:
-                # Always unlink the flag first: prevents double-notify on
-                # restart if send fails, and cleans up malformed files
-                # (e.g., OS temp files) that would otherwise persist forever.
-                flag.unlink(missing_ok=True)
+            if telegram_adapter is not None:
                 try:
-                    interrupted_chat_id = int(flag.name)
-                    await telegram_adapter.bot.send_message(
-                        interrupted_chat_id,
-                        "Sorry, my previous response was interrupted. Please resend your last message.",
-                    )
-                    logging.info("Notified chat %d of interrupted response", interrupted_chat_id)
-                except Exception:
-                    logging.exception("Failed to process interrupted-response flag: %s", flag.name)
+                    flags = list(responding_dir.iterdir()) if responding_dir.is_dir() else []
+                except OSError:
+                    flags = []
+                for flag in flags:
+                    # Always unlink the flag first: prevents double-notify on
+                    # restart if send fails, and cleans up malformed files.
+                    flag.unlink(missing_ok=True)
+                    try:
+                        interrupted_chat_id = int(flag.name)
+                        await telegram_adapter.bot.send_message(
+                            interrupted_chat_id,
+                            "Sorry, my previous response was interrupted. Please resend your last message.",
+                        )
+                        logging.info("Notified chat %d of interrupted response", interrupted_chat_id)
+                    except Exception:
+                        logging.exception("Failed to process interrupted-response flag: %s", flag.name)
 
             # Clean up old single-file flag if it exists (one-time migration).
             # Unlink unconditionally (same pattern as the new-style flags)
             # so malformed content doesn't persist across restarts.
             old_flag = DATA_DIR / ".responding_to"
-            if old_flag.exists():
+            if old_flag.exists() and telegram_adapter is not None:
                 try:
                     old_content = old_flag.read_text().strip()
                     old_flag.unlink(missing_ok=True)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -2465,42 +2465,56 @@ async def _webhook_health_loop(bot, webhook_url: str, webhook_secret: str, chat_
 # ── Lifecycle ────────────────────────────────────────────────────────
 
 
-def _register_routes(app: web.Application, config: Config) -> None:
-    """Register independently gated external routes and always-on internal APIs."""
+def _register_routes(
+    app: web.Application,
+    config: Config,
+    *,
+    telegram_enabled: bool = True,
+) -> None:
+    """Register gated adapter routes and transport-independent internal APIs."""
     app.router.add_get("/health", _handle_health)
 
-    if config.telegram_webhook_url:
+    if telegram_enabled and config.telegram_webhook_url:
         if not config.telegram_webhook_secret:
             raise RuntimeError("Telegram webhook mode requires a non-empty secret")
         app[TELEGRAM_WEBHOOK_SECRET_KEY] = config.telegram_webhook_secret
         app.router.add_post("/webhook/telegram", _handle_telegram_update)
 
-    if config.github_webhook_secret:
+    if telegram_enabled and config.github_webhook_secret:
         app[GITHUB_WEBHOOK_SECRET_KEY] = config.github_webhook_secret
         app.router.add_post("/webhook/github", _handle_github)
-    else:
+    elif telegram_enabled:
         log.warning("GITHUB_WEBHOOK_SECRET not set - GitHub webhook endpoint disabled")
+    elif config.github_webhook_secret:
+        log.info("GitHub webhook endpoint disabled because the Telegram adapter is disabled")
 
-    if config.generic_webhook_secret:
+    if telegram_enabled and config.generic_webhook_secret:
         app[GENERIC_WEBHOOK_SECRET_KEY] = config.generic_webhook_secret
         app.router.add_post("/webhook", _handle_generic)
-    else:
+    elif telegram_enabled:
         log.info("GENERIC_WEBHOOK_SECRET not set - generic webhook endpoint disabled")
+    elif config.generic_webhook_secret:
+        log.info("Generic webhook endpoint disabled because the Telegram adapter is disabled")
 
     # These routes authenticate through INTERNAL_API_AUTH_KEY. Their
     # availability must not be coupled to any public ingress configuration.
-    app.router.add_post("/api/schedule", _handle_schedule)
     app.router.add_get("/api/jobs", _handle_get_jobs)
     app.router.add_get("/api/jobs/{id}", _handle_get_job)
-    app.router.add_delete("/api/jobs/{id}", _handle_delete_job)
-    app.router.add_patch("/api/jobs/{id}", _handle_update_job)
     app.router.add_post("/api/services/{name}", _handle_service_call)
-    app.router.add_post("/api/send-message", _handle_send_message)
-    app.router.add_post("/api/send-file", _handle_send_file)
     app.router.add_post("/api/memory/add", _handle_memory_add)
     app.router.add_post("/api/memory/search", _handle_memory_search)
     app.router.add_get("/api/memory/stats", _handle_memory_stats)
     app.router.add_delete("/api/memory/all", _handle_memory_delete_all)
+    if telegram_enabled:
+        # These compatibility operations still use Telegram's scheduler or
+        # delivery surface. They are absent when the adapter is disabled and
+        # are not silently redirected. Later canonical scheduler, message,
+        # and artifact services will replace them.
+        app.router.add_post("/api/schedule", _handle_schedule)
+        app.router.add_delete("/api/jobs/{id}", _handle_delete_job)
+        app.router.add_patch("/api/jobs/{id}", _handle_update_job)
+        app.router.add_post("/api/send-message", _handle_send_message)
+        app.router.add_post("/api/send-file", _handle_send_file)
 
 
 async def _register_workshop_client_api(
@@ -2554,37 +2568,41 @@ async def _register_workshop_client_api(
 
 
 async def start(
-    telegram_app: Application,
+    telegram_app: Application | None,
     config: Config,
     *,
     core_host: KaiApplicationHost,
     core_services: KaiCoreServices,
-    github_notifications: WorkshopTelegramNotificationService,
+    github_notifications: WorkshopTelegramNotificationService | None,
+    workshop_enabled: bool = True,
 ) -> None:
     """
     Start the HTTP server and optionally register the Telegram webhook.
 
-    The HTTP server always starts regardless of transport mode - it serves the
-    scheduling API, GitHub webhooks, file exchange, and health check. The
-    Telegram webhook route and set_webhook API call are only added/made when
-    config.telegram_webhook_url is set (webhook mode).
+    The HTTP server always starts for health and transport-independent internal
+    APIs. Workshop client routes are independently enabled. Telegram webhook,
+    compatibility scheduling/delivery, and external integration routes are
+    registered only when a Telegram application is supplied.
 
     In polling mode, the server still runs but Telegram updates arrive via
     the Updater's long-polling loop in ``TelegramAdapter`` instead.
 
     Args:
-        telegram_app: The python-telegram-bot Application instance.
         config: The application Config instance.
         core_host: Core lifecycle owner used for health/readiness reporting.
         core_services: Typed core dependencies required by HTTP routes.
-        github_notifications: Telegram adapter for the configured notification feed.
+        telegram_app: Started Telegram application, or None when disabled.
+        github_notifications: Telegram notification service, or None when disabled.
+        workshop_enabled: Whether to publish Workshop client routes.
     """
     global _app, _runner, _workshop_lan_runner, _webhook_registered, _health_monitor_task
 
     _app = web.Application()
     _app[CORE_HOST_KEY] = core_host
-    _app[TELEGRAM_APP_KEY] = telegram_app
-    _app[TELEGRAM_BOT_KEY] = telegram_app.bot
+    telegram_enabled = telegram_app is not None
+    if telegram_enabled:
+        _app[TELEGRAM_APP_KEY] = telegram_app
+        _app[TELEGRAM_BOT_KEY] = telegram_app.bot
 
     pool = core_services.subprocess_pool
     internal_api_auth = getattr(pool, "internal_api_auth", None)
@@ -2595,19 +2613,20 @@ async def start(
     # Set the fallback destination for unattributed external webhook events.
     # Internal API calls never use this value for identity; their credential
     # resolves a principal before the handler runs.
-    admins = config.get_admins()
-    if admins:
-        _app[CHAT_ID_KEY] = admins[0].telegram_id
-    else:
-        fallback = next(iter(config.user_configs.values()))
-        log.warning(
-            "No admin users defined in users.yaml; using %s "
-            "(telegram_id: %d) as default webhook target. "
-            "External notifications may route unexpectedly.",
-            fallback.name,
-            fallback.telegram_id,
-        )
-        _app[CHAT_ID_KEY] = fallback.telegram_id
+    if telegram_enabled:
+        admins = config.get_admins()
+        if admins:
+            _app[CHAT_ID_KEY] = admins[0].telegram_id
+        else:
+            fallback = next(iter(config.user_configs.values()))
+            log.warning(
+                "No admin users defined in users.yaml; using %s "
+                "(telegram_id: %d) as default webhook target. "
+                "External notifications may route unexpectedly.",
+                fallback.name,
+                fallback.telegram_id,
+            )
+            _app[CHAT_ID_KEY] = fallback.telegram_id
 
     # Keep notification destinations separate from Config.allowed_user_ids,
     # which is the immutable-at-runtime source for Telegram inbound auth. The
@@ -2641,11 +2660,11 @@ async def start(
     # users.yaml and DB. This set is intentionally detached from Config's
     # inbound Telegram principals and is not consulted by internal API auth.
     for uc in config.user_configs.values():
-        if uc.github_notify_chat_id is not None:
+        if telegram_enabled and uc.github_notify_chat_id is not None:
             _app[NOTIFICATION_CHAT_IDS_KEY].add(uc.github_notify_chat_id)
     # Also add any DB-stored notify chat IDs (set via /github notify).
     # webhook.start() is already async so the await is fine.
-    for uid in config.user_configs:
+    for uid in config.user_configs if telegram_enabled else ():
         val = await sessions.get_setting(f"github_notify_chat:{uid}")
         if val:
             try:
@@ -2656,14 +2675,17 @@ async def start(
                     uid,
                     val,
                 )
-    _register_routes(_app, config)
+    _register_routes(_app, config, telegram_enabled=telegram_enabled)
     _app[WORKSHOP_PRINCIPAL_STORAGE_KEY] = core_services.principal_storage
-    _app[WORKSHOP_GITHUB_NOTIFICATIONS_KEY] = github_notifications
-    register_workshop_routes = await _register_workshop_client_api(
-        _app,
-        core_services.client_store,
-        command_submitter=core_services.client_commands,
-    )
+    if github_notifications is not None:
+        _app[WORKSHOP_GITHUB_NOTIFICATIONS_KEY] = github_notifications
+    register_workshop_routes: Callable[[web.Application], None] | None = None
+    if workshop_enabled:
+        register_workshop_routes = await _register_workshop_client_api(
+            _app,
+            core_services.client_store,
+            command_submitter=core_services.client_commands,
+        )
 
     _runner = web.AppRunner(_app, access_log=None)
     await _runner.setup()
@@ -2674,7 +2696,8 @@ async def start(
     await site.start()
     log.info("Webhook server listening on 127.0.0.1:%d", config.webhook_port)
 
-    if config.workshop_lan_host:
+    if workshop_enabled and config.workshop_lan_host:
+        assert register_workshop_routes is not None
         workshop_lan_app = web.Application()
         register_workshop_routes(workshop_lan_app)
         _workshop_lan_runner = web.AppRunner(workshop_lan_app, access_log=None)
@@ -2700,7 +2723,7 @@ async def start(
     # especially after a period of downtime when queued updates are flushing.
     # Without retries, a single timeout kills the whole startup and launchd
     # eventually gives up restarting.
-    if config.telegram_webhook_url:
+    if telegram_app is not None and config.telegram_webhook_url:
         requeued = await sessions.requeue_processing_telegram_updates()
         if requeued:
             log.info("Requeued %d unfinished Telegram update(s) from previous run", requeued)

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import os
+import pwd
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -407,7 +408,21 @@ class WorkshopRuntimeProfileRegistry:
         protected = bool(os.environ.get(INSTALL_DIR_ENV, "").strip())
         if not explicit and not protected:
             return cls.from_config(config)
-        return cls.from_yaml(_policy_text(policy_path), backend_registry=load_backend_registry())
+        registry = cls.from_yaml(_policy_text(policy_path), backend_registry=load_backend_registry())
+        if protected:
+            service_uid = os.geteuid()
+            try:
+                service_user = pwd.getpwuid(service_uid).pw_name
+            except KeyError:
+                raise WorkshopRuntimeProfileError(
+                    f"Protected installation could not resolve the Kai service account for effective uid {service_uid}"
+                ) from None
+            registry.validate_protected_os_users(
+                service_user,
+                account_uid=lambda name: pwd.getpwnam(name).pw_uid,
+                service_uid=service_uid,
+            )
+        return registry
 
     @property
     def profiles(self) -> tuple[ProtectedRuntimeProfile, ...]:
@@ -428,3 +443,37 @@ class WorkshopRuntimeProfileRegistry:
         if profile is None:
             raise WorkshopRuntimeProfileError("Configured user has no protected runtime profile")
         return profile
+
+    def validate_protected_os_users(
+        self,
+        service_user: str,
+        *,
+        account_uid: Callable[[str], int],
+        service_uid: int,
+    ) -> None:
+        """Keep protected backend processes off the privileged service account."""
+        errors: list[str] = []
+        normalized_service_user = service_user.strip()
+        for profile in self.profiles:
+            os_user = profile.os_user.strip() if profile.os_user else ""
+            label = f"runtime profile {profile.profile_id} ({profile.display_name!r})"
+            if not os_user:
+                errors.append(f"{label} is missing required os_user")
+                continue
+            if os_user == normalized_service_user:
+                errors.append(f"{label} maps to service account {normalized_service_user!r}")
+                continue
+            try:
+                uid = account_uid(os_user)
+            except KeyError:
+                errors.append(f"{label} maps to nonexistent OS account {os_user!r}")
+                continue
+            if uid == service_uid:
+                errors.append(f"{label} maps to OS account {os_user!r}, which resolves to service uid {service_uid}")
+        if errors:
+            detail = "\n  - ".join(errors)
+            raise WorkshopRuntimeProfileError(
+                "Protected runtime profiles must use existing non-service OS accounts:\n"
+                f"  - {detail}\n"
+                f"Assign every profile an OS account distinct from service account {normalized_service_user!r}."
+            )

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -362,8 +362,13 @@ async def _run(args: argparse.Namespace) -> int:
             return 0
 
         config = load_config()
+        telegram_bot_token = config.telegram_bot_token
+        if not telegram_bot_token:
+            raise DeliveryQualificationError(
+                "Telegram delivery qualification requires the Telegram adapter and bot token"
+            )
         try:
-            async with Bot(config.telegram_bot_token) as bot:
+            async with Bot(telegram_bot_token) as bot:
                 worker = WorkshopTelegramDeliveryWorker(
                     WorkshopDeliveryOutbox(store),
                     WorkshopDeliveryFragments(store),

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -729,6 +729,15 @@ class TestCreateBotTransportMode:
         app = create_bot(config, use_webhook=False, core_services=_bot_core_services(config))
         assert app.updater is not None
 
+    def test_rejects_construction_without_telegram_token(self):
+        config = _make_config(
+            telegram_bot_token=None,
+            enabled_adapters=frozenset({"workshop"}),
+        )
+
+        with pytest.raises(RuntimeError, match="cannot start without TELEGRAM_BOT_TOKEN"):
+            create_bot(config, core_services=_bot_core_services(config))
+
     def test_installs_workshop_shadow_recorder(self):
         config = _make_config()
         app = create_bot(config, core_services=_bot_core_services(config))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,7 @@ from kai.config import (
 
 # All env vars that load_config reads
 _CONFIG_ENV_VARS = [
+    "KAI_ENABLED_ADAPTERS",
     "TELEGRAM_BOT_TOKEN",
     "TELEGRAM_WEBHOOK_URL",
     "TELEGRAM_WEBHOOK_SECRET",
@@ -235,6 +236,48 @@ class TestLoadConfigDefaults:
         assert config.claude_autocompact_pct == 0
         # Agent backend from explicit test config
         assert config.default_backend == "claude"
+        assert config.enabled_adapters == frozenset({"telegram", "workshop"})
+        assert config.telegram_enabled is True
+        assert config.workshop_enabled is True
+
+    def test_workshop_only_does_not_require_telegram_configuration(self, monkeypatch):
+        monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "workshop")
+
+        config = load_config()
+
+        assert config.enabled_adapters == frozenset({"workshop"})
+        assert config.telegram_enabled is False
+        assert config.workshop_enabled is True
+        assert config.telegram_bot_token is None
+        assert config.user_configs == {}
+
+    def test_workshop_only_does_not_load_a_dormant_telegram_token(self, monkeypatch):
+        monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "workshop")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "stored-but-disabled")
+        monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.test/telegram")
+
+        config = load_config()
+
+        assert config.telegram_bot_token is None
+        assert config.telegram_webhook_url is None
+        assert config.telegram_webhook_secret is None
+
+    def test_workshop_only_rejects_a_present_malformed_users_file(self, monkeypatch):
+        monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "workshop")
+        _patch_protected_users_yaml(monkeypatch, "users: invalid\n")
+
+        with pytest.raises(SystemExit, match=r"users\.yaml"):
+            load_config()
+
+    def test_telegram_only_does_not_enable_workshop(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "telegram")
+
+        config = load_config()
+
+        assert config.enabled_adapters == frozenset({"telegram"})
+        assert config.telegram_enabled is True
+        assert config.workshop_enabled is False
 
     def test_autocompact_from_env(self, monkeypatch):
         _set_required(monkeypatch)
@@ -275,6 +318,26 @@ class TestLoadConfigErrors:
 
     def test_missing_token(self):
         with pytest.raises(SystemExit, match="TELEGRAM_BOT_TOKEN"):
+            load_config()
+
+    def test_rejects_unknown_client_adapter(self, monkeypatch):
+        monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "workshop,carrier-pigeon")
+
+        with pytest.raises(SystemExit, match=r"unsupported adapter.*carrier-pigeon"):
+            load_config()
+
+    def test_rejects_explicit_empty_client_adapter_policy(self, monkeypatch):
+        monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "")
+
+        with pytest.raises(SystemExit, match="must enable at least one client adapter"):
+            load_config()
+
+    def test_rejects_workshop_lan_listener_when_workshop_is_disabled(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "telegram")
+        monkeypatch.setenv("WORKSHOP_LAN_HOST", "10.0.0.36")
+
+        with pytest.raises(SystemExit, match=r"WORKSHOP_LAN_HOST.*Workshop adapter.*enabled"):
             load_config()
 
     def test_missing_users_yaml(self, monkeypatch):
@@ -833,6 +896,23 @@ class TestDualModeLoading:
 
 
 class TestProtectedUserIsolation:
+    def test_workshop_only_protected_install_rejects_unreadable_users_yaml(self, monkeypatch):
+        monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "workshop")
+
+        def protected_reader(path):
+            if path == "/etc/kai/env":
+                return "# protected install\n"
+            return None
+
+        monkeypatch.setattr("kai.config._read_protected_file", protected_reader)
+        monkeypatch.setattr(
+            "kai.config.validate_protected_file_metadata",
+            lambda path, **kwargs: path == "/etc/kai/users.yaml",
+        )
+
+        with pytest.raises(SystemExit, match=r"users\.yaml"):
+            load_config()
+
     def test_protected_install_requires_os_user(self, monkeypatch):
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")
         _patch_protected_users_yaml(

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -21,12 +21,15 @@ def http_dependencies(monkeypatch):
         core_host,
         core_services,
         github_notifications,
+        workshop_enabled,
     ) -> None:
-        assert application == "telegram-application"
+        assert application in {None, "telegram-application"}
         assert config.workshop_lan_host in {None, "10.0.0.36"}
         assert core_host == "core-host"
         assert core_services == "core-services"
-        assert github_notifications == "notification-delivery"
+        expected_notifications = "notification-delivery" if application is not None else None
+        assert github_notifications == expected_notifications
+        assert workshop_enabled is config.workshop_enabled
         events.append("http:start")
         state["loopback"] = True
         state["lan"] = True
@@ -51,12 +54,22 @@ def http_dependencies(monkeypatch):
     return events
 
 
-def _adapter(*, workshop_lan_host: str | None = "10.0.0.36") -> HttpAdapter:
-    config = SimpleNamespace(workshop_lan_host=workshop_lan_host)
-    telegram = SimpleNamespace(
-        application="telegram-application",
-        notification_delivery="notification-delivery",
+def _adapter(
+    *,
+    workshop_lan_host: str | None = "10.0.0.36",
+    telegram_enabled: bool = True,
+    workshop_enabled: bool = True,
+) -> HttpAdapter:
+    config = SimpleNamespace(
+        workshop_lan_host=workshop_lan_host,
+        workshop_enabled=workshop_enabled,
     )
+    telegram = None
+    if telegram_enabled:
+        telegram = SimpleNamespace(
+            application="telegram-application",
+            notification_delivery="notification-delivery",
+        )
     return HttpAdapter(  # type: ignore[arg-type]
         config,
         "core-host",  # type: ignore[arg-type]
@@ -100,6 +113,16 @@ async def test_http_adapter_reports_unconfigured_lan_listener_as_not_applicable(
 
     assert adapter.readiness.ready is True
     assert adapter.readiness.workshop_lan_listener is None
+    await adapter.stop()
+
+
+async def test_http_adapter_starts_without_telegram(http_dependencies) -> None:
+    adapter = _adapter(telegram_enabled=False)
+
+    await adapter.start()
+
+    assert adapter.readiness.ready is True
+    assert http_dependencies == ["http:start"]
     await adapter.stop()
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -21,6 +21,7 @@ import kai.install
 from kai.install import (
     _LAUNCHD_LABEL,
     ServiceStartError,
+    _adapter_policy_status,
     _apply_backend_registry,
     _apply_directories,
     _apply_goose_config,
@@ -45,7 +46,9 @@ from kai.install import (
     _collect_user_memory_owners,
     _copy_managed_home_tree,
     _copy_tree,
+    _deployed_adapter_policy_status,
     _deployed_webhook_secret_migration_status,
+    _dormant_compatibility_schedule_status,
     _file_checksum,
     _generate_env_file,
     _generate_launchd_plist,
@@ -1439,6 +1442,7 @@ class TestCmdConfig:
         inputs = iter(
             [
                 "protected",
+                "hybrid",
                 "/opt/kai",
                 "/var/lib/kai",
                 "kai",
@@ -1466,6 +1470,7 @@ class TestCmdConfig:
         inputs = iter(
             [
                 "protected",  # deployment mode
+                "hybrid",  # client mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -1564,6 +1569,7 @@ class TestCmdConfig:
         inputs = iter(
             [
                 "protected",  # deployment mode
+                "hybrid",  # client mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -1647,6 +1653,7 @@ class TestCmdConfig:
         inputs_basic = iter(
             [
                 "protected",  # deployment mode
+                "hybrid",  # client mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -1716,6 +1723,7 @@ class TestCmdConfig:
         inputs_advanced = iter(
             [
                 "protected",
+                "hybrid",
                 "/opt/kai",
                 "/var/lib/kai",
                 "kai",
@@ -1778,6 +1786,7 @@ class TestCmdConfig:
         inputs = iter(
             [
                 "protected",  # deployment mode
+                "hybrid",  # client mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -1913,6 +1922,7 @@ class TestCmdConfig:
         inputs = iter(
             [
                 "protected",  # deployment mode
+                "hybrid",  # client mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -2071,6 +2081,7 @@ class TestCmdConfig:
         agent_backend: str = "claude",
         llm_provider: str = "anthropic",
         llm_api_key: str = "sk-ant-test-key",
+        client_mode: str = "hybrid",
     ) -> list[str]:
         """Default wizard inputs with swappable memory block, effort, and backend.
 
@@ -2128,17 +2139,31 @@ class TestCmdConfig:
                 effort,  # claude effort level ("" = default "high")
             ]
 
+        telegram_setup: list[str] = []
+        telegram_features: list[str] = []
+        if client_mode in {"hybrid", "telegram-only"}:
+            telegram_setup = [
+                "fake-token",  # bot token
+                "12345",  # admin Telegram ID
+                "admin",  # admin display name
+                "testuser",  # required protected os_user
+                "polling",  # transport
+            ]
+            telegram_features = [
+                "false",  # voice
+                "false",  # tts
+            ]
+
+        workshop_listener = [""] if client_mode in {"hybrid", "workshop-only"} else []
+
         return [
             "protected",  # deployment mode
+            client_mode,
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
             "kai",  # service user
             "darwin",  # platform
-            "fake-token",  # bot token
-            "12345",  # admin telegram ID
-            "admin",  # admin display name
-            "testuser",  # required protected os_user
-            "polling",  # transport
+            *telegram_setup,
             agent_backend,  # agent backend
             *backend_block,  # llm_provider + api_key (non-claude only)
             "sonnet",  # model
@@ -2148,17 +2173,139 @@ class TestCmdConfig:
             "1800",  # idle eviction timeout seconds
             *claude_only_pre_webhook,  # autocompact + effort (claude only)
             "8080",  # port
-            "",  # Workshop LAN address (disabled)
+            *workshop_listener,  # Workshop LAN address (disabled)
             "test-secret",  # webhook secret
             "~/Projects",  # workspace base
             "",  # allowed workspaces
             "300",  # pr review cooldown (global resource control)
             "900",  # pr review timeout
-            "false",  # voice
-            "false",  # tts
+            *telegram_features,
             *memory_block,
             "",  # perplexity key
         ]
+
+    @pytest.mark.parametrize(
+        ("client_mode", "expected_adapters", "telegram_configured"),
+        [
+            ("hybrid", "telegram,workshop", True),
+            ("workshop-only", "workshop", False),
+            ("telegram-only", "telegram", True),
+        ],
+    )
+    def test_client_modes_write_explicit_adapter_policy(
+        self,
+        tmp_path,
+        monkeypatch,
+        client_mode,
+        expected_adapters,
+        telegram_configured,
+    ):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._redirect_staging(monkeypatch, tmp_path)
+        if client_mode == "workshop-only":
+            self._simulate_existing_etc_users_yaml(
+                monkeypatch,
+                "users:\n  - telegram_id: 12345\n    name: admin\n    role: admin\n    os_user: testuser\n",
+            )
+            kai.install.RUNTIME_PROFILES_YAML.write_text("version: 1\nruntime_profiles:\n  existing: {}\n")
+
+        inputs = iter(self._base_inputs(["false"], client_mode=client_mode))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        env = conf["env"]
+        assert env["KAI_ENABLED_ADAPTERS"] == expected_adapters
+        assert ("TELEGRAM_BOT_TOKEN" in env) is telegram_configured
+        assert ("users_yaml_staging_path" in conf) is telegram_configured
+
+    def test_workshop_only_removes_token_but_preserves_dormant_telegram_preferences(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "deployment_mode": "protected",
+                    "env": {
+                        "KAI_ENABLED_ADAPTERS": "telegram,workshop",
+                        "TELEGRAM_BOT_TOKEN": "must-not-survive",
+                        "TELEGRAM_TRANSPORT": "webhook",
+                        "TELEGRAM_WEBHOOK_URL": "https://example.test/telegram",
+                        "TELEGRAM_WEBHOOK_SECRET": "dormant-webhook-secret",
+                        "VOICE_ENABLED": "true",
+                        "TTS_ENABLED": "true",
+                        "DEFAULT_BACKEND": "claude",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._redirect_staging(monkeypatch, tmp_path)
+        self._simulate_existing_etc_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 12345\n    name: admin\n    role: admin\n    os_user: testuser\n",
+        )
+        kai.install.RUNTIME_PROFILES_YAML.write_text("version: 1\nruntime_profiles:\n  existing: {}\n")
+
+        inputs = iter(self._base_inputs(["false"], client_mode="workshop-only"))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        env = json.loads(conf_path.read_text())["env"]
+        assert "TELEGRAM_BOT_TOKEN" not in env
+        assert env["TELEGRAM_TRANSPORT"] == "webhook"
+        assert env["TELEGRAM_WEBHOOK_URL"] == "https://example.test/telegram"
+        assert env["TELEGRAM_WEBHOOK_SECRET"] == "dormant-webhook-secret"
+        assert env["VOICE_ENABLED"] == "true"
+        assert env["TTS_ENABLED"] == "true"
+
+    def test_fresh_protected_workshop_only_fails_before_writing_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._redirect_staging(monkeypatch, tmp_path)
+        inputs = iter(
+            [
+                "protected",
+                "workshop-only",
+                "/opt/kai",
+                "/var/lib/kai",
+                "kai",
+                "darwin",
+            ]
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        with pytest.raises(SystemExit, match="requires an existing protected installation"):
+            _cmd_config()
+
+        assert not conf_path.exists()
+
+    def test_single_user_workshop_only_fails_before_writing_config(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        conf_path = tmp_path / "install.conf"
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._redirect_staging(monkeypatch, tmp_path)
+        monkeypatch.setattr("kai.install._read_protected_file", lambda _path: None)
+        inputs = iter(["single_user", "workshop-only"])
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        with pytest.raises(SystemExit, match="single-user bootstrap is not available"):
+            _cmd_config()
+
+        assert not conf_path.exists()
 
     def test_memory_disabled_omits_env_keys(self, tmp_path, monkeypatch):
         """MEMORY_ENABLED=false produces no MEMORY_* env entries."""
@@ -2568,6 +2715,7 @@ class TestCmdConfig:
         inputs = iter(
             [
                 "protected",  # deployment mode
+                "hybrid",  # client mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -2908,6 +3056,7 @@ class TestCmdConfig:
         inputs = iter(
             [
                 "protected",  # deployment mode
+                "hybrid",  # client mode
                 "/opt/kai",  # install dir
                 "/var/lib/kai",  # data dir
                 "kai",  # service user
@@ -3438,6 +3587,7 @@ class TestCmdConfigDefaultModelDispatch:
         """
         return [
             "protected",  # deployment mode
+            "hybrid",  # client mode
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
             "kai",  # service user
@@ -3477,6 +3627,7 @@ class TestCmdConfigDefaultModelDispatch:
         """
         return [
             "protected",  # deployment mode
+            "hybrid",  # client mode
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
             "kai",  # service user
@@ -3512,6 +3663,7 @@ class TestCmdConfigDefaultModelDispatch:
         """Input chain for the users_yaml_exists=True + goose+openai path."""
         return [
             "protected",  # deployment mode
+            "hybrid",  # client mode
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
             "kai",  # service user
@@ -4569,6 +4721,67 @@ class TestCmdStatus:
             }
         )
         assert "legacy-secret" not in _webhook_secret_migration_status({"WEBHOOK_SECRET": "legacy-secret"})
+
+    @pytest.mark.parametrize(
+        ("env", "expected"),
+        [
+            ({}, "telegram,workshop; Telegram enabled, TOKEN MISSING; legacy hybrid default"),
+            (
+                {"KAI_ENABLED_ADAPTERS": "workshop"},
+                "workshop; Telegram disabled, no token configured",
+            ),
+            (
+                {"KAI_ENABLED_ADAPTERS": "telegram", "TELEGRAM_BOT_TOKEN": "secret-token"},
+                "telegram; Telegram enabled, token configured",
+            ),
+        ],
+    )
+    def test_adapter_policy_status_reports_mode_without_token(self, env, expected):
+        status = _adapter_policy_status(env, source="test")
+
+        assert expected in status
+        assert "secret-token" not in status
+
+    def test_deployed_adapter_status_never_exposes_token(self, tmp_path, monkeypatch):
+        env_path = tmp_path / "env"
+        env_path.write_text("KAI_ENABLED_ADAPTERS=workshop\nTELEGRAM_BOT_TOKEN=disabled-secret-token\n")
+        monkeypatch.setattr(
+            "kai.install.validate_protected_file_metadata",
+            lambda *args, **kwargs: True,
+        )
+
+        status = _deployed_adapter_policy_status(env_path)
+
+        assert "workshop; Telegram disabled, stored token ignored" in status
+        assert "disabled-secret-token" not in status
+
+    def test_status_reports_dormant_compatibility_jobs_without_telegram(self, tmp_path, monkeypatch):
+        env_path = tmp_path / "env"
+        env_path.write_text("KAI_ENABLED_ADAPTERS=workshop\n")
+        db_path = tmp_path / "kai.db"
+        connection = sqlite3.connect(db_path)
+        connection.execute("CREATE TABLE jobs (id INTEGER PRIMARY KEY, active INTEGER NOT NULL)")
+        connection.executemany("INSERT INTO jobs(active) VALUES (?)", [(1,), (1,), (0,)])
+        connection.commit()
+        connection.close()
+        monkeypatch.setattr(
+            "kai.install.validate_protected_file_metadata",
+            lambda *args, **kwargs: True,
+        )
+
+        status = _dormant_compatibility_schedule_status(db_path, env_path)
+
+        assert status == "Compatibility schedules: 2 active job(s) dormant; Telegram adapter disabled"
+
+    def test_status_omits_dormant_schedule_line_when_telegram_is_enabled(self, tmp_path, monkeypatch):
+        env_path = tmp_path / "env"
+        env_path.write_text("KAI_ENABLED_ADAPTERS=telegram,workshop\n")
+        monkeypatch.setattr(
+            "kai.install.validate_protected_file_metadata",
+            lambda *args, **kwargs: True,
+        )
+
+        assert _dormant_compatibility_schedule_status(tmp_path / "missing.db", env_path) is None
 
     def test_deployed_status_reports_named_secrets_without_values(self, tmp_path, monkeypatch):
         env_path = tmp_path / "env"
@@ -9362,6 +9575,7 @@ class TestCmdConfigCanonicalUsersYaml:
         """
         return [
             "protected",
+            "hybrid",
             "/opt/kai",
             "/var/lib/kai",
             "kai",
@@ -9831,6 +10045,7 @@ class TestCmdConfigSingleUserMode:
         """
         return [
             "single_user",  # deployment mode
+            "hybrid",  # client mode
             # install_dir / data_dir / service_user / platform are skipped
             "fake-token",  # bot token
             "12345",  # admin telegram id
@@ -9940,7 +10155,7 @@ class TestCmdConfigSingleUserMode:
         # Only the deployment_mode prompt is reached before the refusal
         # fires; the rest of the chain is unused but kept here so the
         # test does not depend on prompt-count specifics.
-        inputs = iter(["single_user"] + ["x"] * 50)
+        inputs = iter(["single_user", "hybrid"] + ["x"] * 50)
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
         with pytest.raises(SystemExit, match="single_user mode was selected"):
             _cmd_config()
@@ -11324,6 +11539,7 @@ class TestOpenCodeConfigWizard:
         """
         return [
             "protected",  # deployment mode
+            "hybrid",  # client mode
             "/opt/kai",  # install dir
             "/var/lib/kai",  # data dir
             "kai",  # service user

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,6 +23,7 @@ from kai.config import UserConfig
 from kai.main import (
     _file_age,
     _file_cleanup_loop,
+    _warn_if_compatibility_jobs_are_dormant,
     _workshop_bootstrap_humans,
     _workshop_bootstrap_notification_channels,
     setup_logging,
@@ -71,6 +72,31 @@ class TestWorkshopBootstrapMapping:
         assert channels[0].transport == "telegram"
         assert channels[0].external_channel_id == "-999"
         assert channels[0].member_external_subjects == ("101", "202")
+
+
+class TestCompatibilityScheduleWarning:
+    async def test_warns_when_active_jobs_are_dormant_without_telegram(self, caplog):
+        config = SimpleNamespace(telegram_enabled=False)
+        with (
+            patch(
+                "kai.main.sessions.get_all_active_jobs",
+                new=AsyncMock(return_value=[{"id": 1}, {"id": 2}]),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            count = await _warn_if_compatibility_jobs_are_dormant(config)
+
+        assert count == 2
+        assert "2 active compatibility scheduled job(s) are dormant" in caplog.text
+
+    async def test_does_not_query_jobs_when_telegram_is_enabled(self):
+        config = SimpleNamespace(telegram_enabled=True)
+        query = AsyncMock()
+        with patch("kai.main.sessions.get_all_active_jobs", new=query):
+            count = await _warn_if_compatibility_jobs_are_dormant(config)
+
+        assert count == 0
+        query.assert_not_awaited()
 
 
 # ── setup_logging() ──────────────────────────────────────────────────

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -26,6 +26,7 @@ from kai.webhook import (
     PR_REVIEW_COOLDOWN_KEY,
     PR_REVIEW_TIMEOUT_S_KEY,
     SPEC_DIR_KEY,
+    TELEGRAM_APP_KEY,
     TELEGRAM_BOT_KEY,
     WEBHOOK_PORT_KEY,
     WORKSPACE_BASE_KEY,
@@ -2567,6 +2568,67 @@ class TestNotificationChatIdMutations:
             await wh.stop()
             wh._app = old_app
             wh._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_start_workshop_only_constructs_no_telegram_surface(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        import kai.webhook as wh
+
+        config = MagicMock()
+        config.user_configs = {}
+        config.allowed_user_ids = set()
+        config.get_admins.return_value = []
+        config.telegram_webhook_url = None
+        config.telegram_webhook_secret = None
+        config.github_webhook_secret = "configured-but-telegram-owned"
+        config.generic_webhook_secret = "configured-but-telegram-owned"
+        config.pr_review_cooldown = 0
+        config.pr_review_timeout_s = 0
+        config.webhook_port = 8080
+        config.workshop_lan_host = ""
+        config.workspace_base = None
+        config.allowed_workspaces = []
+        config.spec_dir = "specs"
+        config.session_db_path = tmp_path / "kai.db"
+
+        store = await WorkshopEventStore.open(config.session_db_path)
+        core_services = SimpleNamespace(
+            subprocess_pool=MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
+            principal_storage=_principal_storage_registry(),
+            client_store=store,
+            client_commands=MagicMock(),
+        )
+        fake_runner = MagicMock()
+        fake_runner.setup = AsyncMock()
+        fake_runner.cleanup = AsyncMock()
+        fake_site = MagicMock()
+        fake_site.start = AsyncMock()
+
+        monkeypatch.setattr("kai.webhook.web.AppRunner", MagicMock(return_value=fake_runner))
+        monkeypatch.setattr("kai.webhook.web.TCPSite", MagicMock(return_value=fake_site))
+
+        await wh.start(
+            None,
+            config,
+            core_host=MagicMock(),
+            core_services=core_services,
+            github_notifications=None,
+            workshop_enabled=True,
+        )
+        try:
+            assert TELEGRAM_APP_KEY not in wh._app
+            assert TELEGRAM_BOT_KEY not in wh._app
+            paths = {resource.canonical for resource in wh._app.router.resources()}
+            assert "/workshop/" in paths
+            assert "/webhook/telegram" not in paths
+            assert "/webhook/github" not in paths
+            assert "/webhook" not in paths
+        finally:
+            await wh.stop()
+            await store.close()
 
     @pytest.mark.asyncio
     async def test_start_lan_listener_exposes_only_workshop_client_routes(

--- a/tests/test_webhook_routes.py
+++ b/tests/test_webhook_routes.py
@@ -67,6 +67,35 @@ def test_telegram_route_is_independent_of_other_webhooks() -> None:
     assert ("POST", "/webhook") not in routes
 
 
+def test_workshop_only_omits_telegram_owned_routes() -> None:
+    app = web.Application()
+
+    _register_routes(
+        app,
+        _config(
+            telegram_webhook_url="https://example.com/webhook/telegram",
+            telegram_webhook_secret="telegram-secret",
+            github_webhook_secret="github-secret",
+            generic_webhook_secret="generic-secret",
+        ),
+        telegram_enabled=False,
+    )
+
+    routes = _routes(app)
+    assert ("GET", "/health") in routes
+    assert ("GET", "/api/jobs") in routes
+    assert ("POST", "/api/services/{name}") in routes
+    assert ("GET", "/api/memory/stats") in routes
+    assert ("POST", "/webhook/telegram") not in routes
+    assert ("POST", "/webhook/github") not in routes
+    assert ("POST", "/webhook") not in routes
+    assert ("POST", "/api/schedule") not in routes
+    assert ("DELETE", "/api/jobs/{id}") not in routes
+    assert ("PATCH", "/api/jobs/{id}") not in routes
+    assert ("POST", "/api/send-message") not in routes
+    assert ("POST", "/api/send-file") not in routes
+
+
 async def test_health_reports_non_sensitive_memory_mode(monkeypatch) -> None:
     monkeypatch.setattr("kai.webhook.memory.is_enabled", lambda: True)
 

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -132,6 +132,55 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
     assert profile.allowed_services == ("perplexity", "weather")
 
 
+@pytest.mark.parametrize(
+    ("os_user", "message"),
+    (
+        (None, "missing required os_user"),
+        ("kai", "maps to service account"),
+        ("missing", "nonexistent OS account"),
+        ("service-alias", "resolves to service uid"),
+    ),
+)
+def test_protected_runtime_profiles_reject_unsafe_execution_accounts(os_user, message):
+    profile = ProtectedRuntimeProfile(
+        runtime_profile_id_for_config_id(101),
+        101,
+        "Daniel",
+        os_user,
+        "codex",
+        "openai",
+        "gpt-5.6-sol",
+        120,
+        (),
+        None,
+        None,
+        (),
+    )
+    registry = WorkshopRuntimeProfileRegistry((profile,))
+
+    def account_uid(name):
+        if name == "missing":
+            raise KeyError(name)
+        return 503 if name == "service-alias" else 501
+
+    with pytest.raises(WorkshopRuntimeProfileError, match=message):
+        registry.validate_protected_os_users(
+            "kai",
+            account_uid=account_uid,
+            service_uid=503,
+        )
+
+
+def test_protected_runtime_profiles_accept_non_service_execution_account():
+    registry = WorkshopRuntimeProfileRegistry.from_config(_config())
+
+    registry.validate_protected_os_users(
+        "kai",
+        account_uid=lambda name: {"daniel": 501, "sellison": 504}[name],
+        service_uid=503,
+    )
+
+
 def test_document_owns_resolved_workspace_policy(tmp_path):
     home = tmp_path / "home"
     base = tmp_path / "projects"
@@ -822,3 +871,33 @@ def test_protected_startup_fails_closed_when_policy_is_unreadable(monkeypatch):
 
     with pytest.raises(WorkshopRuntimeProfileError, match="missing or unreadable"):
         WorkshopRuntimeProfileRegistry.load(_config())
+
+
+def test_protected_startup_validates_runtime_profile_execution_account(tmp_path, monkeypatch):
+    policy = tmp_path / "runtime-profiles.yaml"
+    policy.write_text(
+        """version: 1
+runtime_profiles:
+  rtp_55555555555555555555555555555555:
+    display_name: Unsafe runtime
+    os_user: kai
+    backend: codex
+    provider: openai
+    model: gpt-5.6-sol
+    timeout_seconds: 120
+    allowed_services: []
+    allowed_workspaces: []
+"""
+    )
+    monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
+    monkeypatch.setattr(
+        "kai.workshop.runtime_profiles.load_backend_registry",
+        lambda: {"codex": {}},
+    )
+    monkeypatch.setattr(
+        "kai.workshop.runtime_profiles.pwd.getpwuid",
+        lambda _uid: type("Account", (), {"pw_name": "kai"})(),
+    )
+
+    with pytest.raises(WorkshopRuntimeProfileError, match="maps to service account"):
+        WorkshopRuntimeProfileRegistry.load(_config(), path=policy)


### PR DESCRIPTION
## Summary

- add explicit `hybrid`, `workshop-only`, and `telegram-only` client deployment modes
- make the Telegram token, application, ingress, webhook registration, and delivery workers optional
- keep the core host and HTTP health/internal services available without Telegram
- publish Workshop client and LAN routes only when Workshop is enabled
- report deployed and staged adapter policy without exposing Telegram credentials
- preserve the existing hybrid behavior for installations without explicit adapter policy

## Operator behavior

`make config` now records `KAI_ENABLED_ADAPTERS` from an explicit client-mode choice:

- `hybrid` enables Workshop and Telegram
- `workshop-only` switches an existing protected installation to Workshop and omits `TELEGRAM_BOT_TOKEN`
- `telegram-only` enables Telegram and omits Workshop client routes

The choice is reversible by rerunning `make config` and `make install`. A disabled Telegram adapter is not constructed and does not contact Telegram, even if dormant Telegram transport preferences remain in the configuration artifact for a later switch back.

This first Workshop-only slice is an installed-mode switch. The wizard refuses fresh protected and single-user Workshop-only bootstrap until canonical administration can create the first human and runtime assignment without a transport identity.

`make install-status` reports adapter names, whether Telegram is enabled, and whether a token is present. It never prints the token value.

## Boundaries

This PR implements the Milestone 3 hosting/configuration boundary from #917. Compatibility routes that still own Telegram scheduling or delivery are deliberately absent in Workshop-only mode rather than silently falling back or pretending to be transport-neutral. Their canonical scheduler, integration, artifact, and delivery replacements remain part of the later epic milestones.

The installed qualification and restoration to hybrid mode remain operator-run exit gates after merge; this PR does not mark Milestone 3 complete merely because the code is merged.

## Compatibility and safety

- missing `KAI_ENABLED_ADAPTERS` continues to mean hybrid
- Telegram-enabled modes still require a token and valid `users.yaml`
- Workshop-only mode retains the existing protected human mappings and canonical runtime profiles during qualification
- protected runtime profiles must name an existing OS account distinct from the privileged Kai service account; install preflight and startup both enforce this
- missing, unreadable, or malformed protected `users.yaml` still fails closed
- an explicitly empty adapter policy is rejected instead of enabling every adapter
- `WORKSHOP_LAN_HOST` is rejected when Workshop is disabled
- external GitHub/generic webhook and Telegram-owned schedule/send mutation routes are not exposed when Telegram is disabled
- read-only job inspection plus transport-independent service and memory APIs remain available on loopback
- active compatibility schedules are reported as dormant in startup logs and `make install-status` when Telegram is disabled

## Validation

- `5795 passed, 1 skipped`
- Ruff: clean
- Pyright: clean
- Workshop client: 22 tests passed; generated bundle verified
- install dependency constraints: clean
- module-size report: completed
- `git diff --check`: clean

Closes the implementation portion of Milestone 3 in #917; installed qualification is still required before checking off the milestone.
