### PR TITLE
feat: extend the total-turn deadline to every backend

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -730,6 +730,11 @@ class AcpBackend(AgentBackend):
         # of daemon-read file contents; the user-isolated subprocess
         # can read its own files directly.
         defer_user_file_reads: bool = False,
+        # Total bound on one turn, in seconds. The stream loop's
+        # per-read and idle guards reset whenever output arrives; this
+        # backstop never does. Validated positive at config load (see
+        # Config.turn_deadline_seconds).
+        turn_deadline_seconds: int = 3600,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -741,6 +746,7 @@ class AcpBackend(AgentBackend):
         self.memory_enabled = memory_enabled
         self.os_user = os_user
         self.defer_user_file_reads = defer_user_file_reads
+        self.turn_deadline_seconds = turn_deadline_seconds
         # Session-age recycling limit (ABC surface; checked by the
         # inherited _should_recycle at the top of _send_locked).
         self.max_session_hours = max_session_hours
@@ -1515,9 +1521,34 @@ class AcpBackend(AgentBackend):
             )
         last_activity = time.monotonic()
         max_idle_seconds = self.timeout_seconds * 5
+        turn_started = time.monotonic()
 
         try:
             while True:
+                # Check the total-turn deadline before each readline.
+                # Unlike the idle guard below, this never resets on
+                # output, so a turn that trickles retry notices without
+                # completing still ends here.
+                elapsed = time.monotonic() - turn_started
+                if elapsed > self.turn_deadline_seconds:
+                    log.error(
+                        "%s turn deadline exceeded (%.0fs elapsed, limit %ds)",
+                        self.backend_label,
+                        elapsed,
+                        self.turn_deadline_seconds,
+                    )
+                    await self._kill()
+                    yield StreamEvent(
+                        text_so_far=accumulated,
+                        done=True,
+                        response=AgentResponse(
+                            success=False,
+                            text=accumulated,
+                            error=f"{self.backend_label} turn exceeded its deadline",
+                        ),
+                    )
+                    return
+
                 # Check idle timeout before each readline.
                 idle = time.monotonic() - last_activity
                 if idle > max_idle_seconds:

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -141,6 +141,11 @@ class ClaudeCodeBackend(AgentBackend):
         # of daemon-read file contents; the user-isolated subprocess
         # can read its own files directly.
         defer_user_file_reads: bool = False,
+        # Total bound on one turn, in seconds. The stream loop's
+        # per-read and idle guards reset whenever output arrives; this
+        # backstop never does. Validated positive at config load (see
+        # Config.turn_deadline_seconds).
+        turn_deadline_seconds: int = 3600,
     ):
         # ABC-required attributes (pool.py reads/writes these)
         self.model = model
@@ -157,6 +162,7 @@ class ClaudeCodeBackend(AgentBackend):
         # a default after a /workspace switch (see workspace_config block
         # below for the pattern that DOES need a default shadow).
         self.claude_effort_level = claude_effort_level
+        self.turn_deadline_seconds = turn_deadline_seconds
         self.provider = "anthropic"  # Claude CLI always uses Anthropic
         # Session-age recycling limit (ABC surface; checked by the
         # inherited _should_recycle at the top of _send_locked).
@@ -887,8 +893,32 @@ class ClaudeCodeBackend(AgentBackend):
         # this is a secondary safety net measured across the whole interaction.
         last_activity = time.monotonic()
         max_idle_seconds = self.timeout_seconds * 5  # 10 min of silence at default 120s
+        turn_started = time.monotonic()
         try:
             while True:
+                # Check the total-turn deadline before each readline.
+                # Unlike the idle guard below, this never resets on
+                # output, so a turn that trickles retry notices without
+                # completing still ends here.
+                elapsed = time.monotonic() - turn_started
+                if elapsed > self.turn_deadline_seconds:
+                    log.error(
+                        "Claude turn deadline exceeded (%.0fs elapsed, limit %ds)",
+                        elapsed,
+                        self.turn_deadline_seconds,
+                    )
+                    await self._kill()
+                    yield StreamEvent(
+                        text_so_far=accumulated_text,
+                        done=True,
+                        response=AgentResponse(
+                            success=False,
+                            text=accumulated_text,
+                            error="Claude turn exceeded its deadline",
+                        ),
+                    )
+                    return
+
                 # Check idle timeout before each readline
                 idle_seconds = time.monotonic() - last_activity
                 if idle_seconds > max_idle_seconds:

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1513,12 +1513,18 @@ class Config:
     # Only consulted when the user's effective backend is codex.
     codex_effort_level: str = ""
 
