### PR TITLE
fix: compose claude Edit trace detail as line-prefixed diff text

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -1088,20 +1088,35 @@ class ClaudeCodeBackend(AgentBackend):
                 summary = f"{tool_name}: {tool_input['file_path']}"
             elif tool_input:
                 summary = f"{tool_name}: {', '.join(sorted(tool_input))}"
+            # Content-based rather than name-based so any edit-shaped
+            # tool is rendered rich, and the flag keeps the same
+            # meaning across backend emitters.
+            is_diff = "old_string" in tool_input and "new_string" in tool_input
+            if is_diff:
+                # Diff-shaped inputs compose the file path with line-
+                # prefixed old/new text (the ACP mapper's composition)
+                # so the client's line-prefix diff coloring works on
+                # them; a raw JSON dump would render as a flat blob.
+                lines = []
+                file_path = tool_input.get("file_path")
+                if isinstance(file_path, str):
+                    lines.append(file_path)
+                old_string = tool_input.get("old_string")
+                if isinstance(old_string, str) and old_string:
+                    lines.extend(f"- {line}" for line in old_string.splitlines())
+                new_string = tool_input.get("new_string")
+                if isinstance(new_string, str) and new_string:
+                    lines.extend(f"+ {line}" for line in new_string.splitlines())
+                detail = "\n".join(lines)
+            else:
+                detail = json.dumps(tool_input, ensure_ascii=False)
             return TraceEntry(
                 kind="tool_call",
                 tool_use_id=tool_use_id,
                 summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
-                detail=scrub_trace_text(
-                    json.dumps(tool_input, ensure_ascii=False),
-                    self._trace_secrets,
-                    TRACE_DETAIL_MAX_CHARS,
-                ),
+                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
                 tool_name=tool_name,
-                # Content-based rather than name-based so any edit-shaped
-                # tool is rendered rich, and the flag keeps the same
-                # meaning across backend emitters.
-                is_diff="old_string" in tool_input and "new_string" in tool_input,
+                is_diff=is_diff,
             )
         except Exception:
             log.debug("Skipping malformed tool_use block", exc_info=True)

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -4318,3 +4318,80 @@ class TestTraceEmission:
         (result,) = [e.trace for e in events if e.trace is not None]
         assert result.detail == "value: [redacted]"
         assert "xyz99999" not in result.detail
+
+    @pytest.mark.asyncio
+    async def test_edit_detail_renders_as_line_prefixed_diff(self):
+        """Diff-shaped inputs compose the file path with prefixed old/new
+        lines for the client's line-prefix diff coloring; other inputs
+        keep the JSON detail byte-identical."""
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_content_event(
+                    [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "Edit",
+                            "input": {"file_path": "/w/a.py", "old_string": "a = 1", "new_string": "a = 2\nb = 3"},
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_2",
+                            "name": "Write",
+                            "input": {"file_path": "/w/b.py", "content": "x = 1"},
+                        },
+                    ]
+                ),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        edit, write = [e.trace for e in events if e.trace is not None]
+        assert edit.is_diff is True
+        assert edit.detail == "/w/a.py\n- a = 1\n+ a = 2\n+ b = 3"
+        assert write.is_diff is False
+        assert json.loads(write.detail) == {"file_path": "/w/b.py", "content": "x = 1"}
+
+    @pytest.mark.asyncio
+    async def test_secret_in_edit_text_is_redacted(self):
+        """A snapshot secret in old/new text never survives into the
+        composed diff detail."""
+        secret = "planted-secret-value-123"
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_content_event(
+                    [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "Edit",
+                            "input": {
+                                "file_path": "/w/.env",
+                                "old_string": f"TOKEN={secret}",
+                                "new_string": "TOKEN=rotated",
+                            },
+                        }
+                    ]
+                ),
+                _result_event(),
+                b"",
+            ]
+        )
+        claude = _make_claude()
+        claude._proc = proc
+        claude._fresh_session = False
+        claude._trace_secrets = (secret,)
+
+        events = await _collect_events(claude)
+
+        (edit,) = [e.trace for e in events if e.trace is not None]
+        assert secret not in edit.detail
+        assert edit.detail == "/w/.env\n- TOKEN=[redacted]\n+ TOKEN=rotated"


### PR DESCRIPTION
Closes #984. Follow-up to the run inspector epic (#962), surfaced by the card review: claude was the one backend lane whose `is_diff` rows defeated the card's line-prefix diff coloring.

## Summary

Diff-shaped claude tool inputs (the `old_string`/`new_string` pair that already sets `is_diff`) now compose their trace detail as the file path followed by the old text with a `- ` prefix and the new text with a `+ ` prefix per line, mirroring the ACP mapper's composition. The card's expanded-by-default diff rows render colored for claude edits instead of showing an uncolored JSON blob.

## Implementation

- The change is confined to the `tool_call` trace builder in `claude.py`: the `is_diff` predicate is computed once and selects between the diff composition and the existing JSON dump. Non-diff inputs keep their detail byte-identical.
- Scrubbing still runs on the composed text before the truncation cap, through the shared helpers, unchanged.

## Testing

Two new tests: an Edit block's detail renders as the exact path-plus-prefixed-lines composition while a Write block in the same message keeps byte-identical JSON detail (regression pin); a planted secret in the old text is `[redacted]` in the composed detail.

Full suite: 5888 passed, 1 skipped. Lint clean.
