### PR TITLE
fix: serialize concurrent backend teardown behind a per-instance gate

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -796,6 +796,12 @@ class AcpBackend(AgentBackend):
         # unambiguous across restarts.
         self._next_id: int = 1
         self._lock = asyncio.Lock()  # Serializes all message sends
+        # Serializes _kill/shutdown. Teardown paths await between
+        # reading process state and using it; two teardowns
+        # interleaving across those awaits would let the second read
+        # attributes the first already nulled. Always acquired after
+        # _lock when both are held, never before it.
+        self._teardown_lock = asyncio.Lock()
         # Secret values scrubbed from trace text. Snapshotted from the
         # fully built subprocess environment at spawn so constructor-only
         # credentials (the per-principal webhook secret) are covered.
@@ -1722,27 +1728,28 @@ class AcpBackend(AgentBackend):
         force_kill() call below does not repeat the escalation
         synchronously.
         """
-        if self._proc:
-            if self._effective_os_user is not None and self._pgid is not None:
-                await _kill_target_user_tree(
-                    target_user=self._effective_os_user,
-                    pgid=self._pgid,
-                    purpose="chat",
-                    backend=self.backend_name,
-                )
+        async with self._teardown_lock:
+            if self._proc:
+                if self._effective_os_user is not None and self._pgid is not None:
+                    await _kill_target_user_tree(
+                        target_user=self._effective_os_user,
+                        pgid=self._pgid,
+                        purpose="chat",
+                        backend=self.backend_name,
+                    )
+                    self._pgid = None
+                self.force_kill()
+                try:
+                    await asyncio.wait_for(self._proc.wait(), timeout=5)
+                except TimeoutError:
+                    pass
+                # force_kill() already cancelled _stderr_task and set it to
+                # None, so no additional cleanup needed here.
+                self._proc = None
+                self._session_id = None
                 self._pgid = None
-            self.force_kill()
-            try:
-                await asyncio.wait_for(self._proc.wait(), timeout=5)
-            except TimeoutError:
-                pass
-            # force_kill() already cancelled _stderr_task and set it to
-            # None, so no additional cleanup needed here.
-            self._proc = None
-            self._session_id = None
-            self._pgid = None
-            self._effective_os_user = None
-            self._session_started_at = None
+                self._effective_os_user = None
+                self._session_started_at = None
 
     async def restart(self) -> None:
         """