-    # Total bound on one codex turn, in seconds. The stream loop's
-    # per-read and idle guards both reset whenever output arrives, so
-    # a turn that trickles output without completing (a quota-starved
-    # retry spin) would otherwise run forever; this backstop ends it.
-    # Generous by default so legitimate long agentic turns never hit
-    # it. Must be a positive integer.
+    # Total bound on one turn, in seconds, for every backend. The
+    # stream loops' per-read and idle guards all reset whenever output
+    # arrives, so a turn that trickles output without completing (a
+    # quota-starved retry spin) would otherwise run forever; this
+    # backstop ends it. Generous by default so legitimate long agentic
+    # turns never hit it. Must be a positive integer.
+    turn_deadline_seconds: int = 3600
+
+    # Codex-specific override of turn_deadline_seconds, set-or-absent:
+    # when CODEX_TURN_DEADLINE_SECONDS is unset this field carries the
+    # shared value, so the codex lane never needs to know which one
+    # the operator configured.
     codex_turn_deadline_seconds: int = 3600
 
     # Database - uses DATA_DIR so the db lands in the writable data directory
@@ -3252,13 +3258,27 @@ def load_config() -> Config:
             f"CODEX_EFFORT_LEVEL must be one of {list(CODEX_EFFORT_LEVELS)} or empty, got {codex_effort_level!r}"
         )
 
-    raw_turn_deadline = os.environ.get("CODEX_TURN_DEADLINE_SECONDS", "3600").strip()
+    raw_turn_deadline = os.environ.get("TURN_DEADLINE_SECONDS", "3600").strip()
     try:
-        codex_turn_deadline_seconds = int(raw_turn_deadline)
-        if codex_turn_deadline_seconds <= 0:
+        turn_deadline_seconds = int(raw_turn_deadline)
+        if turn_deadline_seconds <= 0:
             raise ValueError
     except ValueError:
-        raise SystemExit("CODEX_TURN_DEADLINE_SECONDS must be a positive integer") from None
+        raise SystemExit("TURN_DEADLINE_SECONDS must be a positive integer") from None
+
+    # Set-or-absent: empty or unset means the codex lane follows the
+    # shared deadline; a value is a codex-only override that wins over
+    # the shared var.
+    raw_codex_deadline = os.environ.get("CODEX_TURN_DEADLINE_SECONDS", "").strip()
+    if raw_codex_deadline:
+        try:
+            codex_turn_deadline_seconds = int(raw_codex_deadline)
+            if codex_turn_deadline_seconds <= 0:
+                raise ValueError
+        except ValueError:
+            raise SystemExit("CODEX_TURN_DEADLINE_SECONDS must be a positive integer") from None
+    else:
+        codex_turn_deadline_seconds = turn_deadline_seconds
 
     # PR review agent config. The global `pr_review` toggle now lives
     # per-user in users.yaml; PR_REVIEW_COOLDOWN / PR_REVIEW_TIMEOUT_S
@@ -3778,6 +3798,7 @@ def load_config() -> Config:
         claude_effort_level=claude_effort_level,
         codex_auth_mode=codex_auth_mode,
         codex_effort_level=codex_effort_level,
+        turn_deadline_seconds=turn_deadline_seconds,
         codex_turn_deadline_seconds=codex_turn_deadline_seconds,
         webhook_port=webhook_port,
         workshop_lan_host=workshop_lan_host,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2038,6 +2038,19 @@ def _cmd_config() -> None:
             break
         print("  Must be a positive integer.")
 
+    # Total bound on one turn for every backend: the backstop that
+    # ends a turn trickling output without completing, since the idle
+    # guards reset on any output. Generous default so legitimate long
+    # agentic turns never hit it.
+    while True:
+        turn_deadline = _prompt(
+            "Agent turn deadline (seconds)",
+            existing_env.get("TURN_DEADLINE_SECONDS", "3600"),
+        )
+        if _validate_positive_int(turn_deadline):
+            break
+        print("  Must be a positive integer.")
+
     # Session lifecycle tunables. Both govern the subprocess pool for
     # every backend (recycle-by-age and idle eviction), hence the
     # AGENT_ prefix; the CLAUDE_-prefixed forms are legacy aliases
@@ -2124,7 +2137,7 @@ def _cmd_config() -> None:
     # enforces at load so install.conf cannot carry a value that fails
     # at service startup, while accepting "" as the no-override signal.
     codex_effort_level = ""
-    codex_turn_deadline = "3600"
+    codex_turn_deadline = ""
     if agent_backend == "codex":
         codex_effort_level = _prompt_optional_choice(
             "Codex reasoning effort",
@@ -2134,18 +2147,18 @@ def _cmd_config() -> None:
         )
         print()
 
