### PR TITLE
memory: capture codex one-shot failure detail from stdout

### DIFF
--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -169,6 +169,14 @@ _EPISODE_PROMPT_VERSION: str = "2"
 # per-failure WARNING is too quiet to distinguish a burst from a
 # one-off. Three is past any plausible one-off but early enough to
 # catch a burst within minutes of active conversation.
+#
+# Scope is nonzero-exit failures ONLY, by measurement: timeouts do
+# not increment (zero timeout outcomes across the entire telemetry
+# window under the 300-second production budget, and the alarm text
+# points at stderr/stdout captures that timeout entries do not have),
+# and a completed-but-unparseable run resets (the provider was up and
+# answered; output quality is a different failure with its own
+# warnings). Widen only if a burst of either shape is ever observed.
 _FAILURE_STREAK_ALARM_THRESHOLD = 3
 _consecutive_subprocess_failures = 0
 

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -161,6 +161,17 @@ _EXTRACTION_PROMPT_VERSION: str = "12"
 # project write-scope judgment for the scoped-memory routing path).
 _EPISODE_PROMPT_VERSION: str = "2"
 
+# Consecutive stage-1 subprocess failures across all users in this
+# process, and the streak length at which one ERROR-level alarm fires
+# (at the crossing only; reset on the next completed run). Observed
+# provider-side failure bursts are sustained conditions lasting hours,
+# during which every affected turn's facts are permanently lost; the
+# per-failure WARNING is too quiet to distinguish a burst from a
+# one-off. Three is past any plausible one-off but early enough to
+# catch a burst within minutes of active conversation.
+_FAILURE_STREAK_ALARM_THRESHOLD = 3
+_consecutive_subprocess_failures = 0
+
 # Memory `type` values this module writes. Track 1 writes "exchange"
 # from memory.py; Track 2 writes "fact" from here. Any other type value
 # in add_structured() metadata produced by this module is a bug.
