### PR TITLE
feat: add backend-neutral TraceEntry surface with claude emission

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -20,7 +20,7 @@ import shutil
 import tempfile
 import time
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol, runtime_checkable
@@ -294,6 +294,75 @@ class AgentResponse:
             self.failure_kind = classify_agent_failure(self.error)
 
 
+@dataclass(frozen=True)
+class TraceEntry:
+    """
+    One backend-neutral trace record of agent tool activity.
+
+    Attached to a StreamEvent by backend emitters so run observers can
+    surface what the agent is doing between text chunks. Two kinds:
+
+    - "tool_call": the agent invoked a tool. tool_name and is_diff are
+      meaningful; is_error is always False.
+    - "tool_result": the tool finished. is_error is meaningful; tool_name
+      and is_diff keep their defaults.
+
+    Attributes:
+        kind: "tool_call" or "tool_result".
+        tool_use_id: Backend-issued id pairing a result with its call.
+        summary: One-line human-readable description, scrubbed and capped.
+        detail: Fuller payload (tool input / result text), scrubbed and capped.
+        tool_name: Name of the invoked tool (tool_call only).
+        is_diff: True when detail carries an edit-shaped payload the client
+            may render as a diff (tool_call only).
+        is_error: True when the tool reported failure (tool_result only).
+    """
+
+    kind: str
+    tool_use_id: str
+    summary: str
+    detail: str
+    tool_name: str = ""
+    is_diff: bool = False
+    is_error: bool = False
+
+
+# Caps applied by scrub_trace_text. Scrubbing always runs before the cap
+# so truncation can never bisect a secret into a survivable prefix.
+TRACE_SUMMARY_MAX_CHARS = 200
+TRACE_DETAIL_MAX_CHARS = 4096
+_TRACE_TRUNCATION_MARKER = " [truncated]"
+_TRACE_SECRET_NAME_SUFFIXES = ("_SECRET", "_TOKEN", "_KEY", "_PASSWORD")
+# Values shorter than this are too likely to occur as ordinary text
+# (e.g. TERM=xterm under a hypothetical *_KEY name) to scrub safely.
+_TRACE_SECRET_MIN_LENGTH = 8
+
+
+def trace_secret_values(env: Mapping[str, str]) -> tuple[str, ...]:
+    """
+    Snapshot the secret values to scrub from trace text.
+
+    Backends call this on the fully built subprocess environment at spawn
+    time (not the parent process environment at construction), so
+    credentials that exist only as constructor arguments, like the
+    per-principal webhook secret, are always covered.
+    """
+    return tuple(
+        value
+        for name, value in env.items()
+        if name.endswith(_TRACE_SECRET_NAME_SUFFIXES) and len(value) >= _TRACE_SECRET_MIN_LENGTH
+    )
+
+
+def scrub_trace_text(text: str, secrets: tuple[str, ...], max_chars: int) -> str:
+    """Replace known secret values with [redacted], then cap the length."""
+    for secret in secrets:
+        text = text.replace(secret, "[redacted]")
+    if len(text) > max_chars:
+        text = text[:max_chars] + _TRACE_TRUNCATION_MARKER
+    return text
+
+
 @dataclass
 class StreamEvent:
     """
@@ -306,11 +375,16 @@ class StreamEvent:
         text_so_far: Accumulated response text up to this point.
         done: True if this is the final event (response complete or error).
         response: The complete AgentResponse, set only when done=True.
+        trace: Tool activity record. A trace-bearing event always carries
+            text_so_far="" and done=False; every stream observer drops
+            empty-text events, which is what keeps traces invisible to
+            text consumers.
     """
 
     text_so_far: str
     done: bool = False
     response: AgentResponse | None = None