@@ -1797,35 +1804,36 @@ class AcpBackend(AgentBackend):
         force_kill() reaps the wrapper (with _pgid nulled so
         force_kill skips its own sync escalation).
         """
-        if self._proc:
-            try:
-                self._proc.terminate()
-            except OSError:
-                # Process already exited between the _proc check and
-                # terminate(). Fall through to cleanup below.
-                pass
-            else:
+        async with self._teardown_lock:
+            if self._proc:
                 try:
-                    await asyncio.wait_for(self._proc.wait(), timeout=5)
-                except TimeoutError:
-                    if self._effective_os_user is not None and self._pgid is not None:
-                        await _kill_target_user_tree(
-                            target_user=self._effective_os_user,
-                            pgid=self._pgid,
-                            purpose="chat",
-                            backend=self.backend_name,
-                        )
-                        self._pgid = None
-                    self.force_kill()
+                    self._proc.terminate()
+                except OSError:
+                    # Process already exited between the _proc check and
+                    # terminate(). Fall through to cleanup below.
+                    pass
+                else:
                     try:
                         await asyncio.wait_for(self._proc.wait(), timeout=5)
                     except TimeoutError:
-                        log.warning("%s: process did not exit after SIGKILL", self.backend_label)
-        if self._stderr_task:
-            self._stderr_task.cancel()
-            self._stderr_task = None
-        self._proc = None
-        self._session_id = None
-        self._pgid = None
-        self._effective_os_user = None
-        self._session_started_at = None
+                        if self._effective_os_user is not None and self._pgid is not None:
+                            await _kill_target_user_tree(
+                                target_user=self._effective_os_user,
+                                pgid=self._pgid,
+                                purpose="chat",
+                                backend=self.backend_name,
+                            )
+                            self._pgid = None
+                        self.force_kill()
+                        try:
+                            await asyncio.wait_for(self._proc.wait(), timeout=5)
+                        except TimeoutError:
+                            log.warning("%s: process did not exit after SIGKILL", self.backend_label)
+            if self._stderr_task:
+                self._stderr_task.cancel()
+                self._stderr_task = None
+            self._proc = None
+            self._session_id = None
+            self._pgid = None
+            self._effective_os_user = None
+            self._session_started_at = None

--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -800,7 +800,10 @@ class AcpBackend(AgentBackend):
         # reading process state and using it; two teardowns
         # interleaving across those awaits would let the second read
         # attributes the first already nulled. Always acquired after
-        # _lock when both are held, never before it.
+        # _lock when both are held, never before it. The sync
+        # force_kill stays outside this gate: it cannot be interleaved
+        # mid-function, and nothing it nulls is re-read unguarded by a
+        # gated body afterwards.
         self._teardown_lock = asyncio.Lock()
         # Secret values scrubbed from trace text. Snapshotted from the
         # fully built subprocess environment at spawn so constructor-only

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -195,6 +195,12 @@ class ClaudeCodeBackend(AgentBackend):
         self._inner_claude_pid: int | None = None  # Cross-user mode: PID of the claude grandchild under sudo (#456)
         self._effective_claude_user: str | None = None  # Cross-user mode: the resolved sudo target (#456)
         self._lock = asyncio.Lock()  # Serializes all message sends
+        # Serializes _kill/shutdown. Teardown paths await between
+        # reading process state and using it; two teardowns
+        # interleaving across those awaits would let the second read
+        # attributes the first already nulled. Always acquired after
+        # _lock when both are held, never before it.
+        self._teardown_lock = asyncio.Lock()
         self._session_id: str | None = None
         self._fresh_session = True  # True until the first message is sent
         self._stderr_task: asyncio.Task | None = None  # Background stderr drain
@@ -1337,86 +1343,87 @@ class ClaudeCodeBackend(AgentBackend):
         because _stderr_task is only created alongside _proc in _ensure_started().
         If _proc is None, there is no stderr task to cancel.
         """
-        if self._proc:
-            # Save pgid before clearing - the EOF handler in _send_locked()
-            # may call _kill() again after we clear self._pgid, but we need
-            # to ensure the process group gets signaled at least once more
-            # after the wait completes (belt-and-suspenders for the race
-            # where sudo dies but claude survives the initial SIGKILL).
-            saved_pgid = self._pgid
+        async with self._teardown_lock:
+            if self._proc:
+                # Save pgid before clearing - the EOF handler in _send_locked()
+                # may call _kill() again after we clear self._pgid, but we need
+                # to ensure the process group gets signaled at least once more
+                # after the wait completes (belt-and-suspenders for the race
+                # where sudo dies but claude survives the initial SIGKILL).
+                saved_pgid = self._pgid
 
-            # Prime the inner-claude-PID cache BEFORE any signal goes
-            # out. Once the killpg below reaps the sudo wrapper,
-            # pgrep -P <dead_sudo_pid> returns nothing and we lose
-            # the only handle on the orphaned grandchild. The cache
-            # survives the per-signal escalation + killpg sequence
-            # so the final-cleanup sudo-kill below can still reach
-            # the inner claude. See issue #456. Only attempt when
-            # we actually have a sudo target to escalate to; without
-            # _effective_claude_user the lookup result is useless.
-            #
-            # Async pgrep variant so the event loop is not blocked
-            # waiting for the lookup. See #459.
-            saved_user = self._effective_claude_user
-            if saved_user is not None and self._inner_claude_pid is None:
-                self._inner_claude_pid = await self._async_lookup_inner_claude_pid()
-            saved_inner_pid = self._inner_claude_pid
+                # Prime the inner-claude-PID cache BEFORE any signal goes
+                # out. Once the killpg below reaps the sudo wrapper,
+                # pgrep -P <dead_sudo_pid> returns nothing and we lose
+                # the only handle on the orphaned grandchild. The cache
+                # survives the per-signal escalation + killpg sequence
+                # so the final-cleanup sudo-kill below can still reach
+                # the inner claude. See issue #456. Only attempt when
+                # we actually have a sudo target to escalate to; without
+                # _effective_claude_user the lookup result is useless.
+                #
+                # Async pgrep variant so the event loop is not blocked
+                # waiting for the lookup. See #459.
+                saved_user = self._effective_claude_user
+                if saved_user is not None and self._inner_claude_pid is None:
+                    self._inner_claude_pid = await self._async_lookup_inner_claude_pid()
+                saved_inner_pid = self._inner_claude_pid
 
