### PR TITLE
feat: emit trace entries from the pi backend

### DIFF
--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -12,16 +13,21 @@ from typing import Any
 
 from kai.acp import _kill_target_user_tree, _kill_target_user_tree_sync
 from kai.backend import (
+    TRACE_DETAIL_MAX_CHARS,
+    TRACE_SUMMARY_MAX_CHARS,
     AgentBackend,
     AgentResponse,
     ApiContext,
     StreamEvent,
+    TraceEntry,
     apply_workspace_model,
     assemble_turn_context,
     build_foreign_workspace_reminder,
     build_session_context,
     ensure_user_context_files,
     sanitize_agent_environment,
+    scrub_trace_text,
+    trace_secret_values,
 )
 from kai.backend_registry import resolve_backend_command
 from kai.config import DATA_DIR, WorkspaceConfig, parse_env_file, resolve_claude_user
@@ -108,6 +114,23 @@ def _assistant_message_text(message: Any) -> str | None:
     return "".join(parts)
 
 
+def _tool_result_text(result: Any) -> str | None:
+    """
+    Join the text content blocks of a pi tool result, or None when the
+    shape carries no identifiable content list (the per-tool `details`
+    object is not surfaced; the text blocks are the human-readable
+    output).
+    """
+    if not isinstance(result, Mapping):
+        return None
+    content = result.get("content")
+    if not isinstance(content, list):
+        return None
+    return "\n".join(
+        part.get("text", "") for part in content if isinstance(part, Mapping) and part.get("type") == "text"
+    )
+
+
 def _assistant_message_error(message: Any) -> str | None:
     """Extract a terminal model error from a completed assistant message."""
 
@@ -176,6 +199,10 @@ class PiBackend(AgentBackend):
         self._fresh_session = True
         self._stderr_task: asyncio.Task[None] | None = None
         self._lock = asyncio.Lock()
+        # Secret values scrubbed from trace text. Snapshotted from the
+        # fully built subprocess environment at spawn so constructor-only
+        # credentials (the per-principal webhook secret) are covered.
+        self._trace_secrets: tuple[str, ...] = ()
 
     @property
     def is_alive(self) -> bool:
@@ -231,6 +258,7 @@ class PiBackend(AgentBackend):
         effective_os_user = resolve_claude_user(self.os_user)
         argv = self._build_argv()
         env = self._build_env(effective_os_user)
+        self._trace_secrets = trace_secret_values(env)
         if effective_os_user:
             argv = wrap_command_for_target_user(
                 argv,
@@ -485,6 +513,17 @@ class PiBackend(AgentBackend):
                     message.get("toolName"),
                     message.get("toolCallId"),
                 )
+                # tool_execution_update streams accumulated partial
+                # output; the card shows call then result, so progress
+                # churn stays invisible, same as the ACP lanes.
+                if message_type == "tool_execution_start":
+                    trace = self._tool_start_trace(message)
+                    if trace is not None:
+                        yield StreamEvent(text_so_far="", trace=trace)
+                elif message_type == "tool_execution_end":
+                    trace = self._tool_end_trace(message)
+                    if trace is not None:
+                        yield StreamEvent(text_so_far="", trace=trace)
                 continue
 
             if pi_rpc_is_settled(message):
@@ -497,6 +536,67 @@ class PiBackend(AgentBackend):
 
             if message_type == "extension_ui_request":
                 raise PiRpcProtocolError("Pi requested extension UI despite extensions being disabled")
