### PR TITLE
feat: emit trace entries from the codex backend

### DIFF
--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -54,10 +54,13 @@ from pathlib import Path
 import kai
 from kai.acp import _signal_target_user_pid, _signal_target_user_pid_sync
 from kai.backend import (
+    TRACE_DETAIL_MAX_CHARS,
+    TRACE_SUMMARY_MAX_CHARS,
     AgentBackend,
     AgentResponse,
     ApiContext,
     StreamEvent,
+    TraceEntry,
     apply_workspace_model,
     assemble_turn_context,
     build_foreign_workspace_reminder,
@@ -65,6 +68,8 @@ from kai.backend import (
     ensure_user_context_files,
     principal_storage_name,
     sanitize_agent_environment,
+    scrub_trace_text,
+    trace_secret_values,
 )
 from kai.backend_registry import BackendRegistryError, backend_registry_is_authoritative, resolve_backend_command
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
@@ -107,6 +112,23 @@ def _resolve_default_codex_bin() -> str:
             return candidate
     discovered = shutil.which("codex")
     return discovered or "codex"
+
+
+def _file_change_paths(changes: list) -> str:
+    """One-line comma-joined path list of a fileChange item's changes."""
+    return ", ".join(change.get("path", "") for change in changes if isinstance(change, dict))
+
+
+def _file_change_detail(changes: list) -> str:
+    """
+    Concatenated per-file diffs of a fileChange item.
+
+    Each change's path precedes its diff so the client's line-prefix
+    diff rendering keeps file context in multi-file changes.
+    """
+    return "\n".join(
+        f"{change.get('path', '')}\n{change.get('diff', '')}" for change in changes if isinstance(change, dict)
+    )
 
 
 def _grant_turn_image_read_access(path: Path, reader_user: str) -> None:
@@ -355,6 +377,10 @@ class CodexBackend(AgentBackend):
         self._lock = asyncio.Lock()  # Serializes all message sends
         self._fresh_session: bool = True  # True until the first message is sent
         self._stderr_task: asyncio.Task | None = None  # Background stderr drain
+        # Secret values scrubbed from trace text. Snapshotted from the
+        # fully built subprocess environment at spawn so constructor-only
+        # credentials (the per-principal webhook secret) are covered.
+        self._trace_secrets: tuple[str, ...] = ()
 
         # Cross-user teardown apparatus (#456-equivalent for codex).
         # When effective_codex_user is set in _ensure_started, the
@@ -512,6 +538,8 @@ class CodexBackend(AgentBackend):
             self.provider,
             effective_codex_user or "(same as bot)",
         )
