### PR TITLE
fix: make first-import order independent around the workshop package

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -75,11 +75,10 @@ from kai.config import (
     validate_model_for_backend,
 )
 from kai.conversation_compatibility import (
-    CanonicalMemoryProvenance,
-    schedule_memory_ingestion,
+    _pending_memory_tasks as _shared_pending_memory_tasks,
 )
 from kai.conversation_compatibility import (
-    _pending_memory_tasks as _shared_pending_memory_tasks,
+    schedule_memory_ingestion,
 )
 from kai.history import LogEntry, log_message
 from kai.locks import get_lock, get_stop_event
@@ -93,7 +92,7 @@ from kai.tts import DEFAULT_VOICE, VOICES, TTSError, synthesize_speech
 from kai.workshop.artifacts import InboundArtifact
 from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.conversation_runs import PreparedConversationRun
-from kai.workshop.domain import MessageId, PrincipalId, RunId
+from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, PrincipalId, RunId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
     CanonicalExecutionDisposition,

--- a/src/kai/conversation_compatibility.py
+++ b/src/kai/conversation_compatibility.py
@@ -4,33 +4,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from kai.config import ONESHOT_REASONER_BACKENDS, Config
 from kai.history import LogEntry
-from kai.workshop.domain import MessageId, RunId
+
+# Type-only: Workshop modules import this module at runtime, so a runtime
+# import of anything under kai.workshop from here would be circular.
+if TYPE_CHECKING:
+    from kai.workshop.domain import CanonicalMemoryProvenance
 
 log = logging.getLogger(__name__)
 
 _pending_memory_tasks: set[asyncio.Task[None]] = set()
-
-
-@dataclass(frozen=True, slots=True)
-class CanonicalMemoryProvenance:
-    """Canonical messages and run consumed by one memory extraction."""
-
-    run_id: RunId
-    source_message_id: MessageId
-    result_message_id: MessageId
-
-    def metadata(self) -> dict[str, object]:
-        from kai import memory
-
-        return {
-            memory.WORKSHOP_RUN_ID_KEY: str(self.run_id),
-            memory.WORKSHOP_SOURCE_MESSAGE_ID_KEY: str(self.source_message_id),
-            memory.WORKSHOP_RESULT_MESSAGE_ID_KEY: str(self.result_message_id),
-        }
 
 
 def reader_user(config: Config, chat_id: int) -> str | None:

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -42,7 +42,6 @@ from kai.config import (
 )
 from kai.goose import GooseBackend
 from kai.internal_api_auth import InternalAPIAuth
-from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError
 from kai.workspace_utils import is_workspace_allowed
 
 if TYPE_CHECKING:
@@ -218,6 +217,12 @@ class SubprocessPool:
 
     def _protected_profile(self, runtime_config_id: int):
         """Resolve protected policy while preserving the negative-group bridge."""
+        # Imported at call time: kai.workshop's package initialization
+        # reaches back into this module through kai.sessions, so a
+        # module-level import of any workshop submodule from here is
+        # circular for some first-import orders.
+        from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError
+
         if self._runtime_profiles is None:
             return None
         try:

--- a/src/kai/workshop/client_commands.py
+++ b/src/kai/workshop/client_commands.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 from dataclasses import dataclass
 
-from kai.conversation_compatibility import CanonicalMemoryProvenance
 from kai.history import LogEntry
 from kai.streaming_text import stream_publishable_prefix
 from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
@@ -14,7 +13,7 @@ from kai.workshop.conversation_commands import (
     ClientConversationCommandAcceptance,
     ConversationCommandDisposition,
 )
-from kai.workshop.domain import MessageId, RunId, RuntimeProfileId
+from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, RunId, RuntimeProfileId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
     CanonicalExecutionDisposition,

--- a/src/kai/workshop/compatibility_state.py
+++ b/src/kai/workshop/compatibility_state.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass, field
 
 from kai import sessions
 from kai.config import Config
-from kai.conversation_compatibility import CanonicalMemoryProvenance, schedule_memory_ingestion
+from kai.conversation_compatibility import schedule_memory_ingestion
 from kai.history import LogEntry, log_message
-from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.domain import CanonicalMemoryProvenance, RuntimeProfileId
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 
 

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -333,3 +333,30 @@ class EventEnvelope:
         }
         encoded = json.dumps(content, allow_nan=False, separators=(",", ":"), sort_keys=True)
         return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalMemoryProvenance:
+    """Canonical messages and run consumed by one memory extraction.
+
+    Lives here, beside its field types, so that both Workshop modules and
+    top-level ingress code can share it without either importing the
+    other: this module has no kai imports, which keeps it reachable from
+    anywhere.
+    """
+
+    run_id: RunId
+    source_message_id: MessageId
+    result_message_id: MessageId
+
+    def metadata(self) -> dict[str, object]:
+        # Imported at call time: a module-level kai.memory import would
+        # give this leaf module an import-time dependency on the wider
+        # application stack.
+        from kai import memory
+
+        return {
+            memory.WORKSHOP_RUN_ID_KEY: str(self.run_id),
+            memory.WORKSHOP_SOURCE_MESSAGE_ID_KEY: str(self.source_message_id),
+            memory.WORKSHOP_RESULT_MESSAGE_ID_KEY: str(self.result_message_id),
+        }

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -5,16 +5,22 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from kai.backend import StreamEvent
 from kai.config import VALID_BACKENDS, validate_model_for_backend