-        # Total bound on one codex turn: the backstop that ends a turn
-        # trickling output without completing, since the idle guard
-        # resets on any output. Generous default so legitimate long
-        # agentic turns never hit it.
+        # Codex-only override of the shared turn deadline, set-or-
+        # absent like the effort prompt above: empty means the codex
+        # lane follows TURN_DEADLINE_SECONDS. A previously persisted
+        # override prefills and survives a resave.
         while True:
             codex_turn_deadline = _prompt(
-                "Codex turn deadline (seconds)",
-                existing_env.get("CODEX_TURN_DEADLINE_SECONDS", "3600"),
+                "Codex turn deadline override (seconds, empty = shared)",
+                existing_env.get("CODEX_TURN_DEADLINE_SECONDS", ""),
             )
-            if _validate_positive_int(codex_turn_deadline):
+            if not codex_turn_deadline or _validate_positive_int(codex_turn_deadline):
                 break
-            print("  Must be a positive integer.")
+            print("  Must be a positive integer or empty.")
         print()
 
     # -- Webhook server --
@@ -2633,9 +2646,14 @@ def _cmd_config() -> None:
     if codex_effort_level:
         env["CODEX_EFFORT_LEVEL"] = codex_effort_level
 
-    # CODEX_TURN_DEADLINE_SECONDS: delta-from-defaults; only a
-    # non-default value is operator intent worth persisting.
-    if codex_turn_deadline != "3600":
+    # TURN_DEADLINE_SECONDS: delta-from-defaults; only a non-default
+    # value is operator intent worth persisting.
+    if turn_deadline != "3600":
+        env["TURN_DEADLINE_SECONDS"] = turn_deadline
+
+    # CODEX_TURN_DEADLINE_SECONDS: set-or-absent; any value is a
+    # codex-only override of the shared deadline.
+    if codex_turn_deadline:
         env["CODEX_TURN_DEADLINE_SECONDS"] = codex_turn_deadline
 
     # Conditionally add optional values

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -35,6 +35,7 @@ from kai.pi_rpc import (
     PI_RPC_STREAM_LIMIT,
     PiRpcError,
     PiRpcProtocolError,
+    PiRpcTimeoutError,
     PiRpcTransport,
     pi_rpc_extension_error,
     pi_rpc_is_settled,
@@ -164,6 +165,11 @@ class PiBackend(AgentBackend):
         os_user: str | None = None,
         max_session_hours: float = 0,
         defer_user_file_reads: bool = False,
+        # Total bound on one turn, in seconds. The per-receive timeout
+        # resets whenever any RPC record arrives; this backstop never
+        # does. Validated positive at config load (see
+        # Config.turn_deadline_seconds).
+        turn_deadline_seconds: int = 3600,
     ) -> None:
         self.model = model
         self.workspace = workspace
@@ -175,6 +181,7 @@ class PiBackend(AgentBackend):
         self.os_user = os_user
         self.max_session_hours = max_session_hours
         self.defer_user_file_reads = defer_user_file_reads
+        self.turn_deadline_seconds = turn_deadline_seconds
 
         self._api_context = ApiContext(
             webhook_port=webhook_port,
@@ -481,6 +488,20 @@ class PiBackend(AgentBackend):
         terminal_error: str | None = None
 
         while True:
+            # Check the total-turn deadline before each receive. The
+            # per-receive timeout resets whenever any record arrives,
+            # so a turn that trickles retry notices without completing
+            # ends here instead; the raise rides the same
+            # PiRpcError-to-failed-final-event path as a receive
+            # timeout, killing the subprocess in the send handler.
+            elapsed = time.monotonic() - started_at
+            if elapsed > self.turn_deadline_seconds:
+                log.error(
+                    "Pi turn deadline exceeded (%.0fs elapsed, limit %ds)",
+                    elapsed,
+                    self.turn_deadline_seconds,
+                )
+                raise PiRpcTimeoutError("Pi turn exceeded its deadline")
             message = await self._transport.receive(timeout_seconds=self.timeout_seconds)
             message_type = message.get("type")
 

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -491,6 +491,7 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
                 os_user=os_user,
                 max_session_hours=self._config.agent_max_session_hours,
+                turn_deadline_seconds=self._config.turn_deadline_seconds,
                 defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )
 
@@ -513,6 +514,7 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
                 os_user=os_user,
                 max_session_hours=self._config.agent_max_session_hours,
+                turn_deadline_seconds=self._config.turn_deadline_seconds,
                 defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )
 
@@ -557,6 +559,7 @@ class SubprocessPool:
                 memory_enabled=self._config.memory_enabled,
                 os_user=os_user,
                 max_session_hours=self._config.agent_max_session_hours,
+                turn_deadline_seconds=self._config.turn_deadline_seconds,
                 defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )
 
@@ -574,6 +577,7 @@ class SubprocessPool:
                 workspace_config=ws_config,
                 autocompact_pct=self._config.claude_autocompact_pct,
                 claude_effort_level=self._config.claude_effort_level,