+    trace: TraceEntry | None = None
 
 
 # ── API context ─────────────────────────────────────────────────────

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Literal, Protocol, runtime_checkable
 
 from kai.agent_failure import AgentFailureKind, classify_agent_failure
 from kai.config import (
@@ -313,12 +313,13 @@ class TraceEntry:
         summary: One-line human-readable description, scrubbed and capped.
         detail: Fuller payload (tool input / result text), scrubbed and capped.
         tool_name: Name of the invoked tool (tool_call only).
-        is_diff: True when detail carries an edit-shaped payload the client
-            may render as a diff (tool_call only).
+        is_diff: True when detail carries an edit-shaped payload (old/new
+            string pairs or diff content) the client may render as a diff
+            (tool_call only).
         is_error: True when the tool reported failure (tool_result only).
     """
 
-    kind: str
+    kind: Literal["tool_call", "tool_result"]
     tool_use_id: str
     summary: str
     detail: str
@@ -355,8 +356,17 @@ def trace_secret_values(env: Mapping[str, str]) -> tuple[str, ...]:
 
 
 def scrub_trace_text(text: str, secrets: tuple[str, ...], max_chars: int) -> str:
-    """Replace known secret values with [redacted], then cap the length."""
-    for secret in secrets:
+    """
+    Replace known secret values with [redacted], then cap the length.
+
+    Secrets are replaced longest-first so a snapshot value that is a
+    substring of another cannot mangle the longer occurrence and leak
+    its suffix. Matching is exact on the raw value: a secret containing
+    characters that a caller transformed before scrubbing (JSON string
+    escaping, whitespace collapsing) is not caught. Accepted limitation;
+    realistic env credentials are single URL-safe tokens.
+    """
+    for secret in sorted(secrets, key=len, reverse=True):
         text = text.replace(secret, "[redacted]")
     if len(text) > max_chars:
         text = text[:max_chars] + _TRACE_TRUNCATION_MARKER

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -1070,9 +1070,10 @@ class ClaudeCodeBackend(AgentBackend):
         Build a tool_call TraceEntry from an assistant tool_use block.
 
         The summary is one line: Bash shows its command, Edit/Write the
-        target file path, any other tool just its name. Returns None with
-        a debug log on a malformed block; trace emission must never break
-        the text stream.
+        target file path, other tools their name plus a compact list of
+        their input keys, and a tool with no input just its name. Returns
+        None with a debug log on a malformed block; trace emission must
+        never break the text stream.
         """
         try:
             tool_use_id = block["id"]
@@ -1085,6 +1086,8 @@ class ClaudeCodeBackend(AgentBackend):
                 summary = f"Bash: {' '.join(tool_input['command'].split())}"
             elif tool_name in ("Edit", "Write") and isinstance(tool_input.get("file_path"), str):
                 summary = f"{tool_name}: {tool_input['file_path']}"
+            elif tool_input:
+                summary = f"{tool_name}: {', '.join(sorted(tool_input))}"
             return TraceEntry(
                 kind="tool_call",
                 tool_use_id=tool_use_id,
@@ -1095,7 +1098,10 @@ class ClaudeCodeBackend(AgentBackend):
                     TRACE_DETAIL_MAX_CHARS,
                 ),
                 tool_name=tool_name,
-                is_diff=tool_name == "Edit",
+                # Content-based rather than name-based so any edit-shaped
+                # tool is rendered rich, and the flag keeps the same
+                # meaning across backend emitters.
+                is_diff="old_string" in tool_input and "new_string" in tool_input,
             )
         except Exception:
             log.debug("Skipping malformed tool_use block", exc_info=True)

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -30,16 +30,21 @@ from pathlib import Path
 
 from kai.acp import _signal_target_user_pid, _signal_target_user_pid_sync
 from kai.backend import (
+    TRACE_DETAIL_MAX_CHARS,
+    TRACE_SUMMARY_MAX_CHARS,
     AgentBackend,
     AgentResponse,
     ApiContext,
     StreamEvent,
+    TraceEntry,
     apply_workspace_model,
     assemble_turn_context,
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_context_files,
     sanitize_agent_environment,
+    scrub_trace_text,
+    trace_secret_values,
 )
 from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
@@ -194,6 +199,10 @@ class ClaudeCodeBackend(AgentBackend):
         self._fresh_session = True  # True until the first message is sent
         self._stderr_task: asyncio.Task | None = None  # Background stderr drain
         self._session_started_at: float | None = None  # time.monotonic() at process start
+        # Secret values scrubbed from trace text. Snapshotted from the
+        # fully built subprocess environment at spawn so constructor-only
+        # credentials (the per-principal webhook secret) are covered.
+        self._trace_secrets: tuple[str, ...] = ()
 
     @property
     def is_alive(self) -> bool:
