### PR TITLE
memory: isolate eval writes from the production collection

### DIFF
--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -2056,6 +2056,12 @@ async def _run_cli(args: argparse.Namespace) -> int:
     # dedicated store directory, never the production collection, and
     # MEM0_DIR is redirected before init_memory lazily imports mem0.
     eval_store = DATA_DIR / "eval_memory"
+    # Owner-only: sandbox facts derive from real conversation windows,
+    # so the eval store must not be more readable than the production
+    # store it is isolated from. chmod as well as mkdir so a tree
+    # created by an older run is healed rather than trusted.
+    eval_store.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(eval_store, 0o700)
     os.environ["MEM0_DIR"] = str(eval_store / "mem0")
     memory.init_memory(memory_init_config, store_dir=eval_store)
     runs: dict[str, BackendRun] = {}

--- a/src/kai/eval/memory_backend_gate.py
+++ b/src/kai/eval/memory_backend_gate.py
@@ -36,6 +36,7 @@ import dataclasses
 import hashlib
 import json
 import logging
+import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -45,7 +46,15 @@ from pathlib import Path
 from typing import Any
 
 from kai import memory, memory_extraction
-from kai.config import ONESHOT_REASONER_BACKENDS, Config, ModelRole, _resolve_eval_provider, get_model_for, load_config
+from kai.config import (
+    DATA_DIR,
+    ONESHOT_REASONER_BACKENDS,
+    Config,
+    ModelRole,
+    _resolve_eval_provider,
+    get_model_for,
+    load_config,
+)
 from kai.eval.extraction import _window_to_extractor_args
 from kai.eval.replay import _SANDBOX_USER_ID_PREFIX
 
@@ -2043,7 +2052,12 @@ async def _run_cli(args: argparse.Namespace) -> int:
         memory_enabled=True,
         memory_extraction_enabled=True,
     )
-    memory.init_memory(memory_init_config)
+    # Same isolation as the replay harness: sandbox arms write to a
+    # dedicated store directory, never the production collection, and
+    # MEM0_DIR is redirected before init_memory lazily imports mem0.
+    eval_store = DATA_DIR / "eval_memory"
+    os.environ["MEM0_DIR"] = str(eval_store / "mem0")
+    memory.init_memory(memory_init_config, store_dir=eval_store)
     runs: dict[str, BackendRun] = {}
     metrics_by_backend: dict[str, BackendMetrics] = {}
     for backend in args.backends:

--- a/src/kai/eval/replay.py
+++ b/src/kai/eval/replay.py
@@ -52,6 +52,7 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import sys
 from datetime import date, datetime
 from pathlib import Path
@@ -533,7 +534,20 @@ async def _async_main(argv: list[str] | None = None) -> int:
     # consolidation log. Placed AFTER argument validation so a bad
     # `--context-turns` does not trigger the first-run Mem0 embedding-
     # model download (~80MB) only to exit immediately.
-    init_memory(config)
+    #
+    # The store is isolated from the production collection: replay
+    # writes accumulate under sandbox user_ids, and those must never
+    # share a collection with real principals (they distort write
+    # metrics and RAM footprint even though owner filtering keeps
+    # recall correct). The dedicated directory persists across runs
+    # (the accumulating-sandbox design needs that), and MEM0_DIR is
+    # redirected so mem0's auto-created migrations store lands in the
+    # same tree instead of ~/.mem0/ or the production store. MEM0_DIR
+    # is read at mem0 import time, which happens lazily inside
+    # init_memory, so setting it here is early enough.
+    eval_store = DATA_DIR / "eval_memory"
+    os.environ["MEM0_DIR"] = str(eval_store / "mem0")
+    init_memory(config, store_dir=eval_store)
 
     file_paths = _iter_history_files(history_dir, args.start_date, args.end_date)
     if not file_paths:

--- a/src/kai/eval/replay.py
+++ b/src/kai/eval/replay.py
@@ -546,6 +546,12 @@ async def _async_main(argv: list[str] | None = None) -> int:
     # is read at mem0 import time, which happens lazily inside
     # init_memory, so setting it here is early enough.
     eval_store = DATA_DIR / "eval_memory"
+    # Owner-only: replayed facts derive from real conversation history,
+    # so the eval store must not be more readable than the production
+    # store it is isolated from. chmod as well as mkdir so a tree
+    # created by an older run is healed rather than trusted.
+    eval_store.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(eval_store, 0o700)
     os.environ["MEM0_DIR"] = str(eval_store / "mem0")
     init_memory(config, store_dir=eval_store)
 

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -984,14 +984,24 @@ def _resolve_cached_embedding_model(model: str) -> tuple[str, bool]:
     return str(Path(snapshot_path).resolve()), True
 
 
