### PR TITLE
memory: stamp provenance server-side on the API write path

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -317,8 +317,9 @@ _DELETE_PAGE_SIZE = 10_000
 
 # Sources that the /memory Telegram UI surfaces as user-visible rows.
 # Used by `get_by_id` and `get_by_tag` (and via delegation, `delete_by_id`)
-# to gate addressability from the operator-facing surface. Three reasons
-# the set is intentional rather than "everything except legacy":
+# to gate addressability from the operator-facing surface. The set is
+# intentional rather than "everything except legacy"; each entry earns
+# its place:
 #   - extracted: Track 2 Haiku-derived facts; the original target of the
 #     /memory dashboard.
 #   - episode:   per-conversation episode summaries (issue #385/#387).
@@ -327,11 +328,15 @@ _DELETE_PAGE_SIZE = 10_000
 #   - migration: operator-curated MEMORY.md content imported via #408.
 #     Fact-view header reads "Imported" so operators can distinguish at
 #     a glance from extracted facts whose freshness implications differ.
+#   - explicit:  deliberate saves through the /api/memory/add endpoint.
+#     The handler stamps the value server-side, so rows from that path
+#     are first-class: visible, deletable, and ranked by their stamped
+#     speaker/confidence rather than the harshest read-time defaults.
 # Legacy ""-source rows (from pre-spec ingestion paths or any future-
 # additional source not in this set) stay hidden in the UI; they are
 # managed via memory_admin.py / `delete_by_source`. A frozenset is used
 # so the constant cannot be mutated by importing callers.
-USER_VISIBLE_SOURCES: frozenset[str] = frozenset({"extracted", "episode", "migration"})
+USER_VISIBLE_SOURCES: frozenset[str] = frozenset({"extracted", "episode", "migration", "explicit"})
 
 
 # ── Scope metadata: schema for scoped global/project memory ──────────
@@ -632,8 +637,8 @@ class MemoryStats:
     confidence_below_0_6: int = 0
     confirmation_quote_count: int = 0
     by_prompt_version: dict[str, int] = field(default_factory=dict)
-    # Scope distribution over USER-VISIBLE rows (extracted, episode,
-    # migration), unlike the extracted-only aggregates above: scope
+    # Scope distribution over USER-VISIBLE rows (all sources in
+    # USER_VISIBLE_SOURCES), unlike the extracted-only aggregates above: scope
     # applies to every user-visible source, so restricting the
     # distribution to extracted rows would hide mis-scoped episodes
     # and understate the legacy-default backlog that reclassification
@@ -3117,6 +3122,67 @@ def count_points_by_owner() -> dict[str, int]:
     return counts
 
 