@@ -367,6 +376,8 @@ class ClaudeCodeBackend(AgentBackend):
         # /tmp; no cross-user collision is possible there.
         if effective_claude_user:
             env["TMPDIR"] = str(DATA_DIR / "tmp" / effective_claude_user)
+
+        self._trace_secrets = trace_secret_values(env)
 
         self._proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -1007,6 +1018,19 @@ class ClaudeCodeBackend(AgentBackend):
                                     accumulated_text += "\n\n"
                                 accumulated_text += new_text
                                 yield StreamEvent(text_so_far=accumulated_text)
+                            elif block.get("type") == "tool_use":
+                                trace = self._tool_call_trace(block)
+                                if trace is not None:
+                                    yield StreamEvent(text_so_far="", trace=trace)
+
+                elif etype == "user" and "message" in event:
+                    msg_data = event["message"]
+                    if isinstance(msg_data, dict) and isinstance(msg_data.get("content"), list):
+                        for block in msg_data["content"]:
+                            if isinstance(block, dict) and block.get("type") == "tool_result":
+                                trace = self._tool_result_trace(block)
+                                if trace is not None:
+                                    yield StreamEvent(text_so_far="", trace=trace)
 
                 elif etype == "stream_event":
                     inner = event.get("event")
@@ -1040,6 +1064,77 @@ class ClaudeCodeBackend(AgentBackend):
                 done=True,
                 response=AgentResponse(success=False, text=accumulated_text, error=str(e)),
             )
