### PR TITLE
memory: nightly snapshots of the semantic memory corpus

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -45,6 +45,7 @@ from kai.application_host import KaiApplicationHost
 from kai.backend_registry import load_backend_registry
 from kai.config import DATA_DIR, PROJECT_ROOT, _read_protected_file, load_config
 from kai.http_adapter import HttpAdapter
+from kai.memory_backup import run_memory_backup
 from kai.telegram_adapter import TelegramAdapter
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
@@ -248,6 +249,48 @@ async def _file_cleanup_loop(retention_days: int) -> None:
         await asyncio.sleep(_CLEANUP_INTERVAL)
 
 
+# ── Memory backup ────────────────────────────────────────────────────
+
+# How often the backup loop wakes up (seconds). The freshness floor in
+# run_memory_backup (MIN_SNAPSHOT_AGE) is what actually spaces the
+# snapshots; the wake interval just has to be at most nightly.
+_MEMORY_BACKUP_INTERVAL = 86400  # 24 hours
+
+# Initial delay before the first backup attempt (seconds). Long enough
+# to stay clear of startup work, short enough that a restarted service
+# still snapshots promptly when the last snapshot is stale.
+_MEMORY_BACKUP_STARTUP_DELAY = 300
+
+
+async def _memory_backup_loop() -> None:
+    """
+    Nightly snapshot of the semantic memory corpus.
+
+    Runs once after a short startup delay, then every 24 hours,
+    delegating the actual snapshot, freshness skip, and retention to
+    kai.memory_backup.run_memory_backup in a worker thread (the copy is
+    blocking I/O). Failures are logged loudly and the loop keeps
+    running: one bad night must not end backups.
+    """
+    await asyncio.sleep(_MEMORY_BACKUP_STARTUP_DELAY)
+
+    while True:
+        memory_dir = DATA_DIR / "memory"
+        if memory_dir.is_dir():
+            try:
+                snapshot = await asyncio.to_thread(
+                    run_memory_backup,
+                    memory_dir,
+                    DATA_DIR / "backups" / "memory",
+                    datetime.now(UTC),
+                )
+                if snapshot is not None:
+                    logging.info("Memory backup: snapshot written to %s", snapshot)
+            except Exception:
+                logging.exception("Memory backup FAILED - the memory corpus has no fresh snapshot")
+        await asyncio.sleep(_MEMORY_BACKUP_INTERVAL)
+
+
 def main() -> None:
     """
     Top-level entry point for the Kai bot.
@@ -357,6 +400,7 @@ def _start() -> None:
         core_host: KaiApplicationHost | None = None
         telegram_adapter: TelegramAdapter | None = None
         cleanup_task: asyncio.Task[None] | None = None
+        memory_backup_task: asyncio.Task[None] | None = None
 
         # Determine the default compatibility user (admin or first user) for
         # legacy per-user migrations. Workshop-only installations may have no
@@ -479,6 +523,12 @@ def _start() -> None:
             if config.file_retention_days > 0:
                 cleanup_task = asyncio.create_task(_file_cleanup_loop(config.file_retention_days))
 
+            # Start nightly memory backups. Unconditional: the loop
+            # no-ops when DATA_DIR/memory does not exist, and gating on
+            # memory_enabled would leave the MEMORY.md fallback store
+            # (used when memory is disabled) without backups.
+            memory_backup_task = asyncio.create_task(_memory_backup_loop())
+
             # Check for interrupted responses from a crash/restart.
             # Phase 2: check all files in the .responding directory (per-user
             # flags) instead of the old single .responding_to file.
@@ -532,6 +582,9 @@ def _start() -> None:
             if cleanup_task is not None:
                 cleanup_task.cancel()
                 await asyncio.gather(cleanup_task, return_exceptions=True)
+            if memory_backup_task is not None:
+                memory_backup_task.cancel()
+                await asyncio.gather(memory_backup_task, return_exceptions=True)
             from kai.memory import configure_memory_authority
 
             configure_memory_authority(None)

--- a/src/kai/memory_backup.py
+++ b/src/kai/memory_backup.py
@@ -80,6 +80,11 @@ _SQLITE_SIDECAR_ENDINGS = ("-wal", "-shm", "-journal")
 
 # ── Snapshot ─────────────────────────────────────────────────────────
 
+# The unreadable-directory set reported by the previous run in this
+# process, used to demote the repeat warning below. None means no run
+# has happened yet since startup.
+_previous_unreadable: frozenset[str] | None = None
+
 
 def _is_sqlite_sidecar(name: str) -> bool:
     """Check if a filename is a SQLite WAL/SHM/journal sidecar."""
@@ -94,9 +99,10 @@ def _backup_sqlite(source: Path, target: Path) -> None:
     mutate the live store. backup() with default arguments copies the
     whole database in one pass under a read lock, yielding a
     transactionally consistent target even if the daemon commits
-    writes concurrently.
+    writes concurrently. as_uri() percent-encodes the path, so names
+    containing URI metacharacters cannot misparse as query components.
     """
