### PR TITLE
memory: back up foreign-owned fallback stores

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -104,6 +104,14 @@ BACKENDS_YAML = Path("/etc/kai/backends.yaml")
 RUNTIME_PROFILES_YAML = Path("/etc/kai/runtime-profiles.yaml")
 _DEPLOYED_ENV_FILE = Path("/etc/kai/env")
 
+# Root-owned helper the nightly memory backup invokes via sudo to read
+# per-principal MEMORY.md files the service user cannot read directly
+# (protected installs keep those directories 0700 per-owner). The
+# script validates its single argument, so the sudoers grant cannot be
+# steered outside DATA_DIR/memory/<name>/MEMORY.md. memory_backup.py
+# hardcodes the same path; keep them in sync.
+PRINCIPAL_MEMORY_READER = Path("/etc/kai/read-principal-memory")
+
 # Default installation paths
 _DEFAULT_INSTALL_DIR = "/opt/kai"
 _DEFAULT_DATA_DIR = "/var/lib/kai"
@@ -3573,6 +3581,41 @@ def _collect_user_home_overrides(users_yaml_path: str | Path) -> dict[int, Path]
     return result
 
 
+def _generate_principal_memory_reader(data_dir: str) -> str:
+    """
+    Generate the root-owned helper that reads one per-principal MEMORY.md.
+
+    The nightly memory backup runs as the service user and cannot read
+    protected installs' per-principal directories (0700, owned by each
+    inner agent's OS user). Rather than a sudoers `cat` wildcard, which
+    would let path traversal in the matched argument read arbitrary
+    files as root, the grant targets this fixed script, and the script
+    itself confines the read: exactly one argument, flat-name
+    characters only, and a hardcoded path template around it. The data
+    directory is baked in at generation time so the runtime cannot
+    steer the prefix via environment.
+
+    Args:
+        data_dir: Absolute data directory (e.g., /var/lib/kai).
+
+    Returns:
+        The shell script content.
+    """
+    return textwrap.dedent(f"""\
+        #!/bin/sh
+        # Kai - read one per-principal MEMORY.md for the nightly memory backup.
+        # Managed by 'python -m kai install apply'. Do not edit manually.
+        # Confinement: single flat directory-name argument; anything else
+        # (extra args, slashes, dots, empty) exits without reading.
+        set -eu
+        [ "$#" -eq 1 ] || exit 64
+        case "$1" in
+          ''|*[!A-Za-z0-9_-]*) exit 64 ;;
+        esac
+        exec /bin/cat "{data_dir}/memory/$1/MEMORY.md"
+    """)
+
+
 def _generate_sudoers(
     service_user: str,
     os_users: Iterable[str] = (),
@@ -3629,6 +3672,7 @@ def _generate_sudoers(
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/totp.secret
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/totp.attempts
         {service_user} ALL=(root) NOPASSWD: {tee_path} /etc/kai/totp.attempts
+        {service_user} ALL=(root) NOPASSWD: {PRINCIPAL_MEMORY_READER} *
     """)
 
     # Yaml-derived os_users only. Drop self-sudo entries: pool.py uses
@@ -5937,6 +5981,7 @@ def _cmd_apply() -> None:
         _apply_sudoers(
             service_user,
             dry_run,
+            data_dir=data_dir,
             agent_backend=agent_backend,
             runtime_profiles=runtime_policy,
         )
@@ -7554,6 +7599,7 @@ def _apply_sudoers(
     service_user: str,
     dry_run: bool,
     users_yaml_path: str | Path | None = None,
+    data_dir: str | None = None,
     claude_bin: str | None = None,
     codex_bin: str | None = None,
     opencode_bin: str | None = None,
@@ -7578,6 +7624,10 @@ def _apply_sudoers(
     `runtime_profiles` scopes protected per-profile identities and backend
     checks. `agent_backend` and users.yaml retain compatibility coverage for
     the global/default runtime path.
+
+    `data_dir` additionally installs the principal-memory reader helper
+    the new sudoers rule targets; None (direct/dev callers) skips the
+    helper and leaves the rule pointing at whatever is already there.
     """
     # None resolves to the module-level USERS_YAML at call time rather
     # than in the signature: a def-time default would bake the
@@ -7671,9 +7721,28 @@ def _apply_sudoers(
                 )
 
     if dry_run:
+        if data_dir is not None:
+            print(f"[DRY RUN] Would write: {PRINCIPAL_MEMORY_READER} (mode 0755)")
         print(f"[DRY RUN] Would write: {sudoers_path} (mode 0440)")
         print("[DRY RUN] Would validate with visudo -cf")
         return
+
+    # Install the reader helper BEFORE the sudoers rules that target
+    # it, so the grant never points at a path an attacker could race
+    # to create first. Same mkstemp-then-move shape as the sudoers
+    # write below, for the same symlink-attack reason.
+    if data_dir is not None:
+        fd, tmp_name = tempfile.mkstemp(prefix="kai-memreader-", suffix=".tmp")
+        try:
+            os.write(fd, _generate_principal_memory_reader(data_dir).encode())
+            os.close(fd)
+            shutil.move(tmp_name, str(PRINCIPAL_MEMORY_READER))
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        os.chmod(PRINCIPAL_MEMORY_READER, 0o755)
+        os.chown(PRINCIPAL_MEMORY_READER, 0, 0)
+        print(f"  Wrote {PRINCIPAL_MEMORY_READER}")
 
     # Write to a secure temp file first, validate, then move into place.
     # Uses mkstemp (random name, restrictive permissions) instead of a

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3645,7 +3645,13 @@ def _generate_principal_memory_reader(data_dir: str) -> str:
             finally:
                 os.close(root_fd)
             try:
-                fd = os.open("MEMORY.md", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+                # O_NONBLOCK so a planted FIFO opens instantly (and is
+                # then rejected by the S_ISREG check) instead of
+                # blocking this root process forever; regular files
+                # are unaffected by the flag.
+                fd = os.open(
+                    "MEMORY.md", os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=dir_fd
+                )
             except OSError:
                 return 1
             finally:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -3590,29 +3590,75 @@ def _generate_principal_memory_reader(data_dir: str) -> str:
     inner agent's OS user). Rather than a sudoers `cat` wildcard, which
     would let path traversal in the matched argument read arbitrary
     files as root, the grant targets this fixed script, and the script
-    itself confines the read: exactly one argument, flat-name
-    characters only, and a hardcoded path template around it. The data
-    directory is baked in at generation time so the runtime cannot
-    steer the prefix via environment.
+    confines the read at two levels:
+
+    1. Argument: exactly one, flat-name characters only, so the path
+       template cannot be steered. The memory-root literal is embedded
+       via repr(), so no data_dir character can escape the string.
+    2. Filesystem: every component from the memory root down is opened
+       with O_NOFOLLOW anchored to the previous component's fd, and the
+       opened file must be a regular, non-hardlinked (st_nlink == 1),
+       non-root-owned file. The memory root is service-user-writable
+       and the principal dirs are owned by untrusted inner-agent users,
+       so without these checks a planted symlink (or a hard link to a
+       root-readable secret) would turn the grant into an arbitrary
+       read as root; fd-anchored opens make the checks race-free where
+       a check-then-cat shell script would not be.
+
+    /usr/bin/python3 (present on supported macOS and Linux hosts) is
+    the interpreter rather than a discovered path: shutil.which() at
+    install time could resolve to a non-root-owned interpreter (e.g.
+    Homebrew's), which root must never execute.
 
     Args:
         data_dir: Absolute data directory (e.g., /var/lib/kai).
 
     Returns:
-        The shell script content.
+        The Python script content.
     """
+    memory_root = repr(str(Path(data_dir) / "memory"))
     return textwrap.dedent(f"""\
-        #!/bin/sh
+        #!/usr/bin/python3
         # Kai - read one per-principal MEMORY.md for the nightly memory backup.
         # Managed by 'python -m kai install apply'. Do not edit manually.
-        # Confinement: single flat directory-name argument; anything else
-        # (extra args, slashes, dots, empty) exits without reading.
-        set -eu
-        [ "$#" -eq 1 ] || exit 64
-        case "$1" in
-          ''|*[!A-Za-z0-9_-]*) exit 64 ;;
-        esac
-        exec /bin/cat "{data_dir}/memory/$1/MEMORY.md"
+        import os
+        import re
+        import stat
+        import sys
+
+        MEMORY_ROOT = {memory_root}
+
+
+        def main() -> int:
+            if len(sys.argv) != 2 or not re.fullmatch(r"[A-Za-z0-9_-]+", sys.argv[1]):
+                return 64
+            try:
+                root_fd = os.open(MEMORY_ROOT, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+            except OSError:
+                return 1
+            try:
+                dir_fd = os.open(
+                    sys.argv[1], os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=root_fd
+                )
+            except OSError:
+                return 1
+            finally:
+                os.close(root_fd)
+            try:
+                fd = os.open("MEMORY.md", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dir_fd)
+            except OSError:
+                return 1
+            finally:
+                os.close(dir_fd)
+            with os.fdopen(fd, "rb") as fh:
+                info = os.fstat(fh.fileno())
+                if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1 or info.st_uid == 0:
+                    return 1
+                sys.stdout.buffer.write(fh.read())
+            return 0
+
+
+        sys.exit(main())
     """)
 
 
@@ -3672,7 +3718,6 @@ def _generate_sudoers(
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/totp.secret
         {service_user} ALL=(root) NOPASSWD: {cat_path} /etc/kai/totp.attempts
         {service_user} ALL=(root) NOPASSWD: {tee_path} /etc/kai/totp.attempts
-        {service_user} ALL=(root) NOPASSWD: {PRINCIPAL_MEMORY_READER} *
     """)
 
     # Yaml-derived os_users only. Drop self-sudo entries: pool.py uses
@@ -3695,6 +3740,13 @@ def _generate_sudoers(
             raise ValueError(f"Invalid sudoers target user {candidate!r}: must match {_OS_USER_RE.pattern}")
         seen.add(candidate)
         target_users.append(candidate)
+
+    # The privileged MEMORY.md reader for the nightly backup. Gated on
+    # foreign target users: per-principal directories the service user
+    # cannot read only exist when some inner agent runs as a different
+    # OS user, so single-user installs never carry the grant.
+    if target_users:
+        rules += f"{service_user} ALL=(root) NOPASSWD: {PRINCIPAL_MEMORY_READER} *\n"
 
     if target_users:
         # In protected installs, these arguments come from
@@ -7626,8 +7678,9 @@ def _apply_sudoers(
     the global/default runtime path.
 
     `data_dir` additionally installs the principal-memory reader helper
-    the new sudoers rule targets; None (direct/dev callers) skips the
-    helper and leaves the rule pointing at whatever is already there.
+    when the deployment has foreign os_users (the only case where its
+    sudoers rule is emitted); None (direct/dev callers) always skips
+    the helper.
     """
     # None resolves to the module-level USERS_YAML at call time rather
     # than in the signature: a def-time default would bake the
@@ -7720,8 +7773,13 @@ def _apply_sudoers(
                     file=sys.stderr,
                 )
 
+    # The reader helper accompanies its sudoers rule: both exist only
+    # when some inner agent runs as a foreign OS user (mirrors the
+    # target_users gate inside _generate_sudoers).
+    install_reader = data_dir is not None and any(u and u != service_user for u in os_users)
+
     if dry_run:
-        if data_dir is not None:
+        if install_reader:
             print(f"[DRY RUN] Would write: {PRINCIPAL_MEMORY_READER} (mode 0755)")
         print(f"[DRY RUN] Would write: {sudoers_path} (mode 0440)")
         print("[DRY RUN] Would validate with visudo -cf")
@@ -7731,7 +7789,8 @@ def _apply_sudoers(
     # it, so the grant never points at a path an attacker could race
     # to create first. Same mkstemp-then-move shape as the sudoers
     # write below, for the same symlink-attack reason.
-    if data_dir is not None:
+    if install_reader:
+        assert data_dir is not None
         fd, tmp_name = tempfile.mkstemp(prefix="kai-memreader-", suffix=".tmp")
         try:
             os.write(fd, _generate_principal_memory_reader(data_dir).encode())

--- a/src/kai/memory_backup.py
+++ b/src/kai/memory_backup.py
@@ -47,6 +47,7 @@ import os
 import re
 import shutil
 import sqlite3
+import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -77,6 +78,14 @@ _SNAPSHOT_NAME_RE = re.compile(r"^\d{8}_\d{6}$")
 _SQLITE_SUFFIXES = frozenset({".db", ".sqlite", ".sqlite3"})
 _SQLITE_SIDECAR_ENDINGS = ("-wal", "-shm", "-journal")
 
+# Root-owned helper installed by `python -m kai install apply` that
+# reads exactly DATA_DIR/memory/<name>/MEMORY.md after validating the
+# name. Protected installs keep per-principal directories 0700 per
+# inner-agent OS user, so the service user cannot read the MEMORY.md
+# fallback stores directly; the sudoers grant on this fixed script is
+# the narrow read path. install.py owns the path; keep them in sync.
+_PRINCIPAL_MEMORY_READER = "/etc/kai/read-principal-memory"
+
 
 # ── Snapshot ─────────────────────────────────────────────────────────
 
@@ -89,6 +98,29 @@ _previous_unreadable: frozenset[str] | None = None
 def _is_sqlite_sidecar(name: str) -> bool:
     """Check if a filename is a SQLite WAL/SHM/journal sidecar."""
     return name.endswith(_SQLITE_SIDECAR_ENDINGS)
+
+
+def _privileged_read_principal_memory(name: str) -> bytes | None:
+    """
+    Read one foreign-owned principal's MEMORY.md via the sudo helper.
+
+    Returns the file content, or None when the read is unavailable for
+    any reason: helper not installed (non-protected installs), no
+    sudoers grant, or no MEMORY.md in that directory. `-n` keeps sudo
+    from ever prompting; a missing grant fails immediately. Callers
+    treat None as "still unreadable" and fall back to the warning.
+    """
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", _PRINCIPAL_MEMORY_READER, name],
+            capture_output=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
 
 
 def _backup_sqlite(source: Path, target: Path) -> None:
@@ -124,10 +156,12 @@ def _snapshot_tree(memory_dir: Path, snapshot_dir: Path) -> None:
     Per-principal MEMORY.md directories are 0700 and owned by the
     per-OS-user inner agent processes, so the service user cannot read
     them. os.walk's default is to skip unlistable directories silently;
-    that would make the snapshot quietly incomplete, so unreadable
-    subtrees are collected and reported in one loud warning instead.
-    The run still succeeds: the SQLite corpus is the critical asset,
-    and failing outright would mean no backups at all.
+    that would make the snapshot quietly incomplete, so each unreadable
+    top-level directory first gets a salvage attempt through the
+    root-owned sudo reader (which captures its MEMORY.md), and whatever
+    remains unreadable is reported in one loud warning. The run still
+    succeeds either way: the SQLite corpus is the critical asset, and
+    failing outright would mean no backups at all.
     """
     unreadable: list[str] = []
 
@@ -149,6 +183,35 @@ def _snapshot_tree(memory_dir: Path, snapshot_dir: Path) -> None:
             else:
                 shutil.copy2(src, dst)
             os.chmod(dst, 0o600)
+
+    # Salvage pass for foreign-owned per-principal directories: their
+    # MEMORY.md fallback stores are exactly the content the backup
+    # exists to protect, and the sudo helper is the narrow read path
+    # protected installs provide. Only direct children of the memory
+    # root are candidates (that is the per-principal layout); anything
+    # else unreadable stays in the warning. A None from the helper
+    # (not installed, no grant, no MEMORY.md inside) also stays.
+    captured = 0
+    still_unreadable: list[str] = []
+    for dir_path in unreadable:
+        path = Path(dir_path)
+        content = None if path.parent != memory_dir else _privileged_read_principal_memory(path.name)
+        if content is None:
+            still_unreadable.append(dir_path)
+            continue
+        dst_dir = snapshot_dir / path.name
+        dst_dir.mkdir(exist_ok=True)
+        os.chmod(dst_dir, 0o700)
+        dst = dst_dir / "MEMORY.md"
+        dst.write_bytes(content)
+        os.chmod(dst, 0o600)
+        captured += 1
+    unreadable = still_unreadable
+    if captured:
+        log.info(
+            "Memory backup: captured %d foreign-owned MEMORY.md file(s) via the privileged reader",
+            captured,
+        )
 
     # WARNING only when the unreadable set changes (or on the first run
     # after startup), INFO otherwise. In a multi-user deployment the

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,6 +9,7 @@ import signal
 import sqlite3
 import stat
 import subprocess
+import sys
 import time
 from dataclasses import replace
 from pathlib import Path
@@ -401,37 +402,120 @@ class TestGenerateSudoers:
         tee_path = shutil.which("tee") or "/usr/bin/tee"
         assert f"{tee_path} /etc/kai/totp.attempts" in result
 
-    def test_contains_principal_memory_reader_rule(self):
+    def test_principal_memory_reader_rule_requires_foreign_users(self):
         """The nightly backup's privileged MEMORY.md read targets the
         fixed validating helper, never a cat wildcard (which would let
-        traversal in the matched argument read arbitrary files)."""
-        result = _generate_sudoers("kai")
-        assert "kai ALL=(root) NOPASSWD: /etc/kai/read-principal-memory *" in result
+        traversal in the matched argument read arbitrary files), and
+        the grant exists only when some inner agent runs as a foreign
+        OS user; single-user installs have nothing to salvage."""
+        rule = "kai ALL=(root) NOPASSWD: /etc/kai/read-principal-memory *"
+        assert rule in _generate_sudoers("kai", ["daniel"])
+        assert rule not in _generate_sudoers("kai")
+        assert rule not in _generate_sudoers("kai", ["kai"])
         cat_path = shutil.which("cat") or "/bin/cat"
-        assert f"{cat_path} /var/lib" not in result
+        assert f"{cat_path} /var/lib" not in _generate_sudoers("kai", ["daniel"])
 
 
 class TestGeneratePrincipalMemoryReader:
     """The helper script is the confinement boundary for the sudoers
-    grant: it must validate its argument before touching the
-    filesystem, and the data directory must be baked in (not read from
-    env, which sudo would let the caller influence)."""
+    grant: argument validation, fd-anchored O_NOFOLLOW opens (a planted
+    symlink must not turn the grant into an arbitrary read as root),
+    and post-open fstat guards against hard links and root-owned
+    targets. These tests pin the generated content; the execution
+    test below drives the script itself through the attack matrix."""
 
     def test_script_shape(self):
         script = _generate_principal_memory_reader("/var/lib/kai")
-        assert script.startswith("#!/bin/sh\n")
-        # Argument count and character-class validation both present.
-        assert '[ "$#" -eq 1 ] || exit 64' in script
-        assert "*[!A-Za-z0-9_-]*" in script
-        # The read path is a literal prefix around the validated name;
-        # no env expansion anywhere in the path.
-        assert '/bin/cat "/var/lib/kai/memory/$1/MEMORY.md"' in script
-        assert "$DATA_DIR" not in script
+        # Fixed system interpreter: an install-time which() could
+        # resolve to a non-root-owned python that root must not run.
+        assert script.startswith("#!/usr/bin/python3\n")
+        assert 're.fullmatch(r"[A-Za-z0-9_-]+", sys.argv[1])' in script
+        assert "len(sys.argv) != 2" in script
+        # Every component opened O_NOFOLLOW, anchored via dir_fd.
+        assert script.count("os.O_NOFOLLOW") == 3
+        assert script.count("dir_fd=") == 2
+        # Post-open guards: regular file, no hard links, not root-owned.
+        assert "st_nlink != 1" in script
+        assert "info.st_uid == 0" in script
+        assert "stat.S_ISREG" in script
+        # The memory root is a repr'd literal; no env consultation.
+        assert "MEMORY_ROOT = '/var/lib/kai/memory'" in script
+        assert "environ" not in script
         assert "Managed by 'python -m kai install apply'" in script
 
-    def test_data_dir_is_baked_in(self):
+    def test_data_dir_is_baked_in_via_repr(self):
         script = _generate_principal_memory_reader("/srv/kai-data")
-        assert '"/srv/kai-data/memory/$1/MEMORY.md"' in script
+        assert "MEMORY_ROOT = '/srv/kai-data/memory'" in script
+        # A hostile data_dir cannot escape the string literal.
+        weird = _generate_principal_memory_reader("/srv/o'dd\"dir")
+        assert repr("/srv/o'dd\"dir/memory") in weird
+
+    def test_generated_script_compiles(self):
+        compile(_generate_principal_memory_reader("/var/lib/kai"), "<reader>", "exec")
+
+
+class TestPrincipalMemoryReaderExecution:
+    """Drive the generated script through the confinement attack
+    matrix for real. Root-ownership rejection (st_uid == 0) is the one
+    branch that cannot be exercised unprivileged; it is pinned by the
+    content test above."""
+
+    def _run(self, tmp_path, *args: str):
+        script = tmp_path / "reader.py"
+        script.write_text(_generate_principal_memory_reader(str(tmp_path)))
+        result = subprocess.run(
+            [sys.executable, str(script), *args],
+            capture_output=True,
+            timeout=30,
+        )
+        return result.returncode, result.stdout
+
+    def test_valid_name_reads_the_file(self, tmp_path):
+        principal = tmp_path / "memory" / "prn_ok"
+        principal.mkdir(parents=True)
+        (principal / "MEMORY.md").write_bytes(b"# facts\n")
+        assert self._run(tmp_path, "prn_ok") == (0, b"# facts\n")
+
+    def test_argument_validation(self, tmp_path):
+        (tmp_path / "memory").mkdir()
+        assert self._run(tmp_path)[0] == 64
+        assert self._run(tmp_path, "a", "b")[0] == 64
+        assert self._run(tmp_path, "")[0] == 64
+        assert self._run(tmp_path, "../memory")[0] == 64
+        assert self._run(tmp_path, "a/b")[0] == 64
+
+    def test_symlinked_principal_dir_is_refused(self, tmp_path):
+        target = tmp_path / "elsewhere"
+        target.mkdir()
+        (target / "MEMORY.md").write_bytes(b"secret")
+        (tmp_path / "memory").mkdir()
+        (tmp_path / "memory" / "prn_link").symlink_to(target)
+        code, out = self._run(tmp_path, "prn_link")
+        assert (code, out) == (1, b"")
+
+    def test_symlinked_memory_md_is_refused(self, tmp_path):
+        secret = tmp_path / "secret.txt"
+        secret.write_bytes(b"secret")
+        principal = tmp_path / "memory" / "prn_link"
+        principal.mkdir(parents=True)
+        (principal / "MEMORY.md").symlink_to(secret)
+        code, out = self._run(tmp_path, "prn_link")
+        assert (code, out) == (1, b"")
+
+    def test_hardlinked_memory_md_is_refused(self, tmp_path):
+        """A hard link to another file passes O_NOFOLLOW; the
+        st_nlink guard is what refuses it."""
+        secret = tmp_path / "secret.txt"
+        secret.write_bytes(b"secret")
+        principal = tmp_path / "memory" / "prn_hard"
+        principal.mkdir(parents=True)
+        os.link(secret, principal / "MEMORY.md")
+        code, out = self._run(tmp_path, "prn_hard")
+        assert (code, out) == (1, b"")
+
+    def test_missing_memory_md_exits_nonzero(self, tmp_path):
+        (tmp_path / "memory" / "prn_empty").mkdir(parents=True)
+        assert self._run(tmp_path, "prn_empty")[0] == 1
 
     def test_nopasswd(self):
         result = _generate_sudoers("kai")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -53,6 +53,7 @@ from kai.install import (
     _generate_env_file,
     _generate_launchd_plist,
     _generate_launcher_script,
+    _generate_principal_memory_reader,
     _generate_sudoers,
     _generate_systemd_unit,
     _generate_users_yaml,
@@ -399,6 +400,38 @@ class TestGenerateSudoers:
         result = _generate_sudoers("kai")
         tee_path = shutil.which("tee") or "/usr/bin/tee"
         assert f"{tee_path} /etc/kai/totp.attempts" in result
+
+    def test_contains_principal_memory_reader_rule(self):
+        """The nightly backup's privileged MEMORY.md read targets the
+        fixed validating helper, never a cat wildcard (which would let
+        traversal in the matched argument read arbitrary files)."""
+        result = _generate_sudoers("kai")
+        assert "kai ALL=(root) NOPASSWD: /etc/kai/read-principal-memory *" in result
+        cat_path = shutil.which("cat") or "/bin/cat"
+        assert f"{cat_path} /var/lib" not in result
+
+
+class TestGeneratePrincipalMemoryReader:
+    """The helper script is the confinement boundary for the sudoers
+    grant: it must validate its argument before touching the
+    filesystem, and the data directory must be baked in (not read from
+    env, which sudo would let the caller influence)."""
+
+    def test_script_shape(self):
+        script = _generate_principal_memory_reader("/var/lib/kai")
+        assert script.startswith("#!/bin/sh\n")
+        # Argument count and character-class validation both present.
+        assert '[ "$#" -eq 1 ] || exit 64' in script
+        assert "*[!A-Za-z0-9_-]*" in script
+        # The read path is a literal prefix around the validated name;
+        # no env expansion anywhere in the path.
+        assert '/bin/cat "/var/lib/kai/memory/$1/MEMORY.md"' in script
+        assert "$DATA_DIR" not in script
+        assert "Managed by 'python -m kai install apply'" in script
+
+    def test_data_dir_is_baked_in(self):
+        script = _generate_principal_memory_reader("/srv/kai-data")
+        assert '"/srv/kai-data/memory/$1/MEMORY.md"' in script
 
     def test_nopasswd(self):
         result = _generate_sudoers("kai")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -438,6 +438,9 @@ class TestGeneratePrincipalMemoryReader:
         assert "st_nlink != 1" in script
         assert "info.st_uid == 0" in script
         assert "stat.S_ISREG" in script
+        # The file open is non-blocking so a planted FIFO cannot hang
+        # the root process; S_ISREG then rejects it.
+        assert "os.O_NONBLOCK" in script
         # The memory root is a repr'd literal; no env consultation.
         assert "MEMORY_ROOT = '/var/lib/kai/memory'" in script
         assert "environ" not in script
@@ -516,6 +519,16 @@ class TestPrincipalMemoryReaderExecution:
     def test_missing_memory_md_exits_nonzero(self, tmp_path):
         (tmp_path / "memory" / "prn_empty").mkdir(parents=True)
         assert self._run(tmp_path, "prn_empty")[0] == 1
+
+    def test_fifo_memory_md_is_refused_without_blocking(self, tmp_path):
+        """A planted FIFO must be rejected, not block the root helper
+        forever waiting for a writer. O_NONBLOCK makes the open return
+        immediately; S_ISREG then refuses it."""
+        principal = tmp_path / "memory" / "prn_fifo"
+        principal.mkdir(parents=True)
+        os.mkfifo(principal / "MEMORY.md")
+        code, out = self._run(tmp_path, "prn_fifo")
+        assert (code, out) == (1, b"")
 
     def test_nopasswd(self):
         result = _generate_sudoers("kai")

--- a/tests/test_memory_backup.py
+++ b/tests/test_memory_backup.py
@@ -22,6 +22,7 @@ import sqlite3
 import stat
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -184,6 +185,7 @@ class TestFailure:
     def test_unreadable_directory_warns_but_snapshot_succeeds(self, tmp_path, caplog, monkeypatch):
         """Foreign-owned 0700 principal dirs are reported loudly, not silently skipped."""
         monkeypatch.setattr("kai.memory_backup._previous_unreadable", None)
+        monkeypatch.setattr("kai.memory_backup._privileged_read_principal_memory", lambda name: None)
         memory_dir, conn = _make_memory_tree(tmp_path)
         conn.close()
         locked = memory_dir / "prn_locked"
@@ -205,6 +207,7 @@ class TestFailure:
     def test_unchanged_unreadable_set_demotes_to_info(self, tmp_path, caplog, monkeypatch):
         """A repeat of the same unreadable set logs INFO, not nightly WARNING furniture."""
         monkeypatch.setattr("kai.memory_backup._previous_unreadable", None)
+        monkeypatch.setattr("kai.memory_backup._privileged_read_principal_memory", lambda name: None)
         memory_dir, conn = _make_memory_tree(tmp_path)
         conn.close()
         locked = memory_dir / "prn_locked"
@@ -222,3 +225,110 @@ class TestFailure:
         assert first is not None and second is not None
         unreadable_records = [r for r in caplog.records if "prn_locked" in r.message or "skipped" in r.message]
         assert [r.levelno for r in unreadable_records] == [logging.WARNING, logging.INFO]
+
+
+# ── Privileged MEMORY.md salvage ─────────────────────────────────────
+
+
+class TestPrivilegedSalvage:
+    """Foreign-owned per-principal directories get a salvage attempt
+    through the root-owned sudo reader before landing in the warning.
+    The reader itself is stubbed here; its subprocess mechanics have
+    their own tests below."""
+
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory permissions")
+    def test_captured_memory_md_lands_in_snapshot(self, tmp_path, caplog, monkeypatch):
+        monkeypatch.setattr("kai.memory_backup._previous_unreadable", None)
+        calls: list[str] = []
+
+        def fake_reader(name):
+            calls.append(name)
+            return b"# salvaged facts\n"
+
+        monkeypatch.setattr("kai.memory_backup._privileged_read_principal_memory", fake_reader)
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        conn.close()
+        locked = memory_dir / "prn_locked"
+        locked.mkdir()
+        os.chmod(locked, 0o000)
+
+        try:
+            with caplog.at_level(logging.INFO, logger="kai.memory_backup"):
+                snapshot = run_memory_backup(memory_dir, tmp_path / "backups" / "memory", NOW)
+        finally:
+            os.chmod(locked, 0o700)
+
+        assert snapshot is not None
+        assert calls == ["prn_locked"]
+        salvaged = snapshot / "prn_locked" / "MEMORY.md"
+        assert salvaged.read_bytes() == b"# salvaged facts\n"
+        assert stat.S_IMODE(salvaged.stat().st_mode) == 0o600
+        assert stat.S_IMODE(salvaged.parent.stat().st_mode) == 0o700
+        # Covered directory: no unreadable warning, one capture INFO.
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING and "unreadable" in r.message]
+        assert any("captured 1 foreign-owned MEMORY.md" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory permissions")
+    def test_nested_unreadable_directory_is_not_attempted(self, tmp_path, caplog, monkeypatch):
+        """Only direct children of the memory root are per-principal
+        stores; a deeper unreadable directory stays in the warning and
+        never reaches the reader."""
+        monkeypatch.setattr("kai.memory_backup._previous_unreadable", None)
+        calls: list[str] = []
+
+        def fake_reader(name):
+            calls.append(name)
+            return b"never used"
+
+        monkeypatch.setattr("kai.memory_backup._privileged_read_principal_memory", fake_reader)
+        memory_dir, conn = _make_memory_tree(tmp_path)
+        conn.close()
+        nested = memory_dir / "qdrant" / "locked_nested"
+        nested.mkdir()
+        os.chmod(nested, 0o000)
+
+        try:
+            with caplog.at_level(logging.WARNING, logger="kai.memory_backup"):
+                snapshot = run_memory_backup(memory_dir, tmp_path / "backups" / "memory", NOW)
+        finally:
+            os.chmod(nested, 0o700)
+
+        assert snapshot is not None
+        assert calls == []
+        assert any("unreadable" in r.message and "locked_nested" in r.getMessage() for r in caplog.records)
+
+
+class TestPrivilegedReader:
+    """Subprocess mechanics of _privileged_read_principal_memory: the
+    exact sudo -n command shape, and None on every unavailable path."""
+
+    def test_success_returns_stdout(self, monkeypatch):
+        from kai.memory_backup import _privileged_read_principal_memory
+
+        captured = {}
+
+        def fake_run(cmd, capture_output, timeout):
+            captured["cmd"] = cmd
+            return SimpleNamespace(returncode=0, stdout=b"# facts\n")
+
+        monkeypatch.setattr("kai.memory_backup.subprocess.run", fake_run)
+        assert _privileged_read_principal_memory("prn_abc") == b"# facts\n"
+        assert captured["cmd"] == ["sudo", "-n", "/etc/kai/read-principal-memory", "prn_abc"]
+
+    def test_nonzero_exit_returns_none(self, monkeypatch):
+        from kai.memory_backup import _privileged_read_principal_memory
+
+        monkeypatch.setattr(
+            "kai.memory_backup.subprocess.run",
+            lambda cmd, capture_output, timeout: SimpleNamespace(returncode=1, stdout=b""),
+        )
+        assert _privileged_read_principal_memory("prn_abc") is None
+
+    def test_oserror_returns_none(self, monkeypatch):
+        from kai.memory_backup import _privileged_read_principal_memory
+
+        def fake_run(cmd, capture_output, timeout):
+            raise OSError("sudo not found")
+
+        monkeypatch.setattr("kai.memory_backup.subprocess.run", fake_run)
+        assert _privileged_read_principal_memory("prn_abc") is None


### PR DESCRIPTION
Closes #1007.

## What

The nightly memory snapshot can now capture the per-principal MEMORY.md fallback stores it previously had to skip. Protected installs keep those directories 0700 under each inner agent's OS user, and principal directory names are runtime-generated, so of the issue's two candidate shapes this takes the narrow-privileged-read one, with one refinement: the sudoers grant targets a fixed root-owned validating script instead of exact `cat` paths, because exact paths cannot be enumerated at install time (principal ids are minted at runtime) and a `cat` wildcard would let path traversal in the matched argument read arbitrary files as root.

## How

- **`install.py`** generates `/etc/kai/read-principal-memory` (root-owned, written mkstemp-then-move like the sudoers file, and installed before the sudoers rule that targets it). The script confines the read at two levels. Argument: exactly one, flat-name characters only, memory-root literal baked in via `repr()` so neither the caller's environment nor a hostile data-dir string can steer the path. Filesystem: it is a Python script (fixed `/usr/bin/python3` interpreter, since a discovered path could resolve to a non-root-owned binary root must never execute) that opens every component from the memory root down with `O_NOFOLLOW` anchored to the previous component's fd, then requires the opened file to be regular, `st_nlink == 1`, and not root-owned. The fd-anchored opens are race-free where a check-then-cat shell script would not be; the fstat guards close the hard-link variant `O_NOFOLLOW` cannot see. This addresses the review's merge-blocking finding: the memory root is service-user-writable, so a symlink-following reader would have handed a compromised service user arbitrary reads as root, and a malicious inner agent a nightly exfiltration channel into the snapshot.
- **Gating:** the sudoers rule and the helper are emitted only when some inner agent runs as a foreign OS user; single-user installs never carry a grant they cannot benefit from.
- **`memory_backup.py`** attempts a privileged read for each unreadable top-level principal directory before warning. Captured MEMORY.md files land in the snapshot with the same 0700/0600 posture as everything else; covered directories drop out of the unreadable warning (acceptance criterion 3) and produce one INFO line with the capture count. A `None` from the helper, whether it is not installed, the grant is absent, or the directory holds no MEMORY.md, falls back to the existing warn-on-change behavior unchanged.
- **Isolation (acceptance criterion 2):** the only new read path is service-user-to-root on exactly `<data_dir>/memory/<name>/MEMORY.md`, non-root-owned regular files only; no other non-service user gains anything, and snapshot contents stay owner-only under the 0700 backup tree.

## Verification

The generated script is executed for real by the test suite across the full confinement matrix: a valid name returns the content; no-args, empty, `../` traversal, embedded-slash, and multi-argument invocations exit 64 without touching the filesystem; a symlinked principal directory, a symlinked MEMORY.md, a hard-linked MEMORY.md, and a planted FIFO (which the non-blocking open refuses instantly instead of hanging on) all exit 1 with no output; a missing file exits 1. The root-ownership rejection is the one branch that cannot run unprivileged and is pinned by content assertion. After merge and install, the next nightly run on a protected install should log `captured N foreign-owned MEMORY.md file(s)` and drop those directories from the unreadable warning; that is the live confirmation of acceptance criterion 1.

## Tests

16 new, 2 updated. New: the sudoers rule pin including its foreign-os_users gating (present with a foreign user, absent bare and self-only, no cat-wildcard on the data dir); script-content pins (interpreter, argument validation, three `O_NOFOLLOW` opens with two `dir_fd` anchors, nlink/uid/regular-file guards, repr'd memory root, no env consultation, compiles); the six-case execution matrix above; salvage integration (captured file lands 0600 in a 0700 dir with the warning silenced and the INFO emitted; nested unreadable directories never reach the reader and still warn); and the reader-client subprocess mechanics (exact `sudo -n` command shape, `None` on nonzero exit and OSError). Updated: the two existing unreadable-directory tests stub the reader so unit tests never invoke sudo. Full suite 5997 passed, 1 skipped; ruff and pyright strict clean.

