### PR TITLE
fix: let send loops survive teardown nulling process state mid-stream

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -1470,6 +1470,12 @@ class AcpBackend(AgentBackend):
         assert self._proc is not None
         assert self._proc.stdin is not None
         assert self._proc.stdout is not None
+        # Local reference for the streaming loop below: a /stop-shaped
+        # teardown nulls self._proc mid-turn, and the loop must keep
+        # draining the killed process's buffered stdout to its EOF
+        # (ending the turn through the EOF path) instead of crashing
+        # on a None re-read.
+        proc = self._proc
 
         try:
             prompt_id = self._next_id
@@ -1572,7 +1578,7 @@ class AcpBackend(AgentBackend):
 
                 try:
                     line = await asyncio.wait_for(
-                        self._proc.stdout.readline(),
+                        proc.stdout.readline(),
                         timeout=self.timeout_seconds * 3,
                     )
                 except TimeoutError:

--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -1065,21 +1065,30 @@ class AcpBackend(AgentBackend):
         """
         return None
 
-    async def _send_server_response(self, request_id: int, result: dict) -> None:
+    async def _send_server_response(
+        self,
+        proc: asyncio.subprocess.Process,
+        request_id: int,
+        result: dict,
+    ) -> None:
         """
         Write a JSON-RPC response back to the subprocess for a
         server-initiated request.
 
         Distinct from `_write_rpc` (which sends a new request and
         consumes a fresh `_next_id`); this writes a response using the