+                turn_deadline_seconds=self._config.turn_deadline_seconds,
                 memory_enabled=self._config.memory_enabled,
                 defer_user_file_reads=getattr(self._config, "protected_install", False) is True,
             )

--- a/templates/.env
+++ b/templates/.env
@@ -61,12 +61,17 @@ TELEGRAM_BOT_TOKEN=your-token-from-botfather
 # Truly global; applies to every chat's inner Claude subprocess.
 #CLAUDE_EFFORT_LEVEL=high
 
-# Total bound on one codex turn, in seconds (positive integer).
-# The codex stream loop's idle guard resets on any output, so a turn
-# that trickles output without completing (for example a provider
+# Total bound on one turn for every backend, in seconds (positive
+# integer). The stream loops' idle guards reset on any output, so a
+# turn that trickles output without completing (for example a provider
 # quota-exhaustion retry spin) would otherwise run forever; this is
 # the backstop that ends it. Generous default so legitimate long
 # agentic turns never hit it.
+#TURN_DEADLINE_SECONDS=3600
+
+# Codex-only override of TURN_DEADLINE_SECONDS (positive integer).
+# Unset or empty means the codex lane follows the shared deadline;
+# a value wins over it for codex only.
 #CODEX_TURN_DEADLINE_SECONDS=3600
 
 # Maximum session age in hours before recycling (0 = no limit).

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -570,6 +570,55 @@ class TestSendStream:
         assert text_events[0].text_so_far == "ok"
 
     @pytest.mark.asyncio
+    async def test_turn_deadline_ends_a_turn_that_keeps_trickling_output(self):
+        """
+        The idle guard resets on any output, so a turn that trickles
+        text chunks without ever completing is bounded only by the
+        turn deadline; when it fires, the turn ends with a failed
+        response preserving the accumulated text. One check in the
+        ACP base covers both the goose and opencode lanes.
+        """
+        b = _make_fake(turn_deadline_seconds=1)
+        proc = _make_mock_proc([])
+
+        async def trickle() -> bytes:
+            # Frequent-enough output that the idle guard never fires.
+            await asyncio.sleep(0.4)
+            return _text_chunk("still going")
+
+        proc.stdout.readline = trickle
+        b._proc = proc
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        events = await _collect_events(b, prompt="hi")
+
+        assert events[-1].done is True
+        assert events[-1].response.success is False
+        assert events[-1].response.error == f"{b.backend_label} turn exceeded its deadline"
+        assert "still going" in events[-1].text_so_far
+
+    @pytest.mark.asyncio
+    async def test_turn_completing_within_deadline_is_untouched(self):
+        """A normal turn under the deadline ends by completion, not the backstop."""
+        b = _make_fake(turn_deadline_seconds=5)
+        b._proc = _make_mock_proc(
+            [
+                _text_chunk("ok"),
+                _completion_result(prompt_id=3),
+            ]
+        )
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        events = await _collect_events(b, prompt="hi")
+
+        assert events[-1].done is True
+        assert events[-1].response.success is True
+
+    @pytest.mark.asyncio
     async def test_jsonrpc_error_yields_failed_response(self):
         """JSON-RPC error response yields done StreamEvent with the error message."""
         b = _make_fake()

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -599,6 +599,20 @@ class TestSendStream:
         assert events[-1].response.error == f"{b.backend_label} turn exceeded its deadline"
         assert "still going" in events[-1].text_so_far
 
+    def test_concrete_lanes_inherit_the_deadline_carrying_loop(self):
+        """
+        The deadline tests above run against the base class, which is
+        only sufficient while goose and opencode actually use its read
+        loop. A lane that grew its own send path would silently drop
+        the deadline; this pin turns that into a loud failure.
+        """
+        from kai.goose import GooseBackend
+        from kai.opencode import OpenCodeBackend
+
+        for lane in (GooseBackend, OpenCodeBackend):
+            assert lane.send is AcpBackend.send, lane
+            assert lane._send_locked is AcpBackend._send_locked, lane
+
     @pytest.mark.asyncio
     async def test_turn_completing_within_deadline_is_untouched(self):
         """A normal turn under the deadline ends by completion, not the backstop."""

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1218,6 +1218,53 @@ class TestSendLockedBasic:
         monkeypatch.setattr(ClaudeCodeBackend, "_kill", AsyncMock())
 
     @pytest.mark.asyncio
