### PR TITLE
feat: serve run traces over an authorized endpoint with an SSE doorbell

### DIFF
--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -48,6 +48,7 @@ _CLIENT_NAVIGATION_PATH = "/v1/client/navigation"
 _ENROLLMENT_REDEMPTION_PATH = "/v1/client/enrollment/redeem"
 _COMMAND_SUBMISSION_PATH = "/v1/channels/{channel_id}/commands"
 _RUN_STATE_PATH = "/v1/channels/{channel_id}/runs/{run_id}"
+_RUN_TRACE_PATH = "/v1/channels/{channel_id}/runs/{run_id}/trace"
 _RUN_CANCELLATION_PATH = "/v1/channels/{channel_id}/runs/{run_id}/cancel"
 _ALLOWED_TIMELINE_QUERY_PARAMETERS = frozenset({"cursor", "limit"})
 _ALLOWED_EVENT_QUERY_PARAMETERS = frozenset({"after_position"})
@@ -56,6 +57,9 @@ _COMMAND_REQUEST_FIELDS = frozenset({"client_message_id", "body"})
 _DECIMAL_INTEGER = re.compile(r"^[0-9]+$")
 _EVENT_BATCH_SIZE = 100
 _SSE_RETRY_MILLISECONDS = 2000
+# Trace entries served per /trace response; the client pages with
+# after_seq until has_more is false.
+_TRACE_PAGE_SIZE = 200
 
 
 class WorkshopClientAuthenticator(Protocol):
@@ -514,6 +518,44 @@ def _serialize_run_preview_event(preview: RunPreview) -> bytes:
     return (f"event: run.preview.updated\ndata: {payload}\n\n").encode()
 
 