-def _mem0_config(config: Config) -> dict:
+def _mem0_config(config: Config, store_dir: Path | None = None) -> dict:
     """
     Build Mem0 configuration dict from Kai's config.
 
     Creates the Qdrant storage directory if it does not exist. Uses
     local embedded Qdrant (no server needed) with HuggingFace embeddings.
+
+    Args:
+        config: Application config with memory settings.
+        store_dir: Root directory for the Qdrant tree and the Mem0
+            history DB. None means the production store
+            (DATA_DIR/memory). Eval harnesses pass an isolated
+            directory so sandbox writes can never land in the
+            production collection.
     """
-    qdrant_path = DATA_DIR / "memory" / "qdrant"
+    if store_dir is None:
+        store_dir = DATA_DIR / "memory"
+    qdrant_path = store_dir / "qdrant"
     qdrant_path.mkdir(parents=True, exist_ok=True)
     embedding_model, local_only = _resolve_cached_embedding_model(config.memory_embedding_model)
     model_kwargs: dict[str, object] = {"device": "cpu"}
@@ -1017,10 +1027,11 @@ def _mem0_config(config: Config) -> dict:
                 "path": str(qdrant_path),
             },
         },
-        # Keep Mem0's history DB inside DATA_DIR, not ~/.mem0/.
-        # In production DATA_DIR is /var/lib/kai/, so without this
-        # override the history DB would land in the wrong location.
-        "history_db_path": str(DATA_DIR / "memory" / "mem0_history.db"),
+        # Keep Mem0's history DB inside the store dir, not ~/.mem0/.
+        # In production the store dir is /var/lib/kai/memory/, so
+        # without this override the history DB would land in the
+        # wrong location.
+        "history_db_path": str(store_dir / "mem0_history.db"),
     }
 
 
@@ -1445,7 +1456,7 @@ def init_offline_memory(config: Config) -> None:
     init_memory(config)
 
 
-def init_memory(config: Config) -> None:
+def init_memory(config: Config, *, store_dir: Path | None = None) -> None:
     """
     Initialize the Mem0 memory instance with Qdrant embedded storage.
 
@@ -1472,6 +1483,10 @@ def init_memory(config: Config) -> None:
 
     Args:
         config: Application config with memory settings.
+        store_dir: Root directory for the store, passed through to
+            `_mem0_config`. None means the production store
+            (DATA_DIR/memory); eval harnesses pass an isolated
+            directory.
 
     Raises:
         Exception: Propagated to caller (main.py catches and logs).
@@ -1635,7 +1650,7 @@ def init_memory(config: Config) -> None:
     # (~300MB RAM, several seconds) when memory is disabled.
     from mem0 import Memory
 
-    mem0_cfg = _mem0_config(config)
+    mem0_cfg = _mem0_config(config, store_dir)
     m = Memory.from_config(mem0_cfg)
 
     # Validate that the embedding model's output dimensions match the
@@ -1661,7 +1676,7 @@ def init_memory(config: Config) -> None:
         "Memory system ready (model=%s, dims=%d, storage=%s)",
         config.memory_embedding_model,
         actual_dims,
-        DATA_DIR / "memory" / "qdrant",
+        mem0_cfg["vector_store"]["config"]["path"],
     )
 
 
@@ -3028,6 +3043,50 @@ def _patch_memory_payload(*, memory_id: str, payload: dict[str, object]) -> None
             "Semantic-memory provider does not support payload-only ownership migration"
         )
     update(vector_id=memory_id, payload=payload)
+
+
+def count_points_by_owner() -> dict[str, int]:
+    """Count stored points per top-level `user_id` across the whole collection.
+
+    Mem0's `get_all` requires a `user_id` filter, so a collection-wide
+    owner census has no public-API path. Like `_patch_memory_payload`
+    above, this reaches through Mem0's `vector_store` in one isolated
+    boundary: a Qdrant scroll fetching only the `user_id` payload key
+    (no vectors, no other payload). Read-only.
+
+    Used by the `purge-sandbox` admin command to discover eval residue
+    identities and to verify real principals' counts are untouched by
+    the purge.
+
+    Raises RuntimeError when memory is not initialized or the provider
+    does not expose a Qdrant-style scroll: the sole caller is an
+    operator CLI where a loud failure beats an empty census that reads
+    as "nothing to purge".
+    """
+    if _memory is None:
+        raise RuntimeError("Semantic memory is not initialized")
+    vector_store = getattr(_memory, "vector_store", None)
+    client = getattr(vector_store, "client", None)
+    scroll = getattr(client, "scroll", None)
+    if not callable(scroll):
+        raise RuntimeError("Semantic-memory provider does not support an owner census")
+
+    counts: dict[str, int] = {}
+    offset = None
+    while True:
+        points, offset = scroll(
+            collection_name=vector_store.collection_name,
+            limit=1000,
+            offset=offset,
+            with_payload=["user_id"],
+            with_vectors=False,
+        )
+        for point in points:
+            uid = (point.payload or {}).get("user_id", "")
+            counts[uid] = counts.get(uid, 0) + 1
+        if offset is None:
+            break
+    return counts
 
 
 def migrate_memory_namespace(

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -25,6 +25,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1492,6 +1493,33 @@ def init_memory(config: Config, *, store_dir: Path | None = None) -> None:
         Exception: Propagated to caller (main.py catches and logs).
     """
     global _memory, _config
