### PR TITLE
feat: persist run traces durably under lease ownership

### DIFF
--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -22,6 +22,7 @@ from kai.workshop.run_execution_authority import (
     WorkshopRunExecutionAuthority,
 )
 from kai.workshop.run_lifecycle import DurableRun, RunStatus, WorkshopRunLifecycle
+from kai.workshop.run_traces import WorkshopRunTraceStore
 from kai.workshop.runtime_sessions import RuntimeSessionSettlement
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.terminal_transactions import (
@@ -132,6 +133,7 @@ class WorkshopCanonicalExecutionCoordinator:
         self._active: dict[RunId, _ActiveExecution] = {}
         self._map_lock = asyncio.Lock()
         self._database_lock = database_lock or asyncio.Lock()
+        self._trace_store = WorkshopRunTraceStore(store)
 
     async def execute(
         self,
@@ -392,6 +394,7 @@ class WorkshopCanonicalExecutionCoordinator:
 
     async def _consume(
         self,
+        active: _ActiveExecution,
         prepared: PreparedWorkshopExecution,
         *,
         stream_observer: StreamObserver | None,
@@ -405,6 +408,13 @@ class WorkshopCanonicalExecutionCoordinator:
             if event.done:
                 response = event.response
                 break
+            if event.trace is not None and active.claim is not None:
+                # Persisted under the current fenced claim so a
+                # superseded attempt cannot write; staleness raises
+                # and aborts the doomed attempt, the same posture the
+                # lease-renewal task takes.
+                async with self._database_lock:
+                    await self._trace_store.append(active.claim, event.trace, occurred_at=self._now())
             if stream_observer is not None:
                 await stream_observer(event)
         return response
@@ -418,7 +428,7 @@ class WorkshopCanonicalExecutionCoordinator:
     ) -> AgentResponse | None:
         renewal = asyncio.create_task(self._renew_while_running(active))
         try:
-            return await self._consume(prepared, stream_observer=stream_observer)
+            return await self._consume(active, prepared, stream_observer=stream_observer)
         finally:
             active.renewal_stop.set()
             await renewal

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -404,17 +404,23 @@ class WorkshopCanonicalExecutionCoordinator:
             context = await assemble_canonical_conversation_context(self._store, prepared.run)
         prepared.stage_canonical_history(context.text)
         response: AgentResponse | None = None
+        traces_truncated = False
         async for event in prepared.stream(prompt):
             if event.done:
                 response = event.response
                 break
-            if event.trace is not None and active.claim is not None:
+            if event.trace is not None and not traces_truncated:
                 # Persisted under the current fenced claim so a
                 # superseded attempt cannot write; staleness raises
                 # and aborts the doomed attempt, the same posture the
-                # lease-renewal task takes.
+                # lease-renewal task takes. Once the run's cap is
+                # reached, later trace events skip the write
+                # transaction entirely.
+                assert active.claim is not None
                 async with self._database_lock:
-                    await self._trace_store.append(active.claim, event.trace, occurred_at=self._now())
+                    appended = await self._trace_store.append(active.claim, event.trace, occurred_at=self._now())
+                if not appended:
+                    traces_truncated = True
             if stream_observer is not None:
                 await stream_observer(event)
         return response

--- a/src/kai/workshop/run_traces.py
+++ b/src/kai/workshop/run_traces.py
@@ -1,0 +1,117 @@
+"""Durable per-run trace persistence for the Workshop run inspector.
+
+Traces deliberately do not reuse the ephemeral TTL'd preview registry:
+they must survive for runs that finished long ago. Rows live exactly as
+long as the run row does; run pruning deletes them by run_id in the same
+pass, so there is no separate TTL.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from kai.backend import TraceEntry
+from kai.workshop.run_execution_authority import (
+    RunExecutionClaim,
+    StaleRunExecutionAuthorityError,
+)
+from kai.workshop.store import WorkshopEventStore
+
+# Per-run row cap. Tool calls are orders of magnitude rarer than text
+# deltas, so per-entry SQLite writes are fine; the cap only bounds a
+# pathological run. On overflow the new entry is dropped and a single
+# synthetic marker row records the truncation, so the card can say the
+# trace is incomplete instead of silently lying about completeness.
+_TRACE_MAX_ENTRIES = 500
+TRACE_TRUNCATION_KIND = "truncated"
+_TRACE_TRUNCATION_SUMMARY = f"trace truncated at {_TRACE_MAX_ENTRIES} steps"
+
+_INSERT_TRACE = (
+    "INSERT INTO run_traces (run_id, seq, kind, tool_name, tool_use_id, "
+    "summary, detail, is_diff, is_error, created_at) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+
+class WorkshopRunTraceStore:
+    """Append-only run_traces writer gated by execution-claim ownership."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def append(
+        self,
+        claim: RunExecutionClaim,
+        trace: TraceEntry,
+        *,
+        occurred_at: datetime,
+    ) -> None:
+        """Append one trace row for the claim's run.
+
+        The claim must still match the run's active fenced attempt; the
+        preview registry gets the same guarantee structurally by being
+        published only from the owned execution path. A superseded
+        attempt raises StaleRunExecutionAuthorityError and writes
+        nothing. seq is dense per run and assigned here, under the write
+        transaction.
+        """
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            async with connection.execute(
+                "SELECT status FROM run_attempts WHERE id = ? AND run_id = ? AND owner_id = ? AND fence_token = ?",
+                (claim.attempt_id, claim.run_id, claim.owner_id, claim.fence_token),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None or str(row[0]) not in ("granted", "started"):
+                raise StaleRunExecutionAuthorityError("Execution claim no longer holds active authority")
+            async with connection.execute(
+                "SELECT COALESCE(MAX(seq), 0), COUNT(*) FROM run_traces WHERE run_id = ?",
+                (claim.run_id,),
+            ) as cursor:
+                seq_row = await cursor.fetchone()
+            assert seq_row is not None
+            next_seq = int(seq_row[0]) + 1
+            if int(seq_row[1]) >= _TRACE_MAX_ENTRIES:
+                async with connection.execute(
+                    "SELECT 1 FROM run_traces WHERE run_id = ? AND kind = ? LIMIT 1",
+                    (claim.run_id, TRACE_TRUNCATION_KIND),
+                ) as cursor:
+                    already_marked = await cursor.fetchone()
+                if already_marked is None:
+                    await connection.execute(
+                        _INSERT_TRACE,
+                        (
+                            claim.run_id,
+                            next_seq,
+                            TRACE_TRUNCATION_KIND,
+                            None,
+                            None,
+                            _TRACE_TRUNCATION_SUMMARY,
+                            "",
+                            0,
+                            0,
+                            occurred_at.isoformat(),
+                        ),
+                    )
+                await connection.commit()
+                return
+            await connection.execute(
+                _INSERT_TRACE,
+                (
+                    claim.run_id,
+                    next_seq,
+                    trace.kind,
+                    trace.tool_name,
+                    trace.tool_use_id,
+                    trace.summary,
+                    trace.detail,
+                    int(trace.is_diff),
+                    int(trace.is_error),
+                    occurred_at.isoformat(),
+                ),
+            )
+            await connection.commit()
+        except Exception:
+            await connection.rollback()
+            raise

--- a/src/kai/workshop/run_traces.py
+++ b/src/kai/workshop/run_traces.py
@@ -45,7 +45,7 @@ class WorkshopRunTraceStore:
         trace: TraceEntry,
         *,
         occurred_at: datetime,
-    ) -> None:
+    ) -> bool:
         """Append one trace row for the claim's run.
 
         The claim must still match the run's active fenced attempt; the
@@ -54,6 +54,11 @@ class WorkshopRunTraceStore:
         attempt raises StaleRunExecutionAuthorityError and writes
         nothing. seq is dense per run and assigned here, under the write
         transaction.
+
+        Returns True when the entry was appended; False once the run's
+        cap is reached (the marker row is written on the first overflow,
+        further calls write nothing), so the caller can stop paying a
+        write transaction per event for the rest of the run.
         """
         connection = self._store.connection
         try:
@@ -95,15 +100,18 @@ class WorkshopRunTraceStore:
                         ),
                     )
                 await connection.commit()
-                return
+                return False
             await connection.execute(
                 _INSERT_TRACE,
                 (
                     claim.run_id,
                     next_seq,
                     trace.kind,
-                    trace.tool_name,
-                    trace.tool_use_id,
+                    # Absent optional fields store as NULL, never "";
+                    # one representation keeps readers from having to
+                    # treat the two as synonyms.
+                    trace.tool_name or None,
+                    trace.tool_use_id or None,
                     trace.summary,
                     trace.detail,
                     int(trace.is_diff),
@@ -112,6 +120,7 @@ class WorkshopRunTraceStore:
                 ),
             )
             await connection.commit()
+            return True
         except Exception:
             await connection.rollback()
             raise

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 23
+WORKSHOP_SCHEMA_VERSION = 24
 
 
 @dataclass(frozen=True, slots=True)
@@ -1133,6 +1133,33 @@ _CANONICAL_OPERATIONAL_STATE_SCHEMA = SchemaMigration(
     ),
 )
 
+_RUN_TRACE_SCHEMA = SchemaMigration(
+    version=24,
+    name="durable_run_traces",
+    statements=(
+        """
+        CREATE TABLE run_traces (
+            -- run_id deliberately is not a foreign key, matching
+            -- telegram_streaming_previews: rows are pruned with their
+            -- run row by run pruning, not by cascade, and there is no
+            -- separate TTL. seq is dense per run, assigned at
+            -- persistence time under the write transaction.
+            run_id TEXT NOT NULL,
+            seq INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            tool_name TEXT,
+            tool_use_id TEXT,
+            summary TEXT NOT NULL,
+            detail TEXT NOT NULL,
+            is_diff INTEGER NOT NULL DEFAULT 0,
+            is_error INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (run_id, seq)
+        )
+        """,
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1157,6 +1184,7 @@ _MIGRATIONS = (
     _CANONICAL_EXECUTION_STATE_SCHEMA,
     _CANONICAL_MEMORY_AUTHORITY_SCHEMA,
     _CANONICAL_OPERATIONAL_STATE_SCHEMA,
+    _RUN_TRACE_SCHEMA,
 )
 
 

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from kai.agent_failure import AgentFailureKind
-from kai.backend import AgentResponse, StreamEvent
+from kai.backend import AgentResponse, StreamEvent, TraceEntry
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
@@ -245,6 +245,39 @@ class TestCanonicalExecutionCoordinator:
 
             assert result.disposition == CanonicalExecutionDisposition.COMPLETED
             assert [event.text_so_far for event in observed] == ["Stable preview."]
+        finally:
+            await store.close()
+
+    async def test_trace_bearing_events_persist_to_run_traces(self, tmp_path: Path):
+        store, run = await _accepted(tmp_path / "kai.db")
+        prepared = _Prepared(run)
+        original_stream = prepared.stream
+
+        async def stream_with_trace(prompt: str) -> AsyncIterator[StreamEvent]:
+            yield StreamEvent(
+                text_so_far="",
+                trace=TraceEntry(
+                    kind="tool_call",
+                    tool_use_id="toolu_1",
+                    summary="Bash: ls",
+                    detail="{}",
+                    tool_name="Bash",
+                ),
+            )
+            async for event in original_stream(prompt):
+                yield event
+
+        prepared.stream = stream_with_trace  # type: ignore[method-assign]
+        try:
+            result = await _coordinator(store, _Preparation(prepared)).execute(run.run_id)
+
+            assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+            async with store.connection.execute(
+                "SELECT seq, kind, summary FROM run_traces WHERE run_id = ?",
+                (run.run_id,),
+            ) as cursor:
+                rows = list(await cursor.fetchall())
+            assert [tuple(row) for row in rows] == [(1, "tool_call", "Bash: ls")]
         finally:
             await store.close()
 

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -57,7 +57,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -199,7 +199,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 23
+        assert await workshop_store.schema_version() == 24
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -212,7 +212,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 23
+        assert await second.schema_version() == 24
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -233,7 +233,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -274,6 +274,7 @@ class TestWorkshopSchema:
                     21,
                     22,
                     23,
+                    24,
                 ]
         finally:
             await upgraded.close()
@@ -296,7 +297,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -337,7 +338,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -390,7 +391,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -434,7 +435,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -478,7 +479,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -522,7 +523,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -626,7 +627,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -753,7 +754,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -446,7 +446,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -404,7 +404,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_run_traces.py
+++ b/tests/test_workshop_run_traces.py
@@ -1,0 +1,181 @@
+"""Durable run_traces persistence under execution-claim ownership."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from kai.backend import TraceEntry
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.domain import MessageId, RunExecutionOwnerId
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.run_execution_authority import (
+    RunExecutionClaim,
+    RunExecutionSelection,
+    StaleRunExecutionAuthorityError,
+    WorkshopRunExecutionAuthority,
+)
+from kai.workshop.run_lifecycle import WorkshopRunLifecycle
+from kai.workshop.run_traces import (
+    _TRACE_MAX_ENTRIES,
+    TRACE_TRUNCATION_KIND,
+    WorkshopRunTraceStore,
+)
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 8, 17, 18, 0, tzinfo=UTC)
+
+
+async def _open_store(path: Path) -> tuple[WorkshopEventStore, WorkshopRunExecutionAuthority, MessageId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="telegram",
+                external_subject="101",
+                external_channel_id="101",
+            ),
+        ),
+    )
+    inbound = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="telegram",
+            update_id="command-1",
+            message_id="message-1",
+            sender_subject="101",
+            channel_subject="101",
+            body="Perform one durable unit of work",
+            occurred_at=_NOW,
+        ),
+    )
+    inbound_id = MessageId(str(inbound.event.envelope.aggregate_id))
+    authority = WorkshopRunExecutionAuthority(
+        store,
+        selection_resolver=lambda _run: RunExecutionSelection(
+            backend="codex",
+            provider=None,
+            model="gpt-5.6-sol",
+        ),
+        registered_backend_ids=frozenset({"codex"}),
+    )
+    await WorkshopConversationDeliveryAuthority(store).activate()
+    return store, authority, inbound_id
+
+
+async def _granted_claim(
+    store: WorkshopEventStore,
+    authority: WorkshopRunExecutionAuthority,
+    inbound_id: MessageId,
+) -> RunExecutionClaim:
+    accepted = await WorkshopRunLifecycle(store).accept(inbound_id, occurred_at=_NOW + timedelta(seconds=1))
+    granted = await authority.grant(
+        accepted.run.run_id,
+        owner_id=RunExecutionOwnerId.new(),
+        occurred_at=_NOW + timedelta(seconds=2),
+        lease_expires_at=_NOW + timedelta(seconds=62),
+    )
+    return RunExecutionClaim.from_attempt(granted.attempt)
+
+
+def _trace(index: int) -> TraceEntry:
+    return TraceEntry(
+        kind="tool_call",
+        tool_use_id=f"toolu_{index}",
+        summary=f"Bash: step {index}",
+        detail=f"step {index} detail",
+        tool_name="Bash",
+    )
+
+
+async def _rows(store: WorkshopEventStore, run_id) -> list[tuple]:
+    async with store.connection.execute(
+        "SELECT seq, kind, tool_use_id, summary, detail, is_diff, is_error FROM run_traces "
+        "WHERE run_id = ? ORDER BY seq",
+        (run_id,),
+    ) as cursor:
+        return list(await cursor.fetchall())
+
+
+class TestRunTracePersistence:
+    async def test_entries_persist_in_order_with_dense_seq(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_store(tmp_path / "kai.db")
+        try:
+            claim = await _granted_claim(store, authority, inbound_id)
+            traces = WorkshopRunTraceStore(store)
+            for index in range(1, 4):
+                await traces.append(claim, _trace(index), occurred_at=_NOW + timedelta(seconds=2 + index))
+            await traces.append(
+                claim,
+                TraceEntry(
+                    kind="tool_result",
+                    tool_use_id="toolu_3",
+                    summary="done",
+                    detail="output",
+                    is_error=True,
+                ),
+                occurred_at=_NOW + timedelta(seconds=6),
+            )
+
+            rows = await _rows(store, claim.run_id)
+            assert [row[0] for row in rows] == [1, 2, 3, 4]
+            assert [row[1] for row in rows] == ["tool_call", "tool_call", "tool_call", "tool_result"]
+            assert rows[0][2] == "toolu_1"
+            assert rows[0][3] == "Bash: step 1"
+            assert rows[3][6] == 1
+        finally:
+            await store.close()
+
+    async def test_superseded_attempt_writes_are_rejected(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_store(tmp_path / "kai.db")
+        try:
+            first_claim = await _granted_claim(store, authority, inbound_id)
+            traces = WorkshopRunTraceStore(store)
+            await traces.append(first_claim, _trace(1), occurred_at=_NOW + timedelta(seconds=3))
+
+            await authority.expire_grant(first_claim, occurred_at=_NOW + timedelta(seconds=63))
+            second = await authority.grant(
+                first_claim.run_id,
+                owner_id=RunExecutionOwnerId.new(),
+                occurred_at=_NOW + timedelta(seconds=64),
+                lease_expires_at=_NOW + timedelta(seconds=124),
+            )
+            second_claim = RunExecutionClaim.from_attempt(second.attempt)
+
+            with pytest.raises(StaleRunExecutionAuthorityError):
+                await traces.append(first_claim, _trace(2), occurred_at=_NOW + timedelta(seconds=65))
+
+            await traces.append(second_claim, _trace(3), occurred_at=_NOW + timedelta(seconds=66))
+            rows = await _rows(store, first_claim.run_id)
+            assert [row[0] for row in rows] == [1, 2]
+            assert [row[2] for row in rows] == ["toolu_1", "toolu_3"]
+        finally:
+            await store.close()
+
+    async def test_overflow_drops_entry_and_writes_one_truncation_marker(self, tmp_path: Path):
+        store, authority, inbound_id = await _open_store(tmp_path / "kai.db")
+        try:
+            claim = await _granted_claim(store, authority, inbound_id)
+            traces = WorkshopRunTraceStore(store)
+            for index in range(1, _TRACE_MAX_ENTRIES + 1):
+                await traces.append(claim, _trace(index), occurred_at=_NOW + timedelta(seconds=3))
+
+            await traces.append(claim, _trace(_TRACE_MAX_ENTRIES + 1), occurred_at=_NOW + timedelta(seconds=4))
+            await traces.append(claim, _trace(_TRACE_MAX_ENTRIES + 2), occurred_at=_NOW + timedelta(seconds=5))
+
+            rows = await _rows(store, claim.run_id)
+            assert len(rows) == _TRACE_MAX_ENTRIES + 1
+            markers = [row for row in rows if row[1] == TRACE_TRUNCATION_KIND]
+            assert len(markers) == 1
+            assert markers[0][0] == _TRACE_MAX_ENTRIES + 1
+            assert markers[0][3] == f"trace truncated at {_TRACE_MAX_ENTRIES} steps"
+            dropped = [row for row in rows if row[2] == f"toolu_{_TRACE_MAX_ENTRIES + 1}"]
+            assert dropped == []
+        finally:
+            await store.close()

--- a/tests/test_workshop_run_traces.py
+++ b/tests/test_workshop_run_traces.py
@@ -164,10 +164,16 @@ class TestRunTracePersistence:
             claim = await _granted_claim(store, authority, inbound_id)
             traces = WorkshopRunTraceStore(store)
             for index in range(1, _TRACE_MAX_ENTRIES + 1):
-                await traces.append(claim, _trace(index), occurred_at=_NOW + timedelta(seconds=3))
+                assert await traces.append(claim, _trace(index), occurred_at=_NOW + timedelta(seconds=3)) is True
 
-            await traces.append(claim, _trace(_TRACE_MAX_ENTRIES + 1), occurred_at=_NOW + timedelta(seconds=4))
-            await traces.append(claim, _trace(_TRACE_MAX_ENTRIES + 2), occurred_at=_NOW + timedelta(seconds=5))
+            overflow = await traces.append(
+                claim, _trace(_TRACE_MAX_ENTRIES + 1), occurred_at=_NOW + timedelta(seconds=4)
+            )
+            after_marker = await traces.append(
+                claim, _trace(_TRACE_MAX_ENTRIES + 2), occurred_at=_NOW + timedelta(seconds=5)
+            )
+            assert overflow is False
+            assert after_marker is False
 
             rows = await _rows(store, claim.run_id)
             assert len(rows) == _TRACE_MAX_ENTRIES + 1

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -466,7 +466,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -370,7 +370,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 23
+            assert await upgraded.schema_version() == 24
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"


### PR DESCRIPTION
Closes #967. Part of the run inspector epic (#962); depends on the shared surface from #977 and consumes what the four merged emitters produce. Still dark to users: rows are written but nothing reads them until the `/trace` endpoint ships.

## Summary

Trace entries now persist durably per run in a new `run_traces` table, deliberately not reusing the ephemeral TTL'd preview registry; traces must survive for runs that finished long ago.

## Implementation

- **Schema v24**: `run_traces` keyed `(run_id, seq)` with the specced columns. `run_id` is deliberately not a foreign key, matching `telegram_streaming_previews`; rows live exactly as long as the run row does (a future run-pruning pass deletes by `run_id`; none exists today), no separate TTL.
- **Write path**: `WorkshopRunTraceStore.append` runs under `BEGIN IMMEDIATE`, verifies the caller's fenced execution claim still matches the run's active attempt (id + run + owner + fence token + active status, mirroring the authority's `_current_claim` check), assigns dense `seq = MAX(seq) + 1` inside the transaction, and inserts. A superseded attempt raises `StaleRunExecutionAuthorityError` and writes nothing; the exception aborts the doomed attempt, the same posture a stale lease renewal takes.
- **Wiring**: the execution coordinator appends a row per trace-bearing `StreamEvent` from its owned consume loop (the same place the stream observer is invoked), under the shared database lock. Observer forwarding is unchanged; no bootstrap or constructor signature changes.
- **Volume control**: per-run cap of 500 entries. On overflow the new entry is dropped and a single synthetic `truncated` marker row is written once, so the card can say the trace is incomplete. Per-entry SQLite writes, no batching.
- Existing schema-version pins across nine test files bumped 23 → 24, plus the migration version-list pin.

## Testing

Four new tests: entries persist in order with dense `seq` across kinds; a superseded attempt's write is rejected while the successor's claim still writes (with `seq` continuing densely); 500-entry overflow drops entry 501 and writes exactly one marker row at `seq` 501 with further appends inert; and end-to-end coordinator wiring from a trace-bearing stream event to a durable row.

Full suite: 5881 passed, 1 skipped. Lint clean.
