### PR TITLE
fix: snapshot the sudo target before the cross-user escalation await

### DIFF
--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -574,10 +574,13 @@ class ClaudeCodeBackend(AgentBackend):
         by public-API contract).
         """
         if self._pgid is not None:
-            # Snapshot under the guard: a concurrent _kill/shutdown nulls
-            # _effective_claude_user, and the pgrep await below yields to
-            # it, so re-reading the attribute afterwards can hand the
-            # sudo argv a None.
+            # Snapshot both under the guard: a concurrent _kill/shutdown
+            # nulls _effective_claude_user and _pgid together, and the
+            # pgrep and sudo awaits below yield to it, so re-reading
+            # either attribute afterwards can hand None to the sudo argv
+            # or to os.killpg (a TypeError in both cases, which the
+            # OSError handling here never catches).
+            pgid = self._pgid
             target_user = self._effective_claude_user
             if target_user is not None:
                 if self._inner_claude_pid is None:
@@ -589,7 +592,7 @@ class ClaudeCodeBackend(AgentBackend):
                         int(sig),
                     )
             try:
-                os.killpg(self._pgid, sig)
+                os.killpg(pgid, sig)
             except OSError:
                 pass
         elif self._proc is not None:

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -574,12 +574,17 @@ class ClaudeCodeBackend(AgentBackend):
         by public-API contract).
         """
         if self._pgid is not None:
-            if self._effective_claude_user is not None:
+            # Snapshot under the guard: a concurrent _kill/shutdown nulls
+            # _effective_claude_user, and the pgrep await below yields to
+            # it, so re-reading the attribute afterwards can hand the
+            # sudo argv a None.
+            target_user = self._effective_claude_user
+            if target_user is not None:
                 if self._inner_claude_pid is None:
                     self._inner_claude_pid = await self._async_lookup_inner_claude_pid()
                 if self._inner_claude_pid is not None:
                     await self._async_sudo_kill(
-                        self._effective_claude_user,
+                        target_user,
                         self._inner_claude_pid,
                         int(sig),
                     )

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -1643,10 +1643,13 @@ class CodexBackend(AgentBackend):
         blocking). Mirrors claude.py's _async_send_signal_for_close.
         """
         if self._pgid is not None:
-            # Snapshot under the guard: a concurrent _kill/shutdown nulls
-            # _effective_codex_user, and the pgrep await below yields to
-            # it, so re-reading the attribute afterwards can hand the
-            # sudo argv a None.
+            # Snapshot both under the guard: a concurrent _kill/shutdown
+            # nulls _effective_codex_user and _pgid together, and the
+            # pgrep and sudo awaits below yield to it, so re-reading
+            # either attribute afterwards can hand None to the sudo argv
+            # or to os.killpg (a TypeError in both cases, which the
+            # OSError handling here never catches).
+            pgid = self._pgid
             target_user = self._effective_codex_user
             if target_user is not None:
                 if not self._inner_codex_pids:
@@ -1661,7 +1664,7 @@ class CodexBackend(AgentBackend):
                         int(sig),
                     )
             try:
-                os.killpg(self._pgid, sig)
+                os.killpg(pgid, sig)
             except OSError:
                 pass
         elif self._proc is not None:

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -1643,7 +1643,12 @@ class CodexBackend(AgentBackend):
         blocking). Mirrors claude.py's _async_send_signal_for_close.
         """
         if self._pgid is not None:
-            if self._effective_codex_user is not None:
+            # Snapshot under the guard: a concurrent _kill/shutdown nulls
+            # _effective_codex_user, and the pgrep await below yields to
+            # it, so re-reading the attribute afterwards can hand the
+            # sudo argv a None.
+            target_user = self._effective_codex_user
+            if target_user is not None:
                 if not self._inner_codex_pids:
                     self._inner_codex_pids = await self._async_lookup_inner_codex_pids()
                 # Innermost-first; see _send_signal for the full
@@ -1651,7 +1656,7 @@ class CodexBackend(AgentBackend):
                 # mode this guards against.
                 for pid in self._inner_codex_pids:
                     await self._async_sudo_kill(
-                        self._effective_codex_user,
+                        target_user,
                         pid,
                         int(sig),
                     )

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2552,6 +2552,10 @@ class TestKill:
         claude._inner_claude_pid = None
 
         async def lookup_and_null():