-        id the SERVER sent us. Helper kept out of the read loop so the
-        ordering and error handling stay clear.
+        id the SERVER sent us. Takes the caller's process reference
+        rather than re-reading self._proc: a teardown that nulls the
+        attribute mid-turn then surfaces as an OSError from the dead
+        pipe, which the calling branch handles, instead of an assert
+        failure here. Helper kept out of the read loop so the ordering
+        and error handling stay clear.
         """
-        assert self._proc is not None and self._proc.stdin is not None
+        assert proc.stdin is not None
         payload = {"jsonrpc": "2.0", "id": request_id, "result": result}
         line = (json.dumps(payload) + "\n").encode()
-        self._proc.stdin.write(line)
-        await self._proc.stdin.drain()
+        proc.stdin.write(line)
+        await proc.stdin.drain()
 
     # ── Lifecycle properties ──────────────────────────────────────────
 
@@ -1651,7 +1660,7 @@ class AcpBackend(AgentBackend):
                     result = self.handle_server_request(msg)
                     if result is not None:
                         try:
-                            await self._send_server_response(server_id, result)
+                            await self._send_server_response(proc, server_id, result)
                         except OSError as e:
                             log.error(
                                 "Failed to write server-request response to %s: %s",
@@ -1676,7 +1685,7 @@ class AcpBackend(AgentBackend):
                     # subprocess persists across turns). See
                     # drain_late_text for the mechanism.
                     accumulated = await drain_late_text(
-                        proc=self._proc,
+                        proc=proc,
                         accumulated=accumulated,
                         extract_delta=self.extract_text_delta,
                         combine=self.combine_text_chunks,

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -971,6 +971,12 @@ class CodexBackend(AgentBackend):
         assert self._proc is not None
         assert self._proc.stdin is not None
         assert self._proc.stdout is not None
+        # Local reference for the streaming loop below: a /stop-shaped
+        # teardown nulls self._proc mid-turn, and the loop must keep
+        # draining the killed process's buffered stdout to its EOF
+        # (ending the turn through the EOF path) instead of crashing
+        # on a None re-read.
+        proc = self._proc
 
         try:
             turn_params: dict = {
@@ -1120,7 +1126,7 @@ class CodexBackend(AgentBackend):
 
                 try:
                     line = await asyncio.wait_for(
-                        self._proc.stdout.readline(),
+                        proc.stdout.readline(),
                         timeout=self.timeout_seconds * 3,
                     )
                 except TimeoutError:

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -482,6 +482,12 @@ class PiBackend(AgentBackend):
         started_at: float,
     ) -> AsyncIterator[StreamEvent]:
         assert self._transport is not None
+        # Local reference: a /stop-shaped teardown nulls self._transport
+        # mid-turn, and this loop must keep reading the dead process's
+        # buffered records to their end (surfaced as PiRpcEOFError into
+        # the standard failure path) instead of crashing on a None
+        # re-read.
+        transport = self._transport
         accepted = False
         streamed = ""
         completed_messages: list[str] = []
@@ -502,7 +508,7 @@ class PiBackend(AgentBackend):
                     self.turn_deadline_seconds,
                 )
                 raise PiRpcTimeoutError("Pi turn exceeded its deadline")
-            message = await self._transport.receive(timeout_seconds=self.timeout_seconds)
+            message = await transport.receive(timeout_seconds=self.timeout_seconds)
             message_type = message.get("type")
 
             if message_type == "response":

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -608,6 +608,87 @@ class TestSendStream:
         assert events[-1].response.success is True
 
     @pytest.mark.asyncio
+    async def test_shutdown_mid_stream_still_reports_a_completed_turn(self):
+        """
+        The killed process's buffer can hold the turn's own completion
+        response. The completion branch's late-text drain must read
+        through the local reference, so a turn that genuinely finished
+        as the teardown landed reports success instead of failing on a
+        nulled self._proc.
+        """
+        b = _make_fake()
+        proc = _make_mock_proc([])
+        release = asyncio.Event()
+        lines = [_completion_result(prompt_id=3)]
+
+        async def readline() -> bytes:
+            await release.wait()
+            return lines.pop(0) if lines else b""
+
+        proc.stdout.readline = readline
+        b._proc = proc
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        task = asyncio.create_task(_collect_events(b, prompt="hi"))
+        await asyncio.sleep(0.01)
+        await b.shutdown()
+        release.set()
+        events = await task
+
+        assert events[-1].done is True
+        assert events[-1].response.success is True
+
+    @pytest.mark.asyncio
+    async def test_shutdown_mid_stream_survives_a_buffered_server_request(self):
+        """
+        The killed process's buffer can hold a server-initiated request
+        (an OpenCode permission ask). The response write must go through
+        the local reference: against a dead pipe it surfaces as the
+        OSError the branch already handles, never an assert failure on
+        a nulled self._proc, and the loop continues to the completion.
+        """
+
+        class _AutoApprove(_FakeAcp):
+            def handle_server_request(self, msg):
+                if msg.get("method") == "session/request_permission":
+                    return {"outcome": {"outcome": "selected", "optionId": "always"}}
+                return None
+
+        b = _AutoApprove(model="x", workspace=Path("/tmp/ws"))
+        proc = _make_mock_proc([])
+        release = asyncio.Event()
+        server_request = _json_line(
+            {
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "session/request_permission",
+                "params": {},
+            }
+        )
+        lines = [server_request, _completion_result(prompt_id=3)]
+
+        async def readline() -> bytes:
+            await release.wait()
+            return lines.pop(0) if lines else b""
+
+        proc.stdout.readline = readline
+        b._proc = proc
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        task = asyncio.create_task(_collect_events(b, prompt="hi"))
+        await asyncio.sleep(0.01)
+        await b.shutdown()
+        release.set()
+        events = await task
+
+        assert events[-1].done is True
+        assert events[-1].response.success is True
+
+    @pytest.mark.asyncio
     async def test_turn_deadline_ends_a_turn_that_keeps_trickling_output(self):
         """
         The idle guard resets on any output, so a turn that trickles

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -570,6 +570,44 @@ class TestSendStream:
         assert text_events[0].text_so_far == "ok"
 
     @pytest.mark.asyncio