+    async def test_turn_deadline_ends_a_turn_that_keeps_trickling_output(self):
+        """
+        The idle guard resets on any output, so a turn that trickles
+        assistant events without ever completing is bounded only by
+        the turn deadline; when it fires, the turn ends with a failed
+        response preserving the accumulated text.
+        """
+        claude = _make_claude(turn_deadline_seconds=1)
+        proc = _make_mock_proc([])
+
+        async def trickle():
+            # Frequent-enough output that the idle guard never fires.
+            await asyncio.sleep(0.4)
+            return _assistant_event("still going")
+
+        proc.stdout.readline = AsyncMock(side_effect=trickle)
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        assert events[-1].done is True
+        assert events[-1].response.success is False
+        assert events[-1].response.error == "Claude turn exceeded its deadline"
+        assert "still going" in events[-1].text_so_far
+
+    @pytest.mark.asyncio
+    async def test_turn_completing_within_deadline_is_untouched(self):
+        """A normal turn under the deadline ends by completion, not the backstop."""
+        claude = _make_claude(turn_deadline_seconds=5)
+        proc = _make_mock_proc(
+            [
+                _system_event(),
+                _assistant_event("Hello"),
+                _result_event("Hello"),
+                b"",
+            ]
+        )
+        claude._proc = proc
+        claude._fresh_session = False
+
+        events = await _collect_events(claude)
+
+        assert events[-1].done is True
+        assert events[-1].response.success is True
+
+    @pytest.mark.asyncio
     async def test_writes_json_to_stdin(self):
         """Sends a JSON-formatted message to the process stdin."""
         proc = _make_mock_proc([_system_event(), _result_event(), b""])
