### PR TITLE
feat: bound each codex turn with a configurable deadline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Follow the existing pattern exactly:
 2. Validated parsing in `load_config()` (try/except ValueError, SystemExit on bad input)
 3. Pass through `pool.py` to `claude.py` if it affects the inner Claude
 4. Prompt in `install.py` `_cmd_config()` (with validation loop)
-5. Document in `.env.example`
+5. Document in `templates/.env`
 6. Add to `_CONFIG_ENV_VARS` list in `tests/test_config.py`
 
 ## Key Patterns

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -329,6 +329,14 @@ class CodexBackend(AgentBackend):
         # of daemon-read file contents; the user-isolated subprocess
         # can read its own files directly.
         defer_user_file_reads: bool = False,
+        # Total bound on one turn, in seconds. The per-read and idle
+        # guards in the stream loop both reset whenever output arrives,
+        # so a turn that trickles output without completing (a
+        # quota-starved retry spin) would otherwise run forever; this
+        # backstop ends it. Generous by default so legitimate long
+        # agentic turns never hit it. Validated positive at config
+        # load (see Config.codex_turn_deadline_seconds).
+        codex_turn_deadline_seconds: int = 3600,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -341,6 +349,7 @@ class CodexBackend(AgentBackend):
         self.memory_enabled = memory_enabled
         self.codex_effort_level = codex_effort_level
         self.defer_user_file_reads = defer_user_file_reads
+        self.codex_turn_deadline_seconds = codex_turn_deadline_seconds
         # Session-age recycling limit (ABC surface; checked by the
         # inherited _should_recycle at the top of _send_locked).
         self.max_session_hours = max_session_hours
@@ -1051,9 +1060,34 @@ class CodexBackend(AgentBackend):
 
         last_activity = time.monotonic()
         max_idle_seconds = self.timeout_seconds * 5
+        turn_started = time.monotonic()
 
         try:
             while True:
+                # Check the total-turn deadline before each readline.
+                # Unlike the idle guard below, this never resets on
+                # output, so a turn that trickles retry notices without
+                # completing still ends here.
+                elapsed = time.monotonic() - turn_started
+                if elapsed > self.codex_turn_deadline_seconds:
+                    log.error(
+                        "Codex turn deadline exceeded (%.0fs elapsed, limit %ds)",
+                        elapsed,
+                        self.codex_turn_deadline_seconds,
+                    )
+                    await self._kill()
+                    visible = _visible_text()
+                    yield StreamEvent(
+                        text_so_far=visible,
+                        done=True,
+                        response=AgentResponse(
+                            success=False,
+                            text=visible,
+                            error="Codex turn exceeded its deadline",
+                        ),
+                    )
+                    return
+
                 # Check idle timeout before each readline
                 idle = time.monotonic() - last_activity
                 if idle > max_idle_seconds:

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1513,6 +1513,14 @@ class Config:
     # Only consulted when the user's effective backend is codex.
     codex_effort_level: str = ""
 
+    # Total bound on one codex turn, in seconds. The stream loop's
+    # per-read and idle guards both reset whenever output arrives, so
+    # a turn that trickles output without completing (a quota-starved
+    # retry spin) would otherwise run forever; this backstop ends it.
+    # Generous by default so legitimate long agentic turns never hit
+    # it. Must be a positive integer.
+    codex_turn_deadline_seconds: int = 3600
+
     # Database - uses DATA_DIR so the db lands in the writable data directory
     session_db_path: Path = field(default_factory=lambda: DATA_DIR / "kai.db")
 
@@ -3244,6 +3252,14 @@ def load_config() -> Config:
             f"CODEX_EFFORT_LEVEL must be one of {list(CODEX_EFFORT_LEVELS)} or empty, got {codex_effort_level!r}"
         )
 