+
+        self._trace_secrets = trace_secret_values(env)
 
         self._proc = await asyncio.create_subprocess_exec(
             *argv,
@@ -1137,6 +1165,15 @@ class CodexBackend(AgentBackend):
                         current_item_phase = phase if phase in ("commentary", "final_answer") else None
                     else:
                         log.debug("Codex: item/started type=%s id=%s", item.get("type"), item.get("id"))
+                        # Non-text items become tool_call traces; unknown
+                        # item types are traced under their type name so
+                        # new codex vocabulary degrades gracefully.
+                        # reasoning stays invisible, mirroring the claude
+                        # emitter's treatment of thinking.
+                        if item.get("type") != "reasoning":
+                            trace = self._item_call_trace(item)
+                            if trace is not None:
+                                yield StreamEvent(text_so_far="", trace=trace)
 
                 elif method == "item/agentMessage/delta":
                     params = msg.get("params", {})
@@ -1176,6 +1213,10 @@ class CodexBackend(AgentBackend):
                             yield StreamEvent(text_so_far=_visible_text())
                     else:
                         log.debug("Codex: item/completed type=%s", item.get("type"))
+                        if item.get("type") != "reasoning":
+                            trace = self._item_result_trace(item)
+                            if trace is not None:
+                                yield StreamEvent(text_so_far="", trace=trace)
 
                 elif method == "turn/completed":
                     turn = msg.get("params", {}).get("turn", {})
@@ -1290,6 +1331,82 @@ class CodexBackend(AgentBackend):
             _unlink_turn_images(turn_image_paths)
 
     # ── Kill / restart / shutdown ──────────────────────────────────
+
+    def _item_call_trace(self, item: dict) -> TraceEntry | None:
+        """
+        Build a tool_call TraceEntry from a non-text item/started item.
+
+        The summary is one line: commandExecution shows its command,
+        fileChange its changed path(s), any other item type its type
+        name with the full item as detail. Returns None with a debug log
+        on a malformed item; trace emission must never break the text
+        stream.
+        """
+        try:
+            item_id = item["id"]
+            item_type = item["type"]
+            if not isinstance(item_id, str) or not isinstance(item_type, str):
+                raise TypeError("unexpected item field type")
+            is_diff = False
+            if item_type == "commandExecution" and isinstance(item.get("command"), str):
+                summary = f"commandExecution: {' '.join(item['command'].split())}"
+                detail = item["command"]
+            elif item_type == "fileChange" and isinstance(item.get("changes"), list):
+                summary = f"fileChange: {_file_change_paths(item['changes'])}"
+                detail = _file_change_detail(item["changes"])
+                is_diff = bool(detail)
+            else:
+                summary = item_type
+                detail = json.dumps(item, ensure_ascii=False)
+            return TraceEntry(
+                kind="tool_call",
+                tool_use_id=item_id,
+                summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                tool_name=item_type,
+                is_diff=is_diff,
+            )
+        except Exception:
+            log.debug("Skipping malformed item for tool_call trace", exc_info=True)
+            return None
+
+    def _item_result_trace(self, item: dict) -> TraceEntry | None:
+        """
+        Build a tool_result TraceEntry from a non-text item/completed item.
+
+        tool_use_id carries the item id, the same value the tool_call
+        trace carried, so client call/result pairing works unchanged.
+        is_error reflects the item's terminal status (failed or declined).
+        Returns None with a debug log on a malformed item; trace emission
+        must never break the text stream.
+        """
+        try:
+            item_id = item["id"]
+            item_type = item["type"]
+            if not isinstance(item_id, str) or not isinstance(item_type, str):
+                raise TypeError("unexpected item field type")
+            if item_type == "commandExecution":
+                output = item.get("aggregatedOutput")
+                text = output if isinstance(output, str) else ""
+                stripped = text.strip()
+                summary = stripped.split("\n", 1)[0] if stripped else "(no output)"
+                detail = text
+            elif item_type == "fileChange" and isinstance(item.get("changes"), list):
+                summary = f"fileChange: {_file_change_paths(item['changes'])}"
+                detail = _file_change_detail(item["changes"])
+            else:
+                summary = item_type
+                detail = json.dumps(item, ensure_ascii=False)
+            return TraceEntry(
+                kind="tool_result",
+                tool_use_id=item_id,
+                summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                is_error=item.get("status") in ("failed", "declined"),
+            )
+        except Exception:
+            log.debug("Skipping malformed item for tool_result trace", exc_info=True)
+            return None
 
     def _lookup_inner_codex_pids(self) -> list[int]:
         """

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -1131,19 +1131,21 @@ class CodexBackend(AgentBackend):
                 #   - turn/started NOTIFICATION: opted out via
                 #     initialize.capabilities so it never arrives.
                 #   - item/started: full ThreadItem with type and id.
-                #     We only care about agentMessage items for the
-                #     conversational stream; other item types (reasoning,
-                #     commandExecution, fileChange, etc.) are logged at
-                #     DEBUG. We capture the agentMessage item id so
-                #     subsequent deltas can be tied back to the right
-                #     stream.
+                #     agentMessage items feed the conversational stream;
+                #     other item types are logged at DEBUG and traced
+                #     as tool_call entries (reasoning excepted, which
+                #     stays invisible). We capture the agentMessage item
+                #     id so subsequent deltas can be tied back to the
+                #     right stream.
                 #   - item/agentMessage/delta: streaming text chunks.
                 #     Concatenate `delta` per itemId. Codex emits text
                 #     in roughly token-sized chunks.
                 #   - item/completed: authoritative final state of the
                 #     item. For agentMessage this carries the full
                 #     accumulated `text`; we trust this over our own
-                #     concatenation in case any delta was missed.
+                #     concatenation in case any delta was missed. Other
+                #     item types are logged at DEBUG and traced as
+                #     tool_result entries (reasoning excepted).
                 #   - turn/completed: terminal event. Carries turn
                 #     status (`completed` / `interrupted` / `failed`)
                 #     and an optional error payload on failure. This
@@ -1354,7 +1356,7 @@ class CodexBackend(AgentBackend):
             elif item_type == "fileChange" and isinstance(item.get("changes"), list):
                 summary = f"fileChange: {_file_change_paths(item['changes'])}"
                 detail = _file_change_detail(item["changes"])
-                is_diff = bool(detail)
+                is_diff = any(change.get("diff") for change in item["changes"] if isinstance(change, dict))
             else:
                 summary = item_type
                 detail = json.dumps(item, ensure_ascii=False)
@@ -1402,6 +1404,12 @@ class CodexBackend(AgentBackend):
                 tool_use_id=item_id,
                 summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
                 detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                # The item's terminal status enum is the protocol's own
+                # failure signal. exitCode deliberately does not feed
+                # is_error: a command that ran to completion with a
+                # nonzero exit is not an execution failure at this layer,
+                # and the schema does not promise nonzero exit implies
+                # status "failed".
                 is_error=item.get("status") in ("failed", "declined"),
             )
         except Exception:

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -2598,3 +2598,201 @@ class TestSessionAgeRecycling:
         # _kill fires at least once for the recycle (and again from
         # the streaming loop's EOF handler, which is expected).
         assert mock_kill.await_count >= 1
+
+
+# ── Trace emission ───────────────────────────────────────────────────
+
+
+def _item_notification(method: str, item: dict) -> bytes:
+    """Build an item/started or item/completed notification line."""
+    return _json_line({"jsonrpc": "2.0", "method": method, "params": {"item": item}})
+
+
+class TestTraceEmission:
+    """_send_locked emits TraceEntry-bearing events for non-text items."""
+
+    @pytest.mark.asyncio
+    async def test_command_execution_pairs_call_and_result_by_item_id(self):
+        """item/started yields tool_call and item/completed tool_result,
+        sharing the item id in tool_use_id; failed status maps to
+        is_error; trace events carry empty text and done=False."""
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _item_notification(
+                    "item/started",
+                    {"id": "cmd-1", "type": "commandExecution", "command": "git\ndiff --stat", "status": "inProgress"},
+                ),
+                _item_notification(
+                    "item/completed",
+                    {
+                        "id": "cmd-1",
+                        "type": "commandExecution",
+                        "command": "git\ndiff --stat",
+                        "aggregatedOutput": "output line\nmore output",
+                        "exitCode": 0,
+                        "status": "completed",
+                    },
+                ),
+                _item_notification(
+                    "item/started",
+                    {"id": "cmd-2", "type": "commandExecution", "command": "false", "status": "inProgress"},
+                ),
+                _item_notification(
+                    "item/completed",
+                    {"id": "cmd-2", "type": "commandExecution", "command": "false", "status": "failed"},
+                ),
+                _turn_completed("completed"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        trace_events = [e for e in events if e.trace is not None]
+        for event in trace_events:
+            assert event.text_so_far == ""
+            assert event.done is False
+        call_1, result_1, call_2, result_2 = [e.trace for e in trace_events]
+        assert call_1.kind == "tool_call"
+        assert call_1.summary == "commandExecution: git diff --stat"
+        assert call_1.detail == "git\ndiff --stat"
+        assert call_1.tool_name == "commandExecution"
+        assert result_1.kind == "tool_result"
+        assert result_1.tool_use_id == call_1.tool_use_id == "cmd-1"
+        assert result_1.summary == "output line"
+        assert result_1.detail == "output line\nmore output"
+        assert result_1.is_error is False
+        assert call_2.tool_use_id == result_2.tool_use_id == "cmd-2"
+        assert result_2.summary == "(no output)"
+        assert result_2.is_error is True
+
+    @pytest.mark.asyncio
+    async def test_file_change_diff_content_sets_is_diff(self):
+        """fileChange traces list the changed paths and carry the diffs
+        as detail, with is_diff set on the call."""
+        changes = [
+            {"path": "src/a.py", "kind": "update", "diff": "+new\n-old"},
+            {"path": "src/b.py", "kind": "add", "diff": "+line"},
+        ]
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _item_notification(
+                    "item/started", {"id": "fc-1", "type": "fileChange", "changes": changes, "status": "inProgress"}
+                ),
+                _item_notification(
+                    "item/completed", {"id": "fc-1", "type": "fileChange", "changes": changes, "status": "completed"}
+                ),
+                _turn_completed("completed"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        call, result = [e.trace for e in events if e.trace is not None]
+        assert call.kind == "tool_call"
+        assert call.summary == "fileChange: src/a.py, src/b.py"
+        assert call.is_diff is True
+        assert call.detail == "src/a.py\n+new\n-old\nsrc/b.py\n+line"
+        assert result.kind == "tool_result"
+        assert result.tool_use_id == call.tool_use_id == "fc-1"
+        assert result.is_error is False
+
+    @pytest.mark.asyncio
+    async def test_unknown_item_type_is_traced_not_dropped(self):
+        """New codex vocabulary degrades gracefully to a type-named
+        trace; reasoning items stay invisible."""
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _item_notification("item/started", {"id": "r-1", "type": "reasoning"}),
+                _item_notification("item/started", {"id": "ws-1", "type": "webSearch", "query": "kai bot"}),
+                _item_notification("item/completed", {"id": "ws-1", "type": "webSearch", "query": "kai bot"}),
+                _item_notification("item/completed", {"id": "r-1", "type": "reasoning"}),
+                _turn_completed("completed"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        call, result = [e.trace for e in events if e.trace is not None]
+        assert call.kind == "tool_call"
+        assert call.tool_use_id == "ws-1"
+        assert call.summary == "webSearch"
+        assert call.tool_name == "webSearch"
+        assert "kai bot" in call.detail
+        assert result.kind == "tool_result"
+        assert result.tool_use_id == "ws-1"
+
+    @pytest.mark.asyncio
+    async def test_planted_secret_redacted_in_command_output(self):
+        """A snapshot secret value never appears in trace text."""
+        secret = "planted-secret-value-123"
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _item_notification(
+                    "item/started",
+                    {
+                        "id": "cmd-1",
+                        "type": "commandExecution",
+                        "command": f"curl -H 'X-Auth: {secret}'",
+                        "status": "inProgress",
+                    },
+                ),
+                _item_notification(
+                    "item/completed",
+                    {
+                        "id": "cmd-1",
+                        "type": "commandExecution",
+                        "command": f"curl -H 'X-Auth: {secret}'",
+                        "aggregatedOutput": f"token was {secret}",
+                        "status": "completed",
+                    },
+                ),
+                _turn_completed("completed"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+        c._trace_secrets = (secret,)
+
+        events = await _collect_events(c)
+
+        call, result = [e.trace for e in events if e.trace is not None]
+        for trace in (call, result):
+            assert secret not in trace.summary
+            assert secret not in trace.detail
+        assert "[redacted]" in call.summary
+        assert result.summary == "token was [redacted]"
+
+    @pytest.mark.asyncio
+    async def test_malformed_items_are_skipped_without_raising(self):
+        """Items without a usable id yield no trace and never break the
+        stream."""
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _item_notification("item/started", {"type": "commandExecution", "command": "pwd"}),
+                _item_notification("item/completed", {"id": 7, "type": "commandExecution"}),
+                _turn_completed("completed"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        assert [e for e in events if e.trace is not None] == []
+        assert events[-1].done is True

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -2796,3 +2796,31 @@ class TestTraceEmission:
 
         assert [e for e in events if e.trace is not None] == []
         assert events[-1].done is True
+
+    @pytest.mark.asyncio
+    async def test_file_change_without_diff_text_is_not_marked_diff(self):
+        """is_diff reflects diff text being present, not merely a
+        non-empty changes list; declined status maps to is_error."""
+        changes = [{"path": "src/a.py", "kind": "delete", "diff": ""}]
+        c = _make_codex()
+        c._proc = _make_mock_proc(
+            [
+                _item_notification(
+                    "item/started", {"id": "fc-2", "type": "fileChange", "changes": changes, "status": "inProgress"}
+                ),
+                _item_notification(
+                    "item/completed", {"id": "fc-2", "type": "fileChange", "changes": changes, "status": "declined"}
+                ),
+                _turn_completed("completed"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        call, result = [e.trace for e in events if e.trace is not None]
+        assert call.is_diff is False
+        assert call.summary == "fileChange: src/a.py"
+        assert result.is_error is True


### PR DESCRIPTION
Closes #964. Part of the run inspector epic (#962); depends on the shared surface from #977. Ships dark: trace events carry empty text and `done=False`, so every existing stream observer ignores them.

## Summary

The codex backend now emits `TraceEntry` records for non-text items. `item/started` yields a `tool_call` and `item/completed` a `tool_result`, with the item id carried in `tool_use_id` so client call/result pairing works unchanged.

## Implementation

- **`commandExecution`**: the call summarizes its command collapsed to one line with the raw command as detail; the result's summary is the first line of `aggregatedOutput` with the full output as detail. Terminal statuses `failed` and `declined` map to `is_error`.
- **`fileChange`**: call and result summarize the changed path(s); detail carries the per-file diffs with each path preceding its diff, and `is_diff` is set on the call when diff text is present (content-based, consistent with the claude emitter).
- **Unknown item types** are traced under their type name with the full item JSON as detail, not dropped, so new codex vocabulary degrades gracefully. `reasoning` is excluded and stays invisible, mirroring the claude emitter's treatment of thinking. Existing DEBUG logging stays.
- **Scrubbing/truncation** use the shared `backend.py` helpers; the scrub set is snapshotted from the fully built subprocess environment at spawn (after sanitization and webhook-secret injection), matching the claude backend. No local redaction code.
- Item shapes were verified against the codex app-server generated JSON schema (`CommandExecutionThreadItem`, `FileChangeThreadItem`, `FileUpdateChange`) rather than inferred.

## Testing

Five new tests in `tests/test_codex.py`: started/completed pairing via item id including the empty-text/`done=False` invariant and failed-status `is_error`; `fileChange` diff content sets `is_diff` with path-labeled diff detail; unknown item type traced while reasoning stays invisible; planted secret redacted in summary and detail; malformed items skipped without raising.

Full suite: 5864 passed, 1 skipped. Lint clean.