-            # Cross-user escalation (#456) + wrapper killpg / single-
-            # user direct signal. Routed through the async helper so
-            # the event loop stays responsive while sudo + kill
-            # complete. See #459.
-            await self._async_send_signal_for_close(signal.SIGKILL)
+                # Cross-user escalation (#456) + wrapper killpg / single-
+                # user direct signal. Routed through the async helper so
+                # the event loop stays responsive while sudo + kill
+                # complete. See #459.
+                await self._async_send_signal_for_close(signal.SIGKILL)
 
-            try:
-                await asyncio.wait_for(self._proc.wait(), timeout=5)
-            except TimeoutError:
-                pass
-
-            # Cancel the stderr drain BEFORE clearing self._proc.
-            # _drain_stderr's while-loop checks self._proc on each iteration;
-            # if we clear proc first, the drain task could observe None in a
-            # state that was never intended to be visible to it. Cancelling
-            # the task first ensures it stops reading before its dependencies
-            # are destroyed.
-            if self._stderr_task:
-                self._stderr_task.cancel()
-                self._stderr_task = None
-
-            self._proc = None
-            self._pgid = None
-            self._inner_claude_pid = None
-            self._effective_claude_user = None
-            self._session_id = None
-            self._session_started_at = None
-
-            # Final cleanup: signal the saved process group one more time.
-            # If claude was reparented to init during the wait, this catches
-            # it. If everything is already dead, killpg raises OSError which
-            # we ignore. Only applies to claude_user mode (pgid is None
-            # otherwise).
-            if saved_pgid is not None:
                 try:
-                    os.killpg(saved_pgid, signal.SIGKILL)
-                except OSError:
+                    await asyncio.wait_for(self._proc.wait(), timeout=5)
+                except TimeoutError:
                     pass
 