@@ -1594,25 +1641,30 @@ class TestSendLockedErrors:
         """
         claude = _make_claude(timeout_seconds=1)  # idle limit = 5s
 
-        # Control time progression in kai.claude without affecting asyncio.
-        # The streaming loop calls time.monotonic() in a fixed pattern:
-        #   1. Init: last_activity = time.monotonic()
-        #   2. Idle check (iter 1): time.monotonic() - last_activity
-        #   3. Reset after readline 1: last_activity = time.monotonic()
-        #   4. Idle check (iter 2): time.monotonic() - last_activity
-        #   5. Reset after readline 2: last_activity = time.monotonic()
-        #   6. Idle check (iter 3): time.monotonic() - last_activity <- jump here
-        # Calls 1-5 return small values; call 6+ returns 100.0 so the
-        # idle check sees (100.0 - 0.5) > 5s and fires.
+        # Control time progression in kai.claude without affecting
+        # asyncio. Keyed off readline progress rather than a scripted
+        # call count so the pattern survives extra monotonic() calls in
+        # the loop (the turn-deadline check is one): while the first
+        # two reads are being produced the clock creeps in tiny steps,
+        # and once both are out it jumps to 100.0. The next idle check
+        # then sees a gap far past the 5s limit and fires, while the
+        # turn-deadline check stays quiet (100.0 elapsed is far under
+        # the 3600s default).
         mono_call = [0]
+        readline_count = [0]
+        post_read_calls = [0]
 
         def fake_monotonic():
+            if readline_count[0] >= 2:
+                post_read_calls[0] += 1
+                # The first monotonic() call after the second read is
+                # the last_activity reset; it must stay small or the
+                # idle gap this test manufactures would be erased
+                # before the next idle check could see it.
+                if post_read_calls[0] > 1:
+                    return 100.0
             mono_call[0] += 1
-            if mono_call[0] <= 5:
-                return mono_call[0] * 0.1
-            return 100.0
-
-        readline_count = [0]
+            return mono_call[0] * 0.1
 
         async def readline_with_output():
             readline_count[0] += 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,7 @@ _CONFIG_ENV_VARS = [
     "CLAUDE_EFFORT_LEVEL",
     "CODEX_EFFORT_LEVEL",
     "CODEX_TURN_DEADLINE_SECONDS",
+    "TURN_DEADLINE_SECONDS",
     "TOTP_SESSION_MINUTES",
     "TOTP_CHALLENGE_SECONDS",
     "TOTP_LOCKOUT_ATTEMPTS",
@@ -1589,26 +1590,64 @@ class TestCodexEffortLevel:
 # ── CODEX_TURN_DEADLINE_SECONDS config ───────────────────────────────
 
 
-class TestCodexTurnDeadlineSeconds:
-    """Coverage for the CODEX_TURN_DEADLINE_SECONDS env var: the
-    total-turn backstop for the codex stream loop, whose idle guard
-    resets on any output. Positive integer, generous default."""
+class TestTurnDeadlineSeconds:
+    """Coverage for the shared TURN_DEADLINE_SECONDS env var and its
+    codex-only override CODEX_TURN_DEADLINE_SECONDS: the total-turn
+    backstop for every stream loop, whose idle guards reset on any
+    output. Positive integers; the override is set-or-absent."""
 
-    def test_default_when_unset(self, monkeypatch):
+    def test_defaults_when_neither_is_set(self, monkeypatch):
         _set_required(monkeypatch)
         config = load_config()
+        assert config.turn_deadline_seconds == 3600
         assert config.codex_turn_deadline_seconds == 3600
 
-    def test_valid_value_parses(self, monkeypatch):
+    def test_shared_value_governs_every_lane(self, monkeypatch):
+        # The shared var alone must reach the codex field too; the
+        # codex lane never consults the shared field directly.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("TURN_DEADLINE_SECONDS", "5400")
+        config = load_config()
+        assert config.turn_deadline_seconds == 5400
+        assert config.codex_turn_deadline_seconds == 5400
+
+    def test_codex_override_wins_for_codex_only(self, monkeypatch):
+        _set_required(monkeypatch)
+        monkeypatch.setenv("TURN_DEADLINE_SECONDS", "5400")
+        monkeypatch.setenv("CODEX_TURN_DEADLINE_SECONDS", "7200")
+        config = load_config()
+        assert config.turn_deadline_seconds == 5400
+        assert config.codex_turn_deadline_seconds == 7200
+
+    def test_codex_override_alone_keeps_its_meaning(self, monkeypatch):
+        # A pre-existing install.conf carrying only the codex var must
+        # keep binding codex at that value, with every other lane on
+        # the default.
         _set_required(monkeypatch)
         monkeypatch.setenv("CODEX_TURN_DEADLINE_SECONDS", "7200")
         config = load_config()
+        assert config.turn_deadline_seconds == 3600
         assert config.codex_turn_deadline_seconds == 7200
 
+    def test_empty_codex_override_follows_shared(self, monkeypatch):
+        # Empty is unset, not an error: the set-or-absent contract.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("TURN_DEADLINE_SECONDS", "5400")
+        monkeypatch.setenv("CODEX_TURN_DEADLINE_SECONDS", "  ")
+        config = load_config()
+        assert config.codex_turn_deadline_seconds == 5400
+
     @pytest.mark.parametrize("value", ["0", "-5", "not-a-number", "3.5"])
-    def test_non_positive_or_non_integer_raises(self, monkeypatch, value):
+    def test_non_positive_or_non_integer_shared_raises(self, monkeypatch, value):
         # A zero or negative deadline would disable the backstop
         # silently; fail fast at config load instead.
+        _set_required(monkeypatch)
+        monkeypatch.setenv("TURN_DEADLINE_SECONDS", value)
+        with pytest.raises(SystemExit, match="TURN_DEADLINE_SECONDS"):
+            load_config()
+
+    @pytest.mark.parametrize("value", ["0", "-5", "not-a-number", "3.5"])
+    def test_non_positive_or_non_integer_override_raises(self, monkeypatch, value):
         _set_required(monkeypatch)
         monkeypatch.setenv("CODEX_TURN_DEADLINE_SECONDS", value)
         with pytest.raises(SystemExit, match="CODEX_TURN_DEADLINE_SECONDS"):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1484,6 +1484,7 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "3600",  # agent turn deadline (default)
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "80",  # autocompact pct
@@ -1584,6 +1585,7 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "3600",  # agent turn deadline (default)
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "80",  # autocompact pct
@@ -1667,6 +1669,7 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "3600",  # agent turn deadline (default)
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "80",  # autocompact pct
@@ -1737,6 +1740,7 @@ class TestCmdConfig:
                 "sonnet",
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",
+                "3600",  # agent turn deadline (default)
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "10.0",
@@ -1802,6 +1806,7 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "3600",  # agent turn deadline (default)
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "8080",  # port
@@ -1937,6 +1942,7 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "3600",  # agent turn deadline (default)
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "8080",  # port
@@ -2169,6 +2175,7 @@ class TestCmdConfig:
             "sonnet",  # model
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # timeout
+            "3600",  # agent turn deadline (default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
             *claude_only_pre_webhook,  # autocompact + effort (claude only)
@@ -2731,6 +2738,7 @@ class TestCmdConfig:
                 "sonnet",  # model
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # timeout
+                "3600",  # agent turn deadline (default)
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 "8080",  # port
@@ -3071,11 +3079,12 @@ class TestCmdConfig:
                 # model: handled by _prompt_default_model mock
                 "false",  # customize per-role models (decline; use registry defaults)
                 "120",  # agent timeout
+                "3600",  # agent turn deadline (default)
                 "0",  # max session age hours (0 = no limit)
                 "1800",  # idle eviction timeout seconds
                 # autocompact + claude effort skipped on non-claude backend
                 "",  # codex reasoning effort (empty = codex default)
-                "3600",  # codex turn deadline seconds (default)
+                "",  # codex turn deadline override (empty = shared)
                 "8080",  # webhook port
                 "",  # Workshop LAN address (disabled)
                 "test-secret",  # webhook secret
@@ -3599,6 +3608,7 @@ class TestCmdConfigDefaultModelDispatch:
             # no DEFAULT_MODEL prompt; agent default comes from MODEL_REGISTRY
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
+            "3600",  # agent turn deadline (default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
             "80",  # autocompact pct
@@ -3642,11 +3652,12 @@ class TestCmdConfigDefaultModelDispatch:
             # no DEFAULT_MODEL prompt; agent default comes from MODEL_REGISTRY
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
+            "3600",  # agent turn deadline (default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
             # No autocompact_pct / claude effort prompts (claude-only)
             "",  # codex reasoning effort (empty = codex default)
-            "3600",  # codex turn deadline seconds (default)
+            "",  # codex turn deadline override (empty = shared)
             "8080",  # webhook port
             "",  # Workshop LAN address (disabled)
             "test-secret",  # webhook secret
@@ -3678,6 +3689,7 @@ class TestCmdConfigDefaultModelDispatch:
             # no DEFAULT_MODEL prompt; agent default comes from MODEL_REGISTRY
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout (global default)
+            "3600",  # agent turn deadline (default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
             # autocompact_pct / effort prompts are backend-gated
@@ -3748,10 +3760,10 @@ class TestCmdConfigDefaultModelDispatch:
         _, env = self._run(monkeypatch, tmp_path, base, helper_return="gpt-5.5")
         assert env.get("CODEX_EFFORT_LEVEL") == "high"
 
-    def test_codex_turn_deadline_default_omits_env_key(self, tmp_path, monkeypatch):
-        """Accepting the 3600 default keeps CODEX_TURN_DEADLINE_SECONDS
-        out of install.conf: delta-from-defaults, so only operator
-        intent is persisted."""
+    def test_codex_turn_deadline_empty_omits_env_key(self, tmp_path, monkeypatch):
+        """Accepting the empty default keeps CODEX_TURN_DEADLINE_SECONDS
+        out of install.conf: set-or-absent, absence means the codex
+        lane follows the shared deadline."""
         self._setup(monkeypatch, tmp_path)
         _, env = self._run(
             monkeypatch,
@@ -3761,16 +3773,40 @@ class TestCmdConfigDefaultModelDispatch:
         )
         assert "CODEX_TURN_DEADLINE_SECONDS" not in env
 
-    def test_codex_turn_deadline_non_default_writes_env_key(self, tmp_path, monkeypatch):
-        """A non-default deadline round-trips from the wizard prompt
-        into install.conf."""
+    def test_codex_turn_deadline_override_writes_env_key(self, tmp_path, monkeypatch):
+        """A codex override round-trips from the wizard prompt into
+        install.conf."""
         self._setup(monkeypatch, tmp_path)
         base = list(self._inputs_for_codex_subscription())
         idx = base.index("8080")
-        assert base[idx - 1] == "3600"
+        assert base[idx - 1] == ""
         base[idx - 1] = "7200"
         _, env = self._run(monkeypatch, tmp_path, base, helper_return="gpt-5.5")
         assert env.get("CODEX_TURN_DEADLINE_SECONDS") == "7200"
+
+    def test_shared_turn_deadline_default_omits_env_key(self, tmp_path, monkeypatch):
+        """Accepting the 3600 default keeps TURN_DEADLINE_SECONDS out
+        of install.conf: delta-from-defaults, so only operator intent
+        is persisted."""
+        self._setup(monkeypatch, tmp_path)
+        _, env = self._run(
+            monkeypatch,
+            tmp_path,
+            self._inputs_for_codex_subscription(),
+            helper_return="gpt-5.5",
+        )
+        assert "TURN_DEADLINE_SECONDS" not in env
+
+    def test_shared_turn_deadline_non_default_writes_env_key(self, tmp_path, monkeypatch):
+        """A non-default shared deadline round-trips from the wizard
+        prompt into install.conf."""
+        self._setup(monkeypatch, tmp_path)
+        base = list(self._inputs_for_codex_subscription())
+        idx = base.index("3600")
+        assert base[idx - 1] == "120"
+        base[idx] = "5400"
+        _, env = self._run(monkeypatch, tmp_path, base, helper_return="gpt-5.5")
+        assert env.get("TURN_DEADLINE_SECONDS") == "5400"
 
     def test_install_conf_legacy_AGENT_BACKEND_migrates_on_resave(self, tmp_path, monkeypatch):
         """Re-running the wizard against a prior install.conf that