+
+    # Store isolation self-check. Callers passing store_dir (the eval
+    # harnesses) redirect MEM0_DIR into that tree so mem0's
+    # auto-created migrations store lands there too, but mem0 captures
+    # MEM0_DIR into module constants at first import. The redirect is
+    # therefore only effective while mem0's import stays lazy (it
+    # happens below, inside this function). If a future refactor pulls
+    # mem0 into an earlier import graph, the migrations store would
+    # silently land at the captured path instead, where it can
+    # contend with the live daemon's lock on the same embedded store.
+    # Fail loud on the actual invariant (captured home == current
+    # env) rather than on mere prior import, so an early import with
+    # a correctly-set env stays valid. Plain `if/raise`, not assert:
+    # asserts vanish under python -O.
+    if store_dir is not None and "mem0" in sys.modules:
+        from mem0.memory.setup import mem0_dir as _captured_mem0_dir
+
+        if str(_captured_mem0_dir) != os.environ.get("MEM0_DIR", ""):
+            raise RuntimeError(
+                "init_memory(store_dir=...) requires mem0's home to match "
+                f"MEM0_DIR, but mem0 already captured {_captured_mem0_dir!r} "
+                f"at import time while MEM0_DIR is now "
+                f"{os.environ.get('MEM0_DIR', '')!r}. Set MEM0_DIR before "
+                "the first mem0 import (the eval harnesses set it before "
+                "calling init_memory, which normally performs the first "
+                "import lazily)."
+            )
 
     # Structured startup log describing the configured memory state.
     # Emitted exactly once per init regardless of whether memory is

--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -138,6 +138,24 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Confirm deletion. Without this flag the command prints the planned action and exits with status 2.",
     )
 
+    ps = sub.add_parser(
+        "purge-sandbox",
+        help="Delete every eval-residue identity (user_id prefix 'sandbox-') from the store",
+        description=(
+            "Enumerate every owner identity in the collection whose "
+            "user_id starts with 'sandbox-' (the eval-harness naming "
+            "convention shared by the replay and backend-gate tools) "
+            "and delete all of their rows. Real principals are listed "
+            "in the plan and re-counted afterwards so the run verifies "
+            "they were untouched."
+        ),
+    )
+    ps.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm deletion. Without this flag the command prints the planned deletions and exits with status 2.",
+    )
+
     # Lazy import: the choices list is the only config dependency at
     # parser-build time. Importing it here (not at module top) keeps
     # `import kai.memory_admin` itself free of kai.config, preserving