+    async def test_shutdown_mid_stream_drains_to_eof_without_crashing(self):
+        """
+        A /stop-shaped teardown nulls self._proc while the send loop is
+        suspended mid-stream. The loop must drain the killed process's
+        buffered output to EOF and end the turn through the standard
+        EOF path rather than crash re-reading the nulled attribute.
+        """
+        b = _make_fake()
+        proc = _make_mock_proc([])
+        release = asyncio.Event()
+        lines = [_text_chunk("buffered"), b""]
+
+        async def readline() -> bytes:
+            await release.wait()
+            return lines.pop(0) if lines else b""
+
+        proc.stdout.readline = readline
+        b._proc = proc
+        b._session_id = "sess-1"
+        b._fresh_session = False
+        b._next_id = 3
+
+        task = asyncio.create_task(_collect_events(b, prompt="hi"))
+        # Let the send loop reach its readline and suspend on it.
+        await asyncio.sleep(0.01)
+        await b.shutdown()
+        assert b._proc is None
+        release.set()
+        events = await task
+
+        # The clean EOF ending, not the catch-all handler swallowing an
+        # AttributeError from a nulled self._proc re-read: model text
+        # arrived, so the EOF branch reports success.
+        assert events[-1].done is True
+        assert "buffered" in events[-1].text_so_far
+        assert events[-1].response.success is True
+
+    @pytest.mark.asyncio
     async def test_turn_deadline_ends_a_turn_that_keeps_trickling_output(self):
         """
         The idle guard resets on any output, so a turn that trickles

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -603,6 +603,45 @@ class TestStreamParsing:
     """Verify _send_locked() correctly parses streaming responses."""
 
     @pytest.mark.asyncio
+    async def test_shutdown_mid_stream_drains_to_eof_without_crashing(self):
+        """
+        A /stop-shaped teardown nulls self._proc while the send loop is
+        suspended mid-stream. The loop must drain the killed process's
+        buffered output to EOF and end the turn through the standard
+        EOF path rather than crash re-reading the nulled attribute.
+        """
+        c = _make_codex()
+        proc = _make_mock_proc([])
+        release = asyncio.Event()
+        lines = [_agent_message_delta("buffered"), b""]
+
+        async def readline():
+            await release.wait()
+            return lines.pop(0) if lines else b""
+
+        proc.stdout.readline = readline
+        c._proc = proc
+        c._session_id = "test-session"
+        c._fresh_session = False
+        c._next_id = 3
+
+        task = asyncio.create_task(_collect_events(c))
+        # Let the send loop reach its readline and suspend on it.
+        await asyncio.sleep(0.01)
+        await c.shutdown()
+        assert c._proc is None
+        release.set()
+        events = await task
+
+        # The clean EOF ending, not the catch-all handler swallowing an
+        # AttributeError from a nulled self._proc re-read: visible text
+        # arrived, so the EOF branch reports success with no error.
+        assert events[-1].done is True
+        assert "buffered" in events[-1].text_so_far
+        assert events[-1].response.success is True
+        assert events[-1].response.error is None
+
+    @pytest.mark.asyncio
     async def test_turn_deadline_ends_a_turn_that_keeps_trickling_output(self):
         """
         The idle guard resets on any output, so a turn that trickles

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -275,6 +275,54 @@ class TestPiTurns:
         assert backend._transport.sent[0]["images"] == [{"type": "image", "data": "YWJj", "mimeType": "image/png"}]
 
     @pytest.mark.asyncio