+            # Everything a completed _kill clears, so the resumed task
+            # sees the full post-teardown state, not just a missing user.
+            claude._proc = None
+            claude._pgid = None
             claude._effective_claude_user = None
             return 99999
 
@@ -2559,11 +2563,13 @@ class TestKill:
         with (
             patch.object(claude, "_async_lookup_inner_claude_pid", side_effect=lookup_and_null),
             patch.object(claude, "_async_sudo_kill", new=mock_sudo_kill),
-            patch("os.killpg"),
+            patch("os.killpg") as mock_killpg,
         ):
             await claude._async_send_signal_for_close(signal.SIGKILL)
 
         mock_sudo_kill.assert_awaited_once_with("daniel", 99999, int(signal.SIGKILL))
+        # The wrapper reap also uses the snapshot, not the nulled attribute.
+        mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
 
     @pytest.mark.asyncio
     async def test_kill_skips_sudo_when_inner_pid_unknown(self):

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2537,6 +2537,35 @@ class TestKill:
             assert args[2] == int(signal.SIGKILL)
 
     @pytest.mark.asyncio
+    async def test_escalation_survives_concurrent_teardown_nulling_user(self):
+        """
+        The sudo target is snapshotted before the pgrep await: a
+        concurrent _kill/shutdown nulls _effective_claude_user while
+        that await yields, and the escalation must still address the
+        user it was guarded on rather than passing None into the sudo
+        argv.
+        """
+        claude = _make_claude(claude_user="daniel")
+        claude._proc = MagicMock()
+        claude._pgid = 12345
+        claude._effective_claude_user = "daniel"
+        claude._inner_claude_pid = None
+
+        async def lookup_and_null():
+            claude._effective_claude_user = None
+            return 99999
+
+        mock_sudo_kill = AsyncMock()
+        with (
+            patch.object(claude, "_async_lookup_inner_claude_pid", side_effect=lookup_and_null),
+            patch.object(claude, "_async_sudo_kill", new=mock_sudo_kill),
+            patch("os.killpg"),
+        ):
+            await claude._async_send_signal_for_close(signal.SIGKILL)
+
+        mock_sudo_kill.assert_awaited_once_with("daniel", 99999, int(signal.SIGKILL))
+
+    @pytest.mark.asyncio
     async def test_kill_skips_sudo_when_inner_pid_unknown(self):
         """
         If _async_lookup_inner_claude_pid never returns a PID (sudo

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -2243,6 +2243,11 @@ class TestCodexCrossUserTeardown:
         c._inner_codex_pids = []
 
         async def lookup_and_null():
+            # Everything a completed _kill clears, so the resumed task
+            # sees the full post-teardown state, not just a missing user.
+            c._proc = None
+            c._pgid = None
+            c._inner_codex_pids = []
             c._effective_codex_user = None
             return [67890]
 
@@ -2252,14 +2257,18 @@ class TestCodexCrossUserTeardown:
 
         with (
             patch.object(c, "_async_lookup_inner_codex_pids", side_effect=lookup_and_null),
-            patch("kai.codex.asyncio.create_subprocess_exec", AsyncMock(return_value=sudo_proc)) as mock_exec,
-            patch("kai.codex.os.killpg"),
+            # The spawn happens inside the canonical acp helper; patch it
+            # where it runs.
+            patch("kai.acp.asyncio.create_subprocess_exec", AsyncMock(return_value=sudo_proc)) as mock_exec,
+            patch("kai.codex.os.killpg") as mock_killpg,
         ):
             await c._async_send_signal_for_close(signal.SIGKILL)
 
         sudo_argv = mock_exec.call_args[0]
         assert sudo_argv[:5] == ("sudo", "-n", "-u", "ci-fake-user", "/bin/kill")
         assert sudo_argv[6] == "67890"
+        # The wrapper reap also uses the snapshot, not the nulled attribute.
+        mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
 
 
 class TestSudoKillEsrchDemotion:

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -2226,6 +2226,41 @@ class TestCodexCrossUserTeardown:
         # plural cache would silently retain stale PIDs.
         assert c._inner_codex_pids == []
 
+    @pytest.mark.asyncio
+    async def test_escalation_survives_concurrent_teardown_nulling_user(self):
+        """
+        The sudo target is snapshotted before the pgrep await: a
+        concurrent _kill/shutdown nulls _effective_codex_user while
+        that await yields, and the escalation must still address the
+        user it was guarded on rather than passing None into the sudo
+        argv.
+        """
+        c = _make_codex(codex_user="ci-fake-user")
+        c._proc = MagicMock()
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        # Empty cache so the async pgrep lookup (the yield point) runs.
+        c._inner_codex_pids = []
+
+        async def lookup_and_null():
+            c._effective_codex_user = None
+            return [67890]
+
+        sudo_proc = MagicMock()
+        sudo_proc.returncode = 0
+        sudo_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        with (
+            patch.object(c, "_async_lookup_inner_codex_pids", side_effect=lookup_and_null),
+            patch("kai.codex.asyncio.create_subprocess_exec", AsyncMock(return_value=sudo_proc)) as mock_exec,
+            patch("kai.codex.os.killpg"),
+        ):
+            await c._async_send_signal_for_close(signal.SIGKILL)
+
+        sudo_argv = mock_exec.call_args[0]
+        assert sudo_argv[:5] == ("sudo", "-n", "-u", "ci-fake-user", "/bin/kill")
+        assert sudo_argv[6] == "67890"
+
 
 class TestSudoKillEsrchDemotion:
     """