+
+    def _tool_start_trace(self, message: Mapping) -> TraceEntry | None:
+        """
+        Build a tool_call TraceEntry from a tool_execution_start event.
+
+        toolName feeds the summary and the args object the detail; a
+        payload whose args cannot be identified carries the raw event
+        JSON as detail instead, so no information is lost. Returns None
+        with a debug log on a malformed event; trace emission must never
+        break the text stream.
+        """
+        try:
+            tool_call_id = message["toolCallId"]
+            tool_name = message["toolName"]
+            if not isinstance(tool_call_id, str) or not isinstance(tool_name, str):
+                raise TypeError("unexpected tool event field type")
+            args = message.get("args")
+            if isinstance(args, Mapping):
+                detail = json.dumps(args, ensure_ascii=False)
+            else:
+                detail = json.dumps(dict(message), ensure_ascii=False)
+            return TraceEntry(
+                kind="tool_call",
+                tool_use_id=tool_call_id,
+                summary=scrub_trace_text(tool_name, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                tool_name=tool_name,
+            )
+        except Exception:
+            log.debug("Skipping malformed tool_execution_start for trace", exc_info=True)
+            return None
+
+    def _tool_end_trace(self, message: Mapping) -> TraceEntry | None:
+        """
+        Build a tool_result TraceEntry from a tool_execution_end event.
+
+        tool_use_id carries the toolCallId, the same value the tool_call
+        trace carried, so client call/result pairing works unchanged.
+        The result's text content blocks feed the detail; a result whose
+        content cannot be identified carries the raw event JSON instead.
+        Returns None with a debug log on a malformed event; trace
+        emission must never break the text stream.
+        """
+        try:
+            tool_call_id = message["toolCallId"]
+            tool_name = message["toolName"]
+            if not isinstance(tool_call_id, str) or not isinstance(tool_name, str):
+                raise TypeError("unexpected tool event field type")
+            detail = _tool_result_text(message.get("result"))
+            if detail is None:
+                detail = json.dumps(dict(message), ensure_ascii=False)
+            return TraceEntry(
+                kind="tool_result",
+                tool_use_id=tool_call_id,
+                summary=scrub_trace_text(tool_name, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                is_error=bool(message.get("isError", False)),
+            )
+        except Exception:
+            log.debug("Skipping malformed tool_execution_end for trace", exc_info=True)
+            return None
 
     def _final_event(self, text: str, started_at: float, *, error: str | None) -> StreamEvent:
         response = AgentResponse(

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -440,3 +441,140 @@ class TestPiLifecycle:
         await backend.shutdown()
 
         kill.assert_awaited_once()
+
+
+class TestTraceEmission:
+    """_read_turn emits TraceEntry-bearing events for tool execution."""
+
+    @pytest.mark.asyncio
+    async def test_start_and_end_pair_by_tool_call_id(self, tmp_path, monkeypatch):
+        """tool_execution_start yields tool_call and tool_execution_end
+        tool_result sharing the toolCallId; intermediate updates yield
+        nothing; text accumulation across tool events stays
+        byte-identical; trace events carry empty text and done=False."""
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "message_update", "assistantMessageEvent": {"type": "text_delta", "delta": "Looking."}},
+                {
+                    "type": "tool_execution_start",
+                    "toolCallId": "tool-1",
+                    "toolName": "bash",
+                    "args": {"command": "ls -la"},
+                },
+                {
+                    "type": "tool_execution_update",
+                    "toolCallId": "tool-1",
+                    "toolName": "bash",
+                    "args": {"command": "ls -la"},
+                    "partialResult": {"content": [{"type": "text", "text": "partial"}]},
+                },
+                {
+                    "type": "tool_execution_end",
+                    "toolCallId": "tool-1",
+                    "toolName": "bash",
+                    "result": {"content": [{"type": "text", "text": "total 48\nREADME.md"}]},
+                    "isError": False,
+                },
+                {"type": "message_update", "assistantMessageEvent": {"type": "text_delta", "delta": " Done."}},
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        trace_events = [e for e in events if e.trace is not None]
+        for event in trace_events:
+            assert event.text_so_far == ""
+            assert event.done is False
+        call, result = [e.trace for e in trace_events]
+        assert call.kind == "tool_call"
+        assert call.summary == "bash"
+        assert call.tool_name == "bash"
+        assert call.detail == '{"command": "ls -la"}'
+        assert result.kind == "tool_result"
+        assert result.tool_use_id == call.tool_use_id == "tool-1"
+        assert result.summary == "bash"
+        assert result.detail == "total 48\nREADME.md"
+        assert result.is_error is False
+        text_events = [e.text_so_far for e in events if not e.done and e.trace is None]
+        assert text_events == ["Looking.", "Looking. Done."]
+        assert events[-1].response is not None
+        assert events[-1].response.text == "Looking. Done."
+
+    @pytest.mark.asyncio
+    async def test_unidentifiable_payload_falls_back_to_raw_event_json(self, tmp_path, monkeypatch):
+        """A start without an args object and an end whose result has no
+        content list carry the raw event payload as detail, not a drop;
+        isError still passes through."""
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        start = {"type": "tool_execution_start", "toolCallId": "tool-2", "toolName": "mystery"}
+        end = {
+            "type": "tool_execution_end",
+            "toolCallId": "tool-2",
+            "toolName": "mystery",
+            "result": "not-an-object",
+            "isError": True,
+        }
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                start,
+                end,
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        call, result = [e.trace for e in events if e.trace is not None]
+        assert json.loads(call.detail) == start
+        assert json.loads(result.detail) == end
+        assert result.is_error is True
+
+    @pytest.mark.asyncio
+    async def test_planted_secret_redacted(self, tmp_path, monkeypatch):
+        """A snapshot secret value never appears in trace text."""
+        secret = "planted-secret-value-123"
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        backend._trace_secrets = (secret,)
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {
+                    "type": "tool_execution_start",
+                    "toolCallId": "tool-3",
+                    "toolName": "bash",
+                    "args": {"command": f"curl -H 'X-Auth: {secret}'"},
+                },
+                {
+                    "type": "tool_execution_end",
+                    "toolCallId": "tool-3",
+                    "toolName": "bash",
+                    "result": {"content": [{"type": "text", "text": f"token was {secret}"}]},
+                    "isError": False,
+                },
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        call, result = [e.trace for e in events if e.trace is not None]
+        for trace in (call, result):
+            assert secret not in trace.detail
+        assert "[redacted]" in call.detail
+        assert result.detail == "token was [redacted]"

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -578,3 +578,33 @@ class TestTraceEmission:
             assert secret not in trace.detail
         assert "[redacted]" in call.detail
         assert result.detail == "token was [redacted]"
+
+    @pytest.mark.asyncio
+    async def test_recognized_empty_result_keeps_empty_detail(self, tmp_path, monkeypatch):
+        """A result whose content list is present but carries no text is
+        recognized, not a fallback case: detail stays empty rather than
+        becoming raw event JSON."""
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {
+                    "type": "tool_execution_end",
+                    "toolCallId": "tool-4",
+                    "toolName": "bash",
+                    "result": {"content": []},
+                    "isError": False,
+                },
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        (result,) = [e.trace for e in events if e.trace is not None]
+        assert result.detail == ""
+        assert result.summary == "bash"


### PR DESCRIPTION
Closes #966. Final emitter of the run inspector epic (#962); depends on the shared surface from #977. Ships dark: trace events carry empty text and `done=False`, so every existing stream observer ignores them.

## Summary

The pi backend now emits `TraceEntry` records from its tool execution events. `tool_execution_start` yields a `tool_call` and `tool_execution_end` a `tool_result`, with `toolCallId` carried in `tool_use_id` so client call/result pairing works unchanged; `toolName` feeds the summary on both.

## Implementation

- Emission plugs into the existing `tool_execution_*` branch of `_read_turn`; the DEBUG log stays, and intermediate `tool_execution_update` progress events stay invisible, same rationale as the ACP lanes.
- The issue left the argument/output payload fields to be confirmed during implementation; I confirmed them against the installed pi 0.84.1 RPC documentation (vendored `docs/rpc.md`): start carries `args` (object), end carries `result.content` (text-block list) and `isError`. The start's `args` feeds the call detail as JSON; the end's result text blocks feed the result detail; `isError` maps to `is_error`.
- A payload whose detail fields cannot be identified (missing/non-object `args`, or a result without a content list) carries the raw event JSON as detail per the unknown-vocabulary fallback rule, rather than shipping summary-only or being dropped.
- The text lanes (`message_update` deltas, `message_end` authoritative text) are untouched.
- Scrubbing/truncation use the shared `backend.py` helpers; the scrub set is snapshotted from the fully built subprocess environment at spawn, matching the other three backends. No local redaction code.

## Testing

Three new tests in `tests/test_pi.py`: start/end pairing via `toolCallId` with intermediate updates yielding nothing, the empty-text/`done=False` invariant, and byte-identical text accumulation across tool events (regression pin); unidentifiable payloads traced with raw event JSON as detail including `isError` passthrough; planted secret redacted in call and result detail.

Full suite: 5876 passed, 1 skipped. Lint clean.