+def list_api_written_points() -> list[tuple[str, dict[str, object]]]:
+    """List points whose source marks them as API-written, collection-wide.
+
+    Selects points whose `source` payload value is non-empty and not an
+    extraction-pipeline source (extracted / episode / migration): the
+    canonical `explicit` rows plus any drifted variant strings callers
+    self-reported before the server-side stamp existed. Same isolated
+    Qdrant-scroll boundary as `count_points_by_owner` above, and
+    deliberately below the Mem0 read gates: the drifted variants are
+    exactly the rows `USER_VISIBLE_SOURCES`-gated reads refuse to
+    return, and the owner filter must not hide backfill candidates.
+
+    Returns (point_id, payload_subset) pairs where the payload subset
+    carries `user_id`, `source`, `speaker`, and `confidence` (absent
+    keys omitted), which is everything the provenance backfill needs
+    to decide its patch. Read-only. Raises RuntimeError when memory is
+    not initialized or the provider lacks a Qdrant-style scroll, for
+    the same loud-beats-empty reason as the owner census.
+    """
+    if _memory is None:
+        raise RuntimeError("Semantic memory is not initialized")
+    vector_store = getattr(_memory, "vector_store", None)
+    client = getattr(vector_store, "client", None)
+    scroll = getattr(client, "scroll", None)
+    if not callable(scroll):
+        raise RuntimeError("Semantic-memory provider does not support a source scan")
+
+    pipeline_sources = {"extracted", "episode", "migration"}
+    found: list[tuple[str, dict[str, object]]] = []
+    offset = None
+    while True:
+        points, offset = scroll(
+            collection_name=vector_store.collection_name,
+            limit=1000,
+            offset=offset,
+            with_payload=["user_id", "source", "speaker", "confidence"],
+            with_vectors=False,
+        )
+        for point in points:
+            payload = dict(point.payload or {})
+            source = payload.get("source")
+            if isinstance(source, str) and source and source not in pipeline_sources:
+                found.append((str(point.id), payload))
+        if offset is None:
+            break
+    return found
+
+
+def patch_point_payload(*, point_id: str, payload: dict[str, object]) -> None:
+    """Merge payload fields onto one point without a semantic edit.
+
+    Public wrapper over the `_patch_memory_payload` boundary for the
+    provenance backfill: a metadata-only repair is not a semantic edit,
+    so it must not re-embed, must not advance `updated_at` through
+    Mem0's update path, and must not be refused by the
+    `USER_VISIBLE_SOURCES` gate that (correctly) rejects the drifted
+    source variants the backfill exists to normalize.
+    """
+    _patch_memory_payload(memory_id=point_id, payload=payload)
+
+
 def migrate_memory_namespace(
     namespace: _CanonicalMemoryNamespace,
     *,
@@ -3257,14 +3323,14 @@ def get_all_episodes(*, user_id: str) -> list[MemoryResult]:
 
 # A literal frozen set, NOT an alias for `USER_VISIBLE_SOURCES`. The two
 # admit lists serve different purposes and must not drift together: the
-# shared list (extracted, episode, migration) gates per-id and per-tag
-# reads where any of the three sources is acceptable; this list
-# (extracted, migration) gates the fact-bucket enumeration where
-# episodes are intentionally excluded because they have their own
+# shared list gates per-id and per-tag reads where any user-visible
+# source is acceptable; this list gates the fact-bucket enumeration
+# where episodes are intentionally excluded because they have their own
 # browser. Aliasing would silently change the function's semantics if
-# `USER_VISIBLE_SOURCES` ever gains a fourth source. The duplication
-# is deliberate.
-_FACT_BUCKET_SOURCES: frozenset[str] = frozenset({"extracted", "migration"})
+# `USER_VISIBLE_SOURCES` ever gains another source. The duplication is
+# deliberate; `explicit` sits in both because API-written facts belong
+# in the fact list alongside extracted and imported ones.
+_FACT_BUCKET_SOURCES: frozenset[str] = frozenset({"extracted", "migration", "explicit"})
 
 
 def get_all_facts(*, user_id: str) -> list[MemoryResult]:
@@ -3325,8 +3391,8 @@ def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
       - Legacy ""-source rows are out of scope for /memory UI
         surfaces; they belong to memory_admin.py. Hide them here
         rather than letting the dashboard expose them. The accepted
-        sources are those in `USER_VISIBLE_SOURCES` (extracted,
-        episode, migration). Issue #407 expanded the set from
+        sources are those in `USER_VISIBLE_SOURCES`. Issue #407
+        expanded the set from
         extracted-only so episode (#385/#387) and migration (#406/
         #408) rows are addressable from the operator-facing surface;
         `delete_by_id` inherits the broader admit list via its
@@ -3368,8 +3434,7 @@ def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
     if (row.get("metadata") or {}).get("source") not in USER_VISIBLE_SOURCES:
         # Legacy ""-source (or any future-additional non-UI source) is
         # deliberately invisible to /memory. The user-visible set
-        # (extracted, episode, migration) is enumerated in
-        # `USER_VISIBLE_SOURCES`. No log: this is a routine filter,
+        # is enumerated in `USER_VISIBLE_SOURCES`. No log: this is a routine filter,
         # not an anomaly.
         return None
 
@@ -3446,8 +3511,8 @@ def update_metadata(*, user_id: str, memory_id: str, data: str, metadata: dict[s
     only metadata still pay one embedding API call per row.
 
     Source-scope: the user-id gate admits any row whose
-    `metadata.source` is in `USER_VISIBLE_SOURCES` (extracted, episode,
-    migration). Callers wanting narrower scope must filter at the
+    `metadata.source` is in `USER_VISIBLE_SOURCES`. Callers wanting
+    narrower scope must filter at the
     caller level. The `confirmed_action`-tag protection used by the
     tag dedup pass is the caller's responsibility, not this wrapper's.
 

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -305,6 +305,10 @@ _SOURCE_SHORT: dict[str, str] = {
     # distinguish operator-imported facts from conversation-extracted
     # facts when they surface in retrieval.
     "migration": "fact",
+    # Explicit (API-written) rows likewise render as "fact": the
+    # source tag is for provenance, and the reader does not need the
+    # API-written vs conversation-extracted distinction either.
+    "explicit": "fact",
     "": "legacy",
 }
 
@@ -602,9 +606,10 @@ class MemoryStats:
     grouped fields) so a caller that constructs `MemoryStats(total_count=0,
     by_type={})` (the legacy two-arg form) still produces a valid value.
 
-    `episode_count` and `migration_count` are parallel per-source counts,
-    added so the /memory dashboard and stats screens can surface
-    user-visible non-extracted sources alongside the extracted total.
+    `episode_count`, `migration_count`, and `explicit_count` are
+    parallel per-source counts, added so the /memory dashboard and
+    stats screens can surface user-visible non-extracted sources
+    alongside the extracted total.
     Their sum with `extracted_count` may be less than `total_count`
     because legacy ""-source rows still contribute to the total but are
     not enumerated as a separate per-source field. Confidence aggregates
@@ -627,8 +632,10 @@ class MemoryStats:
     # legacy two-arg `MemoryStats(total_count=0, by_type={})`
     # construction in tests stays source-compatible. Episode rows come
     # from issue #385/#387; migration rows come from issue #406/#408.
+    # Explicit rows are API-written deliberate saves.
     episode_count: int = 0
     migration_count: int = 0
+    explicit_count: int = 0
     by_tag: dict[str, int] = field(default_factory=dict)
     confidence_min: float | None = None
     confidence_median: float | None = None
@@ -3125,10 +3132,12 @@ def count_points_by_owner() -> dict[str, int]:
 def list_api_written_points() -> list[tuple[str, dict[str, object]]]:
     """List points whose source marks them as API-written, collection-wide.
 
-    Selects points whose `source` payload value is non-empty and not an
-    extraction-pipeline source (extracted / episode / migration): the
-    canonical `explicit` rows plus any drifted variant strings callers
-    self-reported before the server-side stamp existed. Same isolated
+    Selects points whose `source` payload value starts with `explicit`:
+    the canonical rows plus the drifted variant strings callers
+    self-reported before the server-side stamp existed (all variants
+    share the prefix). The prefix predicate, rather than "anything
+    non-pipeline", so a hypothetical future non-pipeline source can
+    never be silently renamed by the backfill. Same isolated
     Qdrant-scroll boundary as `count_points_by_owner` above, and
     deliberately below the Mem0 read gates: the drifted variants are
     exactly the rows `USER_VISIBLE_SOURCES`-gated reads refuse to
@@ -3149,7 +3158,6 @@ def list_api_written_points() -> list[tuple[str, dict[str, object]]]:
     if not callable(scroll):
         raise RuntimeError("Semantic-memory provider does not support a source scan")
 
-    pipeline_sources = {"extracted", "episode", "migration"}
     found: list[tuple[str, dict[str, object]]] = []
     offset = None
     while True:
@@ -3163,7 +3171,7 @@ def list_api_written_points() -> list[tuple[str, dict[str, object]]]:
         for point in points:
             payload = dict(point.payload or {})
             source = payload.get("source")
-            if isinstance(source, str) and source and source not in pipeline_sources:
+            if isinstance(source, str) and source.startswith("explicit"):
                 found.append((str(point.id), payload))
         if offset is None:
             break
@@ -3602,6 +3610,7 @@ def get_stats(*, user_id: str) -> MemoryStats:
     extracted: list[MemoryResult] = []
     episode_count = 0
     migration_count = 0
+    explicit_count = 0
     by_scope: dict[str, int] = {}
     for m in memories:
         src = m.metadata.get("source")
@@ -3611,6 +3620,8 @@ def get_stats(*, user_id: str) -> MemoryStats:
             episode_count += 1
         elif src == "migration":
             migration_count += 1
+        elif src == "explicit":
+            explicit_count += 1
         # Scope distribution covers every user-visible source, not
         # just extracted: scope is a cross-source axis and the
         # legacy-default bucket is the operator's running measure of
@@ -3705,6 +3716,7 @@ def get_stats(*, user_id: str) -> MemoryStats:
         extracted_count=len(extracted),
         episode_count=episode_count,
         migration_count=migration_count,
+        explicit_count=explicit_count,
         by_tag=by_tag,
         confidence_min=confidence_min,
         confidence_median=confidence_median,

--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -26,6 +26,10 @@ Scope (spec §16 + Phase 4 of spec 320):
   `sandbox-`) from the collection. Censuses owners collection-wide,
   prints the plan, and verifies by re-census that no sandbox rows
   survive and real principals' counts are unchanged.
+- `backfill-explicit`: normalize provenance on API-written rows.
+  Payload-only patches (source variants to `explicit`, missing
+  speaker/confidence to the server-side defaults), verified by
+  re-scan; idempotent once clean.
 
 Commands that modify the store require an explicit `--yes` flag. When
 `--yes` is absent, the command prints the action it WOULD take and
@@ -158,6 +162,24 @@ def _build_parser() -> argparse.ArgumentParser:
         "--yes",
         action="store_true",
         help="Confirm deletion. Without this flag the command prints the planned deletions and exits with status 2.",
+    )
+
+    bx = sub.add_parser(
+        "backfill-explicit",
+        help="Normalize provenance on API-written rows (source variants, missing speaker/confidence)",
+        description=(
+            "Find every row whose source marks it as API-written (the "
+            "canonical 'explicit' plus drifted variant strings) and "
+            "patch it in place: source normalized to 'explicit', and "
+            "speaker/confidence stamped with the server-side defaults "
+            "('assistant', 0.9) where absent. Payload-only patches; no "
+            "re-embedding, no content changes."
+        ),
+    )
+    bx.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm the patches. Without this flag the command prints the plan and exits with status 2.",
     )
 
     # Lazy import: the choices list is the only config dependency at
@@ -507,6 +529,81 @@ def _cmd_purge_sandbox(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_backfill_explicit(args: argparse.Namespace) -> int:
+    """Execute the `backfill-explicit` subcommand. Returns an exit code.
+
+    Patch construction is per-row: source is normalized only when it
+    differs from 'explicit', and speaker/confidence are stamped only
+    when absent, so re-running is a no-op once the corpus is clean.
+    Patches go through the payload-only path (no re-embed, no Mem0
+    update bookkeeping) because a provenance repair is not a semantic
+    edit; success is verified by re-scanning, which must find no row
+    still carrying a variant source or missing either stamped field.
+    """
+    if not _initialize_memory():
+        return 1
+
+    from kai.memory import list_api_written_points, patch_point_payload
+
+    try:
+        points = list_api_written_points()
+    except Exception as e:
+        print(f"memory admin: source scan failed: {e}", file=sys.stderr)
+        return 1
+
+    def _patch_for(payload: dict[str, object]) -> dict[str, object]:
+        patch: dict[str, object] = {}
+        if payload.get("source") != "explicit":
+            patch["source"] = "explicit"
+        if "speaker" not in payload:
+            patch["speaker"] = "assistant"
+        if "confidence" not in payload:
+            patch["confidence"] = 0.9
+        return patch
+
+    todo = [(pid, payload, _patch_for(payload)) for pid, payload in points]
+    todo = [(pid, payload, patch) for pid, payload, patch in todo if patch]
+
+    if not todo:
+        print(f"memory admin: {len(points)} API-written row(s), all fully stamped; nothing to backfill.")
+        return 0
+
+    normalize = sum(1 for _, _, patch in todo if "source" in patch)
+    speaker = sum(1 for _, _, patch in todo if "speaker" in patch)
+    confidence = sum(1 for _, _, patch in todo if "confidence" in patch)
+    print(
+        f"memory admin: {len(todo)} of {len(points)} API-written row(s) need patches: "
+        f"{normalize} source normalization(s), {speaker} missing speaker(s), "
+        f"{confidence} missing confidence value(s)."
+    )
+    for pid, payload, patch in todo:
+        print(f"  {pid} (owner {payload.get('user_id', '?')}, source {payload.get('source')!r}): {patch}")
+
+    if not args.yes:
+        # Dry-run path; exit 2 mirrors the sibling subcommands.
+        print("memory admin: re-run with --yes to execute.")
+        return 2
+
+    for pid, _, patch in todo:
+        try:
+            patch_point_payload(point_id=pid, payload=patch)
+        except Exception as e:
+            print(f"memory admin: patch failed for {pid}: {e}", file=sys.stderr)
+            return 1
+
+    try:
+        remaining = [(pid, payload) for pid, payload in list_api_written_points() if _patch_for(payload)]
+    except Exception as e:
+        print(f"memory admin: post-backfill scan failed: {e}", file=sys.stderr)
+        return 1
+    if remaining:
+        print(f"memory admin: backfill incomplete; rows still need patches: {remaining}", file=sys.stderr)
+        return 1
+
+    print(f"memory admin: patched {len(todo)} row(s); re-scan clean.")
+    return 0
+
+
 def _cmd_reclassify(args: argparse.Namespace) -> int:
     """Execute the `reclassify-scope` subcommand. Returns an exit code.
 
@@ -787,6 +884,8 @@ def cli(argv: list[str]) -> None:
         sys.exit(_cmd_purge(args))
     if args.command == "purge-sandbox":
         sys.exit(_cmd_purge_sandbox(args))
+    if args.command == "backfill-explicit":
+        sys.exit(_cmd_backfill_explicit(args))
     if args.command == "reclassify-scope":
         sys.exit(_cmd_reclassify(args))
     if args.command == "backfill-provenance":

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -23,7 +23,8 @@ Architectural shape:
 Source filtering has three filter-site categories:
 
   1. Multi-source admit list (`memory.USER_VISIBLE_SOURCES`, the
-     frozenset of `extracted`, `episode`, `migration`). The data-
+     frozenset of `extracted`, `episode`, `migration`, `explicit`).
+     The data-
      layer gate is canonical: `memory.get_by_id` and
      `memory.get_by_tag` admit only those sources, and
      `memory.delete_by_id` inherits the gate via its delegation.
@@ -37,10 +38,10 @@ Source filtering has three filter-site categories:
      to the literal `"episode"` source for the dashboard's episode-
      list browser.
   3. Multi-source enumeration scoped to the fact bucket:
-     `memory.get_all_facts`, scoped to `{"extracted", "migration"}`
-     for the dashboard's facts-list browser. Narrower than
-     `USER_VISIBLE_SOURCES` (excludes episode), broader than
-     `get_all_episodes` (admits two sources). Episodes are
+     `memory.get_all_facts`, scoped to `{"extracted", "migration",
+     "explicit"}` for the dashboard's facts-list browser. Narrower
+     than `USER_VISIBLE_SOURCES` (excludes episode), broader than
+     `get_all_episodes` (admits several sources). Episodes are
      intentionally excluded because they have their own browser.
 
 Categories 2 and 3 do not participate in `USER_VISIBLE_SOURCES`:
@@ -1037,7 +1038,10 @@ def _build_fact_view(
     speaker_value, confidence_value = memory._read_time_speaker(md)
     speaker_label = _humanize_speaker(speaker_value)
 
-    if source == "episode" or source == "migration":
+    # Explicit (API-written) rows share the minimal migration shape:
+    # no extractor-only fields (prompt_version, confirmation quotes),
+    # so the extractor arm below would render placeholders for them.
+    if source in ("episode", "migration", "explicit"):
         # Episode and migration rows share a minimal body shape with
         # none of the extractor-only rows. The episode arm splices in
         # Approach / Outcome / Lessons (when present) / Actors between
@@ -1049,10 +1053,10 @@ def _build_fact_view(
         # quoted text plus the Tags / Date footer.
         tags_line = f"Tags:  {', '.join(tags) if tags else '(none)'}"
         speaker_line = f"Speaker:  {speaker_label}"
-        # Migration rows render Confidence (always 0.9 via the
-        # migration default), episode rows omit it (the constant 1.0
+        # Migration and explicit rows render Confidence (a real stored
+        # value in both cases), episode rows omit it (the constant 1.0
         # would be operator-side noise).
-        confidence_line = f"Confidence:  {confidence_value:.2f}" if source == "migration" else None
+        confidence_line = f"Confidence:  {confidence_value:.2f}" if source != "episode" else None
         detail_lines: list[str] = []
         if source == "episode":
             # Episode rows surface the outcome_quality field as a
@@ -1098,12 +1102,13 @@ def _build_fact_view(
         else:
             # Migration rows already include the H3 title and section
             # structure inside `fact.text` (the migration script writes
-            # the chunk as `### <title>\n<body>` per #408), so no
-            # additional section rendering is needed here. The header
-            # matches extracted (`Fact`) rather than calling out
-            # `Imported` because the operator-facing UI no longer
-            # surfaces the extracted/migration distinction; the
-            # data-layer `source` field stays unchanged.
+            # the chunk as `### <title>\n<body>` per #408), and explicit
+            # rows are plain API-written text; neither needs additional
+            # section rendering here. The header matches extracted
+            # (`Fact`) rather than calling out the source because the
+            # operator-facing UI no longer surfaces the per-source
+            # distinction; the data-layer `source` field stays
+            # unchanged.
             header = "Fact"
         # Footer row order: detail_lines (episode-only Approach/Outcome
         # /Lessons/Actors block, empty for migration), Tags, Speaker,
@@ -2376,8 +2381,8 @@ async def _send_search(
     # render "This memory no longer exists." for a row the user just
     # saw - confusing and wrong. Filtering here keeps the UI honest:
     # what the user sees in results is what they can act on.
-    # `USER_VISIBLE_SOURCES` (the {extracted, episode, migration}
-    # frozenset) is read from `memory.py` so a future change to the
+    # `USER_VISIBLE_SOURCES` is read from `memory.py` so a future
+    # change to the
     # admit list lives in one place.
     filtered = [r for r in results if r.score >= floor and r.metadata.get("source") in memory.USER_VISIBLE_SOURCES]
     text, kb, memory_ids = _build_search_results(query, filtered, floor)

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -669,7 +669,7 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
 
     The dashboard surfaces two user-visible counts (facts and episode
     summaries) and a single utility keyboard row holding two optional
-    browse buttons (Facts when extracted_count + migration_count > 0;
+    browse buttons (Facts when the fact-bucket counts sum > 0;
     Episodes when episode_count > 0), plus an unconditional Stats
     button. There is no per-source filter axis: the parent decision
     in #388 settled tags as row decoration only, not a primary
@@ -690,24 +690,31 @@ def _build_dashboard(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup | No
     # source has rows, fall through to render the dashboard - the
     # source-count headline communicates that memory is alive even
     # for an episode-only or migration-only operator.
-    if stats.extracted_count == 0 and stats.episode_count == 0 and stats.migration_count == 0:
+    if (
+        stats.extracted_count == 0
+        and stats.episode_count == 0
+        and stats.migration_count == 0
+        and stats.explicit_count == 0
+    ):
         return _MSG_NO_FACTS, None
 
     # Cache the visibility predicates once. The Facts button rolls
-    # extracted and migration into one count; the Episodes button is
-    # episode-only. The empty-state guard above ensures at least one
-    # of facts_visible or episode_count > 0 is true on every reachable
-    # path through the rest of this function (otherwise all three
-    # counts would be zero, which the guard already returns for).
-    facts_count = stats.extracted_count + stats.migration_count
+    # extracted, migration, and explicit into one count (mirroring
+    # `_FACT_BUCKET_SOURCES`, so the label agrees with the list the
+    # button opens); the Episodes button is episode-only. The
+    # empty-state guard above ensures at least one of facts_visible or
+    # episode_count > 0 is true on every reachable path through the
+    # rest of this function (otherwise all the counts would be zero,
+    # which the guard already returns for).
+    facts_count = stats.extracted_count + stats.migration_count + stats.explicit_count
     facts_visible = facts_count > 0
     episodes_visible = stats.episode_count > 0
 
     lines: list[str] = []
     # Headline assembled from non-zero counts. The fact bucket sums
-    # extracted and migration into a single "facts" count because the
-    # operator does not need to be reminded that some facts arrived
-    # via migration rather than extraction. The summing matches the
+    # extracted, migration, and explicit into a single "facts" count
+    # because the operator does not need to be reminded which write
+    # path a fact arrived through. The summing matches the
     # Facts button label so the headline and the keyboard agree on
     # the same number. Zero-valued counts are omitted from the comma
     # list rather than rendered as "0 episodes" - readability over
@@ -1254,13 +1261,13 @@ def _build_forget_fact_confirm(fact: MemoryResult) -> tuple[str, InlineKeyboardM
 def _source_noun(fact: MemoryResult) -> str:
     """Operator-facing noun for a row, keyed on `metadata.source`.
 
-    Extracted and migration share "fact" because the UI does not
-    surface that distinction; the generic "memory" fallback covers
-    an unknown source slipping through a stale cache during a deploy
-    transition (same defensive posture as the forget flow).
+    Extracted, migration, and explicit share "fact" because the UI
+    does not surface that distinction; the generic "memory" fallback
+    covers an unknown source slipping through a stale cache during a
+    deploy transition (same defensive posture as the forget flow).
     """
     source = (fact.metadata or {}).get("source", "")
-    return {"extracted": "fact", "episode": "episode", "migration": "fact"}.get(source, "memory")
+    return {"extracted": "fact", "episode": "episode", "migration": "fact", "explicit": "fact"}.get(source, "memory")
 
 
 # ── Builder: scope screen and confirm ───────────────────────────────
@@ -1455,7 +1462,12 @@ def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
     # memories yet." Wording mirrors the dashboard's two-bucket
     # surface (facts + episodes); the migration count folds into
     # "facts" so the empty-state phrasing has no third item.
-    if stats.extracted_count == 0 and stats.episode_count == 0 and stats.migration_count == 0:
+    if (
+        stats.extracted_count == 0
+        and stats.episode_count == 0
+        and stats.migration_count == 0
+        and stats.explicit_count == 0
+    ):
         text = "Memory stats\n\nNo facts or episodes yet."
         kb = InlineKeyboardMarkup([[InlineKeyboardButton("back", callback_data=_encode_callback("dash"))]])
         return text, kb
@@ -1463,10 +1475,10 @@ def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
     # Headline block: per-bucket totals, one line per non-zero bucket.
     # Right-padding holds the "Total <bucket>:" labels at consistent
     # width across the header lines so the count column lines up.
-    # The fact bucket sums extracted and migration so a migration-only
-    # operator sees a single "Total facts:" rather than the prior
-    # split rows; the underlying source field stays unchanged.
-    total_facts = stats.extracted_count + stats.migration_count
+    # The fact bucket sums extracted, migration, and explicit so a
+    # single "Total facts:" line matches the facts browser's admit
+    # list; the underlying source field stays unchanged.
+    total_facts = stats.extracted_count + stats.migration_count + stats.explicit_count
     lines = ["Memory stats", ""]
     if total_facts:
         lines.append(f"Total facts:      {total_facts}")

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -2005,6 +2005,14 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
             add_structured; user values for those will be overwritten)
         chat_id: int, optional, defaults to the authenticated principal
 
+    Provenance is stamped server-side: `source` is always "explicit"
+    (a caller-supplied value is overridden, so the convention cannot
+    drift per caller), the scope fields are routed from the caller's
+    detected workspace project exactly like the extraction path with
+    no classifier hint, and `speaker`/`confidence` receive defaults
+    ("assistant", 0.9) that the caller MAY override, since a caller
+    relaying a user-stated fact legitimately knows the speaker.
+
     Responses:
         200 {"id": "<mem0-uuid>"} on success
         400 on bad input (invalid JSON, missing/empty content, bad chat_id)
@@ -2082,6 +2090,32 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
     # int -> str at the memory boundary; do NOT remove the cast.
     user_id = str(chat_id)
 
+    # Server-side provenance stamp. Lazy imports keep
+    # memory_extraction (and its one-shot reasoner stack) out of this
+    # module's import graph for callers that never write memories.
+    from kai.memory_extraction import _route_write_scope
+    from kai.memory_projects import detect_active_memory_project, merged_registry
+
+    final_metadata = dict(metadata) if metadata else {}
+    # Defaults the caller may override; a caller relaying a
+    # user-stated fact legitimately knows the speaker.
+    final_metadata.setdefault("speaker", "assistant")
+    final_metadata.setdefault("confidence", 0.9)
+    # The stamp the caller may NOT override: provenance conventions
+    # drifted when callers self-reported this value from doc examples.
+    final_metadata["source"] = "explicit"
+    # Scope routed from the caller's detected workspace project, same
+    # rules as the extraction path with no classifier hint. A missing
+    # pool (transient startup state) collapses to no-workspace
+    # semantics: global scope, the same posture scoped retrieval takes.
+    pool = request.app.get(POOL_KEY)
+    active_project = None
+    if pool is not None:
+        api_config: Config = request.app[CONFIG_KEY]
+        workspace = await pool.get_effective_workspace(chat_id)
+        active_project = detect_active_memory_project(workspace, merged_registry(api_config.memory_projects))
+    final_metadata.update(_route_write_scope(None, active_project))
+
     # Defense-in-depth guard, matching the pattern used in the other
     # three memory handlers. add_structured catches its own internal
     # exceptions and returns None (which the None-check below maps to
@@ -2096,7 +2130,7 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
             user_id=user_id,
             memory_type=memory_type,
             tags=tags,
-            metadata=metadata,
+            metadata=final_metadata,
         )
     except Exception:
         log.exception("memory.add_structured failed for chat %d", chat_id)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -2074,6 +2074,23 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
     if metadata is not None and not isinstance(metadata, dict):
         return web.json_response({"error": "metadata must be a JSON object"}, status=400)
 
+    # The two caller-overridable provenance keys get the same 400
+    # treatment as every other field: these values feed arithmetic
+    # (ranking multiplies weight by confidence, the browser sorts by
+    # it) and string formatting in now-visible UI rows, so a stored
+    # bad type surfaces later as a broken facts browser rather than a
+    # clean error here. bool is rejected for confidence because JSON
+    # true/false pass isinstance(int) and would silently rank as 1/0.
+    if metadata is not None:
+        speaker = metadata.get("speaker")
+        if speaker is not None and not isinstance(speaker, str):
+            return web.json_response({"error": "metadata.speaker must be a string"}, status=400)
+        confidence = metadata.get("confidence")
+        if confidence is not None and (
+            isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0.0 <= confidence <= 1.0
+        ):
+            return web.json_response({"error": "metadata.confidence must be a number in [0.0, 1.0]"}, status=400)
+
     try:
         chat_id = _resolve_chat_id(principal, payload)
     except ValueError as e:
@@ -2108,12 +2125,20 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
     # rules as the extraction path with no classifier hint. A missing
     # pool (transient startup state) collapses to no-workspace
     # semantics: global scope, the same posture scoped retrieval takes.
-    pool = request.app.get(POOL_KEY)
-    active_project = None
-    if pool is not None:
-        api_config: Config = request.app[CONFIG_KEY]
-        workspace = await pool.get_effective_workspace(chat_id)
-        active_project = detect_active_memory_project(workspace, merged_registry(api_config.memory_projects))
+    # The workspace resolution is guarded because it is not a pure
+    # read (settings DB, path validation); a transient failure there
+    # must surface as the handler's clean JSON 500, not mis-scope the
+    # write to global silently or escape as a framework HTML 500.
+    try:
+        pool = request.app.get(POOL_KEY)
+        active_project = None
+        if pool is not None:
+            api_config: Config = request.app[CONFIG_KEY]
+            workspace = await pool.get_effective_workspace(chat_id)
+            active_project = detect_active_memory_project(workspace, merged_registry(api_config.memory_projects))
+    except Exception:
+        log.exception("memory add: workspace scope resolution failed for chat %d", chat_id)
+        return web.json_response({"error": "Memory storage failed"}, status=500)
     final_metadata.update(_route_write_scope(None, active_project))
 
     # Defense-in-depth guard, matching the pattern used in the other

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -200,10 +200,12 @@ This is distinct from your `MEMORY.md` file, which holds operator notes and proj
 curl -s -X POST http://localhost:8080/api/memory/add \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "content": "User prefers Earl Grey over English Breakfast", "memory_type": "preference", "tags": ["beverage", "preference"], "metadata": {"source": "explicit"}}'
+  -d '{"chat_id": <chat_id>, "content": "User prefers Earl Grey over English Breakfast", "memory_type": "preference", "tags": ["beverage", "preference"]}'
 ```
 
 Fields: `content` (string, required), `memory_type` (string, default `"fact"`), `tags` (list of strings, optional), `metadata` (dict, optional), `chat_id` (integer, required for routing). Response: `{"id": "<mem0-uuid>"}`.
+
+Provenance is stamped by the server: `source` and scope are set automatically (your value would be overridden), and `speaker`/`confidence` default to `"assistant"`/`0.9`. Override the defaults via `metadata` only when you know better, e.g. `"metadata": {"speaker": "user"}` for a fact the user stated directly.
 
 ### Searching memories
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -840,6 +840,38 @@ class TestFormatContext:
         output = await format_context("history", user_id="123")
         assert "- (2026-01-15, legacy) Old pre-spec entry" in output
 
+    async def test_format_context_explicit_source_labeled_fact(self):
+        """API-written rows carry a recognized source and must render
+        with the 'fact' provenance tag, not fall through to 'legacy'
+        (which the inner agent's reading contract treats as schema
+        drift)."""
+        import kai.memory as mem_mod
+        from kai.memory import format_context
+
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {
+            "results": [
+                {
+                    "id": "api-row",
+                    "memory": "User prefers Earl Grey",
+                    "score": 0.9,
+                    "metadata": {
+                        "type": "preference",
+                        "source": "explicit",
+                        "speaker": "assistant",
+                        "confidence": 0.9,
+                    },
+                    "created_at": "2026-08-19T00:00:00",
+                },
+            ]
+        }
+        mem_mod._memory = mock_mem
+        mem_mod._config = _make_config()
+
+        output = await format_context("tea", user_id="123")
+        assert "- (2026-08-19, fact) User prefers Earl Grey" in output
+        assert "legacy" not in output
+
     async def test_format_context_orders_by_weighted_score(self):
         """At equal raw cosine, a user-speaker row ranks above an
         assistant-speaker row. The new ranking key is `cosine *

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6336,3 +6336,25 @@ class TestStoreDirMem0HomeGuard:
         config = replace(_make_config(), memory_enabled=False)
         with patch.dict(sys.modules, {"mem0.memory.setup": setup_mod}):
             init_memory(config)
+
+
+# ── explicit source visibility ───────────────────────────────────────
+
+
+class TestExplicitSourceVisibility:
+    """API-written rows are first-class in the operator UI: `explicit`
+    sits in the shared admit list (per-id and per-tag reads, search
+    post-filter, delete gating) AND in the fact-bucket enumeration, so
+    a stamped row is both listable and addressable."""
+
+    def test_explicit_is_user_visible(self):
+        from kai.memory import USER_VISIBLE_SOURCES
+
+        assert "explicit" in USER_VISIBLE_SOURCES
+
+    def test_explicit_is_in_the_fact_bucket(self):
+        from kai.memory import _FACT_BUCKET_SOURCES
+
+        assert "explicit" in _FACT_BUCKET_SOURCES
+        # Episodes keep their own browser; the bucket must not gain them.
+        assert "episode" not in _FACT_BUCKET_SOURCES

--- a/tests/test_memory_admin.py
+++ b/tests/test_memory_admin.py
@@ -589,3 +589,107 @@ class TestPurgeSandbox:
             memory_admin.cli(["purge-sandbox"])
         assert exc.value.code == 0
         cmd.assert_called_once()
+
+
+# ── backfill-explicit ────────────────────────────────────────────────
+
+
+class TestBackfillExplicit:
+    """Provenance backfill for API-written rows: per-row patches
+    (source normalization, missing speaker/confidence), payload-only
+    application, and verify-by-rescan."""
+
+    @staticmethod
+    def _args(yes: bool):
+        parser = memory_admin._build_parser()
+        return parser.parse_args(["backfill-explicit", "--yes"] if yes else ["backfill-explicit"])
+
+    # Three shapes from the live corpus: a variant source with no
+    # stamps, a canonical source missing both stamps, and a fully
+    # stamped row needing nothing.
+    _POINTS = [
+        ("p1", {"user_id": "prn_a", "source": "explicit-decision"}),
+        ("p2", {"user_id": "prn_a", "source": "explicit"}),
+        ("p3", {"user_id": "prn_b", "source": "explicit", "speaker": "user", "confidence": 0.8}),
+    ]
+
+    def test_dry_run_plans_per_row_patches_and_exits_2(self, capsys):
+        patch_mock = MagicMock()
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.list_api_written_points", return_value=self._POINTS),
+            patch("kai.memory.patch_point_payload", patch_mock),
+        ):
+            code = memory_admin._cmd_backfill_explicit(self._args(yes=False))
+        assert code == 2
+        patch_mock.assert_not_called()
+        out = capsys.readouterr().out
+        assert "2 of 3 API-written row(s) need patches" in out
+        assert "1 source normalization(s)" in out
+        assert "2 missing speaker(s)" in out
+        assert "2 missing confidence value(s)" in out
+
+    def test_yes_patches_only_what_each_row_lacks(self, capsys):
+        patch_mock = MagicMock()
+        clean = [
+            ("p1", {"user_id": "prn_a", "source": "explicit", "speaker": "assistant", "confidence": 0.9}),
+            ("p2", {"user_id": "prn_a", "source": "explicit", "speaker": "assistant", "confidence": 0.9}),
+            ("p3", {"user_id": "prn_b", "source": "explicit", "speaker": "user", "confidence": 0.8}),
+        ]
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.list_api_written_points", side_effect=[self._POINTS, clean]),
+            patch("kai.memory.patch_point_payload", patch_mock),
+        ):
+            code = memory_admin._cmd_backfill_explicit(self._args(yes=True))
+        assert code == 0
+        patches = {c.kwargs["point_id"]: c.kwargs["payload"] for c in patch_mock.call_args_list}
+        assert patches == {
+            "p1": {"source": "explicit", "speaker": "assistant", "confidence": 0.9},
+            "p2": {"speaker": "assistant", "confidence": 0.9},
+        }
+        assert "patched 2 row(s); re-scan clean" in capsys.readouterr().out
+
+    def test_fully_stamped_corpus_is_a_clean_noop(self, capsys):
+        patch_mock = MagicMock()
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.list_api_written_points", return_value=[self._POINTS[2]]),
+            patch("kai.memory.patch_point_payload", patch_mock),
+        ):
+            code = memory_admin._cmd_backfill_explicit(self._args(yes=True))
+        assert code == 0
+        patch_mock.assert_not_called()
+        assert "nothing to backfill" in capsys.readouterr().out
+
+    def test_dirty_rescan_fails_the_run(self, capsys):
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.list_api_written_points", side_effect=[self._POINTS, self._POINTS]),
+            patch("kai.memory.patch_point_payload", MagicMock()),
+        ):
+            code = memory_admin._cmd_backfill_explicit(self._args(yes=True))
+        assert code == 1
+        assert "backfill incomplete" in capsys.readouterr().err
+
+    def test_scan_failure_exits_1(self, capsys):
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=True),
+            patch("kai.memory.list_api_written_points", side_effect=RuntimeError("no scroll")),
+        ):
+            code = memory_admin._cmd_backfill_explicit(self._args(yes=True))
+        assert code == 1
+        assert "source scan failed" in capsys.readouterr().err
+
+    def test_init_failure_exits_1(self):
+        with patch.object(memory_admin, "_initialize_memory", return_value=None):
+            assert memory_admin._cmd_backfill_explicit(self._args(yes=True)) == 1
+
+    def test_cli_dispatches_backfill_explicit(self):
+        with (
+            patch.object(memory_admin, "_cmd_backfill_explicit", return_value=0) as cmd,
+            pytest.raises(SystemExit) as exc,
+        ):
+            memory_admin.cli(["backfill-explicit"])
+        assert exc.value.code == 0
+        cmd.assert_called_once()

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -99,6 +99,7 @@ def _stats(
     confidence_below_0_6: int = 0,
     confirmation_quote_count: int = 0,
     by_prompt_version: dict[str, int] | None = None,
+    explicit_count: int = 0,
 ) -> MemoryStats:
     """Construct a MemoryStats with extracted-only aggregates.
 
@@ -108,11 +109,12 @@ def _stats(
     explicitly.
     """
     return MemoryStats(
-        total_count=extracted_count + episode_count + migration_count,
+        total_count=extracted_count + episode_count + migration_count + explicit_count,
         by_type={"fact": extracted_count} if extracted_count else {},
         extracted_count=extracted_count,
         episode_count=episode_count,
         migration_count=migration_count,
+        explicit_count=explicit_count,
         by_tag=by_tag or {},
         confidence_min=confidence_min,
         confidence_median=confidence_median,
@@ -741,6 +743,22 @@ class TestDashboardMultiSource:
         assert len(kb.inline_keyboard) == 1
         utility_row = kb.inline_keyboard[-1]
         assert [btn.text for btn in utility_row] == ["Episodes (4)", "Stats"]
+
+    def test_dashboard_explicit_only_user_renders(self):
+        """Explicit-only operator (a realistic fresh-install shape:
+        deliberate API saves land before the extractor has anything to
+        extract). The empty-state guard must not fire, and the Facts
+        button and headline must count the explicit rows, matching the
+        list the button opens; otherwise API-written rows would be
+        unreachable in /memory despite being admitted by the browser."""
+        stats = _stats(explicit_count=36)
+        text, kb = memory_command._build_dashboard(stats)
+        assert "No memories yet" not in text
+        assert kb is not None
+        assert "36 facts" in text
+        assert len(kb.inline_keyboard) == 1
+        utility_row = kb.inline_keyboard[-1]
+        assert utility_row[0].text == "Facts (36)"
 
     def test_dashboard_migration_only_user_renders(self):
         """Migration-only operator: migration_count > 0,

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -2747,14 +2747,15 @@ class TestMemoryAdd:
         assert resp.status == 401
 
     async def test_passes_optional_fields_through(self, mock_request):
-        """memory_type, tags, metadata are forwarded to add_structured verbatim."""
+        """memory_type and tags are forwarded verbatim; metadata is
+        forwarded with the server-side provenance stamp on top."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.json = AsyncMock(
             return_value={
                 "content": "User prefers dark mode",
                 "memory_type": "preference",
                 "tags": ["ui", "preference"],
-                "metadata": {"source": "explicit"},
+                "metadata": {"project_note": "kept"},
             }
         )
 
@@ -2771,7 +2772,71 @@ class TestMemoryAdd:
         kwargs = mock_add.call_args.kwargs
         assert kwargs["memory_type"] == "preference"
         assert kwargs["tags"] == ["ui", "preference"]
-        assert kwargs["metadata"] == {"source": "explicit"}
+        assert kwargs["metadata"]["project_note"] == "kept"
+
+    async def test_server_stamp_overrides_caller_source(self, mock_request):
+        """Caller-supplied source cannot override the server stamp;
+        speaker is a caller-overridable default; confidence defaults
+        when absent; scope is routed server-side (global here, since
+        the test app has no pool and therefore no detected project)."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(
+            return_value={
+                "content": "User said they prefer tabs",
+                "metadata": {"source": "extracted", "speaker": "user"},
+            }
+        )
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.add_structured", return_value="id-1") as mock_add,
+        ):
+            await _handle_memory_add(mock_request)
+
+        stamped = mock_add.call_args.kwargs["metadata"]
+        assert stamped["source"] == "explicit"
+        assert stamped["speaker"] == "user"
+        assert stamped["confidence"] == 0.9
+        assert stamped["scope"] == "global"
+        assert stamped["scope_source"] == "extraction_default"
+
+    async def test_stamped_write_is_visible_to_the_memory_ui(self, mock_request):
+        """Integration seam: what the HTTP add endpoint writes must
+        pass the exact gates the /memory UI reads through.
+        The stamped metadata from a real handler call is stored in a
+        fake Mem0 and must come back out of get_all_facts (fact list)
+        and get_by_id (detail view / delete gate)."""
+        from types import SimpleNamespace
+
+        from kai import memory
+
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "User prefers Earl Grey"})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.add_structured", return_value="id-1") as mock_add,
+        ):
+            await _handle_memory_add(mock_request)
+        stamped = mock_add.call_args.kwargs["metadata"]
+
+        row = {
+            "id": "mem-1",
+            "memory": "User prefers Earl Grey",
+            "metadata": stamped,
+            "user_id": "123",
+            "created_at": "2026-08-19T00:00:00+00:00",
+            "updated_at": "2026-08-19T00:00:00+00:00",
+        }
+        fake_mem0 = SimpleNamespace(
+            get_all=lambda filters, top_k: {"results": [row]},
+            get=lambda memory_id: row,
+        )
+        with patch("kai.memory._memory", fake_mem0):
+            facts = memory.get_all_facts(user_id="123")
+            assert [f.id for f in facts] == ["mem-1"]
+            detail = memory.get_by_id(user_id="123", memory_id="mem-1")
+            assert detail is not None and detail.metadata["source"] == "explicit"
 
     async def test_stringifies_chat_id_for_user_id(self, mock_request):
         """Handler converts int chat_id -> str user_id at the memory boundary.

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -2800,6 +2800,53 @@ class TestMemoryAdd:
         assert stamped["scope"] == "global"
         assert stamped["scope_source"] == "extraction_default"
 
+    async def test_returns_400_on_bad_speaker_type(self, mock_request):
+        """The caller-overridable speaker key gets the same 400-boundary
+        treatment as every other field: a non-string speaker would
+        surface later as a broken detail view, not a clean error."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x", "metadata": {"speaker": 42}})
+        with patch("kai.memory.add_structured") as mock_add:
+            resp = await _handle_memory_add(mock_request)
+        assert resp.status == 400
+        mock_add.assert_not_called()
+
+    @pytest.mark.parametrize("bad_confidence", ["high", True, 1.5, -0.1])
+    async def test_returns_400_on_bad_confidence(self, mock_request, bad_confidence):
+        """Confidence feeds ranking arithmetic and formatted rendering;
+        non-numeric, boolean, and out-of-range values are rejected at
+        the boundary (bool passes isinstance(int) and would silently
+        rank as 1/0, so it is rejected explicitly)."""
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x", "metadata": {"confidence": bad_confidence}})
+        with patch("kai.memory.add_structured") as mock_add:
+            resp = await _handle_memory_add(mock_request)
+        assert resp.status == 400
+        mock_add.assert_not_called()
+
+    async def test_returns_500_when_workspace_resolution_fails(self, mock_request):
+        """Scope routing hits the settings DB via the pool; a transient
+        failure there must produce the handler's clean JSON 500, not
+        mis-scope the write to global silently or escape as a framework
+        HTML 500."""
+        from kai.webhook import POOL_KEY
+
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.json = AsyncMock(return_value={"content": "x"})
+        pool = MagicMock()
+        pool.get_effective_workspace = AsyncMock(side_effect=RuntimeError("settings DB down"))
+        mock_request.app[POOL_KEY] = pool
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.add_structured") as mock_add,
+        ):
+            resp = await _handle_memory_add(mock_request)
+
+        assert resp.status == 500
+        assert json.loads(resp.body.decode()) == {"error": "Memory storage failed"}
+        mock_add.assert_not_called()
+
     async def test_stamped_write_is_visible_to_the_memory_ui(self, mock_request):
         """Integration seam: what the HTTP add endpoint writes must
         pass the exact gates the /memory UI reads through.


### PR DESCRIPTION
Closes #1014. Part of epic #1013.

## What

Rows written through `POST /api/memory/add` become first-class. The handler now stamps provenance server-side, `explicit` becomes a user-visible source, and a new admin subcommand backfills the pre-existing rows (36 in the live store: 34 `explicit` plus the two drifted variants `explicit-decision` and `explicit-user-note`).

## How

- **Server stamp in `_handle_memory_add`:** `source` is always `"explicit"`, overriding any caller value, so the convention cannot drift per caller (the drift already happened: callers self-reported the value from the AGENTS.md curl example). Scope is routed from the caller's detected workspace project through the extraction path's own `_route_write_scope` with no classifier hint (single source of routing truth; a missing pool collapses to global, the same posture scoped retrieval takes). `speaker`/`confidence` get defaults (`"assistant"`, 0.9) via `setdefault`, deliberately overridable: a caller relaying a user-stated fact legitimately knows the speaker. The extraction-module import is lazy so the one-shot reasoner stack stays out of webhook's import graph.
- **Read-surface integration (review round 1):** `explicit_count` joins `MemoryStats` and the `get_stats` partition, so the dashboard's empty-state guard, its Facts button label, and the stats screen's Total-facts line all count API-written rows; without it an explicit-only corpus rendered the empty state with no Facts button at all. Recall injection labels explicit rows `fact` (not `legacy`), and the forget-confirm noun map gains the same entry. The caller-overridable `speaker`/`confidence` keys are 400-validated (string; non-bool number in [0.0, 1.0]), and the workspace-resolution block is guarded so a settings-DB failure surfaces as the clean JSON 500. The backfill predicate tightened to the `explicit` prefix so a future non-pipeline source can never be silently renamed.
- **Visibility:** `explicit` joins `USER_VISIBLE_SOURCES` (per-id and per-tag reads, search post-filter, and the delete gate all follow from it) and `_FACT_BUCKET_SOURCES` (facts-list enumeration; episodes stay excluded). The `/memory` detail view renders explicit rows through the minimal migration-style shape with a real Confidence line, since they carry none of the extractor-only fields the extracted arm renders.
- **Backfill (`python -m kai memory backfill-explicit`, dry-run by default):** a collection-wide scan (`list_api_written_points`, same isolated Qdrant-scroll boundary as the owner census) selects rows whose source is non-empty and not an extraction-pipeline source. It deliberately sits below the Mem0 read gates: the drifted variants are exactly what `USER_VISIBLE_SOURCES`-gated reads refuse to return (so `update_metadata` would refuse them too), and the H4 owner filter must not hide candidates. Patches are per-row and minimal (source normalized only when it differs; speaker/confidence stamped only when absent), applied through the payload-only patch boundary, so the pass re-embeds nothing, is idempotent once clean, and cannot trip the M2 wholesale-replace hazard. Verified by re-scan; any row still needing a patch fails the run.
- **Docs:** the AGENTS.md template example drops `"metadata": {"source": "explicit"}` and documents the server stamp plus the overridable defaults.

## Acceptance criteria

- Visible and deletable in `/memory`: the integration test stores the metadata from a real handler call in a fake Mem0 and reads it back through `get_all_facts` (fact list) and `get_by_id` (detail view and the gate `delete_by_id`/`update_metadata` share).
- Caller-supplied `source` cannot override the stamp: test-pinned, alongside the speaker-override and confidence/scope defaults.
- The pre-existing rows: the backfill stamps source/speaker/confidence but deliberately leaves scope legacy; write-time scope is unknowable retroactively, and the #1020 reclassification pass owns that debt (the epic's ordering already encodes this). `backfill-explicit` runs post-merge with the daemon stopped (same procedure as the sandbox purge; embedded store is single-process). The dry-run prints every row's owner, current source, and exact patch for approval before `--yes`.

## Tests

21 new, 1 updated: the server-stamp pin (source forced, speaker kept, confidence and scope defaulted), the UI-visibility integration seam, the updated passthrough test (memory_type/tags verbatim, metadata stamped on top), set-membership pins for both admit lists, and seven backfill tests (dry-run plan with per-class counts, minimal per-row patches with re-scan verification, fully-stamped no-op, dirty-rescan failure, scan failure, init failure, dispatch). Round-1 additions: explicit-only dashboard render, the injection-label pin, speaker/confidence 400s (parametrized), and the workspace-failure 500. Full suite 6016 passed, 1 skipped; ruff and pyright strict clean.