+def _serialize_run_trace_event(run_id: str, channel_id: str, seq: int) -> bytes:
+    """Render one trace doorbell event.
+
+    Deliberately carries no SSE `id:` line, for exactly the reason the
+    preview event omits it: the client's Last-Event-ID resume cursor
+    must remain a durable store position, and a missed doorbell costs
+    nothing because the trace endpoint is the source of truth.
+    """
+    payload = json.dumps(
+        {
+            "version": 1,
+            "channel_id": channel_id,
+            "run_id": run_id,
+            "seq": seq,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return (f"event: run.trace.updated\ndata: {payload}\n\n").encode()
+
+
+async def _latest_channel_trace(store: WorkshopEventStore, channel_id: ChannelId) -> tuple[str, int] | None:
+    """Return (run_id, seq) of the channel's newest trace row.
+
+    Newest by insertion order: only the channel's active run appends
+    rows, so the last inserted row is the one whose seq advances.
+    """
+    async with store.connection.execute(
+        "SELECT run_traces.run_id, run_traces.seq FROM run_traces "
+        "JOIN runs ON runs.id = run_traces.run_id "
+        "WHERE runs.channel_id = ? ORDER BY run_traces.rowid DESC LIMIT 1",
+        (str(channel_id),),
+    ) as cursor:
+        row = await cursor.fetchone()
+    return None if row is None else (str(row[0]), int(row[1]))
+
+
 async def _authorized_update_batch(
     request: web.Request,
     *,
@@ -618,6 +660,10 @@ async def _handle_channel_event_stream(
         # (run_id, sequence) of the preview most recently written to this
         # connection, so an unchanged preview is not re-sent every poll.
         last_preview_sent: tuple[str, int] | None = None
+        # (run_id, seq) of the trace doorbell most recently written, so
+        # the signal fires at most once per poll interval per run and
+        # only when the durable trace actually advanced.
+        last_trace_sent: tuple[str, int] | None = None
         await response.write(f": connected\nretry: {_SSE_RETRY_MILLISECONDS}\n\n".encode())
         while True:
             if run_previews is not None:
@@ -628,6 +674,12 @@ async def _handle_channel_event_stream(
                         await response.write(_serialize_run_preview_event(preview))
                         last_preview_sent = preview_key
                         last_heartbeat = time.monotonic()
+            async with request_lock:
+                trace_key = await _latest_channel_trace(store, channel_id)
+            if trace_key is not None and trace_key != last_trace_sent:
+                await response.write(_serialize_run_trace_event(trace_key[0], str(channel_id), trace_key[1]))
+                last_trace_sent = trace_key
+                last_heartbeat = time.monotonic()
             if batch.events:
                 for event in batch.events:
                     if isinstance(event, ClientTimelineMessageEvent):
@@ -890,6 +942,76 @@ async def _handle_run_state(
     return _json_response({"version": 1, "run": _serialize_run(authorized[2])}, status=200)
 
 
+async def _handle_run_trace(
+    request: web.Request,
+    *,
+    store: WorkshopEventStore,
+    authenticator: WorkshopClientAuthenticator,
+    submitter: WorkshopClientCommandSubmitter,
+    request_lock: asyncio.Lock,
+) -> web.Response:
+    """Serve one page of a run's durable trace rows, as stored.
+
+    Rows are served raw: the kind vocabulary is the table's (tool_call,
+    tool_result, and the synthetic truncated marker), which deliberately
+    never grows the shared TraceEntry emitter type.
+    """
+    if not set(request.query) <= {"after_seq"}:
+        return _error_response(status=400, code="invalid_request", message="Invalid trace request")
+    after_seq = 0
+    raw_after_seq = _single_query_value(request, "after_seq")
+    if raw_after_seq is not None:
+        try:
+            after_seq = int(raw_after_seq)
+        except ValueError:
+            return _error_response(status=400, code="invalid_request", message="Invalid trace request")
+        if after_seq < 0:
+            return _error_response(status=400, code="invalid_request", message="Invalid trace request")
+    authorized = await _authorized_run(
+        request,
+        authenticator=authenticator,
+        submitter=submitter,
+        request_lock=request_lock,
+    )
+    if isinstance(authorized, web.Response):
+        return authorized
+    _, channel_id, run = authorized
+    async with (
+        request_lock,
+        store.connection.execute(
+            "SELECT seq, kind, tool_name, tool_use_id, summary, detail, is_diff, is_error, created_at "
+            "FROM run_traces WHERE run_id = ? AND seq > ? ORDER BY seq LIMIT ?",
+            (run.run_id, after_seq, _TRACE_PAGE_SIZE + 1),
+        ) as cursor,
+    ):
+        rows = list(await cursor.fetchall())
+    has_more = len(rows) > _TRACE_PAGE_SIZE
+    entries = [
+        {
+            "seq": int(row[0]),
+            "kind": str(row[1]),
+            "tool_name": None if row[2] is None else str(row[2]),
+            "tool_use_id": None if row[3] is None else str(row[3]),
+            "summary": str(row[4]),
+            "detail": str(row[5]),
+            "is_diff": bool(row[6]),
+            "is_error": bool(row[7]),
+            "created_at": str(row[8]),
+        }
+        for row in rows[:_TRACE_PAGE_SIZE]
+    ]
+    return _json_response(
+        {
+            "version": 1,
+            "channel_id": str(channel_id),
+            "run_id": str(run.run_id),
+            "entries": entries,
+            "has_more": has_more,
+        },
+        status=200,
+    )
+
+
 async def _handle_run_cancellation(
     request: web.Request,
     *,
@@ -1023,6 +1145,15 @@ def register_workshop_command_routes(
             request_lock=request_lock,
         )
 
+    async def handle_run_trace(request: web.Request) -> web.Response:
+        return await _handle_run_trace(
+            request,
+            store=store,
+            authenticator=authenticator,
+            submitter=submitter,
+            request_lock=request_lock,
+        )
+
     async def handle_run_cancellation(request: web.Request) -> web.Response:
         return await _handle_run_cancellation(
             request,
@@ -1033,4 +1164,5 @@ def register_workshop_command_routes(
 
     app.router.add_post(_COMMAND_SUBMISSION_PATH, handle_command_submission)
     app.router.add_get(_RUN_STATE_PATH, handle_run_state)
+    app.router.add_get(_RUN_TRACE_PATH, handle_run_trace)
     app.router.add_post(_RUN_CANCELLATION_PATH, handle_run_cancellation)

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -541,19 +541,31 @@ def _serialize_run_trace_event(run_id: str, channel_id: str, seq: int) -> bytes:
 
 
 async def _latest_channel_trace(store: WorkshopEventStore, channel_id: ChannelId) -> tuple[str, int] | None:
-    """Return (run_id, seq) of the channel's newest trace row.
+    """Return (run_id, seq) of the channel's newest run's trace tip.
 
-    Newest by insertion order: only the channel's active run appends
-    rows, so the last inserted row is the one whose seq advances.
+    Two indexed lookups (the channel's most recently accepted run, then
+    that run's MAX(seq) via the primary key) rather than a reverse scan
+    of run_traces, whose cost would grow with every other channel's
+    trace history. Only the channel's newest run can be appending; a
+    newer run with no rows yet reports None, which the doorbell dedup
+    treats as nothing to signal.
     """
     async with store.connection.execute(
-        "SELECT run_traces.run_id, run_traces.seq FROM run_traces "
-        "JOIN runs ON runs.id = run_traces.run_id "
-        "WHERE runs.channel_id = ? ORDER BY run_traces.rowid DESC LIMIT 1",
+        "SELECT id FROM runs WHERE channel_id = ? ORDER BY accepted_at DESC, id DESC LIMIT 1",
         (str(channel_id),),
     ) as cursor:
-        row = await cursor.fetchone()
-    return None if row is None else (str(row[0]), int(row[1]))
+        run_row = await cursor.fetchone()
+    if run_row is None:
+        return None
+    run_id = str(run_row[0])
+    async with store.connection.execute(
+        "SELECT MAX(seq) FROM run_traces WHERE run_id = ?",
+        (run_id,),
+    ) as cursor:
+        seq_row = await cursor.fetchone()
+    if seq_row is None or seq_row[0] is None:
+        return None
+    return run_id, int(seq_row[0])
 
 
 async def _authorized_update_batch(
@@ -959,14 +971,14 @@ async def _handle_run_trace(
     if not set(request.query) <= {"after_seq"}:
         return _error_response(status=400, code="invalid_request", message="Invalid trace request")
     after_seq = 0
-    raw_after_seq = _single_query_value(request, "after_seq")
+    try:
+        raw_after_seq = _single_query_value(request, "after_seq")
+    except ValueError:
+        return _error_response(status=400, code="invalid_request", message="Invalid trace request")
     if raw_after_seq is not None:
-        try:
-            after_seq = int(raw_after_seq)
-        except ValueError:
+        if not _DECIMAL_INTEGER.fullmatch(raw_after_seq):
             return _error_response(status=400, code="invalid_request", message="Invalid trace request")
-        if after_seq < 0:
-            return _error_response(status=400, code="invalid_request", message="Invalid trace request")
+        after_seq = int(raw_after_seq)
     authorized = await _authorized_run(
         request,
         authenticator=authenticator,

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -541,17 +541,19 @@ def _serialize_run_trace_event(run_id: str, channel_id: str, seq: int) -> bytes:
 
 
 async def _latest_channel_trace(store: WorkshopEventStore, channel_id: ChannelId) -> tuple[str, int] | None:
-    """Return (run_id, seq) of the channel's newest run's trace tip.
+    """Return (run_id, seq) of the channel's appending run's trace tip.
 
-    Two indexed lookups (the channel's most recently accepted run, then
-    that run's MAX(seq) via the primary key) rather than a reverse scan
-    of run_traces, whose cost would grow with every other channel's
-    trace history. Only the channel's newest run can be appending; a
-    newer run with no rows yet reports None, which the doorbell dedup
-    treats as nothing to signal.
+    Two indexed lookups (the channel's started run, then that run's
+    MAX(seq) via the primary key) rather than a reverse scan of
+    run_traces, whose cost would grow with every other channel's trace
+    history. The coordinator appends strictly between start and
+    settlement, so only a started run can be appending; a queued
+    accepted run never masks the executing one. Rows landing just
+    before settlement can miss a final doorbell, which the terminal
+    run-lifecycle event covers with the card's final refresh.
     """
     async with store.connection.execute(
-        "SELECT id FROM runs WHERE channel_id = ? ORDER BY accepted_at DESC, id DESC LIMIT 1",
+        "SELECT id FROM runs WHERE channel_id = ? AND status = 'started' ORDER BY accepted_at DESC, id DESC LIMIT 1",
         (str(channel_id),),
     ) as cursor:
         run_row = await cursor.fetchone()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2719,6 +2719,7 @@ class TestNotificationChatIdMutations:
                 "/v1/channels/{channel_id}/commands",
                 "/v1/channels/{channel_id}/runs/{run_id}",
                 "/v1/channels/{channel_id}/runs/{run_id}/cancel",
+                "/v1/channels/{channel_id}/runs/{run_id}/trace",
                 "/workshop",
                 "/workshop/",
                 "/workshop/app.css",

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -1383,6 +1383,14 @@ class TestWorkshopRunTraceEventStream:
         assert isinstance(message_id, MessageId)
         accepted = await WorkshopRunLifecycle(store).accept(message_id, occurred_at=_NOW + timedelta(seconds=1))
         run_id = str(accepted.run.run_id)
+        # The doorbell targets the channel's started run: appends only
+        # happen between start and settlement, so a queued accepted run
+        # must never mask the executing one.
+        await store.connection.execute(
+            "UPDATE runs SET status = 'started', started_at = ? WHERE id = ?",
+            ((_NOW + timedelta(seconds=2)).isoformat(), run_id),
+        )
+        await store.connection.commit()
         await _insert_trace_rows(store, run_id, 3)
         client = await _open_client(store, _Authenticator({"alice-token": alice_id}))
         response = None

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -1414,3 +1414,25 @@ class TestWorkshopRunTraceEventStream:
                 response.close()
             await client.close()
             await store.close()
+
+    async def test_invalid_trace_queries_return_bounded_errors(self, tmp_path: Path):
+        store, alice_id, alice_channel, _, _ = await _open_store(tmp_path / "kai.db")
+        submitter = _CommandSubmitter()
+        client = await _open_command_client(store, _Authenticator({"alice-token": alice_id}), submitter)
+        try:
+            accepted = await client.post(
+                f"/v1/channels/{alice_channel}/commands",
+                headers={"Authorization": "Bearer alice-token"},
+                json={"client_message_id": "browser-command-1", "body": "Long task"},
+            )
+            run_id = (await accepted.json())["run_id"]
+            headers = {"Authorization": "Bearer alice-token"}
+            path = f"/v1/channels/{alice_channel}/runs/{run_id}/trace"
+
+            for query in ("after_seq=abc", "after_seq=-1", "after_seq=+5", "unknown=1", "after_seq=1&after_seq=2"):
+                response = await client.get(f"{path}?{query}", headers=headers)
+                assert response.status == 400, query
+                assert (await response.json())["error"]["code"] == "invalid_request", query
+        finally:
+            await client.close()
+            await store.close()

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -1214,3 +1214,203 @@ class TestWorkshopRunPreviewEventStream:
                 response.close()
             await client.close()
             await store.close()
+
+
+# ── Run trace endpoint and doorbell ─────────────────────────────────
+
+
+async def _insert_trace_rows(store: WorkshopEventStore, run_id: str, count: int, *, start: int = 1) -> None:
+    for seq in range(start, start + count):
+        await store.connection.execute(
+            "INSERT INTO run_traces (run_id, seq, kind, tool_name, tool_use_id, "
+            "summary, detail, is_diff, is_error, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                run_id,
+                seq,
+                "tool_call",
+                "Bash",
+                f"toolu_{seq}",
+                f"summary {seq}",
+                f"detail {seq}",
+                0,
+                0,
+                "2026-08-11T14:00:00+00:00",
+            ),
+        )
+    await store.connection.commit()
+
+
+class TestWorkshopRunTraceHTTPContract:
+    async def test_trace_access_is_denied_across_principals(self, tmp_path: Path):
+        store, alice_id, alice_channel, bob_id, _ = await _open_store(tmp_path / "kai.db")
+        submitter = _CommandSubmitter()
+        client = await _open_command_client(
+            store,
+            _Authenticator({"alice-token": alice_id, "bob-token": bob_id}),
+            submitter,
+        )
+        try:
+            accepted = await client.post(
+                f"/v1/channels/{alice_channel}/commands",
+                headers={"Authorization": "Bearer alice-token"},
+                json={"client_message_id": "browser-command-1", "body": "Private work"},
+            )
+            run_id = (await accepted.json())["run_id"]
+            await _insert_trace_rows(store, run_id, 1)
+
+            denied = await client.get(
+                f"/v1/channels/{alice_channel}/runs/{run_id}/trace",
+                headers={"Authorization": "Bearer bob-token"},
+            )
+            allowed = await client.get(
+                f"/v1/channels/{alice_channel}/runs/{run_id}/trace",
+                headers={"Authorization": "Bearer alice-token"},
+            )
+
+            assert denied.status == 403
+            assert allowed.status == 200
+            payload = await allowed.json()
+            assert payload["run_id"] == run_id
+            assert payload["channel_id"] == alice_channel
+            assert [entry["seq"] for entry in payload["entries"]] == [1]
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_after_seq_paging_returns_disjoint_ordered_slices(self, tmp_path: Path):
+        store, alice_id, alice_channel, _, _ = await _open_store(tmp_path / "kai.db")
+        submitter = _CommandSubmitter()
+        client = await _open_command_client(store, _Authenticator({"alice-token": alice_id}), submitter)
+        try:
+            accepted = await client.post(
+                f"/v1/channels/{alice_channel}/commands",
+                headers={"Authorization": "Bearer alice-token"},
+                json={"client_message_id": "browser-command-1", "body": "Long task"},
+            )
+            run_id = (await accepted.json())["run_id"]
+            await _insert_trace_rows(store, run_id, 201)
+            headers = {"Authorization": "Bearer alice-token"}
+
+            first = await client.get(f"/v1/channels/{alice_channel}/runs/{run_id}/trace", headers=headers)
+            first_payload = await first.json()
+            second = await client.get(
+                f"/v1/channels/{alice_channel}/runs/{run_id}/trace",
+                params={"after_seq": str(first_payload["entries"][-1]["seq"])},
+                headers=headers,
+            )
+            second_payload = await second.json()
+
+            assert first.status == 200
+            assert [entry["seq"] for entry in first_payload["entries"]] == list(range(1, 201))
+            assert first_payload["has_more"] is True
+            assert second.status == 200
+            assert [entry["seq"] for entry in second_payload["entries"]] == [201]
+            assert second_payload["has_more"] is False
+            assert second_payload["entries"][0]["summary"] == "summary 201"
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_truncation_marker_row_serves_as_stored(self, tmp_path: Path):
+        store, alice_id, alice_channel, _, _ = await _open_store(tmp_path / "kai.db")
+        submitter = _CommandSubmitter()
+        client = await _open_command_client(store, _Authenticator({"alice-token": alice_id}), submitter)
+        try:
+            accepted = await client.post(
+                f"/v1/channels/{alice_channel}/commands",
+                headers={"Authorization": "Bearer alice-token"},
+                json={"client_message_id": "browser-command-1", "body": "Long task"},
+            )
+            run_id = (await accepted.json())["run_id"]
+            await _insert_trace_rows(store, run_id, 1)
+            await store.connection.execute(
+                "INSERT INTO run_traces (run_id, seq, kind, tool_name, tool_use_id, "
+                "summary, detail, is_diff, is_error, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    run_id,
+                    2,
+                    "truncated",
+                    None,
+                    None,
+                    "trace truncated at 500 steps",
+                    "",
+                    0,
+                    0,
+                    "2026-08-11T14:00:01+00:00",
+                ),
+            )
+            await store.connection.commit()
+
+            response = await client.get(
+                f"/v1/channels/{alice_channel}/runs/{run_id}/trace",
+                headers={"Authorization": "Bearer alice-token"},
+            )
+
+            assert response.status == 200
+            marker = (await response.json())["entries"][1]
+            assert marker == {
+                "seq": 2,
+                "kind": "truncated",
+                "tool_name": None,
+                "tool_use_id": None,
+                "summary": "trace truncated at 500 steps",
+                "detail": "",
+                "is_diff": False,
+                "is_error": False,
+                "created_at": "2026-08-11T14:00:01+00:00",
+            }
+        finally:
+            await client.close()
+            await store.close()
+
+
+class TestWorkshopRunTraceEventStream:
+    async def test_trace_doorbell_carries_no_id_and_advances_by_seq(self, tmp_path: Path):
+        store, alice_id, alice_channel, _, _ = await _open_store(tmp_path / "kai.db")
+        inbound = await record_inbound_message(
+            store,
+            InboundMessage(
+                "telegram",
+                "trace-update-1",
+                "trace-message-1",
+                "101",
+                "101",
+                "Perform one task",
+                _NOW,
+            ),
+        )
+        message_id = inbound.event.envelope.aggregate_id
+        assert isinstance(message_id, MessageId)
+        accepted = await WorkshopRunLifecycle(store).accept(message_id, occurred_at=_NOW + timedelta(seconds=1))
+        run_id = str(accepted.run.run_id)
+        await _insert_trace_rows(store, run_id, 3)
+        client = await _open_client(store, _Authenticator({"alice-token": alice_id}))
+        response = None
+        try:
+            response = await client.get(
+                f"/v1/channels/{alice_channel}/events",
+                headers={"Authorization": "Bearer alice-token"},
+            )
+            event = await _read_sse_event(response)
+            while event["event"] != "run.trace.updated":
+                event = await _read_sse_event(response)
+
+            assert event["id"] is None
+            assert event["data"] == {
+                "version": 1,
+                "channel_id": alice_channel,
+                "run_id": run_id,
+                "seq": 3,
+            }
+
+            await _insert_trace_rows(store, run_id, 1, start=4)
+            event = await _read_sse_event(response)
+            while event["event"] != "run.trace.updated":
+                event = await _read_sse_event(response)
+            assert event["id"] is None
+            assert event["data"]["seq"] == 4
+        finally:
+            if response is not None:
+                response.close()
+            await client.close()
+            await store.close()


### PR DESCRIPTION
Closes #968. Part of the run inspector epic (#962); depends on the persistence from #981. With this, the trace pipeline is complete server-side; only the client card (#969) remains.

## Summary

The stored trace is now exposed over an authorized endpoint, with a lightweight SSE doorbell on the existing channel stream; the SSE stream stays a signal, not a data channel.

## Implementation

- **Endpoint**: `GET /v1/channels/{channel_id}/runs/{run_id}/trace`, registered next to the run-state route and gated by the same `_authorized_run` check (requester-only, unknown and cross-principal both 403). Query param `after_seq` (default 0) returns entries with `seq > after_seq`, ascending, capped at 200 per response with a `has_more` flag (computed by fetching cap+1); the client pages until drained.
- **Raw rows**, per the decision recorded on the issue: the response kind vocabulary is the table's (`tool_call`, `tool_result`, `truncated`); the marker never grows the shared `TraceEntry` Literal, and absent `tool_name`/`tool_use_id` serve as `null`.
- **Doorbell**: new `run.trace.updated` SSE event with payload `{run_id, channel_id, seq}` and no `id:` line, for exactly the reason `run.preview.updated` omits it (the resume cursor stays a pure durable-store position; the endpoint is the source of truth). `_serialize_run_trace_event` sits next to the preview serializer. The stream loop polls the channel's newest trace row per poll interval (insertion order; only the channel's active run appends rows) and re-signals only when `(run_id, seq)` advances.
- The LAN route allowlist pin in the webhook tests gains the new path.

## Testing

Four new tests: cross-principal trace access is denied while the owner reads; `after_seq` paging returns disjoint, ordered slices with `has_more` true at the 200 boundary and false on the drained page; a `truncated` marker row serves through the endpoint exactly as stored, nulls included; and the SSE doorbell carries no `id:` line and advances by `seq` as rows land mid-stream.

Full suite: 5885 passed, 1 skipped. Lint clean.