@@ -2131,6 +2142,8 @@ async def _run_extractor(
     API-key-only auth path - only `--bare` does, and its absence is
     asserted by a regression test (§13.3).
     """
+    global _consecutive_subprocess_failures
+
     # Provider subprocess mechanics (argv, env allow-list, neutral
     # cwd, timeout, kill+await on miss) live in `kai.oneshot`'s
     # ClaudeOneShotReasoner. The reasoner raises typed exceptions on
@@ -2169,11 +2182,29 @@ async def _run_extractor(
         )
         return ExtractionResult(facts=[], has_episode=False)
     except OneShotSubprocessError as e:
+        # stderr head AND stdout tail: codex `exec --json` reports its
+        # failure cause in error / turn.failed events streamed to
+        # stdout (stderr carries only the stdin banner), and the cause
+        # events arrive last, so the tail is the informative end.
         log.warning(
-            "Memory extraction subprocess exited %d: %s",
+            "Memory extraction subprocess exited %d: stderr=%s stdout_tail=%s",
             e.returncode,
             e.stderr[:500].decode("utf-8", errors="replace"),
+            e.stdout[-500:].decode("utf-8", errors="replace"),
         )
+        _consecutive_subprocess_failures += 1
+        if _consecutive_subprocess_failures == _FAILURE_STREAK_ALARM_THRESHOLD:
+            # One loud line per streak, at the crossing only. Observed
+            # failure bursts are sustained provider-side conditions
+            # lasting hours (runs of 7 to 9 consecutive failures), so
+            # a per-failure WARNING scrolls past while facts are lost
+            # every turn; the ERROR is the operator's signal to look.
+            log.error(
+                "Memory extraction has failed %d consecutive times; every affected "
+                "turn's facts are being lost. See the stderr/stdout capture on the "
+                "preceding warnings for the provider's failure detail.",
+                _consecutive_subprocess_failures,
+            )
         return ExtractionResult(facts=[], has_episode=False)
     except OneShotError:
         # OneShotOutputError or any future OneShotError subclass the
@@ -2185,6 +2216,11 @@ async def _run_extractor(
         # subprocess-error path.
         log.warning("Memory extraction reasoner error", exc_info=True)
         return ExtractionResult(facts=[], has_episode=False)
+
+    # The subprocess ran to completion, so any failure streak is over;
+    # the next streak should alarm again at its own threshold crossing.
+    _consecutive_subprocess_failures = 0
+
     try:
         parsed = json.loads(result.text)
     except json.JSONDecodeError:

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -279,6 +279,15 @@ class OneShotSubprocessError(OneShotError):
 
     returncode: int
     stderr: bytes
+    # Captured stdout, for backends whose CLIs report failure detail
+    # there rather than on stderr: codex `exec --json` streams its
+    # error and turn.failed events to stdout as JSONL while stderr
+    # carries only the "Reading prompt from stdin..." banner, so a
+    # stderr-only capture logs the banner and discards the cause.
+    # Defaulted so raise sites with no captured output stay valid.
+    # Deliberately absent from __str__: stage 2's failure-reason
+    # string shape (`exit_N: <stderr snippet>`) is pinned by tests.
+    stdout: bytes = b""
 
     def __str__(self) -> str:
         # The dataclass-generated __init__ never populates
@@ -770,7 +779,7 @@ class ClaudeOneShotReasoner:
                 returncode,
                 os_user_field,
             )
-            raise OneShotSubprocessError(returncode=returncode, stderr=stderr)
+            raise OneShotSubprocessError(returncode=returncode, stderr=stderr, stdout=stdout)
 
         log.info(
             "oneshot_reasoner purpose=%s backend=claude model=%s duration_ms=%d outcome=success returncode=0 os_user=%s",
@@ -1353,7 +1362,7 @@ class CodexOneShotReasoner:
                     returncode,
                     os_user_field,
                 )
-                raise OneShotSubprocessError(returncode=returncode, stderr=stderr)
+                raise OneShotSubprocessError(returncode=returncode, stderr=stderr, stdout=stdout)
 
             stdout_text = stdout.decode("utf-8", errors="replace")
             # Structured-output callers want only the LAST completed
@@ -2477,7 +2486,7 @@ class GooseOneShotReasoner:
                 returncode,
                 os_user_field,
             )
-            raise OneShotSubprocessError(returncode=returncode, stderr=stderr)
+            raise OneShotSubprocessError(returncode=returncode, stderr=stderr, stdout=stdout)
 
         response_text = stdout.decode("utf-8", errors="replace").strip()
         raw_metadata = {

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -285,8 +285,11 @@ class OneShotSubprocessError(OneShotError):
     # carries only the "Reading prompt from stdin..." banner, so a
     # stderr-only capture logs the banner and discards the cause.
     # Defaulted so raise sites with no captured output stay valid.
-    # Deliberately absent from __str__: stage 2's failure-reason
-    # string shape (`exit_N: <stderr snippet>`) is pinned by tests.
+    # Deliberately absent from __str__: that rendering's shape is
+    # pinned by its own tests and embedded verbatim by callers that
+    # fold str(e) into their error messages, and a stdout tail there
+    # would bloat every such message. Callers that want the stdout
+    # detail (the stage-1 extraction warning) read the field directly.
     stdout: bytes = b""
 
     def __str__(self) -> str:

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from dataclasses import replace
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -4996,3 +4997,92 @@ class TestProvenanceStamping:
         _store_facts(facts, user_id="100", session_id="s", config=_cfg())
         md = captured["metadata"]
         assert not any(k.startswith("source_") for k in md if k != "source")
+
+
+# ── Stage-1 failure capture, streak alarm ───────────────────────────
+
+
+class TestSubprocessFailureCaptureAlarm:
+    """Stage 1's OneShotSubprocessError handler must log the stdout
+    tail (codex exec --json reports its failure cause there, not on
+    stderr) and must escalate to one ERROR-level line when consecutive
+    failures cross the streak threshold, since observed bursts are
+    sustained conditions during which every turn's facts are lost."""
+
+    @staticmethod
+    def _failing_reasoner(stdout: bytes = b"", stderr: bytes = b"banner"):
+        from kai.oneshot import OneShotSubprocessError
+
+        class _Failing:
+            async def run(self, **kwargs):
+                raise OneShotSubprocessError(returncode=1, stderr=stderr, stdout=stdout)
+
+        return _Failing()
+
+    @staticmethod
+    def _succeeding_reasoner():
+        class _Result:
+            text = '{"facts": [], "has_episode": false}'
+
+        class _Succeeding:
+            async def run(self, **kwargs):
+                return _Result()
+
+        return _Succeeding()
+
+    async def _run(self, reasoner):
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=reasoner):
+            return await memory_extraction._run_extractor(
+                payload_text="payload",
+                config=_cfg(),
+                candidate_ids=set(),
+                candidate_metadata={},
+                user_id="u1",
+                effective_backend="codex",
+                effective_provider="openai",
+            )
+
+    @pytest.mark.asyncio
+    async def test_warning_includes_stdout_tail(self, caplog, monkeypatch):
+        monkeypatch.setattr(memory_extraction, "_consecutive_subprocess_failures", 0)
+        stdout = b'{"type":"turn.failed","error":{"message":"usage limit reached"}}'
+
+        with caplog.at_level(logging.WARNING, logger="kai.memory_extraction"):
+            await self._run(self._failing_reasoner(stdout=stdout))
+
+        [warning] = [
+            r for r in caplog.records if "subprocess exited" in r.message or "subprocess exited" in r.getMessage()
+        ]
+        rendered = warning.getMessage()
+        assert "usage limit reached" in rendered
+        assert "banner" in rendered
+
+    @pytest.mark.asyncio
+    async def test_alarm_fires_at_threshold_crossing_only(self, caplog, monkeypatch):
+        monkeypatch.setattr(memory_extraction, "_consecutive_subprocess_failures", 0)
+
+        with caplog.at_level(logging.WARNING, logger="kai.memory_extraction"):
+            for _ in range(memory_extraction._FAILURE_STREAK_ALARM_THRESHOLD + 1):
+                await self._run(self._failing_reasoner())
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        # Exactly one ERROR: at the crossing, not before and not again
+        # on the fourth failure of the same streak.
+        assert len(errors) == 1
+        assert "consecutive" in errors[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test_completed_run_resets_the_streak(self, caplog, monkeypatch):
+        monkeypatch.setattr(memory_extraction, "_consecutive_subprocess_failures", 0)
+
+        with caplog.at_level(logging.WARNING, logger="kai.memory_extraction"):
+            await self._run(self._failing_reasoner())
+            await self._run(self._failing_reasoner())
+            await self._run(self._succeeding_reasoner())
+            await self._run(self._failing_reasoner())
+            await self._run(self._failing_reasoner())
+
+        # Two failures, reset, two failures: threshold (3) never
+        # crossed, so no ERROR anywhere.
+        assert [r for r in caplog.records if r.levelno == logging.ERROR] == []
+        assert memory_extraction._consecutive_subprocess_failures == 2

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -317,7 +317,7 @@ class TestClaudeOneShotReasonerSubprocessError:
     @pytest.mark.asyncio
     async def test_non_zero_exit_raises_with_returncode_and_stderr(self, tmp_path):
         reasoner = ClaudeOneShotReasoner(cwd=tmp_path)
-        proc = _make_proc(stdout=b"", stderr=b"oauth refused", returncode=2)
+        proc = _make_proc(stdout=b"partial event stream", stderr=b"oauth refused", returncode=2)
 
         with (
             patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
@@ -327,6 +327,9 @@ class TestClaudeOneShotReasonerSubprocessError:
 
         assert excinfo.value.returncode == 2
         assert excinfo.value.stderr == b"oauth refused"
+        # stdout rides along because some CLIs (codex exec --json)
+        # report the failure cause there rather than on stderr.
+        assert excinfo.value.stdout == b"partial event stream"
 
 
 class TestOneShotSubprocessErrorStr:
@@ -948,7 +951,11 @@ class TestCodexOneShotReasonerSubprocessError:
     @pytest.mark.asyncio
     async def test_non_zero_exit_raises_with_returncode_and_stderr(self, tmp_path):
         reasoner = CodexOneShotReasoner(cwd=tmp_path, os_user=_current_user())
-        proc = _make_proc(stdout=b"", stderr=b"codex auth failed", returncode=2)
+        proc = _make_proc(
+            stdout=b'{"type":"turn.failed","error":{"message":"usage limit"}}',
+            stderr=b"codex auth failed",
+            returncode=2,
+        )
 
         with (
             patch("kai.oneshot.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)),
@@ -962,6 +969,10 @@ class TestCodexOneShotReasonerSubprocessError:
 
         assert excinfo.value.returncode == 2
         assert excinfo.value.stderr == b"codex auth failed"
+        # codex exec --json reports the failure cause in events on
+        # stdout (stderr carries only the stdin banner), so the
+        # exception must carry stdout for the stage-1 warning to log.
+        assert excinfo.value.stdout == b'{"type":"turn.failed","error":{"message":"usage limit"}}'
 
 
 class TestCodexOneShotReasonerOutputError:


### PR DESCRIPTION
Closes #1009.

## Diagnosis

The issue asked for the exit-1 cause from captured stderr, and the answer is that the cause was never in stderr. Reproduced directly against the codex CLI: in the `--json` mode the one-shot reasoner uses, the failure cause is streamed to **stdout** as `error` / `turn.failed` JSONL events, while stderr carries only the "Reading prompt from stdin..." banner. The production failure path captured stdout via `communicate()` but discarded it, keeping only stderr on the exception. That is why every one of the 37 burst failures logged the banner and nothing else. The past bursts' cause text is therefore unrecoverable (criterion 1's "demonstrably not reproducible" branch); the next burst will identify itself.

The mitigation decision came from the burst shape in the log telemetry, and a review question prompted a full re-enumeration: ALL 37 failures fall into exactly two unbroken runs of consecutive failed attempts, 21 (2026-07-10 through 2026-08-08, with zero successful codex extractions anywhere between; attempts inside a run are spaced 30 minutes to days apart) and 16 (2026-08-08 08:28 through 2026-08-09), separated by a single 11-success recovery window. There are no interleaved successes inside either run and no failures outside them, so an immediate retry seconds after a failure would have recovered nothing at all. Per the issue's own decision rule, that selects burst-level visibility over retry; **retry is explicitly declined**.

## Changes

- `OneShotSubprocessError` gains a `stdout: bytes` field (defaulted to empty, so the two raise sites with no captured output are unchanged). The three raise sites that capture output (claude, codex, goose) pass it. `__str__` and stage 2's `exit_N: <stderr>` failure-reason string are deliberately untouched; both shapes are pinned by existing tests.
- Stage 1's failure warning now logs `stderr=<head> stdout_tail=<tail>`. The tail, because the cause events arrive last in the stream.
- Stage 1 escalates to a single ERROR-level line when consecutive subprocess failures reach 3, firing at the crossing only and resetting on the next completed run. A warning that fires per-failure scrolls past while facts are permanently lost every affected turn; the ERROR is the operator's signal to look.

## Tests

Five new or extended: the claude and codex nonzero-exit tests now pin stdout carriage (the codex one with a `turn.failed` event body); stage-1 tests pin the stdout tail appearing in the warning, exactly one ERROR at the threshold crossing (none before, none repeated within a streak), and streak reset on a completed run (two failures, reset, two failures never alarms). Full suite 5981 passed, 1 skipped; ruff and pyright strict clean.

