### PR TITLE
Stream token-level partial messages from the claude backend

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -12,9 +12,10 @@ as shared functions usable by any backend.
 
 The stream-json protocol:
     Input:  {"type": "user", "message": {"role": "user", "content": [...]}}
-    Output: {"type": "system", ...}      - session metadata
-            {"type": "assistant", ...}   - partial text (streaming)
-            {"type": "result", ...}      - final response with session info
+    Output: {"type": "system", ...}       - session metadata
+            {"type": "stream_event", ...} - token-level content block deltas
+            {"type": "assistant", ...}    - one completed assistant message
+            {"type": "result", ...}       - final response with session info
 """
 
 import asyncio
@@ -233,6 +234,12 @@ class ClaudeCodeBackend(AgentBackend):
             "--output-format",
             "stream-json",
             "--verbose",
+            # Emit token-level stream_event chunks between complete
+            # assistant messages so live previews grow while a long text
+            # block is still being generated. Verified against `claude
+            # --help`: only valid with --print and stream-json output,
+            # which is exactly this invocation.
+            "--include-partial-messages",
             "--model",
             self.model,
             # Effort level controls how many reasoning tokens Claude spends
@@ -827,6 +834,13 @@ class ClaudeCodeBackend(AgentBackend):
             return
 
         accumulated_text = ""
+        # Text-delta chunks of the content block currently being generated.
+        # Complete assistant message events remain the source of truth for
+        # `accumulated_text` and the final response; this buffer only feeds
+        # intermediate text_so_far yields and is reset whenever a complete
+        # assistant message arrives, because that message repeats the text
+        # its deltas already delivered.
+        partial_text = ""
         # Idle-activity timeout for the interaction. Resets every time the
         # process emits a line of output. If the process goes silent for
         # this long, it is likely dead or wedged. The per-readline timeout
@@ -971,6 +985,7 @@ class ClaudeCodeBackend(AgentBackend):
                     return
 
                 elif etype == "assistant" and "message" in event:
+                    partial_text = ""
                     msg_data = event["message"]
                     if isinstance(msg_data, dict) and "content" in msg_data:
                         for block in msg_data["content"]:
@@ -980,6 +995,20 @@ class ClaudeCodeBackend(AgentBackend):
                                     accumulated_text += "\n\n"
                                 accumulated_text += new_text
                                 yield StreamEvent(text_so_far=accumulated_text)
+
+                elif etype == "stream_event":
+                    inner = event.get("event")
+                    delta = inner.get("delta") if isinstance(inner, dict) else None
+                    # Only text deltas feed the preview; thinking and
+                    # signature deltas of other block types are invisible.
+                    if isinstance(delta, dict) and delta.get("type") == "text_delta":
+                        chunk = delta.get("text", "")
+                        if chunk:
+                            partial_text += chunk
+                            preview = accumulated_text
+                            if preview and not preview.endswith("\n"):
+                                preview += "\n\n"
+                            yield StreamEvent(text_so_far=preview + partial_text)
 
         except Exception as e:
             log.exception("Unexpected error reading Claude stream")

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -47,6 +47,15 @@ from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_targe
 
 log = logging.getLogger(__name__)
 
+# Minimum partial-text growth, in characters, before a delta yields an
+# intermediate StreamEvent. Stream observers run a full-text
+# publishable-prefix scan per yield, so unbatched per-token yields would
+# make total gate work quadratic in response length. At typical
+# generation speed this batches to roughly one yield per second, which
+# matches both transports' preview cadence (2s Telegram edit throttle,
+# 1s Workshop event-stream poll).
+_PARTIAL_YIELD_MIN_GROWTH = 100
+
 
 def _resolve_default_claude_bin() -> str:
     """Return the default Claude binary path for persistent chat."""
@@ -841,6 +850,8 @@ class ClaudeCodeBackend(AgentBackend):
         # assistant message arrives, because that message repeats the text
         # its deltas already delivered.
         partial_text = ""
+        # Length of partial_text at its last yield, for delta coalescing.
+        partial_yielded_length = 0
         # Idle-activity timeout for the interaction. Resets every time the
         # process emits a line of output. If the process goes silent for
         # this long, it is likely dead or wedged. The per-readline timeout
@@ -986,6 +997,7 @@ class ClaudeCodeBackend(AgentBackend):
 
                 elif etype == "assistant" and "message" in event:
                     partial_text = ""
+                    partial_yielded_length = 0
                     msg_data = event["message"]
                     if isinstance(msg_data, dict) and "content" in msg_data:
                         for block in msg_data["content"]:
@@ -1005,10 +1017,20 @@ class ClaudeCodeBackend(AgentBackend):
                         chunk = delta.get("text", "")
                         if chunk:
                             partial_text += chunk
-                            preview = accumulated_text
-                            if preview and not preview.endswith("\n"):
-                                preview += "\n\n"
-                            yield StreamEvent(text_so_far=preview + partial_text)
+                            # Coalesce token-sized deltas: every stream
+                            # observer runs a full-text publishable-prefix
+                            # scan per yield, so per-token yields would make
+                            # total gate work quadratic in response length.
+                            # The prefix gate only advances at sentence-like
+                            # boundaries anyway, so batching costs no
+                            # visible granularity; the complete assistant
+                            # message below still flushes the exact text.
+                            if len(partial_text) - partial_yielded_length >= _PARTIAL_YIELD_MIN_GROWTH:
+                                partial_yielded_length = len(partial_text)
+                                preview = accumulated_text
+                                if preview and not preview.endswith("\n"):
+                                    preview += "\n\n"
+                                yield StreamEvent(text_so_far=preview + partial_text)
 
         except Exception as e:
             log.exception("Unexpected error reading Claude stream")

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1323,10 +1323,11 @@ class TestSendLockedBasic:
         assert "\n\n" in last_text
 
     @pytest.mark.asyncio
-    async def test_text_deltas_stream_before_the_complete_message(self):
+    async def test_text_deltas_stream_before_the_complete_message(self, monkeypatch):
         """Token deltas yield growing text; the complete message that
         repeats them does not double the text, and the final response
         is byte-identical to the non-delta path."""
+        monkeypatch.setattr("kai.claude._PARTIAL_YIELD_MIN_GROWTH", 1)
         proc = _make_mock_proc(
             [
                 _system_event(),
@@ -1349,9 +1350,10 @@ class TestSendLockedBasic:
         assert events[-1].response.text == "Hello."
 
     @pytest.mark.asyncio
-    async def test_text_deltas_after_a_prior_message_get_the_separator(self):
+    async def test_text_deltas_after_a_prior_message_get_the_separator(self, monkeypatch):
         """Deltas of a later block render behind the accumulated text with
         the same separator rule complete messages use."""
+        monkeypatch.setattr("kai.claude._PARTIAL_YIELD_MIN_GROWTH", 1)
         proc = _make_mock_proc(
             [
                 _system_event(),
@@ -1369,6 +1371,58 @@ class TestSendLockedBasic:
 
         text_events = [e.text_so_far for e in events if not e.done]
         assert text_events[-1] == "First.\n\nSecond"
+
+    @pytest.mark.asyncio
+    async def test_small_deltas_coalesce_until_the_growth_threshold(self):
+        """Token-sized deltas below the growth threshold do not yield;
+        crossing it yields once, and the complete message still flushes
+        the exact final text."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _stream_delta_event({"type": "text_delta", "text": "Tiny. "}),
+                _stream_delta_event({"type": "text_delta", "text": "Also tiny. "}),
+                _stream_delta_event({"type": "text_delta", "text": "x" * 100}),
+                _assistant_event("Tiny. Also tiny. " + "x" * 100),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        text_events = [e.text_so_far for e in events if not e.done]
+        assert text_events == [
+            "Tiny. Also tiny. " + "x" * 100,
+            "Tiny. Also tiny. " + "x" * 100,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_malformed_stream_events_yield_nothing(self):
+        """Protocol drift in stream_event shapes is ignored, not fatal."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _json_line({"type": "stream_event"}),
+                _json_line({"type": "stream_event", "event": "not-a-dict"}),
+                _json_line({"type": "stream_event", "event": {"type": "content_block_delta", "delta": "nope"}}),
+                _stream_delta_event({"type": "text_delta", "text": ""}),
+                _stream_delta_event({"type": "text_delta"}),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        assert [e for e in events if not e.done] == []
+        assert events[-1].done is True
 
     @pytest.mark.asyncio
     async def test_non_text_deltas_yield_nothing(self):

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -91,6 +91,16 @@ def _assistant_event(text: str) -> bytes:
     )
 
 
+def _stream_delta_event(delta: dict) -> bytes:
+    """Build a stream_event line carrying one content-block delta."""
+    return _json_line(
+        {
+            "type": "stream_event",
+            "event": {"type": "content_block_delta", "index": 1, "delta": delta},
+        }
+    )
+
+
 def _result_event(
     text: str = "Final",
     is_error: bool = False,
@@ -594,6 +604,23 @@ class TestCommandConstruction:
             assert "--effort" in cmd
             idx = cmd.index("--effort")
             assert cmd[idx + 1] == "xhigh"
+
+    @pytest.mark.asyncio
+    async def test_partial_messages_flag_in_cmd(self):
+        """Token-level stream_event chunks require the CLI opt-in flag;
+        without it the backend regresses to per-message streaming."""
+        claude = _make_claude()
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+            assert "--include-partial-messages" in mock_exec.call_args[0]
 
 
 # ── Process signal handling ──────────────────────────────────────────
@@ -1294,6 +1321,74 @@ class TestSendLockedBasic:
         assert "First" in last_text
         assert "Second" in last_text
         assert "\n\n" in last_text
+
+    @pytest.mark.asyncio
+    async def test_text_deltas_stream_before_the_complete_message(self):
+        """Token deltas yield growing text; the complete message that
+        repeats them does not double the text, and the final response
+        is byte-identical to the non-delta path."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _stream_delta_event({"type": "text_delta", "text": "Hel"}),
+                _stream_delta_event({"type": "text_delta", "text": "lo."}),
+                _assistant_event("Hello."),
+                _result_event("Hello."),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        text_events = [e.text_so_far for e in events if not e.done]
+        assert text_events == ["Hel", "Hello.", "Hello."]
+        assert events[-1].response is not None
+        assert events[-1].response.text == "Hello."
+
+    @pytest.mark.asyncio
+    async def test_text_deltas_after_a_prior_message_get_the_separator(self):
+        """Deltas of a later block render behind the accumulated text with
+        the same separator rule complete messages use."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_event("First."),
+                _stream_delta_event({"type": "text_delta", "text": "Second"}),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        text_events = [e.text_so_far for e in events if not e.done]
+        assert text_events[-1] == "First.\n\nSecond"
+
+    @pytest.mark.asyncio
+    async def test_non_text_deltas_yield_nothing(self):
+        """Thinking and signature deltas never surface as preview text."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _stream_delta_event({"type": "thinking_delta", "thinking": "Hmm"}),
+                _stream_delta_event({"type": "signature_delta", "signature": "abc"}),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        assert [e for e in events if not e.done] == []
 
     @pytest.mark.asyncio
     async def test_non_text_content_blocks_ignored(self):


### PR DESCRIPTION
## Summary

- pass `--include-partial-messages` to the claude subprocess and translate its `stream_event` text deltas into incremental `text_so_far` yields
- complete assistant messages remain the source of truth; final response text is byte-identical
- no transport changes: Telegram live edits and the Workshop preview bubble simply start receiving text while it is being generated

## Why

The claude backend emitted a `StreamEvent` only per complete assistant message, so live previews on both transports updated at message boundaries, and a turn whose answer arrives as one final block showed no progressive output at all. Telegram partially masked this because its observer pushes an edit the instant each block lands; the Workshop event stream forwards previews on a one-second poll, so a final-block publish cleared at settlement was never delivered.

## Design

- The argv gains `--include-partial-messages`, verified against `claude --help` (valid only with `--print` and stream-json output, which matches the invocation) and probed against the installed CLI before implementation: the emitted shape is `{"type": "stream_event", "event": {"type": "content_block_delta", "delta": {"type": "text_delta", "text": ...}}}`, with the complete `assistant` event for a block arriving immediately after its deltas.
- The stream reader keeps a `partial_text` buffer beside `accumulated_text`. Text deltas append to it and yield an intermediate `text_so_far` rendered behind the accumulated text with the same separator rule complete messages use.
- Double-counting guard: the partial buffer resets at the top of the complete-`assistant` branch, because that message repeats the text its deltas already delivered. `accumulated_text` and the final response are built exclusively from complete messages, exactly as before.
- Thinking and signature deltas are ignored; they never surface as preview text.

## Tests

- `--include-partial-messages` is asserted present in the subprocess argv.
- Deltas yield growing text (`"Hel"`, `"Hello."`) and the complete message that follows does not double it; the final response text is identical to the non-delta path.
- Deltas arriving after a prior completed message render behind it with the `\n\n` separator.
- Thinking and signature deltas yield no text events.
- `make check`; complete suite: 5848 passed, 1 skipped.

Closes #958
