### PR TITLE
memory: owner-only permissions for the vector store tree

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1027,6 +1027,14 @@ def _mem0_config(config: Config, store_dir: Path | None = None) -> dict:
         store_dir = DATA_DIR / "memory"
     qdrant_path = store_dir / "qdrant"
     qdrant_path.mkdir(parents=True, exist_ok=True)
+    # Owner-only from birth (audit: any local user could read every
+    # principal's extracted facts straight from disk). mkdir's mode
+    # argument is umask-masked, so an explicit chmod is the
+    # deterministic way to land tight. Files mem0/qdrant create
+    # inside are tightened by `_tighten_store_permissions` after
+    # construction; SQLite then propagates the db file's mode to the
+    # WAL/journal siblings it creates at runtime.
+    os.chmod(qdrant_path, 0o700)
     embedding_model, local_only = _resolve_cached_embedding_model(config.memory_embedding_model)
     model_kwargs: dict[str, object] = {"device": "cpu"}
     if local_only:
@@ -1057,6 +1065,45 @@ def _mem0_config(config: Config, store_dir: Path | None = None) -> dict:
         # wrong location.
         "history_db_path": str(store_dir / "mem0_history.db"),
     }
+
+
+def _tighten_store_permissions(store_dir: Path) -> None:
+    """
+    Force owner-only modes on everything the memory store owns.
+
+    The isolation model for the file store (per-user MEMORY.md dirs)
+    is 0700 per owner, but the vector store's isolation was
+    query-time only: mem0 and embedded qdrant create their files
+    with umask-default modes, leaving every principal's extracted
+    facts group/world-readable on disk. This sweep closes that gap
+    at the one place all store layouts pass through (production
+    init, eval stores via `store_dir`, a fresh install's first run).
+
+    Scope is deliberately the three store-owned paths rather than
+    the whole store root: in production the root also holds the
+    per-user MEMORY.md fallback dirs (owned by other os_users,
+    0700 per owner already, not ours to chmod) and the neutral
+    extractor cwd (which foreign os_users must be able to enter,
+    and which holds no memory content). The root's own
+    execute-only mode is likewise the file store's traversal
+    posture, not this function's concern.
+
+    Runs on every init rather than only on creation: files mem0
+    creates mid-run land with umask modes and are caught on the
+    next startup, and the sweep doubles as repair for a tree that
+    predates this enforcement. SQLite copies the main db file's
+    mode onto the WAL/journal files it creates, so 0600 on the two
+    db files covers their runtime siblings.
+    """
+    for root in (store_dir / "qdrant", store_dir / "migrations_qdrant"):
+        if not root.exists():
+            continue
+        os.chmod(root, 0o700)
+        for p in root.rglob("*"):
+            os.chmod(p, 0o700 if p.is_dir() else 0o600)
+    history_db = store_dir / "mem0_history.db"
+    if history_db.exists():
+        os.chmod(history_db, 0o600)
 
 
 def _wrap_result(raw: dict) -> MemoryResult:
@@ -1709,6 +1756,13 @@ def init_memory(config: Config, *, store_dir: Path | None = None) -> None:
 
     mem0_cfg = _mem0_config(config, store_dir)
     m = Memory.from_config(mem0_cfg)
+
+    # Construction is the moment the store's files all exist
+    # (qdrant meta/collection tree, history db, mem0's migrations
+    # store), so tighten before anything else can run; deliberately
+    # ahead of the dims-mismatch bailout below so even that early
+    # return leaves the tree owner-only.
+    _tighten_store_permissions(store_dir if store_dir is not None else DATA_DIR / "memory")
 
     # Validate that the embedding model's output dimensions match the
     # hardcoded 384 in the Qdrant config. A mismatch means the user

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -320,6 +320,99 @@ class TestEmbeddingModelResolution:
         assert config["history_db_path"] == str(override / "mem0_history.db")
         assert (override / "qdrant").is_dir()
 
