### PR TITLE
memory: drain in-flight extraction work at shutdown

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -36,6 +36,7 @@ The shutdown sequence (in the finally block) reverses this order:
 import asyncio
 import logging
 import re
+import signal
 from datetime import UTC, datetime, timedelta
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
@@ -260,6 +261,66 @@ _MEMORY_BACKUP_INTERVAL = 86400  # 24 hours
 # to stay clear of startup work, short enough that a restarted service
 # still snapshots promptly when the last snapshot is stale.
 _MEMORY_BACKUP_STARTUP_DELAY = 300
+
+
+# Budget for finishing in-flight memory work at shutdown. Bounded by
+# launchd's SIGTERM-to-SIGKILL grace, which defaults to 20 seconds
+# (ExitTimeOut is not set in the service plist): the drain must fit
+# inside that window alongside adapter teardown and the launcher's
+# port-release wait, or the whole process group is SIGKILLed
+# mid-drain and the warning below never lands in the log.
+_MEMORY_DRAIN_TIMEOUT_S = 10.0
+
+
+async def _drain_pending_memory_work() -> None:
+    """
+    Await in-flight extraction and episode tasks before the loop dies.
+
+    Both stages of memory ingestion are fire-and-forget tasks
+    (`_pending_memory_tasks` holds stage-1 extraction wrappers,
+    `_pending_episode_tasks` holds stage-2 episode generation).
+    Without this drain, closing the event loop cancels them silently
+    and every restart discards whatever the extractor was in the
+    middle of learning from the last exchange.
+
+    Runs after `core_host.stop()`: the adapters are down, so no new
+    ingestion can start while the drain waits; the loop below only
+    has to chase tasks that already existed plus their direct
+    descendants. The loop shape (re-collect, wait, repeat) exists
+    because completing a stage-1 task can SPAWN a stage-2 task; a
+    single `asyncio.wait` over the initial snapshot would drain
+    stage 1 and then close the loop on the freshly spawned stage 2.
+
+    On deadline, survivors are cancelled and one WARNING states what
+    was dropped; losing a turn's facts on a slow provider call is
+    acceptable, losing them silently is the audit finding.
+    """
+    from kai import memory_extraction
+    from kai.conversation_compatibility import _pending_memory_tasks
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _MEMORY_DRAIN_TIMEOUT_S
+    while True:
+        pending = _pending_memory_tasks | memory_extraction._pending_episode_tasks
+        if not pending:
+            return
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        logging.info("Draining %d in-flight memory task(s) before shutdown", len(pending))
+        _, not_done = await asyncio.wait(pending, timeout=remaining)
+        if not_done:
+            break
+    leftover = _pending_memory_tasks | memory_extraction._pending_episode_tasks
+    for task in leftover:
+        task.cancel()
+    await asyncio.gather(*leftover, return_exceptions=True)
+    logging.warning(
+        "Shutdown drain exceeded %.0fs; cancelled %d in-flight memory task(s); "
+        "facts or episodes from those turns are lost",
+        _MEMORY_DRAIN_TIMEOUT_S,
+        len(leftover),
+    )
 
 
 async def _memory_backup_loop() -> None:
@@ -571,7 +632,36 @@ def _start() -> None:
                     old_flag.unlink(missing_ok=True)
 
             logging.info("Kai is running. Press Ctrl+C to stop.")