-from kai.pool import PreparedBackendExecution
 from kai.workshop.conversation_runs import resolve_canonical_conversation_run
 from kai.workshop.domain import RunId, RuntimeProfileId
 from kai.workshop.run_execution_authority import RunExecutionSelection
 from kai.workshop.run_lifecycle import DurableRun, RunStatus, WorkshopRunLifecycle
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.store import WorkshopEventStore
+
+# Type-only: kai.pool imports kai.sessions, which imports this package, so
+# a runtime import here would close an import cycle. The prepared execution
+# arrives from the runtime pool; only its type name is needed here.
+if TYPE_CHECKING:
+    from kai.pool import PreparedBackendExecution
 
 type AgentPrompt = str | list[dict[str, str]]
 

--- a/src/kai/workshop/runtime_pool.py
+++ b/src/kai/workshop/runtime_pool.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from kai.backend import StreamEvent
-from kai.pool import PreparedBackendExecution, SubprocessPool
 from kai.workshop.domain import RuntimeProfileId
 from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
+
+# Type-only: kai.pool imports kai.sessions, which imports this package, so
+# a runtime import here would close an import cycle. The pool arrives as a
+# constructor argument; only its type names are needed at module scope.
+if TYPE_CHECKING:
+    from kai.pool import PreparedBackendExecution, SubprocessPool
 
 type AgentPrompt = str | list[dict[str, str]]
 

--- a/tests/test_import_independence.py
+++ b/tests/test_import_independence.py
@@ -14,12 +14,17 @@ import sys
 
 import pytest
 
+# When breaking a new import cycle, add its entry module here so the fix
+# stays proven; the list only covers what it names.
 _ENTRY_MODULES = (
+    "kai.bot",
     "kai.conversation_compatibility",
     "kai.pool",
     "kai.sessions",
     "kai.workshop",
     "kai.workshop.client_commands",
+    "kai.workshop.protected_execution",
+    "kai.workshop.runtime_pool",
 )
 
 

--- a/tests/test_import_independence.py
+++ b/tests/test_import_independence.py
@@ -1,0 +1,34 @@
+"""First-import order independence for cycle-prone kai modules.
+
+kai.workshop's package initialization eagerly imports the execution stack,
+which reaches back into several top-level modules. Each entry below must
+therefore import cleanly as the very first kai import of a process, which
+only a fresh interpreter per module can prove: importing them in-process
+would inherit whatever sys.modules state earlier tests created.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+_ENTRY_MODULES = (
+    "kai.conversation_compatibility",
+    "kai.pool",
+    "kai.sessions",
+    "kai.workshop",
+    "kai.workshop.client_commands",
+)
+
+
+@pytest.mark.parametrize("module", _ENTRY_MODULES)
+def test_module_imports_first(module: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_workshop_client_commands.py
+++ b/tests/test_workshop_client_commands.py
@@ -7,10 +7,9 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, call
 
-from kai.conversation_compatibility import CanonicalMemoryProvenance
 from kai.workshop.client_commands import WorkshopClientCommandExecutor
 from kai.workshop.conversation_commands import ConversationCommandDisposition
-from kai.workshop.domain import ChannelId, MessageId, PrincipalId, RunId
+from kai.workshop.domain import CanonicalMemoryProvenance, ChannelId, MessageId, PrincipalId, RunId
 from kai.workshop.execution_coordinator import (
     CanonicalExecutionDisposition,
     CanonicalExecutionResult,

--- a/tests/test_workshop_compatibility_state.py
+++ b/tests/test_workshop_compatibility_state.py
@@ -3,9 +3,8 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, call
 
-from kai.conversation_compatibility import CanonicalMemoryProvenance
 from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
-from kai.workshop.domain import MessageId, RunId
+from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, RunId
 from tests.workshop_profiles import profile_id
 
 


### PR DESCRIPTION
Two latent circular-import rings around the `kai.workshop` package made several modules fail to import unless something imported `kai.workshop` first. Production start-up happens to do that, which is the only reason both rings stayed invisible; `pytest tests/test_workshop_client_commands.py` run alone reproduced one of them at collection time.

## The two rings

1. `kai.conversation_compatibility` imported `kai.workshop.domain`, which triggers the workshop package initialization, whose eager chain (`client_api` → `client_commands`) imported `kai.conversation_compatibility` back mid-initialization.
2. `kai.pool` imported `kai.sessions`, which imports the workshop package broadly; the same eager chain reached `kai.workshop.runtime_pool`, which imported `kai.pool` back mid-initialization.

## Fixes

- **`CanonicalMemoryProvenance` moves to `kai.workshop.domain`**, beside the `RunId`/`MessageId` types it is made of, in the package's only kai-import-free module. Its lazy `kai.memory` import stays call-time, so the module remains an import-time leaf. With the class gone, `kai.conversation_compatibility` has no runtime workshop import left (a `TYPE_CHECKING` import remains for one signature), which breaks ring 1 in both directions. Importers updated: `bot.py`, `workshop/client_commands.py`, `workshop/compatibility_state.py`, and two test modules.
- **`workshop/runtime_pool.py` and `workshop/protected_execution.py` import `kai.pool` under `TYPE_CHECKING`**; both use the names purely as annotations (constructor parameter, return type, dataclass field), so nothing changes at runtime and ring 2 is broken.
- **`kai.pool` defers its `WorkshopRuntimeProfileError` import** into the one method whose `except` clause needs it, removing the module's last module-level workshop dependency.

## Regression coverage

`tests/test_import_independence.py` imports each cycle-prone entry module (`conversation_compatibility`, `pool`, `sessions`, `workshop`, `workshop.client_commands`) in a fresh interpreter per module, where it must load as the process's first kai import. In-process imports cannot prove this because they inherit `sys.modules` state from earlier tests; the original reproducer only fired when its test file ran alone for exactly that reason.

Full suite passes (5907 tests), `make check` clean, `make typecheck` (pyright strict) clean. No behaviour change; every moved or deferred import resolves to the same objects at call time.