+    raw_turn_deadline = os.environ.get("CODEX_TURN_DEADLINE_SECONDS", "3600").strip()
+    try:
+        codex_turn_deadline_seconds = int(raw_turn_deadline)
+        if codex_turn_deadline_seconds <= 0:
+            raise ValueError
+    except ValueError:
+        raise SystemExit("CODEX_TURN_DEADLINE_SECONDS must be a positive integer") from None
+
     # PR review agent config. The global `pr_review` toggle now lives
     # per-user in users.yaml; PR_REVIEW_COOLDOWN / PR_REVIEW_TIMEOUT_S
     # remain as global resource controls.
@@ -3762,6 +3778,7 @@ def load_config() -> Config:
         claude_effort_level=claude_effort_level,
         codex_auth_mode=codex_auth_mode,
         codex_effort_level=codex_effort_level,
+        codex_turn_deadline_seconds=codex_turn_deadline_seconds,
         webhook_port=webhook_port,
         workshop_lan_host=workshop_lan_host,
         github_webhook_secret=github_webhook_secret,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2124,6 +2124,7 @@ def _cmd_config() -> None:
     # enforces at load so install.conf cannot carry a value that fails
     # at service startup, while accepting "" as the no-override signal.
     codex_effort_level = ""
+    codex_turn_deadline = "3600"
     if agent_backend == "codex":
         codex_effort_level = _prompt_optional_choice(
             "Codex reasoning effort",
@@ -2131,6 +2132,20 @@ def _cmd_config() -> None:
             existing_env.get("CODEX_EFFORT_LEVEL", ""),
             empty_hint="empty = codex default",
         )
+        print()
+
+        # Total bound on one codex turn: the backstop that ends a turn
+        # trickling output without completing, since the idle guard
+        # resets on any output. Generous default so legitimate long
+        # agentic turns never hit it.
+        while True:
+            codex_turn_deadline = _prompt(
+                "Codex turn deadline (seconds)",
+                existing_env.get("CODEX_TURN_DEADLINE_SECONDS", "3600"),
+            )
+            if _validate_positive_int(codex_turn_deadline):
+                break
+            print("  Must be a positive integer.")
         print()
 
     # -- Webhook server --
@@ -2617,6 +2632,11 @@ def _cmd_config() -> None:
     # install.conf entirely.
     if codex_effort_level:
         env["CODEX_EFFORT_LEVEL"] = codex_effort_level
+
+    # CODEX_TURN_DEADLINE_SECONDS: delta-from-defaults; only a
+    # non-default value is operator intent worth persisting.
+    if codex_turn_deadline != "3600":
+        env["CODEX_TURN_DEADLINE_SECONDS"] = codex_turn_deadline
 
     # Conditionally add optional values
     if transport == "webhook":

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -537,6 +537,7 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
                 max_session_hours=self._config.agent_max_session_hours,
                 codex_effort_level=self._config.codex_effort_level,
+                codex_turn_deadline_seconds=self._config.codex_turn_deadline_seconds,
                 defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )
 

--- a/templates/.env
+++ b/templates/.env
@@ -61,6 +61,14 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # Truly global; applies to every chat's inner Claude subprocess.
 #CLAUDE_EFFORT_LEVEL=high
 
+# Total bound on one codex turn, in seconds (positive integer).
+# The codex stream loop's idle guard resets on any output, so a turn
+# that trickles output without completing (for example a provider
+# quota-exhaustion retry spin) would otherwise run forever; this is
+# the backstop that ends it. Generous default so legitimate long
+# agentic turns never hit it.
+#CODEX_TURN_DEADLINE_SECONDS=3600
+
 # Maximum session age in hours before recycling (0 = no limit).
 # Prevents unbounded memory growth in the inner agent process.
 # Recommended: 4-8 hours for memory-constrained machines.

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -603,6 +603,57 @@ class TestStreamParsing:
     """Verify _send_locked() correctly parses streaming responses."""
 
     @pytest.mark.asyncio