-            await core_host.wait()
+            # launchd stops the service with SIGTERM (the launcher
+            # script forwards it to this process group). Python's
+            # default SIGTERM action terminates the interpreter
+            # WITHOUT running finally blocks, so before this handler
+            # existed every service stop skipped the shutdown path
+            # below entirely; the graceful path only ever ran on
+            # Ctrl+C. The handler turns SIGTERM into an event so the
+            # supervision wait returns and the finally block (host
+            # stop, memory drain, db close) actually executes.
+            stop_requested = asyncio.Event()
+            asyncio.get_running_loop().add_signal_handler(signal.SIGTERM, stop_requested.set)
+            host_supervision = asyncio.create_task(core_host.wait())
+            sigterm_wait = asyncio.create_task(stop_requested.wait())
+            done, pending = await asyncio.wait(
+                {host_supervision, sigterm_wait},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            if sigterm_wait in done:
+                logging.info("SIGTERM received; shutting down")
+            # Preserve the pre-existing failure semantics: a
+            # supervised worker's crash must still propagate out of
+            # _init_and_run as an exception, not be flattened into a
+            # clean-looking exit by the wait restructure.
+            if host_supervision in done:
+                supervision_error = host_supervision.exception()
+                if supervision_error is not None:
+                    raise supervision_error
         finally:
             # Shutdown in reverse order of startup
             if core_host is not None:
@@ -585,6 +675,14 @@ def _start() -> None:
             if memory_backup_task is not None:
                 memory_backup_task.cancel()
                 await asyncio.gather(memory_backup_task, return_exceptions=True)
+            # After host stop (no new ingestion), before the db and
+            # memory authority go away (a draining extraction still
+            # stores through them). Guarded like core_host.stop()
+            # above: an exception here must not skip close_db.
+            try:
+                await _drain_pending_memory_work()
+            except Exception:
+                logging.exception("Shutdown memory drain failed")
             from kai.memory import configure_memory_authority
 
             configure_memory_authority(None)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -636,3 +636,97 @@ class TestStartCrashExit:
             _start()
 
         assert calls == [("local", str(Path(__file__).resolve().parents[1] / "services.yaml"))]
+
+
+class TestDrainPendingMemoryWork:
+    """The shutdown drain for in-flight extraction and episode tasks.
+    Uses real (fast) asyncio tasks against the actual module-level
+    pending sets; each test leaves both sets empty so state cannot
+    leak between tests."""
+
+    async def test_waits_for_pending_tasks(self):
+        """Tasks in both sets complete and the drain returns without
+        cancelling anything."""
+        from kai import memory_extraction
+        from kai.conversation_compatibility import _pending_memory_tasks
+        from kai.main import _drain_pending_memory_work
+
+        finished: list[str] = []
+
+        async def work(tag: str) -> None:
+            await asyncio.sleep(0)
+            finished.append(tag)
+
+        t1 = asyncio.create_task(work("extraction"))
+        _pending_memory_tasks.add(t1)
+        t1.add_done_callback(_pending_memory_tasks.discard)
+        t2 = asyncio.create_task(work("episode"))
+        memory_extraction._pending_episode_tasks.add(t2)
+        t2.add_done_callback(memory_extraction._pending_episode_tasks.discard)
+
+        await _drain_pending_memory_work()
+
+        assert sorted(finished) == ["episode", "extraction"]
+        assert not _pending_memory_tasks
+        assert not memory_extraction._pending_episode_tasks
+
+    async def test_waits_for_episode_task_spawned_by_extraction(self):
+        """The production shape the loop exists for: completing a
+        stage-1 task spawns a stage-2 task into the episode set. A
+        single-snapshot drain would miss it; the re-collect loop must
+        wait for the descendant too."""
+        from kai import memory_extraction
+        from kai.conversation_compatibility import _pending_memory_tasks
+        from kai.main import _drain_pending_memory_work
+
+        finished: list[str] = []
+
+        async def episode() -> None:
+            await asyncio.sleep(0)
+            finished.append("episode")
+
+        async def extraction() -> None:
+            await asyncio.sleep(0)
+            ep = asyncio.create_task(episode())
+            memory_extraction._pending_episode_tasks.add(ep)
+            ep.add_done_callback(memory_extraction._pending_episode_tasks.discard)
+            finished.append("extraction")
+
+        t = asyncio.create_task(extraction())
+        _pending_memory_tasks.add(t)
+        t.add_done_callback(_pending_memory_tasks.discard)
+
+        await _drain_pending_memory_work()
+
+        assert sorted(finished) == ["episode", "extraction"]
+        assert not memory_extraction._pending_episode_tasks
+
+    async def test_deadline_cancels_survivors_with_warning(self, monkeypatch, caplog):
+        """A task that outlives the budget is cancelled and one
+        WARNING names the loss; silence was the audit finding. The
+        timeout is patched tiny per the no-real-timeouts rule."""
+        from kai.conversation_compatibility import _pending_memory_tasks
+        from kai.main import _drain_pending_memory_work
+
+        monkeypatch.setattr("kai.main._MEMORY_DRAIN_TIMEOUT_S", 0.05)
+
+        hung = asyncio.create_task(asyncio.sleep(3600))
+        _pending_memory_tasks.add(hung)
+        hung.add_done_callback(_pending_memory_tasks.discard)
+
+        with caplog.at_level(logging.WARNING):
+            await _drain_pending_memory_work()
+
+        assert hung.cancelled()
+        assert not _pending_memory_tasks
+        assert "cancelled 1 in-flight memory task(s)" in caplog.text
+
+    async def test_no_op_when_nothing_pending(self, caplog):
+        """Empty sets: return immediately, no drain chatter in the
+        log (every restart would print it otherwise)."""
+        from kai.main import _drain_pending_memory_work
+
+        with caplog.at_level(logging.INFO):
+            await _drain_pending_memory_work()
+
+        assert "Draining" not in caplog.text


### PR DESCRIPTION
Closes #1016.

## What

Two coupled changes in `main.py`.

**SIGTERM now reaches the shutdown path at all.** The daemon had no SIGTERM handler, and Python's default action terminates the interpreter without running `finally` blocks. Consequence: every real service stop (launchd sends SIGTERM through the launcher script) skipped the graceful shutdown code entirely; the cleanup path only ever ran on Ctrl+C. The handler sets an event; the supervision wait becomes a first-completed race between host supervision and that event, with supervised-worker crash propagation preserved explicitly.

**The now-reachable shutdown path drains in-flight memory work.** `_drain_pending_memory_work` awaits the fire-and-forget stage-1 extraction tasks and stage-2 episode tasks before the loop dies, re-collecting in a loop because a completing stage-1 task spawns its stage-2 descendant into the pending set mid-drain; a single-snapshot wait would miss it. It runs after `core_host.stop()` (adapters down, no new ingestion) and before the session DB and memory authority close (a draining extraction still writes through them). Budget: 10 seconds, sized inside launchd's default 20-second SIGTERM-to-SIGKILL grace alongside the rest of teardown. Survivors past the deadline are cancelled with one WARNING stating how many tasks' facts were lost; loss on a slow provider call is acceptable, silent loss was the finding.

## The third acceptance criterion

Cause detail on non-codex failure paths was verified already satisfied rather than re-implemented: the stderr-head plus stdout-tail capture from the earlier codex work sits at the shared `OneShotSubprocessError` catch that all backends flow through, timeouts log duration next to the reasoner's own outcome line, and both outer layers (`extract_and_store`'s shell, the ingestion wrapper) log with `exc_info`. No layer swallows without cause detail today.

## Tests

Four drain tests against the real module-level pending sets: completion of both task kinds, the stage-1-spawns-stage-2 shape that motivates the re-collect loop, deadline cancellation with the warning pinned (timeout patched tiny per the no-real-timeouts rule), and the quiet no-op on empty sets. The SIGTERM wiring itself is process-level and is verified at deploy time: a service stop now logs "SIGTERM received; shutting down" followed by the drain lines. Suite: 6034 passed, 1 skipped; ruff and pyright clean.