-            # Final cross-user cleanup: even after the killpg above,
-            # the inner claude grandchild may still be alive because
-            # the service user cannot signal a target-user process
-            # (#456). Escalate via sudo to kill the captured PID
-            # directly. Skipped silently when:
-            # - single-user mode (no saved_user / saved_inner_pid),
-            # - pgrep failed to find a child PID at any point
-            #   (sudo never forked, or sudo died with no child),
-            # - the inner claude is already dead (sudo kill returns
-            #   ESRCH; the shared helper classifies that benign race
-            #   at DEBUG).
-            #
-            # Async sudo-kill so the event loop is not blocked on the
-            # 5s ceiling. See #459.
-            if saved_user is not None and saved_inner_pid is not None:
-                await self._async_sudo_kill(saved_user, saved_inner_pid, int(signal.SIGKILL))
+                # Cancel the stderr drain BEFORE clearing self._proc.
+                # _drain_stderr's while-loop checks self._proc on each iteration;
+                # if we clear proc first, the drain task could observe None in a
+                # state that was never intended to be visible to it. Cancelling
+                # the task first ensures it stops reading before its dependencies
+                # are destroyed.
+                if self._stderr_task:
+                    self._stderr_task.cancel()
+                    self._stderr_task = None
+
+                self._proc = None
+                self._pgid = None
+                self._inner_claude_pid = None
+                self._effective_claude_user = None
+                self._session_id = None
+                self._session_started_at = None
+
+                # Final cleanup: signal the saved process group one more time.
+                # If claude was reparented to init during the wait, this catches
+                # it. If everything is already dead, killpg raises OSError which
+                # we ignore. Only applies to claude_user mode (pgid is None
+                # otherwise).
+                if saved_pgid is not None:
+                    try:
+                        os.killpg(saved_pgid, signal.SIGKILL)
+                    except OSError:
+                        pass
+
+                # Final cross-user cleanup: even after the killpg above,
+                # the inner claude grandchild may still be alive because
+                # the service user cannot signal a target-user process
+                # (#456). Escalate via sudo to kill the captured PID
+                # directly. Skipped silently when:
+                # - single-user mode (no saved_user / saved_inner_pid),
+                # - pgrep failed to find a child PID at any point
+                #   (sudo never forked, or sudo died with no child),
+                # - the inner claude is already dead (sudo kill returns
+                #   ESRCH; the shared helper classifies that benign race
+                #   at DEBUG).
+                #
+                # Async sudo-kill so the event loop is not blocked on the
+                # 5s ceiling. See #459.
+                if saved_user is not None and saved_inner_pid is not None:
+                    await self._async_sudo_kill(saved_user, saved_inner_pid, int(signal.SIGKILL))
 
     async def shutdown(self) -> None:
         """
@@ -1441,11 +1448,14 @@ class ClaudeCodeBackend(AgentBackend):
         # start a concurrent stdout read during _save_prompt().
         # If a stream is in flight, this blocks until it finishes.
         # Note: _kill() (called from _send_locked error paths) does
-        # NOT acquire _lock, so there is no deadlock risk.
+        # NOT acquire _lock, so there is no deadlock risk. The
+        # teardown gate nests INSIDE _lock here, matching the
+        # _lock-then-_teardown_lock order of the _send_locked error
+        # paths that call _kill while holding _lock.
         saved_pgid = None
         saved_inner_pid: int | None = None
         saved_user: str | None = None
-        async with self._lock:
+        async with self._lock, self._teardown_lock:
             if self._proc:
                 try:
                     await self._save_prompt()

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -199,7 +199,10 @@ class ClaudeCodeBackend(AgentBackend):
         # reading process state and using it; two teardowns
         # interleaving across those awaits would let the second read
         # attributes the first already nulled. Always acquired after
-        # _lock when both are held, never before it.
+        # _lock when both are held, never before it. The sync
+        # force_kill stays outside this gate: it cannot be interleaved
+        # mid-function, and nothing it nulls is re-read unguarded by a
+        # gated body afterwards.
         self._teardown_lock = asyncio.Lock()
         self._session_id: str | None = None
         self._fresh_session = True  # True until the first message is sent

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -384,6 +384,12 @@ class CodexBackend(AgentBackend):
         self._session_started_at: float | None = None
         self._next_id: int = 1  # Monotonically increasing JSON-RPC request ID
         self._lock = asyncio.Lock()  # Serializes all message sends
+        # Serializes _kill/shutdown. Teardown paths await between
+        # reading process state and using it; two teardowns
+        # interleaving across those awaits would let the second read
+        # attributes the first already nulled. Always acquired after
+        # _lock when both are held, never before it.
+        self._teardown_lock = asyncio.Lock()
         self._fresh_session: bool = True  # True until the first message is sent
         self._stderr_task: asyncio.Task | None = None  # Background stderr drain
         # Secret values scrubbed from trace text. Snapshotted from the
@@ -1732,23 +1738,25 @@ class CodexBackend(AgentBackend):
         Sends SIGKILL via the async escalation path (so cross-user
         installs do not orphan the codex grandchild), waits up to 5
         seconds for exit, then nulls all process references.
-        Idempotent.
+        Idempotent: a teardown that loses the lock race re-checks
+        _proc under the lock and returns without re-killing.
         """