@@ -419,6 +437,72 @@ def _cmd_purge(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_purge_sandbox(args: argparse.Namespace) -> int:
+    """Execute the `purge-sandbox` subcommand. Returns a process exit code.
+
+    Deletion goes through the existing `delete_all` primitive per
+    identity. That primitive swallows provider exceptions by design
+    (it serves the bot's forget-all path), so success is verified by
+    re-running the owner census afterwards rather than by trusting
+    the calls: any surviving sandbox row, or any change to a real
+    principal's count, fails the run with exit 1.
+    """
+    if not _initialize_memory():
+        return 1
+
+    from kai.memory import count_points_by_owner, delete_all
+
+    try:
+        before = count_points_by_owner()
+    except Exception as e:
+        print(f"memory admin: owner census failed: {e}", file=sys.stderr)
+        return 1
+
+    sandbox = {uid: n for uid, n in sorted(before.items()) if uid.startswith("sandbox-")}
+    real = {uid: n for uid, n in sorted(before.items()) if not uid.startswith("sandbox-")}
+
+    if not sandbox:
+        print("memory admin: no sandbox-prefixed identities in the store; nothing to purge.")
+        return 0
+
+    print(f"memory admin: {sum(sandbox.values())} row(s) across {len(sandbox)} sandbox identit(ies):")
+    for uid, n in sandbox.items():
+        print(f"  {uid}: {n}")
+    print(f"memory admin: {len(real)} real principal(s) will be left untouched:")
+    for uid, n in real.items():
+        print(f"  {uid}: {n}")
+
+    if not args.yes:
+        # Dry-run path; exit 2 mirrors `purge` (distinct from success
+        # and error so automation can tell them apart).
+        print("memory admin: re-run with --yes to execute.")
+        return 2
+
+    for uid in sandbox:
+        delete_all(user_id=uid)
+
+    try:
+        after = count_points_by_owner()
+    except Exception as e:
+        print(f"memory admin: post-purge census failed: {e}", file=sys.stderr)
+        return 1
+
+    leftover = {uid: n for uid, n in sorted(after.items()) if uid.startswith("sandbox-")}
+    real_after = {uid: n for uid, n in sorted(after.items()) if not uid.startswith("sandbox-")}
+    if leftover:
+        print(f"memory admin: purge incomplete; sandbox rows remain: {leftover}", file=sys.stderr)
+        return 1
+    if real_after != real:
+        print(
+            f"memory admin: real principal counts changed during the purge: before={real} after={real_after}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"memory admin: deleted {sum(sandbox.values())} row(s); real principal counts unchanged.")
+    return 0
+
+
 def _cmd_reclassify(args: argparse.Namespace) -> int:
     """Execute the `reclassify-scope` subcommand. Returns an exit code.
 
@@ -697,6 +781,8 @@ def cli(argv: list[str]) -> None:
 
     if args.command == "purge":
         sys.exit(_cmd_purge(args))
+    if args.command == "purge-sandbox":
+        sys.exit(_cmd_purge_sandbox(args))
     if args.command == "reclassify-scope":
         sys.exit(_cmd_reclassify(args))
     if args.command == "backfill-provenance":

--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -22,6 +22,10 @@ Scope (spec §16 + Phase 4 of spec 320):
   `source_*` keys onto surviving rows with pre-images dumped first;
   `--rollback` restores rows whose source block has not drifted.
   The pass logic lives in `src/kai/memory_provenance_backfill.py`.
+- `purge-sandbox`: delete every eval-residue identity (user_id prefix
+  `sandbox-`) from the collection. Censuses owners collection-wide,
+  prints the plan, and verifies by re-census that no sandbox rows
+  survive and real principals' counts are unchanged.
 
 Commands that modify the store require an explicit `--yes` flag. When
 `--yes` is absent, the command prints the action it WOULD take and
@@ -31,11 +35,11 @@ ops scripts and cron invocations should either set `--yes` upfront or
 fail fast on missing authorization, rather than blocking on stdin.
 
 The broader `delete_all(user_id=...)` primitive exists in
-`src/kai/memory.py` and is documented in spec §16. It is intentionally
-NOT exposed here: Phase 4 is scoped to legacy cleanup, and a
-per-source purge is sufficient for the advertised use case
-(`--source ""` to drop rows from pre-Phase-1 installations). If a
-future incident requires the nuclear option, add it as a separate
+`src/kai/memory.py`. The only exposure here is the constrained one
+inside `purge-sandbox`: identities are discovered by census, gated on
+the `sandbox-` prefix, and verified by re-census afterwards. An
+unconstrained wipe of an arbitrary user_id remains intentionally NOT
+exposed; if a future incident requires that, add it as a separate
 `nuke` subcommand with its own review.
 
 This module should NOT import `kai.bot`, `kai.pool`, or other

--- a/tests/test_eval_memory_backend_gate.py
+++ b/tests/test_eval_memory_backend_gate.py
@@ -14,6 +14,7 @@ because it can contain conversation fragments.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import replace
 from pathlib import Path
 
@@ -1003,6 +1004,11 @@ class TestCLIInitializesMemory:
         before the first run_backend invocation."""
         from unittest.mock import patch
 
+        # The CLI overwrites MEM0_DIR as part of store isolation;
+        # registering it with monkeypatch first makes pytest restore
+        # the pre-test value at teardown.
+        monkeypatch.setenv("MEM0_DIR", "pre-test-value")
+
         # Build a minimum-valid probe fixture so the preflight passes.
         path = tmp_path / "probes.jsonl"
         rows = []
@@ -1042,9 +1048,11 @@ class TestCLIInitializesMemory:
         _write_jsonl(path, rows)
 
         call_order: list[str] = []
+        init_store_dirs: list = []
 
-        def _fake_init(_config):
+        def _fake_init(_config, *, store_dir=None):
             call_order.append("init_memory")
+            init_store_dirs.append(store_dir)
 
         async def _fake_run_backend(**kwargs):
             call_order.append("run_backend")
@@ -1085,6 +1093,12 @@ class TestCLIInitializesMemory:
         assert rc == 0
         assert "init_memory" in call_order
         assert call_order.index("init_memory") < call_order.index("run_backend")
+        # store_dir pins the eval-isolation guardrail: the gate's
+        # sandbox arms must never open the production collection.
+        from kai.config import DATA_DIR
+
+        assert init_store_dirs == [DATA_DIR / "eval_memory"]
+        assert os.environ["MEM0_DIR"] == str(DATA_DIR / "eval_memory" / "mem0")
 
 
 # ── --os-user override threading ────────────────────────────────────
@@ -1156,6 +1170,7 @@ class TestOsUserOverride:
         )()
 
     def test_codex_without_os_user_proceeds(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MEM0_DIR", "pre-test-value")
         """Issue #522: codex same-user spawn is supported. Running
         the gate with `--backends codex` and no `--os-user` reaches
         `run_backend` with `os_user_override=None`; no preflight
@@ -1184,7 +1199,7 @@ class TestOsUserOverride:
             )
 
         with (
-            patch("kai.eval.memory_backend_gate.memory.init_memory", lambda _c: None),
+            patch("kai.eval.memory_backend_gate.memory.init_memory", lambda _c, store_dir=None: None),
             patch("kai.eval.memory_backend_gate.load_config", return_value=_BASE_CONFIG),
             patch("kai.eval.memory_backend_gate.run_backend", _fake_run_backend),
         ):
@@ -1193,6 +1208,7 @@ class TestOsUserOverride:
         assert captured == [None, None]
 
     def test_claude_only_does_not_require_os_user(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MEM0_DIR", "pre-test-value")
         """Single-arm claude run with no `--os-user` proceeds the
         same way it always has."""
         import asyncio
@@ -1216,7 +1232,7 @@ class TestOsUserOverride:
             )
 
         with (
-            patch("kai.eval.memory_backend_gate.memory.init_memory", lambda _c: None),
+            patch("kai.eval.memory_backend_gate.memory.init_memory", lambda _c, store_dir=None: None),
             patch("kai.eval.memory_backend_gate.load_config", return_value=_BASE_CONFIG),
             patch("kai.eval.memory_backend_gate.run_backend", _fake_run_backend),
         ):
@@ -1224,6 +1240,7 @@ class TestOsUserOverride:
         assert rc == 0
 
     def test_os_user_flows_into_run_backend(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MEM0_DIR", "pre-test-value")
         """When `--os-user` is supplied, the value is threaded into
         `run_backend(..., os_user_override=...)` for both arms."""
         import asyncio
@@ -1250,7 +1267,7 @@ class TestOsUserOverride:
             )
 
         with (
-            patch("kai.eval.memory_backend_gate.memory.init_memory", lambda _c: None),
+            patch("kai.eval.memory_backend_gate.memory.init_memory", lambda _c, store_dir=None: None),
             patch("kai.eval.memory_backend_gate.load_config", return_value=_BASE_CONFIG),
             patch("kai.eval.memory_backend_gate.run_backend", _fake_run_backend),
         ):

--- a/tests/test_eval_replay.py
+++ b/tests/test_eval_replay.py
@@ -20,6 +20,7 @@ PII posture: tests use synthetic JSONL fixtures generated inside
 from __future__ import annotations
 
 import json
+import os
 from datetime import date
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -375,7 +376,11 @@ class TestInitMemory:
     `outcome=dropped_backend`."""
 
     @pytest.mark.asyncio
-    async def test_async_main_initializes_memory(self, tmp_path):
+    async def test_async_main_initializes_memory(self, tmp_path, monkeypatch):
+        # The command overwrites MEM0_DIR in the process env as part of
+        # store isolation; registering the var with monkeypatch first
+        # makes pytest restore the pre-test value at teardown.
+        monkeypatch.setenv("MEM0_DIR", "pre-test-value")
         # Create a history file with one valid pair so the replay walks
         # but does not block on missing files.
         history_dir = tmp_path / "history" / str(_CHAT_ID)
@@ -412,7 +417,13 @@ class TestInitMemory:
             )
 
         assert rc == 0
-        init_mock.assert_called_once_with(config_mock)
+        # store_dir pins the eval-isolation guardrail: replay must
+        # never open the production collection; before isolation
+        # existed, eval runs left sandbox points in the real store.
+        from kai.config import DATA_DIR
+
+        init_mock.assert_called_once_with(config_mock, store_dir=DATA_DIR / "eval_memory")
+        assert os.environ["MEM0_DIR"] == str(DATA_DIR / "eval_memory" / "mem0")
 
 
 # ── --log-file structured-log capture ───────────────────────────────
@@ -443,13 +454,14 @@ class TestLogFileCapture:
         return history_dir
 
     @pytest.mark.asyncio
-    async def test_log_file_flag_captures_intent_log_lines(self, tmp_path):
+    async def test_log_file_flag_captures_intent_log_lines(self, tmp_path, monkeypatch):
         """End-to-end: an INFO-level `memory.consolidate.intent` line
         emitted via the production `_emit_intent_log` helper must
         appear in the file the operator named. The replay loop is
         short-circuited (no real extraction) and we directly emit a
         synthetic intent log from inside the patched extract path so
         the test is fast and deterministic."""
+        monkeypatch.setenv("MEM0_DIR", "pre-test-value")
         history_dir = self._make_history(tmp_path)
         log_path = tmp_path / "replay-with-logs.log"
 
@@ -516,13 +528,14 @@ class TestLogFileCapture:
         return len(logging.getLogger().handlers)
 
     @pytest.mark.asyncio
-    async def test_log_file_default_attaches_no_handler(self, tmp_path):
+    async def test_log_file_default_attaches_no_handler(self, tmp_path, monkeypatch):
         """Regression guard: without `--log-file` the replay must NOT
         attach a handler to the root logger. The previous behavior
         (no logging) was a bug, but the FIX must be explicit (the
         flag), not silent. A future refactor that auto-enables logging
         could leak handlers across test runs or surprise an operator
         whose terminal session was previously quiet."""
+        monkeypatch.setenv("MEM0_DIR", "pre-test-value")
         history_dir = self._make_history(tmp_path)
         before = self._root_handler_count()
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -19,7 +19,7 @@ import re
 import sys
 from dataclasses import replace
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -283,6 +283,42 @@ class TestEmbeddingModelResolution:
             "model": str(snapshot),
             "model_kwargs": {"device": "cpu", "local_files_only": True},
         }