+
+    def _tool_call_trace(self, block: dict) -> TraceEntry | None:
+        """
+        Build a tool_call TraceEntry from an assistant tool_use block.
+
+        The summary is one line: Bash shows its command, Edit/Write the
+        target file path, any other tool just its name. Returns None with
+        a debug log on a malformed block; trace emission must never break
+        the text stream.
+        """
+        try:
+            tool_use_id = block["id"]
+            tool_name = block["name"]
+            tool_input = block.get("input", {})
+            if not isinstance(tool_use_id, str) or not isinstance(tool_name, str) or not isinstance(tool_input, dict):
+                raise TypeError("unexpected tool_use field type")
+            summary = tool_name
+            if tool_name == "Bash" and isinstance(tool_input.get("command"), str):
+                summary = f"Bash: {' '.join(tool_input['command'].split())}"
+            elif tool_name in ("Edit", "Write") and isinstance(tool_input.get("file_path"), str):
+                summary = f"{tool_name}: {tool_input['file_path']}"
+            return TraceEntry(
+                kind="tool_call",
+                tool_use_id=tool_use_id,
+                summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                detail=scrub_trace_text(
+                    json.dumps(tool_input, ensure_ascii=False),
+                    self._trace_secrets,
+                    TRACE_DETAIL_MAX_CHARS,
+                ),
+                tool_name=tool_name,
+                is_diff=tool_name == "Edit",
+            )
+        except Exception:
+            log.debug("Skipping malformed tool_use block", exc_info=True)
+            return None
+
+    def _tool_result_trace(self, block: dict) -> TraceEntry | None:
+        """
+        Build a tool_result TraceEntry from a user-message tool_result block.
+
+        The CLI emits result content either as a plain string or as a list
+        of typed blocks, of which only text blocks carry human-readable
+        output. Returns None with a debug log on a malformed block; trace
+        emission must never break the text stream.
+        """
+        try:
+            tool_use_id = block["tool_use_id"]
+            if not isinstance(tool_use_id, str):
+                raise TypeError("unexpected tool_use_id type")
+            content = block.get("content", "")
+            if isinstance(content, list):
+                text = "\n".join(
+                    part.get("text", "") for part in content if isinstance(part, dict) and part.get("type") == "text"
+                )
+            elif isinstance(content, str):
+                text = content
+            else:
+                text = ""
+            stripped = text.strip()
+            summary = stripped.split("\n", 1)[0] if stripped else "(no output)"
+            return TraceEntry(
+                kind="tool_result",
+                tool_use_id=tool_use_id,
+                summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                detail=scrub_trace_text(text, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                is_error=bool(block.get("is_error", False)),
+            )
+        except Exception:
+            log.debug("Skipping malformed tool_result block", exc_info=True)
+            return None
 
     def force_kill(self) -> None:
         """

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -4001,3 +4001,281 @@ class TestWorkspaceConfig:
 
             call_kwargs = mock_exec.call_args.kwargs
             assert call_kwargs["env"]["SHARED"] == "from_inline"
+
+
+# ── Trace emission ───────────────────────────────────────────────────
+
+
+def _assistant_content_event(content: list) -> bytes:
+    """Build an assistant event JSON line with arbitrary content blocks."""
+    return _json_line({"type": "assistant", "message": {"content": content}})
+
+
+def _user_tool_result_event(*blocks: dict) -> bytes:
+    """Build a user event JSON line carrying the given content blocks."""
+    return _json_line({"type": "user", "message": {"content": list(blocks)}})
+
+
+class TestTraceEmission:
+    """_send_locked emits TraceEntry-bearing events for tool activity."""
+
+    @pytest.mark.asyncio
+    async def test_tool_use_yields_tool_call_and_text_is_unchanged(self):
+        """tool_use blocks yield tool_call traces with composed one-line
+        summaries while text accumulation stays byte-identical to the
+        trace-free path."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_content_event(
+                    [
+                        {"type": "text", "text": "Looking."},
+                        {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "ls\n-la"}},
+                        {"type": "tool_use", "id": "toolu_2", "name": "Edit", "input": {"file_path": "/w/a.py"}},
+                        {"type": "tool_use", "id": "toolu_3", "name": "Write", "input": {"file_path": "/w/b.py"}},
+                        {"type": "tool_use", "id": "toolu_4", "name": "Mystery", "input": {}},
+                    ]
+                ),
+                _assistant_event("Done."),
+                _result_event("ignored"),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        traces = [e.trace for e in events if e.trace is not None]
+        assert [t.summary for t in traces] == [
+            "Bash: ls -la",
+            "Edit: /w/a.py",
+            "Write: /w/b.py",
+            "Mystery",
+        ]
+        assert [t.kind for t in traces] == ["tool_call"] * 4
+        assert [t.is_diff for t in traces] == [False, True, False, False]
+        assert traces[0].tool_name == "Bash"
+        assert json.loads(traces[0].detail) == {"command": "ls\n-la"}
+        text_events = [e.text_so_far for e in events if not e.done and e.trace is None]
+        assert text_events == ["Looking.", "Looking.\n\nDone."]
+        assert events[-1].response is not None
+        assert events[-1].response.text == "Looking.\n\nDone."
+
+    @pytest.mark.asyncio
+    async def test_trace_events_carry_no_text_and_are_not_done(self):
+        """Every trace-bearing event has empty text and done=False; the
+        observers' empty-text guard is what keeps traces invisible to
+        text consumers."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_content_event(
+                    [
+                        {"type": "text", "text": "Hi."},
+                        {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "pwd"}},
+                    ]
+                ),
+                _user_tool_result_event({"type": "tool_result", "tool_use_id": "toolu_1", "content": "/w"}),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        trace_events = [e for e in events if e.trace is not None]
+        assert len(trace_events) == 2
+        for event in trace_events:
+            assert event.text_so_far == ""
+            assert event.done is False
+
+    @pytest.mark.asyncio
+    async def test_tool_result_pairs_with_its_call_by_tool_use_id(self):
+        """tool_result traces carry the tool_use_id of their call, string
+        and block-list content shapes both surface, and is_error passes
+        through."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_content_event(
+                    [{"type": "tool_use", "id": "toolu_9", "name": "Bash", "input": {"command": "pwd"}}]
+                ),
+                _user_tool_result_event(
+                    {"type": "tool_result", "tool_use_id": "toolu_9", "content": "line one\nline two"},
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_a",
+                        "content": [{"type": "text", "text": "boom"}],
+                        "is_error": True,
+                    },
+                ),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        call, first, second = [e.trace for e in events if e.trace is not None]
+        assert call.kind == "tool_call"
+        assert first.kind == "tool_result"
+        assert first.tool_use_id == call.tool_use_id == "toolu_9"
+        assert first.summary == "line one"
+        assert first.detail == "line one\nline two"
+        assert first.is_error is False
+        assert second.tool_use_id == "toolu_a"
+        assert second.detail == "boom"
+        assert second.is_error is True
+
+    @pytest.mark.asyncio
+    async def test_planted_secret_is_redacted_in_summary_and_detail(self):
+        """A value from the scrub snapshot never appears in trace text."""
+        secret = "planted-secret-value-123"
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_content_event(
+                    [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "Bash",
+                            "input": {"command": f"curl -H 'X-Auth: {secret}'"},
+                        }
+                    ]
+                ),
+                _user_tool_result_event(
+                    {"type": "tool_result", "tool_use_id": "toolu_1", "content": f"token was {secret}"}
+                ),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+        claude._trace_secrets = (secret,)
+
+        events = await _collect_events(claude)
+
+        call, result = [e.trace for e in events if e.trace is not None]
+        for trace in (call, result):
+            assert secret not in trace.summary
+            assert secret not in trace.detail
+        assert "[redacted]" in call.summary
+        assert "[redacted]" in call.detail
+        assert result.summary == "token was [redacted]"
+
+    @pytest.mark.asyncio
+    async def test_trace_secrets_snapshot_from_spawned_child_env(self, monkeypatch):
+        """The scrub set is snapshotted from the fully built child
+        environment at spawn, so it covers both parent-env secrets and
+        the webhook secret that exists only as a constructor argument."""
+        monkeypatch.setattr("kai.claude._resolve_default_claude_bin", lambda: "claude")
+        monkeypatch.setenv("KAITEST_PLANTED_SECRET", "parent-env-secret-1")
+        claude = _make_claude(webhook_secret="webhook-secret-value")
+
+        with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+            mock_proc = MagicMock()
+            mock_proc.returncode = None
+            mock_proc.stderr = MagicMock()
+            mock_proc.stderr.readline = AsyncMock(return_value=b"")
+            mock_exec.return_value = mock_proc
+
+            await claude._ensure_started()
+
+        assert "parent-env-secret-1" in claude._trace_secrets
+        assert "webhook-secret-value" in claude._trace_secrets
+
+    @pytest.mark.asyncio
+    async def test_truncation_appends_an_explicit_marker(self):
+        """summary caps at 200 chars and detail at 4096, each with the
+        truncation marker."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_content_event(
+                    [{"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "z" * 300}}]
+                ),
+                _user_tool_result_event({"type": "tool_result", "tool_use_id": "toolu_1", "content": "y" * 5000}),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        call, result = [e.trace for e in events if e.trace is not None]
+        assert call.summary == ("Bash: " + "z" * 300)[:200] + " [truncated]"
+        assert result.detail == "y" * 4096 + " [truncated]"
+        assert result.summary == "y" * 200 + " [truncated]"
+
+    @pytest.mark.asyncio
+    async def test_scrub_runs_before_truncation(self):
+        """A secret straddling the detail cap boundary is redacted whole;
+        truncation can never leave a survivable secret prefix."""
+        secret = "hunter2secret999"
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _user_tool_result_event(
+                    {"type": "tool_result", "tool_use_id": "toolu_1", "content": "x" * 4090 + secret}
+                ),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+        claude._trace_secrets = (secret,)
+
+        events = await _collect_events(claude)
+
+        (result,) = [e.trace for e in events if e.trace is not None]
+        assert secret not in result.detail
+        assert "hunter" not in result.detail
+        assert result.detail.endswith(" [truncated]")
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_blocks_are_skipped_without_raising(self):
+        """Protocol drift in tool_use / tool_result shapes yields no trace
+        and never breaks the stream."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_content_event(
+                    [
+                        {"type": "tool_use"},
+                        {"type": "tool_use", "id": 5, "name": "Bash", "input": {}},
+                        {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": "not-a-dict"},
+                    ]
+                ),
+                _user_tool_result_event(
+                    {"type": "tool_result"},
+                    {"type": "tool_result", "tool_use_id": 7},
+                ),
+                _json_line({"type": "user", "message": {"content": "plain string"}}),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        assert [e for e in events if e.trace is not None] == []
+        assert events[-1].done is True

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -4031,9 +4031,20 @@ class TestTraceEmission:
                     [
                         {"type": "text", "text": "Looking."},
                         {"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {"command": "ls\n-la"}},
-                        {"type": "tool_use", "id": "toolu_2", "name": "Edit", "input": {"file_path": "/w/a.py"}},
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_2",
+                            "name": "Edit",
+                            "input": {"file_path": "/w/a.py", "old_string": "x", "new_string": "y"},
+                        },
                         {"type": "tool_use", "id": "toolu_3", "name": "Write", "input": {"file_path": "/w/b.py"}},
-                        {"type": "tool_use", "id": "toolu_4", "name": "Mystery", "input": {}},
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_4",
+                            "name": "Read",
+                            "input": {"file_path": "/w/c.py", "limit": 5},
+                        },
+                        {"type": "tool_use", "id": "toolu_5", "name": "Mystery", "input": {}},
                     ]
                 ),
                 _assistant_event("Done."),
