### PR TITLE
memory: filter reads on principal, align delete_all with reads

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -956,10 +956,45 @@ def _memory_result_has_owner(
     result: MemoryResult,
     namespace: _CanonicalMemoryNamespace | None,
 ) -> bool:
+    """Strict four-key provenance match (principal, channel, agent,
+    runtime profile). Used ONLY by `_memory_owner_state` to classify
+    rows during authority migration, where exact-vs-sibling matters.
+    Read and delete paths use `_memory_result_belongs_to_principal`
+    instead; see that function for the ownership model decision."""
     if namespace is None:
         return True
     expected = _owner_metadata(namespace)
     return all(result.metadata.get(key) == value for key, value in expected.items())
+
+
+def _memory_result_belongs_to_principal(
+    result: MemoryResult,
+    namespace: _CanonicalMemoryNamespace | None,
+) -> bool:
+    """Ownership predicate for reads and deletes: principal id only.
+
+    DECISION (audit follow-up): semantic memory is PER-PRINCIPAL,
+    not per-profile. Storage has always been namespaced on the
+    principal alone, and the memory is about the person, not the
+    transport they used: a fact learned through one runtime profile
+    must be recallable through the principal's other profiles.
+    The previous filter required equality on all four owner keys,
+    so a principal with two profiles read back only the subset its
+    current profile had written; the rest was silently invisible.
+
+    Channel, agent, and runtime profile remain STAMPED on every
+    row (`_owner_metadata`) as provenance, and the strict four-key
+    check above still guards authority migration; they are simply
+    no longer part of the ownership test. Rows with no principal
+    stamp, or a different principal's stamp, stay invisible exactly
+    as before.
+
+    `delete_all` applies this same predicate, so what a caller can
+    see and what a caller can wipe coincide by construction.
+    """
+    if namespace is None:
+        return True
+    return result.metadata.get(WORKSHOP_PRINCIPAL_ID_KEY) == str(namespace.principal_id)
 
 
 def _memory_owner_state(
@@ -1893,7 +1928,11 @@ def search(query: str, *, user_id: str, limit: int | None = None) -> list[Memory
         )
         # Mem0 v2.0.0 wraps results in {"results": [...]}
         raw_results = result.get("results", []) if isinstance(result, dict) else result
-        return [wrapped for raw in raw_results if _memory_result_has_owner((wrapped := _wrap_result(raw)), namespace)]
+        return [
+            wrapped
+            for raw in raw_results
+            if _memory_result_belongs_to_principal((wrapped := _wrap_result(raw)), namespace)
+        ]
     except Exception:
         log.warning("Memory search failed", exc_info=True)
         return []
@@ -2833,7 +2872,7 @@ def count_by_source(user_id: str, source: str) -> int:
     count = 0
     for row in rows:
         if namespace is not None and (
-            not isinstance(row, dict) or not _memory_result_has_owner(_wrap_result(row), namespace)
+            not isinstance(row, dict) or not _memory_result_belongs_to_principal(_wrap_result(row), namespace)
         ):
             continue
         row_source = row.get("metadata", {}).get("source") if isinstance(row, dict) else None
@@ -2935,7 +2974,7 @@ async def delete_by_source(user_id: str, source: str) -> int:
         matches: list[dict] = []
         for row in rows:
             if namespace is not None and (
-                not isinstance(row, dict) or not _memory_result_has_owner(_wrap_result(row), namespace)
+                not isinstance(row, dict) or not _memory_result_belongs_to_principal(_wrap_result(row), namespace)
             ):
                 continue
             row_source = row.get("metadata", {}).get("source") if isinstance(row, dict) else None
@@ -3120,7 +3159,11 @@ def get_all(*, user_id: str, limit: int | None = 1000) -> list[MemoryResult]:
     try:
         result = _memory.get_all(filters={"user_id": storage_user_id}, top_k=effective_top_k)
         raw_results = result.get("results", []) if isinstance(result, dict) else result
-        return [wrapped for raw in raw_results if _memory_result_has_owner((wrapped := _wrap_result(raw)), namespace)]
+        return [
+            wrapped
+            for raw in raw_results
+            if _memory_result_belongs_to_principal((wrapped := _wrap_result(raw)), namespace)
+        ]
     except Exception:
         log.warning("Memory get_all failed", exc_info=True)
         return []
@@ -3518,7 +3561,7 @@ def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
         return None
 
     result = _wrap_result(row)
-    return result if _memory_result_has_owner(result, namespace) else None
+    return result if _memory_result_belongs_to_principal(result, namespace) else None
 
 
 def delete_by_id(*, user_id: str, memory_id: str) -> bool:
@@ -3624,17 +3667,46 @@ def update_metadata(*, user_id: str, memory_id: str, data: str, metadata: dict[s
 
 def delete_all(*, user_id: str) -> None:
     """
-    Delete all memories for a user.
+    Delete every memory the caller can see.
 
     No-op if disabled. Used for the future /memory forget all
     command and for testing.
+
+    Applies `_memory_result_belongs_to_principal`, the same owner
+    filter every read path uses, via per-row deletes instead of
+    Mem0's namespace-wide `delete_all`. The namespace-wide call
+    deleted rows the read filter refuses to show (unowned or
+    foreign-stamped rows sharing the storage namespace), so what a
+    caller could see and what a caller could wipe did not coincide.
+    Per-row deletes also record one DELETE per row in the history
+    DB, which the bulk call bypasses.
+
+    Paged like `delete_by_source`: fetch a page, delete the matches,
+    refetch; stop when a page yields no matches. Non-matching rows
+    are exactly the rows reads hide, and they are left in place.
     """
     if _memory is None:
         return
 
-    storage_user_id, _ = _canonical_memory_owner(user_id)
+    storage_user_id, namespace = _canonical_memory_owner(user_id)
     try:
-        _memory.delete_all(user_id=storage_user_id)
+        while True:
+            result = _memory.get_all(
+                filters={"user_id": storage_user_id},
+                top_k=_DELETE_PAGE_SIZE,
+            )
+            rows = result.get("results", []) if isinstance(result, dict) else result or []
+            matching_ids = [
+                row["id"]
+                for row in rows
+                if isinstance(row, dict)
+                and row.get("id")
+                and _memory_result_belongs_to_principal(_wrap_result(row), namespace)
+            ]
+            if not matching_ids:
+                break
+            for memory_id in matching_ids:
+                _memory.delete(memory_id=memory_id)
     except Exception:
         log.warning("Memory delete_all failed", exc_info=True)
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1851,16 +1851,29 @@ class TestDeleteAll:
         # Should not raise
         delete_all(user_id="123")
 
-    def test_delete_all_calls_mem0(self):
-        """delete_all() delegates to Mem0's delete_all."""
+    def test_delete_all_deletes_per_row_not_namespace_wide(self):
+        """delete_all() enumerates and deletes row by row through the
+        read-side owner filter instead of delegating to Mem0's
+        namespace-wide delete_all. The bulk call wiped rows the read
+        filter refuses to show, and it bypassed the history DB's
+        per-row DELETE audit trail."""
         import kai.memory as mem_mod
         from kai.memory import delete_all
 
         mock_mem = MagicMock()
+        mock_mem.get_all.side_effect = [
+            {"results": [{"id": "row-1", "memory": "a"}, {"id": "row-2", "memory": "b"}]},
+            {"results": []},
+        ]
         mem_mod._memory = mock_mem
 
         delete_all(user_id="user-abc")
-        mock_mem.delete_all.assert_called_once_with(user_id="user-abc")
+
+        mock_mem.delete_all.assert_not_called()
+        assert [c.kwargs["memory_id"] for c in mock_mem.delete.call_args_list] == [
+            "row-1",
+            "row-2",
+        ]
 
 
 class TestDeleteBySource:
@@ -3841,6 +3854,71 @@ class TestGetAllFacts:
         assert mock_mem.get_all.call_args.kwargs["top_k"] >= 100_000
 
 
+class TestPrincipalOwnershipPredicate:
+    """Unit pins for `_memory_result_belongs_to_principal`, the
+    ownership-model decision (per-principal, not per-profile). A
+    regression back to four-key equality re-opens the audit finding:
+    sibling-profile rows silently invisible on read."""
+
+    @staticmethod
+    def _namespace(principal_id=None, config_id: int = 1):
+        from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
+        from kai.workshop.execution_state import WorkshopExecutionStateNamespace
+
+        return WorkshopExecutionStateNamespace(
+            principal_id=principal_id or PrincipalId.new(),
+            channel_id=ChannelId.new(),
+            agent_id=AgentId.new(),
+            runtime_profile_id=RuntimeProfileId.new(),
+            runtime_config_id=config_id,
+        )
+
+    @staticmethod
+    def _row(metadata: dict):
+        from kai.memory import MemoryResult
+
+        return MemoryResult(
+            id="m1",
+            text="t",
+            score=0.9,
+            memory_type="fact",
+            metadata=metadata,
+            created_at="",
+        )
+
+    def test_sibling_profile_row_is_visible(self):
+        """The audit case: a row stamped by profile A must satisfy
+        the predicate for profile B of the same principal. Only the
+        principal key decides ownership; channel, agent, and profile
+        are provenance."""
+        from kai.memory import _memory_result_belongs_to_principal, _owner_metadata
+
+        profile_a = self._namespace()
+        profile_b = self._namespace(principal_id=profile_a.principal_id, config_id=2)
+        row = self._row(dict(_owner_metadata(profile_a)))
+        assert _memory_result_belongs_to_principal(row, profile_b)
+
+    def test_foreign_principal_row_is_hidden(self):
+        from kai.memory import _memory_result_belongs_to_principal, _owner_metadata
+
+        row = self._row(dict(_owner_metadata(self._namespace())))
+        assert not _memory_result_belongs_to_principal(row, self._namespace())
+
+    def test_unstamped_row_is_hidden(self):
+        """Rows without a workshop stamp stay invisible under a
+        canonical namespace, matching the old filter."""
+        from kai.memory import _memory_result_belongs_to_principal
+
+        assert not _memory_result_belongs_to_principal(self._row({}), self._namespace())
+
+    def test_no_namespace_passes_everything(self):
+        """Callers with no authority registry (namespace None) keep
+        unfiltered reads, matching the old filter."""
+        from kai.memory import _memory_result_belongs_to_principal
+
+        assert _memory_result_belongs_to_principal(self._row({}), None)
+
+
 # ── Integration tests (real Mem0 + Qdrant, slower) ──────────────────
 
 
@@ -4029,6 +4107,78 @@ class TestMemoryIntegration:
         finally:
             mem_mod.configure_memory_authority(None)
             real_memory_instance.delete_all(user_id=legacy_user_id)
+            real_memory_instance.delete_all(user_id=canonical_user_id)
+
+    def test_two_profile_principal_reads_and_wipes_the_same_rows(self, real_memory_instance):
+        """The audit's two-profile fixture, end to end. Storage is
+        namespaced on the principal; a fact written through profile
+        A must be readable through profile B of the same principal
+        (the old four-key filter hid it), and delete_all through
+        either profile must wipe exactly what reads show: the
+        principal's rows, never a foreign-stamped row sharing the
+        storage namespace."""
+        import kai.memory as mem_mod
+        from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
+        from kai.workshop.execution_state import (
+            WorkshopExecutionStateNamespace,
+            WorkshopExecutionStateRegistry,
+        )
+
+        principal = PrincipalId.new()
+
+        def profile(config_id: int) -> WorkshopExecutionStateNamespace:
+            return WorkshopExecutionStateNamespace(
+                principal_id=principal,
+                channel_id=ChannelId.new(),
+                agent_id=AgentId.new(),
+                runtime_profile_id=RuntimeProfileId.new(),
+                runtime_config_id=config_id,
+            )
+
+        profile_a, profile_b = profile(910001), profile(910002)
+        canonical_user_id = str(principal)
+        foreign = WorkshopExecutionStateNamespace(
+            principal_id=PrincipalId.new(),
+            channel_id=ChannelId.new(),
+            agent_id=AgentId.new(),
+            runtime_profile_id=RuntimeProfileId.new(),
+            runtime_config_id=910003,
+        )
+
+        mem_mod._memory = real_memory_instance
+        mem_mod._config = _make_config()
+        real_memory_instance.delete_all(user_id=canonical_user_id)
+
+        try:
+            mem_mod.configure_memory_authority(WorkshopExecutionStateRegistry((profile_a, profile_b)))
+            memory_id = mem_mod.add_structured(
+                "User prefers dark roast coffee",
+                user_id=str(profile_a.runtime_config_id),
+                memory_type="fact",
+            )
+            assert memory_id is not None
+            # A foreign-stamped row planted in the SAME storage
+            # namespace: the trap the audit named. Reads must hide
+            # it and delete_all must leave it.
+            real_memory_instance.add(
+                "Foreign principal's fact",
+                user_id=canonical_user_id,
+                infer=False,
+                metadata=dict(mem_mod._owner_metadata(foreign)),
+            )
+
+            # Read through the OTHER profile: visible.
+            visible = mem_mod.get_all(user_id=str(profile_b.runtime_config_id))
+            assert [item.id for item in visible] == [memory_id]
+
+            # Wipe through the other profile: the principal's row
+            # goes, the foreign-stamped row stays.
+            mem_mod.delete_all(user_id=str(profile_b.runtime_config_id))
+            assert mem_mod.get_all(user_id=str(profile_a.runtime_config_id)) == []
+            leftover = mem_mod._get_all_raw(user_id=canonical_user_id)
+            assert [row.text for row in leftover] == ["Foreign principal's fact"]
+        finally:
+            mem_mod.configure_memory_authority(None)
             real_memory_instance.delete_all(user_id=canonical_user_id)
 
     async def test_format_context_integration(self, real_memory_instance):


### PR DESCRIPTION
Closes #1017.

## Decision

Memory is **per-principal**. Storage has always been namespaced on the principal alone, and the memory is about the person, not the transport: a fact learned through one runtime profile must be recallable through the principal's other profiles. The alternative (documenting per-profile memory as intended) would have blessed the trap: rows a profile can never see but a wipe would delete.

## What

- New `_memory_result_belongs_to_principal` predicate (principal key only) replaces the four-key equality check at every read and delete site: `search`, `get_all`, `get_by_id`, `count_by_source`, `delete_by_source`. Channel, agent, and runtime profile stay stamped on every row as provenance; they no longer gate ownership. Unstamped and foreign-stamped rows stay invisible exactly as before.
- The strict four-key check survives only inside the authority-migration classifier (`_memory_owner_state`), where exact-versus-sibling provenance is the point; its docstring now says so.
- `delete_all` no longer delegates to Mem0's namespace-wide bulk delete. It enumerates pages and deletes row by row through the same read predicate, so visibility and wipe scope coincide by construction, foreign-stamped rows sharing the storage namespace are spared, and the history DB gains the per-row DELETE audit trail the bulk call bypassed.

## Behavior notes

- Principal-id reads for a multi-profile principal were already unfiltered (the ambiguous principal lookup returns no namespace); the invisibility bit on runtime-config-id reads, which are the production path. Single-profile principals see no behavior change on reads.
- The live corpus is single-profile-stamped per principal today, so nothing changes for existing rows until a second profile writes; this closes the trap before it springs.

## Tests

Unit pins for the predicate (sibling visible, foreign hidden, unstamped hidden, no-namespace unfiltered), a rewritten `delete_all` unit test pinning per-row deletion with no bulk call, and the acceptance criterion's two-profile fixture as an end-to-end integration test: write through profile A, read through profile B, wipe through profile B, foreign-stamped row in the same namespace hidden from reads and spared by the wipe. Suite: 6039 passed, 1 skipped; ruff and pyright clean. The audit document's H4 section carries the decision record.