+
+    def test_default_store_dir_is_production_memory_tree(self, tmp_path):
+        from kai.memory import _mem0_config
+
+        with (
+            patch("kai.memory.DATA_DIR", tmp_path),
+            patch(
+                "kai.memory._resolve_cached_embedding_model",
+                return_value=("m", False),
+            ),
+        ):
+            config = _mem0_config(_make_config())
+
+        assert config["vector_store"]["config"]["path"] == str(tmp_path / "memory" / "qdrant")
+        assert config["history_db_path"] == str(tmp_path / "memory" / "mem0_history.db")
+
+    def test_store_dir_override_relocates_qdrant_and_history(self, tmp_path):
+        """The eval-isolation override must move BOTH stores: an
+        override that relocated the vectors but left the history DB on
+        the production path would silently keep polluting the
+        production write metrics the override exists to protect."""
+        from kai.memory import _mem0_config
+
+        override = tmp_path / "eval_memory"
+        with (
+            patch("kai.memory.DATA_DIR", tmp_path),
+            patch(
+                "kai.memory._resolve_cached_embedding_model",
+                return_value=("m", False),
+            ),
+        ):
+            config = _mem0_config(_make_config(), store_dir=override)
+
+        assert config["vector_store"]["config"]["path"] == str(override / "qdrant")
+        assert config["history_db_path"] == str(override / "mem0_history.db")
+        assert (override / "qdrant").is_dir()
 
 
 # Third-party warnings scoped to this class: qdrant-client's local