@@ -9618,6 +9654,7 @@ class TestCmdConfigCanonicalUsersYaml:
             "sonnet",
             "false",  # customize per-role models (decline)
             "120",
+            "3600",  # agent turn deadline (default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
             "10.0",
@@ -10085,6 +10122,7 @@ class TestCmdConfigSingleUserMode:
             "sonnet",  # model
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # timeout
+            "3600",  # agent turn deadline (default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
             "80",  # autocompact
@@ -11584,6 +11622,7 @@ class TestOpenCodeConfigWizard:
             # model: handled by _prompt_default_model mock
             "false",  # customize per-role models (decline; use registry defaults)
             "120",  # agent timeout
+            "3600",  # agent turn deadline (default)
             "0",  # max session age hours (0 = no limit)
             "1800",  # idle eviction timeout seconds
             "8080",  # webhook port

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -275,6 +275,65 @@ class TestPiTurns:
         assert backend._transport.sent[0]["images"] == [{"type": "image", "data": "YWJj", "mimeType": "image/png"}]
 
     @pytest.mark.asyncio
+    async def test_turn_deadline_ends_a_turn_that_keeps_trickling_output(self, tmp_path, monkeypatch):
+        """
+        The per-receive timeout resets on any record, so a turn that
+        trickles deltas without settling is bounded only by the turn
+        deadline; when it fires, the turn ends with a failed response
+        and the subprocess is killed via the standard error path.
+        """
+        backend = make_backend(tmp_path, turn_deadline_seconds=1)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+
+        class TricklingTransport(FakeTransport):
+            async def receive(self, *, timeout_seconds=None):
+                if self.records:
+                    return self.records.pop(0)
+                # Frequent-enough records that the per-receive timeout
+                # never fires.
+                await asyncio.sleep(0.4)
+                return {
+                    "type": "message_update",
+                    "assistantMessageEvent": {"type": "text_delta", "delta": "still going"},
+                }
+
+        backend._transport = TricklingTransport(
+            [{"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True}]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        assert events[-1].done is True
+        assert events[-1].response.success is False
+        assert "Pi turn exceeded its deadline" in (events[-1].response.error or "")
+        assert "still going" in events[-1].text_so_far
+        # The send handler killed the subprocess on the deadline error.
+        assert backend._proc is None
+
+    @pytest.mark.asyncio
+    async def test_turn_completing_within_deadline_is_untouched(self, tmp_path, monkeypatch):
+        """A normal turn under the deadline ends by settling, not the backstop."""
+        backend = make_backend(tmp_path, turn_deadline_seconds=5)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        events = await collect(backend)
+
+        assert events[-1].done is True
+        assert events[-1].response.success is True
+
+    @pytest.mark.asyncio
     async def test_unsupported_image_gets_visible_notice(self, tmp_path, monkeypatch):
         backend = make_backend(tmp_path)
         backend._proc = FakeProcess()


### PR DESCRIPTION
Closes #999.

Extends the total-turn backstop to every backend, following the shape the codex lane established: a deadline check that never resets on output, sitting beside each lane's existing guards, firing exactly like that lane's own timeout path.

## Survey results (the issue's first task)

- **claude**: idle check plus per-readline `wait_for`, structurally identical to codex; the deadline check mirrors its idle-timeout block (kill, failed response carrying accumulated text).
- **goose / opencode**: verified to share one read loop in the ACP base, so a single check covers both lanes, using `backend_label` in the log and error text.
- **pi**: no idle/readline structure; a per-receive timeout that resets on any RPC record. The deadline check sits before each receive and raises through the same `PiRpcTimeoutError` channel as a receive timeout, so it rides the existing send-handler path (kill, failed final event). Overrun is bounded by one receive.

## Configuration (naming as decided on the issue)

One shared `TURN_DEADLINE_SECONDS` (default 3600) consumed by all lanes, through the standard six-step env-var flow. `CODEX_TURN_DEADLINE_SECONDS` becomes a set-or-absent codex-only override: a value wins over the shared var for codex only; unset or empty, the codex lane follows the shared value. A previously persisted codex value keeps its exact meaning, and the wizard prefills it on resave. The wizard gains one backend-independent "Agent turn deadline" prompt beside the agent timeout; the codex prompt becomes the override (empty = shared), matching the set-or-absent posture of the neighbouring effort prompt.

## Tests

- Firing and non-firing pairs for claude, the ACP base, and pi, in the style of the codex pair from the prior change: a turn trickling output frequently enough that the per-lane guards never fire is ended by the deadline with the accumulated text preserved; a normal turn under the deadline completes by itself.
- Config precedence: shared alone governs every lane including codex; both set means the override wins for codex only; neither set means 3600 everywhere; an empty override follows the shared value; rejection shapes for both vars.
- Wizard: emission branches for both vars (shared persisted delta-from-defaults, override persisted set-or-absent); every scripted chain gained the new answer slot.
- The claude idle-timeout test's scripted clock is now keyed off readline progress instead of a fixed monotonic-call count, which the new check would otherwise have silently shifted.

The long-turn trade-off recorded on the codex change applies uniformly: a legitimate turn exceeding the deadline is killed with a failed response (text preserved); the generous shared default plus configurability is the mitigation.

Full suite passes (5944 tests), ruff and pyright strict clean.