-    src_conn = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
+    src_conn = sqlite3.connect(source.as_uri() + "?mode=ro", uri=True)
     try:
         dst_conn = sqlite3.connect(target)
         try:
@@ -144,13 +150,28 @@ def _snapshot_tree(memory_dir: Path, snapshot_dir: Path) -> None:
                 shutil.copy2(src, dst)
             os.chmod(dst, 0o600)
 
+    # WARNING only when the unreadable set changes (or on the first run
+    # after startup), INFO otherwise. In a multi-user deployment the
+    # foreign-owned principal dirs are unreadable every night; a warning
+    # that always fires trains the operator to skim past backup
+    # warnings, which this log line most needs taken seriously.
+    global _previous_unreadable
+    current = frozenset(unreadable)
     if unreadable:
-        log.warning(
-            "Memory backup: %d unreadable director%s not captured in the snapshot (owned by another user): %s",
-            len(unreadable),
-            "y" if len(unreadable) == 1 else "ies",
-            ", ".join(unreadable),
-        )
+        if current != _previous_unreadable:
+            log.warning(
+                "Memory backup: %d unreadable director%s not captured in the snapshot (owned by another user): %s",
+                len(unreadable),
+                "y" if len(unreadable) == 1 else "ies",
+                ", ".join(sorted(unreadable)),
+            )
+        else:
+            log.info(
+                "Memory backup: %d unreadable director%s skipped (unchanged since last run)",
+                len(unreadable),
+                "y" if len(unreadable) == 1 else "ies",
+            )
+    _previous_unreadable = current
 
 
 def _latest_snapshot_time(backup_root: Path) -> datetime | None:

--- a/src/kai/memory_backup.py
+++ b/src/kai/memory_backup.py
@@ -1,0 +1,234 @@
+"""
+Nightly on-disk snapshots of the semantic memory corpus.
+
+Provides functionality to:
+1. Snapshot the entire DATA_DIR/memory/ tree (embedded Qdrant vector
+   store, Mem0 history DB, per-principal MEMORY.md fallback dirs) into
+   a dated directory under DATA_DIR/backups/memory/
+2. Copy SQLite databases through the sqlite3 backup API so a snapshot
+   taken while the daemon is writing is still transactionally
+   consistent (a plain file copy of a live database risks torn state)
+3. Skip a run when a recent snapshot already exists, so service
+   restarts don't churn through the retention window
+4. Enforce a fixed retention window by pruning the oldest snapshots
+5. Restrict every snapshot directory and file to owner-only permissions
+
+The snapshot runs in-process (scheduled from main.py) because embedded
+local-mode Qdrant is single-process and the daemon holds it for its
+lifetime; an external job could never coordinate with the writer. The
+SQLite backup API makes quiescing unnecessary: it takes a consistent
+read of the source database even while other connections write.
+
+Restore procedure (exercised end to end against a scratch DATA_DIR;
+see PR for the transcript):
+
+1. Stop the service so nothing holds the embedded Qdrant store:
+   macOS:  sudo launchctl bootout system/com.syrinx.kai
+   Linux:  sudo systemctl stop kai
+2. Move the damaged store aside (do not delete it):
+   mv "$DATA_DIR/memory" "$DATA_DIR/memory.damaged"
+3. Copy the chosen snapshot back into place, preserving permissions:
+   cp -Rp "$DATA_DIR/backups/memory/<YYYYMMDD_HHMMSS>" "$DATA_DIR/memory"
+4. If the copy ran as root, restore ownership to the service user:
+   chown -R <service_user> "$DATA_DIR/memory"
+5. Start the service again:
+   macOS:  sudo launchctl bootstrap system /Library/LaunchDaemons/com.syrinx.kai.plist
+   Linux:  sudo systemctl start kai
+6. Verify reads: the /memory dashboard should list facts, or
+   `/api/memory/search` should return results.
+
+Note the restored tree carries the snapshot's owner-only permissions,
+which is tighter than the historical live-store permissions and safe
+to keep: only the service user reads the store.
+"""
+
+import logging
+import os
+import re
+import shutil
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# ── Policy constants ─────────────────────────────────────────────────
+
+# How many dated snapshots to keep. Pruning runs after each successful
+# snapshot and deletes the oldest beyond this count.
+RETENTION_SNAPSHOTS = 7
+
+# Skip a run when the newest snapshot is younger than this. The backup
+# loop ticks once per day but restarts its clock on service restart;
+# without this floor, a day with several deploys would write several
+# snapshots and rotate real history out of the retention window.
+MIN_SNAPSHOT_AGE = timedelta(hours=20)
+
+# Snapshot directory names are UTC timestamps in this format. The
+# retention scan only considers names matching this shape, so foreign
+# files in the backup root are never deleted.
+_SNAPSHOT_NAME_FORMAT = "%Y%m%d_%H%M%S"
+_SNAPSHOT_NAME_RE = re.compile(r"^\d{8}_\d{6}$")
+
+# SQLite databases get the backup-API treatment; their WAL/SHM/journal
+# sidecars are skipped entirely because the backup API folds pending
+# WAL content into the copied main database, and a plain copy of a
+# live sidecar would be torn anyway.
+_SQLITE_SUFFIXES = frozenset({".db", ".sqlite", ".sqlite3"})
+_SQLITE_SIDECAR_ENDINGS = ("-wal", "-shm", "-journal")
+
+
+# ── Snapshot ─────────────────────────────────────────────────────────
+
+
+def _is_sqlite_sidecar(name: str) -> bool:
+    """Check if a filename is a SQLite WAL/SHM/journal sidecar."""
+    return name.endswith(_SQLITE_SIDECAR_ENDINGS)
+
+
+def _backup_sqlite(source: Path, target: Path) -> None:
+    """
+    Copy one SQLite database via the sqlite3 backup API.
+
+    The source is opened read-only (uri=True) so a backup can never
+    mutate the live store. backup() with default arguments copies the
+    whole database in one pass under a read lock, yielding a
+    transactionally consistent target even if the daemon commits
+    writes concurrently.
+    """
+    src_conn = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
+    try:
+        dst_conn = sqlite3.connect(target)
+        try:
+            src_conn.backup(dst_conn)
+        finally:
+            dst_conn.close()
+    finally:
+        src_conn.close()
+
+
+def _snapshot_tree(memory_dir: Path, snapshot_dir: Path) -> None:
+    """
+    Copy the memory tree into snapshot_dir with owner-only permissions.
+
+    Directories are created 0700 and files chmodded 0600 as they land,
+    so the snapshot never replicates the live store's historical
+    group/world-readable modes.
+
+    Per-principal MEMORY.md directories are 0700 and owned by the
+    per-OS-user inner agent processes, so the service user cannot read
+    them. os.walk's default is to skip unlistable directories silently;
+    that would make the snapshot quietly incomplete, so unreadable
+    subtrees are collected and reported in one loud warning instead.
+    The run still succeeds: the SQLite corpus is the critical asset,
+    and failing outright would mean no backups at all.
+    """
+    unreadable: list[str] = []
+
+    def _record_walk_error(error: OSError) -> None:
+        unreadable.append(str(error.filename))
+
+    for dirpath, _dirnames, filenames in os.walk(memory_dir, onerror=_record_walk_error):
+        src_dir = Path(dirpath)
+        dst_dir = snapshot_dir / src_dir.relative_to(memory_dir)
+        dst_dir.mkdir(exist_ok=True)
+        os.chmod(dst_dir, 0o700)
+        for filename in filenames:
+            if _is_sqlite_sidecar(filename):
+                continue
+            src = src_dir / filename
+            dst = dst_dir / filename
+            if src.suffix in _SQLITE_SUFFIXES:
+                _backup_sqlite(src, dst)
+            else:
+                shutil.copy2(src, dst)
+            os.chmod(dst, 0o600)
+
+    if unreadable:
+        log.warning(
+            "Memory backup: %d unreadable director%s not captured in the snapshot (owned by another user): %s",
+            len(unreadable),
+            "y" if len(unreadable) == 1 else "ies",
+            ", ".join(unreadable),
+        )
+
+
+def _latest_snapshot_time(backup_root: Path) -> datetime | None:
+    """Return the UTC timestamp of the newest snapshot, or None if there are none."""
+    names = sorted(
+        entry.name for entry in backup_root.iterdir() if entry.is_dir() and _SNAPSHOT_NAME_RE.match(entry.name)
+    )
+    if not names:
+        return None
+    return datetime.strptime(names[-1], _SNAPSHOT_NAME_FORMAT).replace(tzinfo=UTC)
+
+
+def _prune_old_snapshots(backup_root: Path) -> None:
+    """
+    Delete the oldest snapshots beyond RETENTION_SNAPSHOTS.
+
+    Snapshot names sort chronologically, so retention is a name sort.
+    Only names matching the timestamp shape are candidates; anything
+    else in the backup root is left alone.
+    """
+    snapshots = sorted(
+        entry for entry in backup_root.iterdir() if entry.is_dir() and _SNAPSHOT_NAME_RE.match(entry.name)
+    )
+    for stale in snapshots[:-RETENTION_SNAPSHOTS]:
+        shutil.rmtree(stale)
+        log.info("Memory backup: pruned old snapshot %s", stale.name)
+
+
+def run_memory_backup(memory_dir: Path, backup_root: Path, now: datetime) -> Path | None:
+    """
+    Take one snapshot of the memory tree and prune old snapshots.
+
+    Returns the new snapshot directory, or None when the run was
+    skipped because the newest existing snapshot is younger than
+    MIN_SNAPSHOT_AGE. Raises on any failure; the caller is responsible
+    for logging loudly (a backup that fails silently reproduces the
+    no-backups problem it exists to solve).
+
+    The snapshot is written under a dot-prefixed working name and
+    renamed into place only when complete, so a crash mid-copy can
+    never leave a directory that looks like a valid snapshot. A
+    leftover working directory from a previous failed run is removed
+    at the start of the next one (the working name is deterministic
+    per timestamp, but any prior partial is stale by definition).
+
+    Args:
+        memory_dir: The live memory tree (DATA_DIR/memory).
+        backup_root: Where snapshots live (DATA_DIR/backups/memory).
+        now: Current UTC time; names the snapshot and drives the
+            freshness skip.
+    """
+    backup_root.mkdir(parents=True, exist_ok=True)
+    # Owner-only from the root down: the parent backups/ dir too, since
+    # mkdir(parents=True) applies default modes to created parents.
+    os.chmod(backup_root.parent, 0o700)
+    os.chmod(backup_root, 0o700)
+
+    latest = _latest_snapshot_time(backup_root)
+    if latest is not None and now - latest < MIN_SNAPSHOT_AGE:
+        log.debug("Memory backup: newest snapshot %s is fresh, skipping", latest)
+        return None
+
+    # Clear any partial left behind by a previous crashed run.
+    for entry in backup_root.iterdir():
+        if entry.is_dir() and entry.name.startswith(".partial-"):
+            shutil.rmtree(entry)
+
+    name = now.strftime(_SNAPSHOT_NAME_FORMAT)
+    partial = backup_root / f".partial-{name}"
+    snapshot = backup_root / name
+    try:
+        partial.mkdir()
+        os.chmod(partial, 0o700)
+        _snapshot_tree(memory_dir, partial)
+        partial.rename(snapshot)
+    except BaseException:
+        shutil.rmtree(partial, ignore_errors=True)
+        raise
+
+    _prune_old_snapshots(backup_root)
+    return snapshot

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,6 +23,7 @@ from kai.config import UserConfig
 from kai.main import (
     _file_age,
     _file_cleanup_loop,
+    _memory_backup_loop,
     _warn_if_compatibility_jobs_are_dormant,
     _workshop_bootstrap_humans,
     _workshop_bootstrap_notification_channels,
@@ -415,6 +416,94 @@ class TestFileCleanupLoop:
         # Error was logged
         mock_log.assert_called()
         # Should not raise - error is counted, not propagated
+
+
+# ── _memory_backup_loop() ────────────────────────────────────────────
+
+
+class TestMemoryBackupLoop:
+    @pytest.mark.asyncio
+    async def test_writes_snapshot(self, tmp_path, monkeypatch):
+        """One loop iteration produces a dated snapshot of DATA_DIR/memory."""
+        monkeypatch.setattr("kai.main.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.main._MEMORY_BACKUP_STARTUP_DELAY", 0)
+        monkeypatch.setattr("kai.main._MEMORY_BACKUP_INTERVAL", 0)
+
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        (memory_dir / "MEMORY.md").write_text("# facts\n")
+
+        call_count = 0
+
+        async def mock_sleep(duration):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError
+
+        with patch("kai.main.asyncio.sleep", side_effect=mock_sleep):
+            try:
+                await _memory_backup_loop()
+            except asyncio.CancelledError:
+                pass
+
+        snapshots = list((tmp_path / "backups" / "memory").iterdir())
+        assert len(snapshots) == 1
+        assert (snapshots[0] / "MEMORY.md").read_text() == "# facts\n"
+
+    @pytest.mark.asyncio
+    async def test_missing_memory_directory_is_a_noop(self, tmp_path, monkeypatch):
+        """Without DATA_DIR/memory (memory never used), nothing is written."""
+        monkeypatch.setattr("kai.main.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.main._MEMORY_BACKUP_STARTUP_DELAY", 0)
+        monkeypatch.setattr("kai.main._MEMORY_BACKUP_INTERVAL", 0)
+
+        call_count = 0
+
+        async def mock_sleep(duration):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 1:
+                raise asyncio.CancelledError
+
+        with patch("kai.main.asyncio.sleep", side_effect=mock_sleep):
+            try:
+                await _memory_backup_loop()
+            except asyncio.CancelledError:
+                pass
+
+        assert not (tmp_path / "backups").exists()
+
+    @pytest.mark.asyncio
+    async def test_failure_is_logged_and_loop_survives(self, tmp_path, monkeypatch):
+        """A failed backup logs loudly and the loop keeps running."""
+        monkeypatch.setattr("kai.main.DATA_DIR", tmp_path)
+        monkeypatch.setattr("kai.main._MEMORY_BACKUP_STARTUP_DELAY", 0)
+        monkeypatch.setattr("kai.main._MEMORY_BACKUP_INTERVAL", 0)
+
+        (tmp_path / "memory").mkdir()
+
+        call_count = 0
+
+        async def mock_sleep(duration):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 2:
+                raise asyncio.CancelledError
+
+        with (
+            patch("kai.main.asyncio.sleep", side_effect=mock_sleep),
+            patch("kai.main.run_memory_backup", side_effect=OSError("disk full")),
+            patch("kai.main.logging.exception") as mock_log,
+        ):
+            try:
+                await _memory_backup_loop()
+            except asyncio.CancelledError:
+                pass
+
+        # Loop ran twice (not terminated after the first failure)
+        assert call_count == 3
+        mock_log.assert_called()
 
 
 # ── main() startup-error choke point ─────────────────────────────────

--- a/tests/test_memory_backup.py
+++ b/tests/test_memory_backup.py
@@ -1,0 +1,201 @@
+"""
+Tests for memory_backup.py - snapshotting the semantic memory corpus.
+
+Covers:
+1. Snapshot content: plain files and nested directories are copied,
+   SQLite databases are copied consistently via the backup API, and
+   WAL/SHM sidecars are excluded
+2. Owner-only permissions on every snapshot directory and file
+3. The freshness skip that stops service restarts from churning
+   through the retention window
+4. Retention pruning of the oldest snapshots, leaving foreign
+   directories in the backup root untouched
+5. Failure behavior: a failed run raises and leaves no partial or
+   complete snapshot behind
+6. Unreadable per-principal directories are skipped with a loud
+   warning instead of silently or fatally
+"""
+
+import logging
+import os
+import sqlite3
+import stat
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from kai.memory_backup import (
+    MIN_SNAPSHOT_AGE,
+    RETENTION_SNAPSHOTS,
+    run_memory_backup,
+)
+
+# A fixed "now" for deterministic snapshot names.
+NOW = datetime(2026, 8, 18, 3, 0, 0, tzinfo=UTC)
+
+
+def _make_memory_tree(root: Path) -> tuple[Path, sqlite3.Connection]:
+    """
+    Build a miniature DATA_DIR/memory tree shaped like production.
+
+    Returns the memory dir and an OPEN WAL-mode connection to the
+    embedded database, so tests exercise the backup against a live
+    store the way the daemon holds it. Callers close the connection.
+    """
+    memory_dir = root / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "MEMORY.md").write_text("# core\n")
+    (memory_dir / "config.json").write_text("{}")
+    principal = memory_dir / "prn_abc123"
+    principal.mkdir()
+    (principal / "MEMORY.md").write_text("# principal\n")
+    qdrant = memory_dir / "qdrant" / "collection" / "kai_memory"
+    qdrant.mkdir(parents=True)
+    (memory_dir / "qdrant" / "meta.json").write_text('{"collections": {}}')
+    # A real SQLite database standing in for storage.sqlite, in WAL
+    # mode with the connection held open so live -wal/-shm sidecars
+    # exist on disk during the backup, like the production daemon.
+    conn = sqlite3.connect(qdrant / "storage.sqlite")
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("CREATE TABLE points (id INTEGER PRIMARY KEY, payload TEXT)")
+    conn.executemany("INSERT INTO points (payload) VALUES (?)", [("a",), ("b",), ("c",)])
+    conn.commit()
+    return memory_dir, conn
+
+
+class TestSnapshot:
+    def test_snapshot_copies_tree_and_databases(self, tmp_path):
+        """The snapshot contains the whole tree; SQLite content survives a live copy."""
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        backup_root = tmp_path / "backups" / "memory"
+
+        snapshot = run_memory_backup(memory_dir, backup_root, NOW)
+        conn.close()
+
+        assert snapshot == backup_root / "20260818_030000"
+        assert (snapshot / "MEMORY.md").read_text() == "# core\n"
+        assert (snapshot / "prn_abc123" / "MEMORY.md").read_text() == "# principal\n"
+        assert (snapshot / "qdrant" / "meta.json").exists()
+
+        # The backed-up database must be a valid, complete SQLite file
+        # even though the source connection was open in WAL mode.
+        copied = snapshot / "qdrant" / "collection" / "kai_memory" / "storage.sqlite"
+        rows = sqlite3.connect(copied).execute("SELECT payload FROM points ORDER BY id").fetchall()
+        assert rows == [("a",), ("b",), ("c",)]
+
+    def test_sidecars_are_not_copied(self, tmp_path):
+        """Live -wal/-shm sidecars are excluded (their content is folded into the copy)."""
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        db_dir = memory_dir / "qdrant" / "collection" / "kai_memory"
+        assert (db_dir / "storage.sqlite-wal").exists(), "test setup must produce a live WAL"
+
+        snapshot = run_memory_backup(memory_dir, tmp_path / "backups" / "memory", NOW)
+        conn.close()
+
+        assert snapshot is not None
+        copied_dir = snapshot / "qdrant" / "collection" / "kai_memory"
+        assert not (copied_dir / "storage.sqlite-wal").exists()
+        assert not (copied_dir / "storage.sqlite-shm").exists()
+
+    def test_snapshot_is_owner_only(self, tmp_path):
+        """Every directory is 0700 and every file 0600, including the backup root."""
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        backup_root = tmp_path / "backups" / "memory"
+
+        snapshot = run_memory_backup(memory_dir, backup_root, NOW)
+        conn.close()
+
+        assert snapshot is not None
+        assert stat.S_IMODE(backup_root.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(backup_root.stat().st_mode) == 0o700
+        for path in [snapshot, *snapshot.rglob("*")]:
+            expected = 0o700 if path.is_dir() else 0o600
+            assert stat.S_IMODE(path.stat().st_mode) == expected, path
+
+
+class TestFreshnessSkip:
+    def test_skips_when_newest_snapshot_is_fresh(self, tmp_path):
+        """A snapshot younger than MIN_SNAPSHOT_AGE suppresses the run."""
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        conn.close()
+        backup_root = tmp_path / "backups" / "memory"
+        backup_root.mkdir(parents=True)
+        fresh = NOW - MIN_SNAPSHOT_AGE / 2
+        (backup_root / fresh.strftime("%Y%m%d_%H%M%S")).mkdir()
+
+        assert run_memory_backup(memory_dir, backup_root, NOW) is None
+        assert len(list(backup_root.iterdir())) == 1
+
+    def test_runs_when_newest_snapshot_is_stale(self, tmp_path):
+        """A snapshot older than MIN_SNAPSHOT_AGE does not suppress the run."""
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        conn.close()
+        backup_root = tmp_path / "backups" / "memory"
+        backup_root.mkdir(parents=True)
+        stale = NOW - MIN_SNAPSHOT_AGE * 2
+        (backup_root / stale.strftime("%Y%m%d_%H%M%S")).mkdir()
+
+        assert run_memory_backup(memory_dir, backup_root, NOW) is not None
+
+
+class TestRetention:
+    def test_prunes_oldest_beyond_retention(self, tmp_path):
+        """Only the newest RETENTION_SNAPSHOTS dated directories survive."""
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        conn.close()
+        backup_root = tmp_path / "backups" / "memory"
+        backup_root.mkdir(parents=True)
+        # More old snapshots than the retention window holds, all stale
+        # enough not to trigger the freshness skip.
+        old_names = [f"202608{day:02d}_010000" for day in range(1, 10)]
+        for name in old_names:
+            (backup_root / name).mkdir()
+        # A foreign directory must never be a pruning candidate.
+        (backup_root / "keep-me").mkdir()
+
+        snapshot = run_memory_backup(memory_dir, backup_root, NOW)
+
+        assert snapshot is not None
+        survivors = sorted(p.name for p in backup_root.iterdir() if p.name != "keep-me")
+        assert len(survivors) == RETENTION_SNAPSHOTS
+        # The new snapshot is the newest; the oldest fakes are gone.
+        assert survivors[-1] == "20260818_030000"
+        assert old_names[0] not in survivors
+        assert (backup_root / "keep-me").exists()
+
+
+class TestFailure:
+    def test_failed_run_raises_and_leaves_no_snapshot(self, tmp_path):
+        """A copy failure propagates and removes the partial directory."""
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        # Garbage bytes under a database suffix make the sqlite backup
+        # path fail when the backup API tries to read pages.
+        (memory_dir / "broken.db").write_bytes(b"this is not a sqlite database")
+        backup_root = tmp_path / "backups" / "memory"
+
+        with pytest.raises(sqlite3.Error):
+            run_memory_backup(memory_dir, backup_root, NOW)
+
+        assert list(backup_root.iterdir()) == []
+
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory permissions")
+    def test_unreadable_directory_warns_but_snapshot_succeeds(self, tmp_path, caplog):
+        """Foreign-owned 0700 principal dirs are reported loudly, not silently skipped."""
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        conn.close()
+        locked = memory_dir / "prn_locked"
+        locked.mkdir()
+        (locked / "MEMORY.md").write_text("secret")
+        os.chmod(locked, 0o000)
+
+        try:
+            with caplog.at_level(logging.WARNING, logger="kai.memory_backup"):
+                snapshot = run_memory_backup(memory_dir, tmp_path / "backups" / "memory", NOW)
+        finally:
+            os.chmod(locked, 0o700)
+
+        assert snapshot is not None
+        assert not (snapshot / "prn_locked" / "MEMORY.md").exists()
+        assert any("unreadable" in r.message and "prn_locked" in r.message for r in caplog.records)

--- a/tests/test_memory_backup.py
+++ b/tests/test_memory_backup.py
@@ -181,8 +181,9 @@ class TestFailure:
         assert list(backup_root.iterdir()) == []
 
     @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory permissions")
-    def test_unreadable_directory_warns_but_snapshot_succeeds(self, tmp_path, caplog):
+    def test_unreadable_directory_warns_but_snapshot_succeeds(self, tmp_path, caplog, monkeypatch):
         """Foreign-owned 0700 principal dirs are reported loudly, not silently skipped."""
+        monkeypatch.setattr("kai.memory_backup._previous_unreadable", None)
         memory_dir, conn = _make_memory_tree(tmp_path)
         conn.close()
         locked = memory_dir / "prn_locked"
@@ -199,3 +200,25 @@ class TestFailure:
         assert snapshot is not None
         assert not (snapshot / "prn_locked" / "MEMORY.md").exists()
         assert any("unreadable" in r.message and "prn_locked" in r.message for r in caplog.records)
+
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory permissions")
+    def test_unchanged_unreadable_set_demotes_to_info(self, tmp_path, caplog, monkeypatch):
+        """A repeat of the same unreadable set logs INFO, not nightly WARNING furniture."""
+        monkeypatch.setattr("kai.memory_backup._previous_unreadable", None)
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        conn.close()
+        locked = memory_dir / "prn_locked"
+        locked.mkdir()
+        os.chmod(locked, 0o000)
+
+        try:
+            with caplog.at_level(logging.INFO, logger="kai.memory_backup"):
+                # Two runs spaced past the freshness floor, same unreadable set.
+                first = run_memory_backup(memory_dir, tmp_path / "backups" / "memory", NOW)
+                second = run_memory_backup(memory_dir, tmp_path / "backups" / "memory", NOW + MIN_SNAPSHOT_AGE * 2)
+        finally:
+            os.chmod(locked, 0o700)
+
+        assert first is not None and second is not None
+        unreadable_records = [r for r in caplog.records if "prn_locked" in r.message or "skipped" in r.message]
+        assert [r.levelno for r in unreadable_records] == [logging.WARNING, logging.INFO]


### PR DESCRIPTION
Closes #1004.

## What

A nightly in-process job snapshots `DATA_DIR/memory/` (embedded Qdrant store, Mem0 history DB, per-principal MEMORY.md fallbacks) into dated directories under `DATA_DIR/backups/memory/`, keeping the newest 7.

## How

- **Consistency without quiescing.** SQLite databases (`storage.sqlite`, `mem0_history.db`) are copied through the sqlite3 backup API, opened read-only on the source side. The API takes a consistent read even while the daemon commits writes, so no quiesce is needed. WAL/SHM/journal sidecars are excluded; their pending content is folded into the copied main database. Everything else in the tree is a plain `copy2`. The issue offered backup-API-or-quiesce; this takes the backup API.
- **In-process, mirroring the existing file-cleanup loop.** `_memory_backup_loop` in `main.py` follows the `_file_cleanup_loop` pattern exactly: startup delay, daily wake, task cancelled in the shutdown finally. The copy itself runs in a worker thread. Unconditional start: the loop no-ops when `DATA_DIR/memory` does not exist, and gating on `memory_enabled` would leave the MEMORY.md fallback store (used when memory is disabled) without backups. No new env vars.
- **Restart churn does not eat the retention window.** The loop clock resets on service restart, so a 20-hour freshness floor skips a run when the newest snapshot is younger than that. Without it, a day with several deploys would write several snapshots and rotate real history out of the 7-snapshot window.
- **No plausible-looking partial snapshots.** Snapshots are written under a dot-prefixed working name and renamed into place only when complete. A failed run raises, removes its partial, and is logged with a full traceback; the loop survives to try again the next night.
- **Owner-only permissions** (0700 dirs / 0600 files) from `backups/` down, deliberately tighter than the live store's current group/world-readable modes.
- **Unreadable principal dirs are loud, not silent.** Per-principal MEMORY.md directories are 0700 and owned by the per-OS-user inner agent processes, so the service user cannot read them. `os.walk`'s default is to skip those silently; instead they are collected and reported in one warning per run. The run still succeeds because the SQLite corpus is the critical asset and failing outright would mean no backups at all.
- **Retention is a name sort** over directories matching the `YYYYMMDD_HHMMSS` shape; foreign files in the backup root are never pruning candidates.

## Restore

The procedure is documented in the `memory_backup.py` module docstring (stop service, move damaged tree aside, `cp -Rp` the snapshot into place, restore ownership, start, verify reads).

Exercised end to end against a scratch `DATA_DIR` per acceptance criterion 4: a fact written through a live embedded store (same Mem0 config shape the daemon uses, connection open in WAL mode) was snapshotted with `run_memory_backup`, restored into a second scratch `DATA_DIR` with `cp -Rp`, and the restored store served semantic search cold:

```
PHASE A OK: fact written and searchable in .../live/memory
PHASE B OK: snapshot at .../live/backups/memory/20260818_134625
PHASE C OK: restored into .../restored/memory
PHASE D OK: restored store serves reads (top hit score 0.687: "The operator's favorite tea is genmaicha.")
```

## Tests

12 new tests: snapshot content and SQLite consistency against a live WAL-mode connection, sidecar exclusion, owner-only permissions including the backup root, freshness skip both directions, retention pruning with a foreign directory left untouched, failure cleanup, the unreadable-directory warning plus its unchanged-set demotion to INFO, and three loop tests (snapshot written, missing-dir no-op, failure logged and loop survives). Full suite 5962 passed, 1 skipped; ruff and pyright strict clean.

The structural half of the unreadable-directory situation (fallback stores the service user can never read) is tracked in #1007.