-        if self._proc:
-            await self._async_send_signal_for_close(signal.SIGKILL)
-            if self._stderr_task:
-                self._stderr_task.cancel()
-                self._stderr_task = None
-            try:
-                await asyncio.wait_for(self._proc.wait(), timeout=5)
-            except TimeoutError:
-                pass
-            self._proc = None
-            self._session_id = None
-            self._pgid = None
-            self._inner_codex_pids = []
-            self._effective_codex_user = None
-            self._session_started_at = None
+        async with self._teardown_lock:
+            if self._proc:
+                await self._async_send_signal_for_close(signal.SIGKILL)
+                if self._stderr_task:
+                    self._stderr_task.cancel()
+                    self._stderr_task = None
+                try:
+                    await asyncio.wait_for(self._proc.wait(), timeout=5)
+                except TimeoutError:
+                    pass
+                self._proc = None
+                self._session_id = None
+                self._pgid = None
+                self._inner_codex_pids = []
+                self._effective_codex_user = None
+                self._session_started_at = None
 
     async def restart(self) -> None:
         """
@@ -1798,22 +1806,23 @@ class CodexBackend(AgentBackend):
         Falls back to SIGKILL (also through the escalation path) if
         the process doesn't terminate in time.
         """
-        if self._proc:
-            await self._async_send_signal_for_close(signal.SIGTERM)
-            try:
-                await asyncio.wait_for(self._proc.wait(), timeout=5)
-            except TimeoutError:
-                await self._async_send_signal_for_close(signal.SIGKILL)
+        async with self._teardown_lock:
+            if self._proc:
+                await self._async_send_signal_for_close(signal.SIGTERM)
                 try:
                     await asyncio.wait_for(self._proc.wait(), timeout=5)
                 except TimeoutError:
-                    log.warning("CodexBackend: process did not exit after SIGKILL")
-        if self._stderr_task:
-            self._stderr_task.cancel()
-            self._stderr_task = None
-        self._proc = None
-        self._session_id = None
-        self._pgid = None
-        self._inner_codex_pids = []
-        self._effective_codex_user = None
-        self._session_started_at = None
+                    await self._async_send_signal_for_close(signal.SIGKILL)
+                    try:
+                        await asyncio.wait_for(self._proc.wait(), timeout=5)
+                    except TimeoutError:
+                        log.warning("CodexBackend: process did not exit after SIGKILL")
+            if self._stderr_task:
+                self._stderr_task.cancel()
+                self._stderr_task = None
+            self._proc = None
+            self._session_id = None
+            self._pgid = None
+            self._inner_codex_pids = []
+            self._effective_codex_user = None
+            self._session_started_at = None

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -388,7 +388,10 @@ class CodexBackend(AgentBackend):
         # reading process state and using it; two teardowns
         # interleaving across those awaits would let the second read
         # attributes the first already nulled. Always acquired after
-        # _lock when both are held, never before it.
+        # _lock when both are held, never before it. The sync
+        # force_kill stays outside this gate: it cannot be interleaved
+        # mid-function, and nothing it nulls is re-read unguarded by a
+        # gated body afterwards.
         self._teardown_lock = asyncio.Lock()
         self._fresh_session: bool = True  # True until the first message is sent
         self._stderr_task: asyncio.Task | None = None  # Background stderr drain

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -199,6 +199,12 @@ class PiBackend(AgentBackend):
         self._fresh_session = True
         self._stderr_task: asyncio.Task[None] | None = None
         self._lock = asyncio.Lock()
+        # Serializes _kill (shutdown delegates to it). Teardown paths
+        # await between reading process state and using it; two
+        # teardowns interleaving across those awaits would let the
+        # second read attributes the first already nulled. Always
+        # acquired after _lock when both are held, never before it.
+        self._teardown_lock = asyncio.Lock()
         # Secret values scrubbed from trace text. Snapshotted from the
         # fully built subprocess environment at spawn so constructor-only
         # credentials (the per-principal webhook secret) are covered.
@@ -627,27 +633,28 @@ class PiBackend(AgentBackend):
             self._stderr_task = None
 
     async def _kill(self) -> None:
-        if self._proc is not None:
-            if self._effective_os_user is not None and self._pgid is not None:
-                await _kill_target_user_tree(
-                    target_user=self._effective_os_user,
-                    pgid=self._pgid,
-                    purpose="chat",
-                    backend=self.backend_name,
-                )
-                self._pgid = None
-            self.force_kill()
-            try:
-                await asyncio.wait_for(self._proc.wait(), timeout=5)
-            except TimeoutError:
-                pass
-        self._proc = None
-        self._transport = None
-        self._session_id = None
-        self._effective_os_user = None
-        self._pgid = None
-        self._session_started_at = None
-        self._supports_image_input = False
+        async with self._teardown_lock:
+            if self._proc is not None:
+                if self._effective_os_user is not None and self._pgid is not None:
+                    await _kill_target_user_tree(
+                        target_user=self._effective_os_user,
+                        pgid=self._pgid,
+                        purpose="chat",
+                        backend=self.backend_name,
+                    )
+                    self._pgid = None
+                self.force_kill()
+                try:
+                    await asyncio.wait_for(self._proc.wait(), timeout=5)
+                except TimeoutError:
+                    pass
+            self._proc = None
+            self._transport = None
+            self._session_id = None
+            self._effective_os_user = None
+            self._pgid = None
+            self._session_started_at = None
+            self._supports_image_input = False
 
     async def restart(self) -> None:
         await self._kill()

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -204,6 +204,9 @@ class PiBackend(AgentBackend):
         # teardowns interleaving across those awaits would let the
         # second read attributes the first already nulled. Always
         # acquired after _lock when both are held, never before it.
+        # The sync force_kill stays outside this gate: it cannot be
+        # interleaved mid-function, and nothing it nulls is re-read
+        # unguarded by a gated body afterwards.
         self._teardown_lock = asyncio.Lock()
         # Secret values scrubbed from trace text. Snapshotted from the
         # fully built subprocess environment at spawn so constructor-only

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1925,6 +1925,25 @@ class TestCrossUserKillEscalation:
         assert b._proc is None
         assert b._effective_os_user is None
 
