### PR TITLE
feat: emit trace entries from the ACP lanes via one shared mapper

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -620,12 +620,19 @@ def _signal_target_user_pid_sync(
 
 # Session-update discriminators that never produce a trace entry: the
 # text lane (surfaced by extract_text_delta), thinking (invisible in
-# every backend lane, mirroring the claude and codex emitters), and the
-# housekeeping shapes with no tool semantics.
+# every backend lane, mirroring the claude and codex emitters), the
+# user's own prompt echo, and the housekeeping shapes with no tool
+# semantics. All are ACP v1 spec vocabulary except usage_update, an
+# observed OpenCode extension. The unknown-vocabulary fallback in
+# _session_update_trace is reserved for shapes outside this known set.
 _UNTRACED_SESSION_UPDATES = (
     "agent_message_chunk",
     "agent_thought_chunk",
+    "user_message_chunk",
+    "plan",
     "available_commands_update",
+    "current_mode_update",
+    "config_options_update",
     "usage_update",
 )
 
@@ -933,11 +940,11 @@ class AcpBackend(AgentBackend):
                     kind="tool_result",
                     tool_use_id=tool_call_id,
                     summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
-                    detail=scrub_trace_text(
-                        detail or json.dumps(update, ensure_ascii=False),
-                        self._trace_secrets,
-                        TRACE_DETAIL_MAX_CHARS,
-                    ),
+                    # A recognized result with no content blocks keeps an
+                    # empty detail, matching the codex emitter's no-output
+                    # results; the raw-payload fallback is for shapes that
+                    # would otherwise lose information.
+                    detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
                     is_error=status == "failed",
                 )
             if update_type == "tool_call":

--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -47,16 +47,21 @@ from pathlib import Path
 
 import kai
 from kai.backend import (
+    TRACE_DETAIL_MAX_CHARS,
+    TRACE_SUMMARY_MAX_CHARS,
     AgentBackend,
     AgentResponse,
     ApiContext,
     StreamEvent,
+    TraceEntry,
     apply_workspace_model,
     assemble_turn_context,
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_context_files,
     sanitize_agent_environment,
+    scrub_trace_text,
+    trace_secret_values,
 )
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
 from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