+    async def test_turn_deadline_ends_a_turn_that_keeps_trickling_output(self):
+        """
+        The idle guard resets on any output, so a turn that trickles
+        deltas without ever completing is bounded only by the turn
+        deadline; when it fires, the turn ends with a failed response
+        and the subprocess is killed.
+        """
+        c = _make_codex(codex_turn_deadline_seconds=1)
+        proc = _make_mock_proc([])
+
+        async def trickle():
+            # Frequent-enough output that the idle guard never fires.
+            await asyncio.sleep(0.4)
+            return _agent_message_delta("still going")
+
+        proc.stdout.readline = AsyncMock(side_effect=trickle)
+        c._proc = proc
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        with patch.object(c, "_kill", new=AsyncMock()) as mock_kill:
+            events = await _collect_events(c)
+
+        assert events[-1].done is True
+        assert events[-1].response.success is False
+        assert events[-1].response.error == "Codex turn exceeded its deadline"
+        # The trickled text survives into the failed response.
+        assert "still going" in events[-1].text_so_far
+        mock_kill.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_turn_completing_within_deadline_is_untouched(self):
+        """A normal turn under the deadline ends by completion, not the backstop."""
+        c = _make_codex(codex_turn_deadline_seconds=5)
+        c._proc = _make_mock_proc(
+            [
+                _agent_message_delta("Hello"),
+                _turn_completed("completed"),
+            ]
+        )
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        events = await _collect_events(c)
+
+        assert events[-1].done is True
+        assert events[-1].response.success is True
+
+    @pytest.mark.asyncio
     async def test_agent_message_chunk_accumulation(self):
         """agent_message_chunk events accumulate text and yield StreamEvents."""
         c = _make_codex()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,7 @@ _CONFIG_ENV_VARS = [
     "CLAUDE_AUTOCOMPACT_PCT",
     "CLAUDE_EFFORT_LEVEL",
     "CODEX_EFFORT_LEVEL",
+    "CODEX_TURN_DEADLINE_SECONDS",
     "TOTP_SESSION_MINUTES",
     "TOTP_CHALLENGE_SECONDS",
     "TOTP_LOCKOUT_ATTEMPTS",
@@ -1583,6 +1584,35 @@ class TestCodexEffortLevel:
         monkeypatch.setenv("CODEX_EFFORT_LEVEL", "   ")
         config = load_config()
         assert config.codex_effort_level == ""
+
+
+# ── CODEX_TURN_DEADLINE_SECONDS config ───────────────────────────────
+
+
+class TestCodexTurnDeadlineSeconds:
+    """Coverage for the CODEX_TURN_DEADLINE_SECONDS env var: the
+    total-turn backstop for the codex stream loop, whose idle guard
+    resets on any output. Positive integer, generous default."""
+
+    def test_default_when_unset(self, monkeypatch):
+        _set_required(monkeypatch)
+        config = load_config()
+        assert config.codex_turn_deadline_seconds == 3600
+
+    def test_valid_value_parses(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CODEX_TURN_DEADLINE_SECONDS", "7200")
+        config = load_config()
+        assert config.codex_turn_deadline_seconds == 7200
+
+    @pytest.mark.parametrize("value", ["0", "-5", "not-a-number", "3.5"])
+    def test_non_positive_or_non_integer_raises(self, monkeypatch, value):
+        # A zero or negative deadline would disable the backstop
+        # silently; fail fast at config load instead.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("CODEX_TURN_DEADLINE_SECONDS", value)
+        with pytest.raises(SystemExit, match="CODEX_TURN_DEADLINE_SECONDS"):
+            load_config()
 
 
 # ── Memory extraction config (spec §6.4, §13.1) ─────────────────────

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3075,6 +3075,7 @@ class TestCmdConfig:
                 "1800",  # idle eviction timeout seconds
                 # autocompact + claude effort skipped on non-claude backend
                 "",  # codex reasoning effort (empty = codex default)
+                "3600",  # codex turn deadline seconds (default)
                 "8080",  # webhook port
                 "",  # Workshop LAN address (disabled)
                 "test-secret",  # webhook secret
@@ -3645,6 +3646,7 @@ class TestCmdConfigDefaultModelDispatch:
             "1800",  # idle eviction timeout seconds
             # No autocompact_pct / claude effort prompts (claude-only)
             "",  # codex reasoning effort (empty = codex default)
+            "3600",  # codex turn deadline seconds (default)
             "8080",  # webhook port
             "",  # Workshop LAN address (disabled)
             "test-secret",  # webhook secret
@@ -3739,12 +3741,36 @@ class TestCmdConfigDefaultModelDispatch:
         self._setup(monkeypatch, tmp_path)
         base = list(self._inputs_for_codex_subscription())
         idx = base.index("8080")
-        # The slot immediately before the webhook port is the codex
-        # effort answer in this chain.
-        assert base[idx - 1] == ""
-        base[idx - 1] = "HIGH"
+        # The codex answers sit right before the webhook port in this
+        # chain: effort, then the turn deadline.
+        assert base[idx - 2] == ""
+        base[idx - 2] = "HIGH"
         _, env = self._run(monkeypatch, tmp_path, base, helper_return="gpt-5.5")
         assert env.get("CODEX_EFFORT_LEVEL") == "high"
+
+    def test_codex_turn_deadline_default_omits_env_key(self, tmp_path, monkeypatch):
+        """Accepting the 3600 default keeps CODEX_TURN_DEADLINE_SECONDS
+        out of install.conf: delta-from-defaults, so only operator
+        intent is persisted."""
+        self._setup(monkeypatch, tmp_path)
+        _, env = self._run(
+            monkeypatch,
+            tmp_path,
+            self._inputs_for_codex_subscription(),
+            helper_return="gpt-5.5",
+        )
+        assert "CODEX_TURN_DEADLINE_SECONDS" not in env
+
+    def test_codex_turn_deadline_non_default_writes_env_key(self, tmp_path, monkeypatch):
+        """A non-default deadline round-trips from the wizard prompt
+        into install.conf."""
+        self._setup(monkeypatch, tmp_path)
+        base = list(self._inputs_for_codex_subscription())
+        idx = base.index("8080")
+        assert base[idx - 1] == "3600"
+        base[idx - 1] = "7200"
+        _, env = self._run(monkeypatch, tmp_path, base, helper_return="gpt-5.5")
+        assert env.get("CODEX_TURN_DEADLINE_SECONDS") == "7200"
 
     def test_install_conf_legacy_AGENT_BACKEND_migrates_on_resave(self, tmp_path, monkeypatch):
         """Re-running the wizard against a prior install.conf that


### PR DESCRIPTION
Closes #996.

Decision, as the issue asked for one: option 1, a configurable total-turn deadline, applied to the codex backend where the wedge was observed. Option 2 (wedge-shape detection) buys little over a generous backstop at real complexity cost, and option 3 leaves the failure unbounded. The other backends are untouched; if the same trickle-without-completing shape ever shows up there, this pattern extends per backend.

## Behaviour

The stream loop gains a deadline check beside the existing idle check. Unlike the idle guard, it never resets on output, so a turn trickling retry notices (the provider quota-exhaustion spin) ends at the deadline exactly the way an idle turn ends today: the subprocess is killed and the turn yields a failed response carrying whatever text accumulated. A turn that completes within the deadline is untouched.

## Configuration

`CODEX_TURN_DEADLINE_SECONDS`, default 3600, following the standard env-var pattern end to end: `Config` field, positive-integer validation at load (`SystemExit` on zero, negative, or non-integer input), pool pass-through to the backend constructor, a wizard prompt in the codex section (persisted only when non-default, matching the delta-from-defaults posture of the neighbouring codex setting), and a documented entry in the env template. The generous default is the point: legitimate long agentic turns never hit the backstop, while an infinite spin cannot outlive it.

## Tests

- Firing: a turn trickling message deltas frequently enough that the idle guard never fires is ended by the deadline, with the failed response preserving the accumulated text and the subprocess killed.
- Non-firing: a normal turn under the deadline completes by itself.
- Config: default, valid override, and rejection of zero/negative/non-integer values.
- Wizard: the default omits the key from install.conf; a non-default value round-trips into it. Existing scripted wizard chains gained the new answer slot.

Full suite passes (5922 tests), ruff and pyright strict clean.