+    @pytest.mark.asyncio
+    async def test_kill_racing_shutdown_is_serialized(self):
+        """Same interleaving with shutdown as the losing teardown."""
+        b, proc = self._wrapped_backend()
+
+        async def tree_kill(**kwargs):
+            await asyncio.sleep(0.01)
+
+        with (
+            patch("kai.acp._kill_target_user_tree", side_effect=tree_kill),
+            patch("kai.acp._kill_target_user_tree_sync"),
+        ):
+            await asyncio.gather(b._kill(), b.shutdown())
+
+        assert b._proc is None
+        # The losing shutdown found _proc already cleared under the
+        # gate, so it never sent its own SIGTERM.
+        proc.terminate.assert_not_called()
+
     def test_force_kill_escalates_sync_then_kills_wrapper(self):
         """force_kill (sync, the pool's last resort) runs the sync
         group-kill variant before SIGKILLing the wrapper, and nulls

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1902,6 +1902,29 @@ class TestCrossUserKillEscalation:
         b._stderr_task = None
         return b, proc
 
+    @pytest.mark.asyncio
+    async def test_concurrent_kills_are_serialized(self):
+        """
+        Two _kill tasks racing across the group-kill await: the loser
+        must wait at the teardown gate, re-check _proc under it, and
+        return instead of reading attributes the winner nulled.
+        """
+        b, _proc = self._wrapped_backend()
+
+        async def tree_kill(**kwargs):
+            # A real suspension, so the competing teardown interleaves
+            # here exactly the way concurrent teardown does in production.
+            await asyncio.sleep(0.01)
+
+        with (
+            patch("kai.acp._kill_target_user_tree", side_effect=tree_kill),
+            patch("kai.acp._kill_target_user_tree_sync"),
+        ):
+            await asyncio.gather(b._kill(), b._kill())
+
+        assert b._proc is None
+        assert b._effective_os_user is None
+
     def test_force_kill_escalates_sync_then_kills_wrapper(self):
         """force_kill (sync, the pool's last resort) runs the sync
         group-kill variant before SIGKILLing the wrapper, and nulls

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2571,6 +2571,61 @@ class TestKill:
         # The wrapper reap also uses the snapshot, not the nulled attribute.
         mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
 
+    @staticmethod
+    def _teardown_race_backend() -> ClaudeCodeBackend:
+        """Cross-user backend primed so a teardown reaches the escalation."""
+        claude = _make_claude(claude_user="daniel")
+        proc = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        claude._proc = proc
+        claude._pgid = 12345
+        claude._effective_claude_user = "daniel"
+        claude._inner_claude_pid = 99999
+        claude._stderr_task = None
+        return claude
+
+    @pytest.mark.asyncio
+    async def test_concurrent_kills_are_serialized(self):
+        """
+        Two _kill tasks racing across the escalation await: the loser
+        must wait at the teardown gate, re-check _proc under it, and
+        return instead of reading attributes the winner nulled.
+        """
+        claude = self._teardown_race_backend()
+
+        async def escalate(sig):
+            # A real suspension, so the competing teardown interleaves
+            # here exactly the way concurrent teardown does in production.
+            await asyncio.sleep(0.01)
+
+        with (
+            patch.object(claude, "_async_send_signal_for_close", side_effect=escalate),
+            patch.object(claude, "_async_sudo_kill", new=AsyncMock()),
+            patch("os.killpg"),
+        ):
+            await asyncio.gather(claude._kill(), claude._kill())
+
+        assert claude._proc is None
+        assert claude._effective_claude_user is None
+
+    @pytest.mark.asyncio
+    async def test_kill_racing_shutdown_is_serialized(self):
+        """Same interleaving with shutdown as the losing teardown."""
+        claude = self._teardown_race_backend()
+
+        async def escalate(sig):
+            await asyncio.sleep(0.01)
+
+        with (
+            patch.object(claude, "_async_send_signal_for_close", side_effect=escalate),
+            patch.object(claude, "_async_sudo_kill", new=AsyncMock()),
+            patch.object(claude, "_save_prompt", new=AsyncMock()),
+            patch("os.killpg"),
+        ):
+            await asyncio.gather(claude._kill(), claude.shutdown())
+
+        assert claude._proc is None
+
     @pytest.mark.asyncio
     async def test_kill_skips_sudo_when_inner_pid_unknown(self):
         """

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -2321,6 +2321,58 @@ class TestCodexCrossUserTeardown:
         # The wrapper reap also uses the snapshot, not the nulled attribute.
         mock_killpg.assert_called_once_with(12345, signal.SIGKILL)
 
+    @staticmethod
+    def _teardown_race_backend() -> CodexBackend:
+        """Cross-user backend primed so a teardown reaches the escalation."""
+        c = _make_codex(codex_user="ci-fake-user")
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.wait = AsyncMock(return_value=0)
+        c._proc = proc
+        c._pgid = 12345
+        c._effective_codex_user = "ci-fake-user"
+        c._inner_codex_pids = [67890]
+        c._stderr_task = None
+        return c
+
+    @pytest.mark.asyncio
+    async def test_concurrent_kills_are_serialized(self):
+        """
+        Two _kill tasks racing across the escalation await: the loser
+        must wait at the teardown gate, re-check _proc under it, and
+        return instead of reading attributes the winner nulled.
+        """
+        c = self._teardown_race_backend()
+
+        async def escalate(sig):
+            # A real suspension, so the competing teardown interleaves
+            # here exactly the way concurrent teardown does in production.
+            await asyncio.sleep(0.01)
+
+        with patch.object(c, "_async_send_signal_for_close", side_effect=escalate):
+            await asyncio.gather(c._kill(), c._kill())
+
+        assert c._proc is None
+        assert c._effective_codex_user is None
+
+    @pytest.mark.asyncio
+    async def test_kill_racing_shutdown_is_serialized(self):
+        """Same interleaving with shutdown as the losing teardown."""
+        c = self._teardown_race_backend()
+        escalations = []
+
+        async def escalate(sig):
+            escalations.append(int(sig))
+            await asyncio.sleep(0.01)
+
+        with patch.object(c, "_async_send_signal_for_close", side_effect=escalate):
+            await asyncio.gather(c._kill(), c.shutdown())
+
+        assert c._proc is None
+        # The losing shutdown found _proc already cleared under the
+        # gate, so only the winning _kill signalled anything.
+        assert escalations == [int(signal.SIGKILL)]
+
 
 class TestSudoKillEsrchDemotion:
     """

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -441,6 +442,35 @@ class TestPiLifecycle:
         await backend.shutdown()
 
         kill.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_kill_racing_shutdown_is_serialized(self, tmp_path, monkeypatch):
+        """
+        Two teardowns racing across the escalation await: the loser
+        must wait at the teardown gate, re-check _proc under it, and
+        return instead of reading attributes the winner nulled.
+        """
+        backend = make_backend(tmp_path)
+        proc = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+        proc.kill = MagicMock()
+        backend._proc = proc
+        backend._pgid = 4242
+        backend._effective_os_user = "other-user"
+        backend._stderr_task = None
+
+        async def tree_kill(**kwargs):
+            # A real suspension, so the competing teardown interleaves
+            # here exactly the way concurrent teardown does in production.
+            await asyncio.sleep(0.01)
+
+        monkeypatch.setattr("kai.pi._kill_target_user_tree", tree_kill)
+        monkeypatch.setattr("kai.pi._kill_target_user_tree_sync", MagicMock())
+
+        await asyncio.gather(backend._kill(), backend.shutdown())
+
+        assert backend._proc is None
+        assert backend._effective_os_user is None
 
 
 class TestTraceEmission:


### PR DESCRIPTION
Closes #997.

Every async teardown path awaits between reading process state and using it, so two teardowns interleaving across those awaits let the second read attributes the first already nulled. The concrete open crash was `_kill` resuming from the escalation await into `self._proc.wait()` after a concurrent teardown set `_proc` to None (an AttributeError past the `except TimeoutError`). Per-attribute snapshots harden one read at a time and each new teardown-adjacent await reopens the question; this lands the durable shape the issue asked for.

## The gate

All four backends gain a per-instance `_teardown_lock` held across `_kill` and `shutdown`. The loser of a race waits at the gate, re-checks `_proc` under it, and returns without re-killing; the winner's sequence, including the escalation-before-killpg ordering, is untouched inside the gate.

Shape notes, per backend:

- **codex, acp**: `_kill` and `shutdown` have independent bodies; both are gated.
- **claude**: `shutdown` holds the send lock through save-plus-terminate, and the send-path error handlers call `_kill` while holding that lock, so the gate nests inside it (`async with self._lock, self._teardown_lock`). Lock ordering is uniform everywhere: the teardown gate is only ever acquired after the send lock when both are held, so no ordering inversion exists. The pre-existing `saved_pgid`/`saved_user` snapshots in claude's `_kill` are left in place; the gate subsumes their race but they remain correct.
- **pi**: `shutdown` delegates to `_kill`, so only `_kill` is gated; gating both would self-deadlock on the non-reentrant lock.
- **`force_kill`** (sync) is unchanged on every backend and stays outside the gate, safe in both directions: synchronous code cannot interleave mid-function on a single-threaded event loop, and in the reverse direction a force_kill firing into a gated teardown suspended at an await nulls nothing that a gated body re-reads unguarded (`_proc` is never touched; `_stderr_task` and pgid re-reads are guarded or snapshotted).

Most of the diff bulk is re-indentation of the gated bodies; the one gate-adjacent behaviour change is intended, namely that a second teardown now waits for the first instead of racing it.

## Tests

One concurrency test per backend, plus kill-versus-shutdown variants for codex, claude, and acp (seven total): each drives two concurrent teardowns with `asyncio.gather` across an escalation stub that genuinely suspends, asserting clean state and, for the codex variant, that only the winning teardown signalled. All six were run against the ungated code and fail there.

Full suite passes (5928 tests), ruff and pyright strict clean.