@@ -4052,10 +4063,11 @@ class TestTraceEmission:
             "Bash: ls -la",
             "Edit: /w/a.py",
             "Write: /w/b.py",
+            "Read: file_path, limit",
             "Mystery",
         ]
-        assert [t.kind for t in traces] == ["tool_call"] * 4
-        assert [t.is_diff for t in traces] == [False, True, False, False]
+        assert [t.kind for t in traces] == ["tool_call"] * 5
+        assert [t.is_diff for t in traces] == [False, True, False, False, False]
         assert traces[0].tool_name == "Bash"
         assert json.loads(traces[0].detail) == {"command": "ls\n-la"}
         text_events = [e.text_so_far for e in events if not e.done and e.trace is None]
@@ -4279,3 +4291,30 @@ class TestTraceEmission:
 
         assert [e for e in events if e.trace is not None] == []
         assert events[-1].done is True
+
+    @pytest.mark.asyncio
+    async def test_overlapping_secrets_are_scrubbed_longest_first(self):
+        """A snapshot value that is a prefix of another cannot mangle the
+        longer occurrence and leak its suffix."""
+        short_secret = "abc12345"
+        long_secret = "abc12345xyz99999"
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _user_tool_result_event(
+                    {"type": "tool_result", "tool_use_id": "toolu_1", "content": f"value: {long_secret}"}
+                ),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+        claude._trace_secrets = (short_secret, long_secret)
+
+        events = await _collect_events(claude)
+
+        (result,) = [e.trace for e in events if e.trace is not None]
+        assert result.detail == "value: [redacted]"
+        assert "xyz99999" not in result.detail