@@ -6194,3 +6230,67 @@ class TestEmbedTexts:
         # Order matters: callers (centroid computation) rely on
         # vectors lining up with the input texts by index.
         assert mock_mem.embedding_model.embed.call_count == 3
+
+
+# ── count_points_by_owner ────────────────────────────────────────────
+
+
+class TestCountPointsByOwner:
+    """Collection-wide owner census used by the purge-sandbox admin
+    command. Reaches through Mem0's vector_store to a Qdrant scroll,
+    so the fake mirrors that surface: client.scroll returning
+    (points, next_offset) pages."""
+
+    @staticmethod
+    def _fake_memory(pages):
+        """Build a fake Mem0 whose client.scroll serves the given pages."""
+        calls = {"offsets": []}
+
+        def scroll(*, collection_name, limit, offset, with_payload, with_vectors):
+            calls["offsets"].append(offset)
+            points, next_offset = pages[len(calls["offsets"]) - 1]
+            return points, next_offset
+
+        client = SimpleNamespace(scroll=scroll)
+        vector_store = SimpleNamespace(client=client, collection_name="kai_memory")
+        return SimpleNamespace(vector_store=vector_store), calls
+
+    def test_counts_owners_across_pages(self):
+        from kai.memory import count_points_by_owner
+
+        p = lambda uid: SimpleNamespace(payload={"user_id": uid})  # noqa: E731
+        fake, calls = self._fake_memory(
+            [
+                ([p("prn_a"), p("sandbox-1"), p("prn_a")], "cursor"),
+                ([p("sandbox-1"), p("prn_b")], None),
+            ]
+        )
+        with patch("kai.memory._memory", fake):
+            counts = count_points_by_owner()
+
+        assert counts == {"prn_a": 2, "sandbox-1": 2, "prn_b": 1}
+        # Pagination contract: first call starts at None, second call
+        # resumes from the returned cursor.
+        assert calls["offsets"] == [None, "cursor"]
+
+    def test_missing_payload_counts_as_empty_owner(self):
+        from kai.memory import count_points_by_owner
+
+        fake, _ = self._fake_memory([([SimpleNamespace(payload=None)], None)])
+        with patch("kai.memory._memory", fake):
+            assert count_points_by_owner() == {"": 1}
+
+    def test_raises_when_memory_uninitialized(self):
+        from kai.memory import count_points_by_owner
+
+        with patch("kai.memory._memory", None), pytest.raises(RuntimeError):
+            count_points_by_owner()
+
+    def test_raises_when_provider_has_no_scroll(self):
+        """A provider without a Qdrant-style scroll must fail loud, not
+        return an empty census that reads as 'nothing to purge'."""
+        from kai.memory import count_points_by_owner
+
+        fake = SimpleNamespace(vector_store=SimpleNamespace(client=object(), collection_name="x"))
+        with patch("kai.memory._memory", fake), pytest.raises(RuntimeError):
+            count_points_by_owner()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6294,3 +6294,45 @@ class TestCountPointsByOwner:
         fake = SimpleNamespace(vector_store=SimpleNamespace(client=object(), collection_name="x"))
         with patch("kai.memory._memory", fake), pytest.raises(RuntimeError):
             count_points_by_owner()