### PR DESCRIPTION
Fixes a race in the cross-user teardown escalation, reproduced from a production traceback: `TypeError: expected str, bytes or os.PathLike object, not NoneType` out of `create_subprocess_exec` in the shared cross-user kill helper.

## Root cause

`_async_send_signal_for_close` (codex and claude backends) guards on the effective cross-user attribute, awaits the inner-PID pgrep lookup, then re-reads the attribute when building the sudo escalation call. `_kill()` and `shutdown()` null that attribute at the end of their cleanup, and the lookup await yields to them, so under concurrent teardown the second read returns None. The shared helper builds `["sudo", "-n", "-u", target_user, "/bin/kill", ...]` with the value raw and catches only `OSError`, so the TypeError escapes into the caller (in the production case, the codex stream-reader's error handling). The escalation never fires and the target-user process is left to the `killpg` fallback, which POSIX signal permissions prevent from reaching a target-user grandchild.

The concurrency is real, not hypothetical: the production sequence was the codex app-server dying mid-turn, after which the send path's error handler and the reader's EOF handler both drove teardown.

## Fix

Both cross-user backends snapshot the target user AND the process group into locals under the guard and pass the snapshots after the awaits. The pgid snapshot matters on the same interleaving: teardown nulls both attributes in one synchronous stretch, so with only the user snapshotted, the escalation fires correctly and then `os.killpg(None, sig)` raises the same escaping TypeError one line later (`except OSError` does not catch it).

Survey of the other escalation sites, each verified to read `_effective_os_user` and `_pgid` in the same synchronous stretch as its guard, with no await between check and use: three in the ACP backend (`force_kill`, `_kill`, and the `shutdown` timeout path) and two in the pi backend (`force_kill`, `_kill`). None has this race.

## Tests

One regression test per backend: the mocked inner-PID lookup performs the full concurrent teardown from inside its await (nulling proc, pgid, PID caches, and the effective user together, exactly what a completed `_kill` clears), and the test asserts both that the sudo escalation addresses the user the guard saw and that `killpg` receives the snapshot group. Both tests were run against the unfixed code and fail there. The codex test patches `create_subprocess_exec` at `kai.acp`, where the canonical helper actually spawns, rather than leaning on the shared module object making a `kai.codex` patch global.

With the fix, the full suite passes (5912 tests), ruff and pyright strict clean.

## Known adjacent gap, deliberately out of scope

One step further down the same interleaving, `_kill` re-reads `self._proc` after the escalation await (`self._proc.wait()`), which can raise AttributeError under the same concurrency. That code is untouched by this PR and the durable fix is an idempotence gate at `_kill`/`shutdown` entry rather than more snapshots; tracked separately.