@@ -613,6 +618,52 @@ def _signal_target_user_pid_sync(
 # ── ACP base backend ──────────────────────────────────────────────
 
 
+# Session-update discriminators that never produce a trace entry: the
+# text lane (surfaced by extract_text_delta), thinking (invisible in
+# every backend lane, mirroring the claude and codex emitters), and the
+# housekeeping shapes with no tool semantics.
+_UNTRACED_SESSION_UPDATES = (
+    "agent_message_chunk",
+    "agent_thought_chunk",
+    "available_commands_update",
+    "usage_update",
+)
+
+
+def _tool_call_content_text(content: object) -> tuple[str, bool]:
+    """
+    Render ACP ToolCallContent blocks to detail text; flag diff blocks.
+
+    A diff block renders as its file path followed by the old text with
+    a `- ` prefix and the new text with a `+ ` prefix per line, so the
+    client's line-prefix diff rendering works on it. A content block
+    contributes its inner text. Terminal blocks carry no text.
+    """
+    if not isinstance(content, list):
+        return "", False
+    parts: list[str] = []
+    is_diff = False
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "diff":
+            is_diff = True
+            lines = [str(block.get("path", ""))]
+            old_text = block.get("oldText")
+            if isinstance(old_text, str) and old_text:
+                lines.extend(f"- {line}" for line in old_text.splitlines())
+            new_text = block.get("newText")
+            if isinstance(new_text, str) and new_text:
+                lines.extend(f"+ {line}" for line in new_text.splitlines())
+            parts.append("\n".join(lines))
+        elif block_type == "content":
+            inner = block.get("content")
+            if isinstance(inner, dict) and inner.get("type") == "text":
+                parts.append(inner.get("text", ""))
+    return "\n".join(parts), is_diff
+
+
 class AcpBackend(AgentBackend):
     """
     AgentBackend implementation for the ACP JSON-RPC 2.0 wire shape.
@@ -738,6 +789,10 @@ class AcpBackend(AgentBackend):
         # unambiguous across restarts.
         self._next_id: int = 1
         self._lock = asyncio.Lock()  # Serializes all message sends
+        # Secret values scrubbed from trace text. Snapshotted from the
+        # fully built subprocess environment at spawn so constructor-only
+        # credentials (the per-principal webhook secret) are covered.
+        self._trace_secrets: tuple[str, ...] = ()
         # True until the first send() finishes; first-message context
         # (AGENTS.md / PREFERENCES.md / session_context) is injected
         # exactly once per session.
@@ -838,6 +893,91 @@ class AcpBackend(AgentBackend):
         but Kai should not surface.
         """
         raise NotImplementedError
+
+    def _session_update_trace(self, update: dict) -> TraceEntry | None:
+        """
+        Build a TraceEntry from a non-text ACP session update, shared by
+        every ACP lane.
+
+        tool_call updates yield kind tool_call (title feeds the summary,
+        the ACP kind the tool name, content the detail, with is_diff for
+        diff blocks); tool_call_update with terminal status yields kind
+        tool_result keyed by the same toolCallId. Non-terminal progress
+        states yield None: the card shows call then result, and status
+        churn is noise at this granularity. Unknown vocabulary degrades
+        to a trace named by the ACP kind or the literal update type with
+        the raw update payload as detail, not dropped. Returns None with
+        a debug log on a malformed update; trace emission must never
+        break the text stream.
+        """
+        try:
+            update_type = update.get("sessionUpdate")
+            if not isinstance(update_type, str) or update_type in _UNTRACED_SESSION_UPDATES:
+                return None
+            if update_type == "tool_call_update":
+                status = update.get("status")
+                if status not in ("completed", "failed"):
+                    return None
+                tool_call_id = update["toolCallId"]
+                if not isinstance(tool_call_id, str):
+                    raise TypeError("unexpected toolCallId type")
+                detail, _ = _tool_call_content_text(update.get("content"))
+                title = update.get("title")
+                if isinstance(title, str) and title:
+                    summary = title
+                elif detail.strip():
+                    summary = detail.strip().split("\n", 1)[0]
+                else:
+                    summary = "(no output)"
+                return TraceEntry(
+                    kind="tool_result",
+                    tool_use_id=tool_call_id,
+                    summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                    detail=scrub_trace_text(
+                        detail or json.dumps(update, ensure_ascii=False),
+                        self._trace_secrets,
+                        TRACE_DETAIL_MAX_CHARS,
+                    ),
+                    is_error=status == "failed",
+                )
+            if update_type == "tool_call":
+                tool_call_id = update["toolCallId"]
+                if not isinstance(tool_call_id, str):
+                    raise TypeError("unexpected toolCallId type")
+                acp_kind = update.get("kind")
+                tool_name = acp_kind if isinstance(acp_kind, str) else ""
+                detail, is_diff = _tool_call_content_text(update.get("content"))
+                title = update.get("title")
+                summary = title if isinstance(title, str) and title else (tool_name or update_type)
+                return TraceEntry(
+                    kind="tool_call",
+                    tool_use_id=tool_call_id,
+                    summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                    detail=scrub_trace_text(
+                        detail or json.dumps(update, ensure_ascii=False),
+                        self._trace_secrets,
+                        TRACE_DETAIL_MAX_CHARS,
+                    ),
+                    tool_name=tool_name,
+                    is_diff=is_diff,
+                )
+            name = update.get("kind") if isinstance(update.get("kind"), str) else update_type
+            tool_call_id = update.get("toolCallId")
+            return TraceEntry(
+                kind="tool_call",
+                tool_use_id=tool_call_id if isinstance(tool_call_id, str) else "",
+                summary=scrub_trace_text(name, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                detail=scrub_trace_text(
+                    json.dumps(update, ensure_ascii=False),
+                    self._trace_secrets,
+                    TRACE_DETAIL_MAX_CHARS,
+                ),
+                tool_name=name,
+                is_diff=False,
+            )
+        except Exception:
+            log.debug("Skipping malformed session update for trace", exc_info=True)
+            return None
 
     def is_completion(self, msg: dict, prompt_id: int) -> bool:
         """
@@ -1005,6 +1145,8 @@ class AcpBackend(AgentBackend):
             self.model,
             effective_os_user or "(same as bot)",
         )
+
+        self._trace_secrets = trace_secret_values(env)
 
         self._proc = await asyncio.create_subprocess_exec(
             *argv,
@@ -1438,6 +1580,10 @@ class AcpBackend(AgentBackend):
                         accumulated = self.combine_text_chunks(accumulated, text)
                         got_model_text = True
                         yield StreamEvent(text_so_far=accumulated)
+                    elif msg.get("method") == "session/update":
+                        trace = self._session_update_trace(msg.get("params", {}).get("update", {}))
+                        if trace is not None:
+                            yield StreamEvent(text_so_far="", trace=trace)
                     continue
 
                 # Server-initiated JSON-RPC request (has BOTH method AND

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -1376,7 +1376,7 @@ class TestTraceEmission:
                         "content": [{"type": "content", "content": {"type": "text", "text": "line one\nline two"}}],
                     }
                 ),
-                _session_update_line({"sessionUpdate": "tool_call_update", "toolCallId": "tc-1", "status": "failed"}),
+                _session_update_line({"sessionUpdate": "tool_call_update", "toolCallId": "tc-9", "status": "failed"}),
                 _completion_result(prompt_id=3),
             ]
         )
@@ -1399,7 +1399,10 @@ class TestTraceEmission:
         assert result.summary == "line one"
         assert result.detail == "line one\nline two"
         assert result.is_error is False
+        assert failed.tool_use_id == "tc-9"
         assert failed.is_error is True
+        assert failed.summary == "(no output)"
+        assert failed.detail == ""
 
     @pytest.mark.asyncio
     async def test_diff_content_sets_is_diff(self):
@@ -1442,6 +1445,8 @@ class TestTraceEmission:
             [
                 _agent_thought_chunk("thinking"),
                 _session_update_line({"sessionUpdate": "usage_update", "tokens": 5}),
+                _session_update_line({"sessionUpdate": "plan", "entries": []}),
+                _session_update_line({"sessionUpdate": "current_mode_update", "currentModeId": "code"}),
                 _session_update_line({"sessionUpdate": "plan_update", "steps": ["a", "b"]}),
                 _completion_result(prompt_id=3),
             ]

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -109,7 +109,7 @@ def _agent_thought_chunk(text: str, session_id: str = "20260406_01") -> bytes:
 
 
 def _tool_call_event(session_id: str = "20260406_01") -> bytes:
-    """Build a session/update notification with tool_call (should be skipped)."""
+    """Build a session/update notification with tool_call."""
     return _json_line(
         {
             "jsonrpc": "2.0",
@@ -527,8 +527,9 @@ class TestStreamParsing:
         assert events[1].done is True
 
     @pytest.mark.asyncio
-    async def test_tool_call_events_skipped(self):
-        """tool_call events are silently skipped."""
+    async def test_tool_call_events_yield_trace_not_text(self):
+        """tool_call events surface as empty-text trace events and never
+        reach the accumulated text."""
         g = _make_goose()
         g._proc = _make_mock_proc(
             [
@@ -543,8 +544,13 @@ class TestStreamParsing:
 
         events = await _collect_events(g)
 
-        assert len(events) == 2
-        assert events[0].text_so_far == "done"
+        assert len(events) == 3
+        assert events[0].trace is not None
+        assert events[0].text_so_far == ""
+        assert events[0].done is False
+        assert events[1].text_so_far == "done"
+        assert events[2].response is not None
+        assert events[2].response.text == "done"
 
     @pytest.mark.asyncio
     async def test_non_json_lines_skipped(self):
@@ -1323,3 +1329,163 @@ class TestPreservedEnvVars:
         )
         assert argv[7] == "--"
         assert argv[8:] == ["goose", "acp", "--with-builtin", "developer"]
+
+
+# ── Trace emission through the shared ACP mapper ─────────────────────
+
+
+def _session_update_line(update: dict, session_id: str = "20260406_01") -> bytes:
+    """Build a session/update notification carrying the given update."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {"sessionId": session_id, "update": update},
+        }
+    )
+
+
+class TestTraceEmission:
+    """The goose lane emits TraceEntry events via the shared ACP mapper."""
+
+    @pytest.mark.asyncio
+    async def test_call_and_terminal_result_pair_by_tool_call_id(self):
+        """tool_call yields tool_call and a terminal tool_call_update
+        tool_result sharing the toolCallId; non-terminal progress
+        updates yield nothing."""
+        g = _make_goose()
+        g._proc = _make_mock_proc(
+            [
+                _session_update_line(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc-1",
+                        "title": "Read kai.py",
+                        "kind": "read",
+                        "status": "pending",
+                    }
+                ),
+                _session_update_line(
+                    {"sessionUpdate": "tool_call_update", "toolCallId": "tc-1", "status": "in_progress"}
+                ),
+                _session_update_line(
+                    {
+                        "sessionUpdate": "tool_call_update",
+                        "toolCallId": "tc-1",
+                        "status": "completed",
+                        "content": [{"type": "content", "content": {"type": "text", "text": "line one\nline two"}}],
+                    }
+                ),
+                _session_update_line({"sessionUpdate": "tool_call_update", "toolCallId": "tc-1", "status": "failed"}),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        g._session_id = "test-session"
+        g._fresh_session = False
+        g._next_id = 3
+
+        events = await _collect_events(g)
+
+        trace_events = [e for e in events if e.trace is not None]
+        for event in trace_events:
+            assert event.text_so_far == ""
+            assert event.done is False
+        call, result, failed = [e.trace for e in trace_events]
+        assert call.kind == "tool_call"
+        assert call.summary == "Read kai.py"
+        assert call.tool_name == "read"
+        assert result.kind == "tool_result"
+        assert result.tool_use_id == call.tool_use_id == "tc-1"
+        assert result.summary == "line one"
+        assert result.detail == "line one\nline two"
+        assert result.is_error is False
+        assert failed.is_error is True
+
+    @pytest.mark.asyncio
+    async def test_diff_content_sets_is_diff(self):
+        """ACP diff content blocks render line-prefixed old/new text and
+        set is_diff on the call."""
+        g = _make_goose()
+        g._proc = _make_mock_proc(
+            [
+                _session_update_line(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc-2",
+                        "title": "Edit config.py",
+                        "kind": "edit",
+                        "content": [
+                            {"type": "diff", "path": "/w/config.py", "oldText": "a = 1", "newText": "a = 2\nb = 3"}
+                        ],
+                    }
+                ),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        g._session_id = "test-session"
+        g._fresh_session = False
+        g._next_id = 3
+
+        events = await _collect_events(g)
+
+        (call,) = [e.trace for e in events if e.trace is not None]
+        assert call.is_diff is True
+        assert call.detail == "/w/config.py\n- a = 1\n+ a = 2\n+ b = 3"
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_update_shape_traced_with_raw_payload(self):
+        """Unknown session-update vocabulary degrades to a type-named
+        trace carrying the raw payload, not a drop; thoughts and
+        housekeeping stay invisible."""
+        g = _make_goose()
+        g._proc = _make_mock_proc(
+            [
+                _agent_thought_chunk("thinking"),
+                _session_update_line({"sessionUpdate": "usage_update", "tokens": 5}),
+                _session_update_line({"sessionUpdate": "plan_update", "steps": ["a", "b"]}),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        g._session_id = "test-session"
+        g._fresh_session = False
+        g._next_id = 3
+
+        events = await _collect_events(g)
+
+        (trace,) = [e.trace for e in events if e.trace is not None]
+        assert trace.kind == "tool_call"
+        assert trace.summary == "plan_update"
+        assert trace.tool_name == "plan_update"
+        assert json.loads(trace.detail) == {"sessionUpdate": "plan_update", "steps": ["a", "b"]}
+
+    @pytest.mark.asyncio
+    async def test_planted_secret_redacted(self):
+        """A snapshot secret value never appears in trace text."""
+        secret = "planted-secret-value-123"
+        g = _make_goose()
+        g._proc = _make_mock_proc(
+            [
+                _session_update_line(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc-3",
+                        "title": f"curl -H 'X-Auth: {secret}'",
+                        "kind": "execute",
+                        "content": [{"type": "content", "content": {"type": "text", "text": f"token was {secret}"}}],
+                    }
+                ),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        g._session_id = "test-session"
+        g._fresh_session = False
+        g._next_id = 3
+        g._trace_secrets = (secret,)
+
+        events = await _collect_events(g)
+
+        (call,) = [e.trace for e in events if e.trace is not None]
+        assert secret not in call.summary
+        assert secret not in call.detail
+        assert "[redacted]" in call.summary
+        assert call.detail == "token was [redacted]"

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -1008,6 +1008,8 @@ class TestTraceEmission:
         b._proc = _make_mock_proc(
             [
                 _session_update_line({"sessionUpdate": "usage_update", "tokens": 5}),
+                _session_update_line({"sessionUpdate": "plan", "entries": []}),
+                _session_update_line({"sessionUpdate": "current_mode_update", "currentModeId": "code"}),
                 _session_update_line({"sessionUpdate": "plan_update", "steps": ["a"]}),
                 _completion_result(prompt_id=3),
             ]

--- a/tests/test_opencode.py
+++ b/tests/test_opencode.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kai.backend import StreamEvent
 from kai.opencode import OpenCodeBackend
 
 
@@ -882,3 +883,174 @@ class TestPreservedEnvVars:
         )
         assert argv[7] == "--"
         assert argv[8:] == ["opencode", "acp"]
+
+
+# ── Trace emission through the shared ACP mapper ─────────────────────
+
+
+def _session_update_line(update: dict, session_id: str = "ses_test01") -> bytes:
+    """Build a session/update notification carrying the given update."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {"sessionId": session_id, "update": update},
+        }
+    )
+
+
+def _completion_result(prompt_id: int = 3) -> bytes:
+    """Build a completion result (end_turn) for a given prompt id."""
+    return _json_line(
+        {
+            "jsonrpc": "2.0",
+            "id": prompt_id,
+            "result": {"stopReason": "end_turn"},
+        }
+    )
+
+
+async def _collect_events(b: OpenCodeBackend, prompt: str | list = "test") -> list[StreamEvent]:
+    """Send a prompt and collect all yielded StreamEvents."""
+    events = []
+    async for event in b._send_locked(prompt):
+        events.append(event)
+    return events
+
+
+class TestTraceEmission:
+    """The opencode lane emits TraceEntry events via the shared ACP mapper."""
+
+    @pytest.mark.asyncio
+    async def test_call_and_terminal_result_pair_by_tool_call_id(self):
+        """tool_call yields tool_call and a terminal tool_call_update
+        tool_result sharing the toolCallId; non-terminal progress
+        updates yield nothing."""
+        b = _make_opencode()
+        b._proc = _make_mock_proc(
+            [
+                _session_update_line(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc-1",
+                        "title": "Read kai.py",
+                        "kind": "read",
+                        "status": "pending",
+                    }
+                ),
+                _session_update_line(
+                    {"sessionUpdate": "tool_call_update", "toolCallId": "tc-1", "status": "in_progress"}
+                ),
+                _session_update_line(
+                    {
+                        "sessionUpdate": "tool_call_update",
+                        "toolCallId": "tc-1",
+                        "status": "completed",
+                        "content": [{"type": "content", "content": {"type": "text", "text": "line one\nline two"}}],
+                    }
+                ),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "test-session"
+        b._fresh_session = False
+        b._next_id = 3
+
+        events = await _collect_events(b)
+
+        trace_events = [e for e in events if e.trace is not None]
+        for event in trace_events:
+            assert event.text_so_far == ""
+            assert event.done is False
+        call, result = [e.trace for e in trace_events]
+        assert call.kind == "tool_call"
+        assert call.summary == "Read kai.py"
+        assert call.tool_name == "read"
+        assert result.kind == "tool_result"
+        assert result.tool_use_id == call.tool_use_id == "tc-1"
+        assert result.summary == "line one"
+        assert result.is_error is False
+
+    @pytest.mark.asyncio
+    async def test_diff_content_sets_is_diff(self):
+        """ACP diff content blocks render line-prefixed old/new text and
+        set is_diff on the call."""
+        b = _make_opencode()
+        b._proc = _make_mock_proc(
+            [
+                _session_update_line(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc-2",
+                        "title": "Edit config.py",
+                        "kind": "edit",
+                        "content": [{"type": "diff", "path": "/w/config.py", "oldText": "a = 1", "newText": "a = 2"}],
+                    }
+                ),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "test-session"
+        b._fresh_session = False
+        b._next_id = 3
+
+        events = await _collect_events(b)
+
+        (call,) = [e.trace for e in events if e.trace is not None]
+        assert call.is_diff is True
+        assert call.detail == "/w/config.py\n- a = 1\n+ a = 2"
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_update_shape_traced_with_raw_payload(self):
+        """Unknown session-update vocabulary degrades to a type-named
+        trace carrying the raw payload; housekeeping stays invisible."""
+        b = _make_opencode()
+        b._proc = _make_mock_proc(
+            [
+                _session_update_line({"sessionUpdate": "usage_update", "tokens": 5}),
+                _session_update_line({"sessionUpdate": "plan_update", "steps": ["a"]}),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "test-session"
+        b._fresh_session = False
+        b._next_id = 3
+
+        events = await _collect_events(b)
+
+        (trace,) = [e.trace for e in events if e.trace is not None]
+        assert trace.kind == "tool_call"
+        assert trace.tool_name == "plan_update"
+        assert json.loads(trace.detail) == {"sessionUpdate": "plan_update", "steps": ["a"]}
+
+    @pytest.mark.asyncio
+    async def test_planted_secret_redacted(self):
+        """A snapshot secret value never appears in trace text."""
+        secret = "planted-secret-value-123"
+        b = _make_opencode()
+        b._proc = _make_mock_proc(
+            [
+                _session_update_line(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc-3",
+                        "title": f"curl -H 'X-Auth: {secret}'",
+                        "kind": "execute",
+                        "content": [{"type": "content", "content": {"type": "text", "text": f"token was {secret}"}}],
+                    }
+                ),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "test-session"
+        b._fresh_session = False
+        b._next_id = 3
+        b._trace_secrets = (secret,)
+
+        events = await _collect_events(b)
+
+        (call,) = [e.trace for e in events if e.trace is not None]
+        assert secret not in call.summary
+        assert secret not in call.detail
+        assert "[redacted]" in call.summary
+        assert call.detail == "token was [redacted]"


### PR DESCRIPTION
Closes #965. Part of the run inspector epic (#962); depends on the shared surface from #977. Ships dark: trace events carry empty text and `done=False`, so every existing stream observer ignores them.

## Summary

The two ACP lanes (goose and opencode) now emit `TraceEntry` records through one mapper at the shared ACP layer; neither module carries its own emission code. ACP `tool_call` session updates yield `tool_call` entries and `tool_call_update` with terminal status yields `tool_result`, keyed by the ACP `toolCallId` so client call/result pairing works unchanged.

## Implementation

- The mapper plugs into the shared streaming loop's notification branch, firing only when text extraction declines a `session/update`.
- ACP `title` feeds the summary, `kind` the tool name, and content blocks the detail. Diff content blocks set `is_diff` and render as the file path followed by `- `/`+ ` line-prefixed old/new text; ACP carries before/after texts rather than unified diffs, and the prefixing is what makes the client's line-prefix diff rendering work.
- Non-terminal `tool_call_update` statuses (`pending`, `in_progress`) yield nothing: the card shows call then result, and status churn is noise at this granularity. `failed` maps to `is_error`.
- Unknown session-update vocabulary degrades to a trace named by the ACP `kind` or the literal update type with the raw update payload JSON as detail, not dropped, matching the codex emitter's fallback rule. A `tool_call` missing a usable title or content degrades the same way.
- The text lane, thinking (`agent_thought_chunk`), and the known housekeeping shapes (`available_commands_update`, `usage_update`) stay invisible. ACP multiplexes housekeeping through the same channel that codex carries on separate notification methods; tracing it would add per-turn churn no other backend lane produces.
- Scrubbing/truncation use the shared `backend.py` helpers; the scrub set is snapshotted from the fully built subprocess environment at spawn, matching the claude and codex backends.
- Field shapes verified against the ACP v1 tool-calls schema (discriminators, `toolCallId`, `kind`/`status` enums, and the `content`/`diff`/`terminal` block variants).

## Behavior change

goose's `test_tool_call_events_skipped` pinned the old drop behavior; it is now `test_tool_call_events_yield_trace_not_text`, asserting the tool_call surfaces as an empty-text trace event while the accumulated text stays byte-identical.

## Testing

Four tests per lane, duplicated across `tests/test_goose.py` and `tests/test_opencode.py` to pin that both lanes flow through the shared mapper: call/terminal-result pairing by id with non-terminal updates yielding nothing and the empty-text/`done=False` invariant; diff content rendering with `is_diff`; an unrecognized update shape traced with the raw payload while housekeeping stays invisible; planted secret redacted.

Full suite: 5873 passed, 1 skipped. Lint clean.