+
+
+# ── store_dir mem0-home invariant guard ──────────────────────────────
+
+
+class TestStoreDirMem0HomeGuard:
+    """init_memory(store_dir=...) must fail loud when mem0 was already
+    imported with a home that does not match the current MEM0_DIR: the
+    redirect the eval harnesses rely on is only effective while mem0's
+    import stays lazy, and a silent no-op would drop the migrations
+    store outside the isolated tree (where it can contend with the
+    live daemon's lock)."""
+
+    def test_stale_captured_home_raises(self, tmp_path, monkeypatch):
+        from kai.memory import init_memory
+
+        setup_mod = ModuleType("mem0.memory.setup")
+        setup_mod.mem0_dir = "/frozen/at/import/time"  # type: ignore[attr-defined]
+        fakes = {
+            "mem0": ModuleType("mem0"),
+            "mem0.memory": ModuleType("mem0.memory"),
+            "mem0.memory.setup": setup_mod,
+        }
+        monkeypatch.setenv("MEM0_DIR", str(tmp_path / "eval" / "mem0"))
+        with patch.dict(sys.modules, fakes), pytest.raises(RuntimeError, match="already captured"):
+            init_memory(_make_config(), store_dir=tmp_path / "eval")
+
+    def test_no_store_dir_skips_the_guard(self, monkeypatch):
+        """Production init (no store_dir) must not consult the guard at
+        all: the daemon sets its own MEM0_DIR at service level and a
+        mismatch there is not this invariant's business."""
+        from kai.memory import init_memory
+
+        setup_mod = ModuleType("mem0.memory.setup")
+        setup_mod.mem0_dir = "/frozen/at/import/time"  # type: ignore[attr-defined]
+        monkeypatch.setenv("MEM0_DIR", "/somewhere/else")
+        # memory_enabled=False makes init a no-op immediately after
+        # the guard region, so reaching the return proves the guard
+        # did not fire.
+        config = replace(_make_config(), memory_enabled=False)
+        with patch.dict(sys.modules, {"mem0.memory.setup": setup_mod}):
+            init_memory(config)

--- a/tests/test_memory_admin.py
+++ b/tests/test_memory_admin.py
@@ -481,3 +481,111 @@ class TestReclassifyGates:
         assert kwargs["threshold"] == 0.8
         assert kwargs["sample"] == 10
         assert kwargs["backend"] is None
+
+
+# ── purge-sandbox ────────────────────────────────────────────────────
+
+
+class TestPurgeSandbox:
+    """The eval-residue purge: census -> delete per sandbox identity ->
+    re-census verification. delete_all swallows provider errors by
+    design, so the command's success signal is the after-census, and
+    these tests pin that contract."""
+
+    @staticmethod
+    def _args(yes: bool):
+        parser = memory_admin._build_parser()
+        return parser.parse_args(["purge-sandbox", "--yes"] if yes else ["purge-sandbox"])
+
+    def test_dry_run_lists_plan_and_exits_2(self, capsys):
+        census = {"prn_a": 500, "sandbox-464": 300, "sandbox-465": 74}
+        delete_mock = MagicMock()
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.count_points_by_owner", return_value=census),
+            patch("kai.memory.delete_all", delete_mock),
+        ):
+            code = memory_admin._cmd_purge_sandbox(self._args(yes=False))
+        assert code == 2
+        delete_mock.assert_not_called()
+        out = capsys.readouterr().out
+        assert "sandbox-464: 300" in out
+        assert "prn_a: 500" in out
+        assert "--yes" in out
+
+    def test_yes_deletes_each_identity_and_verifies(self, capsys):
+        before = {"prn_a": 500, "sandbox-464": 300, "sandbox-465": 74}
+        after = {"prn_a": 500}
+        delete_mock = MagicMock()
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.count_points_by_owner", side_effect=[before, after]),
+            patch("kai.memory.delete_all", delete_mock),
+        ):
+            code = memory_admin._cmd_purge_sandbox(self._args(yes=True))
+        assert code == 0
+        assert {c.kwargs["user_id"] for c in delete_mock.call_args_list} == {
+            "sandbox-464",
+            "sandbox-465",
+        }
+        out = capsys.readouterr().out
+        assert "deleted 374 row(s)" in out
+        assert "unchanged" in out
+
+    def test_surviving_sandbox_rows_fail_the_run(self, capsys):
+        before = {"prn_a": 500, "sandbox-464": 300}
+        after = {"prn_a": 500, "sandbox-464": 12}
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.count_points_by_owner", side_effect=[before, after]),
+            patch("kai.memory.delete_all", MagicMock()),
+        ):
+            code = memory_admin._cmd_purge_sandbox(self._args(yes=True))
+        assert code == 1
+        assert "sandbox rows remain" in capsys.readouterr().err
+
+    def test_changed_real_principal_counts_fail_the_run(self, capsys):
+        before = {"prn_a": 500, "sandbox-464": 300}
+        after = {"prn_a": 499}
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.count_points_by_owner", side_effect=[before, after]),
+            patch("kai.memory.delete_all", MagicMock()),
+        ):
+            code = memory_admin._cmd_purge_sandbox(self._args(yes=True))
+        assert code == 1
+        assert "real principal counts changed" in capsys.readouterr().err
+
+    def test_no_sandbox_identities_is_a_clean_noop(self, capsys):
+        delete_mock = MagicMock()
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.count_points_by_owner", return_value={"prn_a": 5}),
+            patch("kai.memory.delete_all", delete_mock),
+        ):
+            code = memory_admin._cmd_purge_sandbox(self._args(yes=True))
+        assert code == 0
+        delete_mock.assert_not_called()
+        assert "nothing to purge" in capsys.readouterr().out
+
+    def test_init_failure_exits_1(self):
+        with patch.object(memory_admin, "_initialize_memory", return_value=None):
+            assert memory_admin._cmd_purge_sandbox(self._args(yes=True)) == 1
+
+    def test_census_failure_exits_1(self, capsys):
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.count_points_by_owner", side_effect=RuntimeError("no scroll")),
+        ):
+            code = memory_admin._cmd_purge_sandbox(self._args(yes=True))
+        assert code == 1
+        assert "census failed" in capsys.readouterr().err
+
+    def test_cli_dispatches_purge_sandbox(self):
+        with (
+            patch.object(memory_admin, "_cmd_purge_sandbox", return_value=0) as cmd,
+            pytest.raises(SystemExit) as exc,
+        ):
+            memory_admin.cli(["purge-sandbox"])
+        assert exc.value.code == 0
+        cmd.assert_called_once()


