### PR TITLE
Make repository instructions backend-neutral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ models/
 install.conf
 
 # Claude Code local config
-/CLAUDE.md
+.claude/
 
 # OS / IDE
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Kai
+
+Personal AI assistant accessed via Telegram. Python package at src/kai/.
+
+## Development
+
+- Run: `make run` or `python -m kai`
+- Test: `make test` (pytest, ~1200 tests)
+- Lint: `make check` (ruff check + ruff format)
+- Config wizard: `make config`
+- Install: `sudo make install`
+
+## Adding a New Env Var
+
+Follow the existing pattern exactly:
+1. Dataclass field in `config.py` (with default)
+2. Validated parsing in `load_config()` (try/except ValueError, SystemExit on bad input)
+3. Pass through `pool.py` to `claude.py` if it affects the inner Claude
+4. Prompt in `install.py` `_cmd_config()` (with validation loop)
+5. Document in `.env.example`
+6. Add to `_CONFIG_ENV_VARS` list in `tests/test_config.py`
+
+## Key Patterns
+
+- `config.py` anchors all path resolution via `PROJECT_ROOT` and `DATA_DIR`
+- Inner Claude uses stream-json I/O, not interactive mode (auto-memory doesn't work)
+- Inner Claude CLI flags: verify with `claude --help` before use; use `--settings` for settings.json options
+- Pyright strict: use assert-narrowing for Optional, helper functions for @property returns
+
+## Don'ts
+
+- Don't manually re-register the Telegram webhook. Just restart the service.
+- Don't add features or refactor beyond what was asked.
+- Spec files go in `home/docs/specs/`, not the project root.
+- Kai (the inner agent, on any backend) must NEVER modify source files in this repo. Read, review, and report only.
+- Don't push follow-up commits without waiting for CI and the review bot to finish their cooldown period.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- move the repository's project instructions to a root `AGENTS.md` so every backend discovers them
- add a one-line root `CLAUDE.md` containing `@AGENTS.md`, the documented alternative project-instruction location; imports resolve relative to the importing file
- replace the stale `/CLAUDE.md` ignore with `.claude/` so local settings can never be committed and the new root adapter is trackable
- the previous Claude-only `.claude/CLAUDE.md` is removed (it was untracked, so this PR shows no deletion); its content moved verbatim into `AGENTS.md`

## Why

Project instructions for agents working in this repository existed only as a Claude-specific `.claude/CLAUDE.md`, which only the claude backend discovers. The codex, goose, opencode, and pi backends look for `AGENTS.md` and found nothing, so rules meant to bind every backend, including the rule that Kai working in its own source tree is read-only, silently applied to one backend only.

This mirrors the adapter pattern the managed per-user home tree already uses: canonical content in `AGENTS.md`, a one-line import for Claude.

## Changes

- `AGENTS.md` (new): the project instructions, migrated verbatim except one wording change: the read-only rule now names "the inner agent, on any backend" rather than the claude backend specifically, which is the point of the change.
- `CLAUDE.md` (new): `@AGENTS.md`.
- `.gitignore`: `/CLAUDE.md` (stale "local config" ignore that would have blocked the tracked adapter) replaced with `.claude/`. No ignore/negate patterns are needed because no tracked file lives inside the ignored directory.

## Verification

- Content is byte-identical to the previous instructions apart from the one named wording change.
- `git check-ignore` confirms `.claude/settings.local.json` is ignored by the new rule and the two new root files are not.
- goose already lists `AGENTS.md` in its configured context file names; codex/opencode/pi discover it natively; claude loads it through the import. No code changes.

Closes #953