+    async def test_shutdown_mid_stream_ends_through_the_error_path(self, tmp_path, monkeypatch):
+        """
+        A /stop-shaped teardown nulls self._transport while the turn
+        loop is suspended mid-stream. The loop must keep reading the
+        dead process's remaining records and end the turn through the
+        standard error path rather than crash re-reading the nulled
+        attribute.
+        """
+        backend = make_backend(tmp_path)
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._fresh_session = False
+        release = asyncio.Event()
+
+        class BlockingTransport(FakeTransport):
+            async def receive(self, *, timeout_seconds=None):
+                if self.records:
+                    value = self.records.pop(0)
+                    if value == "block":
+                        await release.wait()
+                        return {
+                            "type": "message_update",
+                            "assistantMessageEvent": {"type": "text_delta", "delta": "buffered"},
+                        }
+                    return value
+                raise PiRpcEOFError("stream exhausted")
+
+        backend._transport = BlockingTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                "block",
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        task = asyncio.create_task(collect(backend))
+        # Let the turn loop reach its receive and suspend on it.
+        await asyncio.sleep(0.01)
+        await backend.shutdown()
+        assert backend._transport is None
+        release.set()
+        events = await task
+
+        assert events[-1].done is True
+        assert events[-1].response.success is False
+        assert "buffered" in events[-1].text_so_far
+
+    @pytest.mark.asyncio
     async def test_turn_deadline_ends_a_turn_that_keeps_trickling_output(self, tmp_path, monkeypatch):
         """
         The per-receive timeout resets on any record, so a turn that


### PR DESCRIPTION
Closes #1001.

## Survey verdicts (the issue's first task)

Enumerated every post-await re-read of process state in each send path:

- **codex: reachable.** The stream loop re-reads `self._proc.stdout` on every readline. When teardown nulls `_proc` while the loop drains the killed process's buffered output, the re-read hits None; the loop's catch-all handler swallowed the AttributeError into a generic failed response plus a spurious error traceback in the log (the same "Unexpected error reading Codex stream" shape seen in production). The pre-loop write path reads `_proc` in the same synchronous stretch as its narrowing asserts and is safe.
- **goose / opencode: reachable**, identically, through the one shared ACP loop; same catch-all masking. Review found two further conditional re-reads the first survey pass missed, both now fixed the same way: the server-request branch reached `self._proc` through `_send_server_response`'s narrowing assert (a buffered OpenCode permission ask during teardown became a swallowed assert failure), and the completion branch passed `self._proc` to `drain_late_text` (a turn that genuinely finished as teardown landed was mislabelled failed with an empty error string). `_send_server_response` now takes the caller's process reference and the drain receives the loop's local; a post-fix sweep confirms the only remaining attribute reads in all three send paths sit in the synchronous assert stretches before turn dispatch.
- **pi: reachable and worse.** `_read_turn` re-reads `self._transport` on every receive, and nothing catches the AttributeError; it escaped the turn entirely.
- **claude: not reachable.** Its `shutdown` holds the send lock (so it waits out or ceilings past an in-flight stream), its send-path `_kill` calls run under that lock, and the pool's 5-second ceiling degrades to the sync `force_kill`, which nulls nothing the send loop re-reads. No change made.

Residual, surveyed and accepted: the narrowing asserts before each turn dispatch (`assert self._proc is not None` and pi's transport equivalent) could observe a teardown that lands during pre-turn context assembly, a milliseconds-wide window versus the minutes-wide streaming window; they are the house pyright-narrowing idiom and are left as is.

## Fix

The issue's suggested direction, not the named anti-pattern: each fixed loop captures a local reference where the existing asserts already prove the attribute non-None, and reads through the local. No lock is taken in `shutdown`, so `/stop` still aborts an in-flight turn promptly. A turn interrupted by teardown drains the remaining buffered output and ends through its lane's standard path: the EOF branch on codex and the ACP lanes (success reflecting whether visible text arrived, no spurious log traceback), and the `PiRpcEOFError`-to-failed-final-event channel on pi.

## Tests

One `/stop`-shaped regression test per fixed lane, plus two ACP branch tests (a buffered completion still reports success through the local drain; a buffered permission request is answered through the local without disturbing the completion), each verified failing without its fix: the send loop suspends mid-stream on a gated read, `shutdown()` runs to completion (asserted: process state nulled), the stream is released with one buffered chunk followed by end-of-stream, and the test asserts the clean lane-standard ending, including that codex/ACP report EOF-path success rather than the catch-all's stringified AttributeError. All three fail against the unfixed code (pi with the escaping AttributeError, codex/ACP on the response shape) and pass with it.

Full suite passes (5950 tests), ruff and pyright strict clean.