+    def test_qdrant_dir_created_owner_only(self, tmp_path):
+        """The qdrant dir must land 0700 at creation regardless of
+        umask (mkdir's mode argument is umask-masked; the explicit
+        chmod is what makes the mode deterministic). Any local user
+        able to list or read this tree can read every principal's
+        extracted facts."""
+        from kai.memory import _mem0_config
+
+        with (
+            patch("kai.memory.DATA_DIR", tmp_path),
+            patch(
+                "kai.memory._resolve_cached_embedding_model",
+                return_value=("m", False),
+            ),
+        ):
+            _mem0_config(_make_config())
+
+        mode = (tmp_path / "memory" / "qdrant").stat().st_mode & 0o777
+        assert mode == 0o700
+
+
+class TestTightenStorePermissions:
+    """The post-construction sweep that closes the vector store's
+    on-disk exposure. Modes are pinned exactly (0700 dirs, 0600
+    files) so a regression to umask-default creation surfaces here,
+    and the scope boundary (store-owned paths only) is pinned so the
+    sweep can never start chmodding the per-user MEMORY.md dirs or
+    the extractor cwd that foreign os_users must traverse."""
+
+    def _build_store(self, root):
+        """Synthetic store tree with deliberately loose modes."""
+        coll = root / "qdrant" / "collection" / "kai_memory"
+        coll.mkdir(parents=True)
+        (coll / "storage.sqlite").write_bytes(b"x")
+        (root / "qdrant" / "meta.json").write_text("{}")
+        (root / "migrations_qdrant").mkdir()
+        (root / "migrations_qdrant" / "m.sqlite").write_bytes(b"x")
+        (root / "mem0_history.db").write_bytes(b"x")
+        for p in (root / "qdrant").rglob("*"):
+            p.chmod(0o755 if p.is_dir() else 0o644)
+        (root / "qdrant").chmod(0o755)
+        (root / "migrations_qdrant").chmod(0o755)
+        (root / "migrations_qdrant" / "m.sqlite").chmod(0o644)
+        (root / "mem0_history.db").chmod(0o644)
+
+    def test_tightens_store_owned_paths(self, tmp_path):
+        from kai.memory import _tighten_store_permissions
+
+        self._build_store(tmp_path)
+        _tighten_store_permissions(tmp_path)
+
+        for d in (
+            tmp_path / "qdrant",
+            tmp_path / "qdrant" / "collection",
+            tmp_path / "qdrant" / "collection" / "kai_memory",
+            tmp_path / "migrations_qdrant",
+        ):
+            assert d.stat().st_mode & 0o777 == 0o700, d
+        for f in (
+            tmp_path / "qdrant" / "meta.json",
+            tmp_path / "qdrant" / "collection" / "kai_memory" / "storage.sqlite",
+            tmp_path / "migrations_qdrant" / "m.sqlite",
+            tmp_path / "mem0_history.db",
+        ):
+            assert f.stat().st_mode & 0o777 == 0o600, f
+
+    def test_leaves_non_store_paths_alone(self, tmp_path):
+        """The store root also hosts per-user MEMORY.md fallback dirs
+        and the neutral extractor cwd; the sweep must not touch
+        anything outside the three store-owned paths."""
+        from kai.memory import _tighten_store_permissions
+
+        self._build_store(tmp_path)
+        foreign = tmp_path / "2114582497"
+        foreign.mkdir()
+        (foreign / "MEMORY.md").write_text("x")
+        foreign.chmod(0o755)
+        (foreign / "MEMORY.md").chmod(0o644)
+
+        _tighten_store_permissions(tmp_path)
+
+        assert foreign.stat().st_mode & 0o777 == 0o755
+        assert (foreign / "MEMORY.md").stat().st_mode & 0o777 == 0o644
+
+    def test_no_op_on_missing_paths(self, tmp_path):
+        """A dev-shaped store without a migrations dir or history DB
+        (mem0's home elsewhere, nothing written yet) must not raise."""
+        from kai.memory import _tighten_store_permissions
+
+        (tmp_path / "qdrant").mkdir()
+        _tighten_store_permissions(tmp_path)
+        assert (tmp_path / "qdrant").stat().st_mode & 0o777 == 0o700
+
 
 # Third-party warnings scoped to this class: qdrant-client's local
 # mode opens a transient `:memory:` sqlite inside a `with` block


### PR DESCRIPTION
Closes #1015.

## What

The vector store's on-disk files (`storage.sqlite`, `meta.json`, `mem0_history.db`, the migrations store) were group/world-readable, so any local user could read every principal's extracted facts directly, bypassing the query-time isolation. The per-user MEMORY.md file store was already 0700 per owner; this brings the vector store to the same posture.

- `_mem0_config` chmods the qdrant dir 0700 at creation (mkdir's mode argument is umask-masked; the explicit chmod makes the mode deterministic).
- A new `_tighten_store_permissions` sweep runs in `init_memory` immediately after mem0 construction: 0700 on the `qdrant/` and `migrations_qdrant/` trees' directories, 0600 on their files and on `mem0_history.db`. Running on every init catches files mem0 creates mid-run with umask modes and repairs trees predating the enforcement; a fresh install lands tight on first start.
- Eval stores are covered by the same code path, since the harnesses call `init_memory(store_dir=...)`.

## Scope boundary

The sweep deliberately covers only the three store-owned paths, not the whole store root: the root also hosts the per-user MEMORY.md fallback dirs (other os_users' property, already 0700 per owner) and the neutral extractor cwd, which foreign os_users must be able to enter and which contains no memory content. The root's own execute-only mode is the file store's traversal posture and is unchanged. SQLite propagates the main db file's mode to the WAL/journal files it creates, so runtime transients inherit 0600.

## Production state

The live tree was tightened by hand ahead of this change (same modes the sweep enforces); the sweep re-asserts it on every restart, so the manual pass was a bridge, not the mechanism.

## Tests

Creation mode pinned for the qdrant dir; the sweep pinned for exact modes on every store-owned path, for the scope boundary (a synthetic per-user dir at the root must be left untouched), and for the missing-paths no-op on dev-shaped stores. Suite: 6030 passed, 1 skipped; ruff and pyright clean.