### PR DESCRIPTION
Closes #1008.

## What

Two halves, matching the issue's scope:

1. **Guardrail:** the replay and memory-backend-gate eval harnesses no longer open the production memory store. `init_memory` / `_mem0_config` accept an optional `store_dir` that relocates both the Qdrant tree and the Mem0 history DB; both eval CLIs pass `DATA_DIR/eval_memory` and redirect `MEM0_DIR` into the same tree before mem0's lazy import, in line with the mode-switch harness's existing isolation. The directory persists across runs because the replay design accumulates sandbox facts deliberately.
2. **Purge:** `python -m kai memory purge-sandbox` removes the residue already in the production collection. It censuses owners collection-wide, prints the per-identity plan plus the real principals it will leave untouched, and (with `--yes`) deletes each `sandbox-*` identity through the existing `delete_all` primitive. Because `delete_all` swallows provider errors by design, success is verified by a second census: any surviving sandbox row, or any change to a real principal's count, exits 1.

## Design notes

- The owner census (`count_points_by_owner`) is the one new primitive. Mem0's `get_all` requires a `user_id` filter, so a collection-wide census has no public-API path; the function reaches through `vector_store.client.scroll` in the same isolated-boundary style as the existing payload-patch helper, read-only, fetching only the `user_id` payload key. It raises rather than returning an empty census when the provider surface is missing, because its sole caller is an operator CLI where "nothing to purge" and "census broken" must not look alike.
- The existing tests that pinned "eval CLI calls init_memory" now also pin `store_dir=DATA_DIR/eval_memory` and the `MEM0_DIR` redirect; that is the acceptance criterion's "verifiably cannot write to the production collection" for both entry points.
- `init_memory(store_dir=...)` self-verifies the `MEM0_DIR` redirect: it fails loud when mem0 was already imported with a home that does not match the current env, checking the actual invariant rather than mere prior import so pytest ordering cannot false-positive. The eval store is created 0700 and re-chmodded each run, since replayed facts derive from real conversation history.
- No new env vars, no changes to the recall or extraction paths.
- The eval CLIs overwrite `MEM0_DIR` in their process env; tests that drive those CLIs register the variable with monkeypatch first so pytest restores it (the mem0 telemetry-isolation regression test cross-checks that env value and caught the leak).

## Purge execution plan (post-merge)

The embedded store is single-process, so the purge runs with the daemon stopped:

1. Confirm the nightly snapshot exists from before the purge (acceptance criterion 3).
2. Stop the service, run `python -m kai memory purge-sandbox` (dry-run), review the plan, re-run with `--yes`, restart the service.
3. The command's own re-census prints the verification for acceptance criterion 1.

## Tests

16 new tests, plus 7 updated: store-dir override relocates both stores (and the default remains the production tree); owner census across scroll pages with pagination-cursor pinning, empty-payload handling, and loud failure without init or scroll; purge-sandbox dry-run plan, per-identity deletion with post-verify, surviving-row and changed-real-count failures, clean no-op, init/census failure exits, and CLI dispatch; both eval harnesses pinned to the isolated store dir; the MEM0_DIR invariant guard raise path and its production (no store_dir) bypass. Full suite 5978 passed, 1 skipped; ruff and pyright strict clean.