### PR DESCRIPTION
Closes #963. Foundation for the run inspector epic (#962); ships dark with no consumer changes.

## Summary

Adds the backend-neutral trace surface and the first emitter. `TraceEntry` is a frozen dataclass in `backend.py` with `tool_call` and `tool_result` kinds, attached to `StreamEvent` through a new optional `trace` field defaulting to `None`. A trace-bearing event always carries `text_so_far=""` and `done=False`; every existing stream observer drops empty-text events, which is what keeps traces invisible to current consumers.

## Implementation

- **Scrub/truncate helpers** live in `backend.py` next to `TraceEntry`, never in a backend module. Secret scrubbing is value-based: the scrub set is snapshotted from the fully built subprocess environment at spawn time (after `sanitize_agent_environment` and the per-principal webhook secret injection), not the parent environment at construction, so constructor-only credentials are always covered. Values whose names match `*_SECRET` / `*_TOKEN` / `*_KEY` / `*_PASSWORD` (length >= 8) are replaced with `[redacted]`. Scrub runs before truncation so a cap can never bisect a secret into a survivable prefix. `detail` caps at 4096 chars, `summary` at 200, each with an explicit marker.
- **claude emission**: assistant `tool_use` blocks yield `tool_call` entries with a composed one-line summary (Bash shows its command collapsed to one line, Edit/Write the file path, unknown tools fall back to the tool name; `is_diff` marks Edit). A new `user` branch yields `tool_result` entries, handling both string and block-list content shapes. Malformed shapes are skipped with a debug log, never raised. Text accumulation, separator logic, and final `result` handling are untouched.

## Testing

Eight new tests: composed summaries with a byte-identical text accumulation regression pin; the invariant pin that every trace-bearing event has empty text and `done=False`; result-to-call pairing via `tool_use_id`; a planted env secret redacted in summary and detail; the webhook secret (present only in the spawned child environment) redacted; truncation markers on both caps; scrub-before-truncate pinned by a secret straddling the detail cap boundary; malformed blocks skipped without raising.

Full suite: 5858 passed, 1 skipped. Lint clean.
