### PR TITLE
Render /stats timestamps in the host local zone

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1461,6 +1461,19 @@ async def handle_voice_callback(update: Update, context: ContextTypes.DEFAULT_TY
 # ── Info and management commands ─────────────────────────────────────
 
 
+def _stats_local_time(utc_timestamp: str) -> str:
+    """Render a stored UTC session timestamp in the host's local zone.
+
+    The sessions table stores SQLite CURRENT_TIMESTAMP values, which are
+    always UTC at second precision with no zone marker. Readers compare
+    /stats output against their local wall clock, so the value is
+    converted to the host zone and labeled with the zone name. Storage
+    stays UTC; only rendering changes.
+    """
+    parsed = datetime.strptime(utc_timestamp, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC)
+    return parsed.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
 @_require_auth
 async def handle_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle /stats: show session info, model, and process status."""
@@ -1475,8 +1488,8 @@ async def handle_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await update.message.reply_text(
         f"Session: {stats['session_id'][:8]}...\n"
         f"Model: {stats['model']}\n"
-        f"Started: {stats['created_at']}\n"
-        f"Last used: {stats['last_used_at']}\n"
+        f"Started: {_stats_local_time(stats['created_at'])}\n"
+        f"Last used: {_stats_local_time(stats['last_used_at'])}\n"
         f"Process alive: {alive}"
     )
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1305,14 +1305,22 @@ class TestHandleStats:
         stats = {
             "session_id": "abcd1234efgh",
             "model": "sonnet",
-            "created_at": "2026-01-01",
-            "last_used_at": "2026-01-02",
+            "created_at": "2026-01-01 12:00:00",
+            "last_used_at": "2026-01-02 15:30:45",
         }
         with patch("kai.bot.sessions.get_stats", new_callable=AsyncMock, return_value=stats):
             await handle_stats(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "abcd1234" in reply
         assert "sonnet" in reply
+        # Stored values are UTC; the reply must show them converted to the
+        # host zone with a zone label. Expected values are computed with an
+        # independent conversion so the assertion holds in any host zone,
+        # including across the EST/EDT boundary.
+        expected_started = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+        expected_last_used = datetime(2026, 1, 2, 15, 30, 45, tzinfo=UTC).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+        assert f"Started: {expected_started}" in reply
+        assert f"Last used: {expected_last_used}" in reply
 
 
 # ── handle_jobs ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- convert the two `/stats` timestamps from stored UTC to the host's local zone at render time, labeled with the zone name (e.g. `2026-08-15 16:27:45 EDT`)
- storage stays UTC; `get_stats` and the write path are unchanged

## Why

The `sessions` table stores SQLite `CURRENT_TIMESTAMP` values, which are always UTC with no zone marker, and the `/stats` handler interpolated them verbatim. To a reader in a non-UTC zone the times looked hours off with no indication they were UTC.

## Changes

- `src/kai/bot.py`: a small `_stats_local_time` helper parses the stored `%Y-%m-%d %H:%M:%S` value as UTC, converts with `astimezone()`, and formats with the zone abbreviation. The `Started:` and `Last used:` lines render through it.
- `tests/test_bot.py`: the fixture now uses realistic full `CURRENT_TIMESTAMP`-shaped values (the previous date-only strings cannot occur in real rows), and the test asserts both converted lines against expected values computed with an independent conversion, so it is deterministic in any host zone and across the EST/EDT transition.

## Validation

- `make check`
- `tests/test_bot.py`: 377 passed
- complete suite: 5836 passed, 1 skipped

Closes #952
