### PR TITLE
docs: remove the unusable delete-all recipe from the agent template

### DIFF
--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -187,6 +187,8 @@ You have a per-user vector store that holds extracted facts about the user (pref
 
 This is distinct from your `MEMORY.md` file, which holds operator notes and project state. In enabled mode, MEMORY.md is not injected; the vector store is the active fact surface, populated automatically by the extractor and on demand via the API.
 
+There is deliberately no delete endpoint in this API. When the user asks to remove memories, point them at the `/memory` Telegram command (per-fact review and forget) or at the operator; do not attempt deletion through this API or retry variations hoping for one.
+
 ### When to store a fact via the API
 
 - The user states a stable preference, constraint, or piece of identity
@@ -235,23 +237,12 @@ For a fresh user with no extracted facts (`extracted_count == 0`), the confidenc
 
 `null` here means "no extracted facts to summarize," NOT a store failure. Treat it as expected for new users.
 
-### Deleting all memories
-
-```bash
-curl -s -X DELETE http://localhost:8080/api/memory/all \
-  -H 'Content-Type: application/json' \
-  -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "confirm": "delete-all-memories"}'
-```
-
-The `confirm` field MUST equal the literal string `"delete-all-memories"`. Anything else returns 400. This is intentional: a stray curl or prompt-injected fetch call cannot accidentally wipe a user's memory store. Only invoke this when the user has explicitly asked to clear their memories. Response: `{"status": "deleted"}`.
-
 ### Error handling
 
-- `400` - your request was bad (missing field, invalid JSON, wrong confirm token). Fix the request and retry.
+- `400` - your request was bad (missing field, invalid JSON). Fix the request and retry.
 - `401` - wrong webhook secret. Configuration bug; surface to the operator.
-- `403` - the chat_id you sent isn't authorized. Use your own chat_id.
-- `503` - the memory system is disabled. Don't retry; surface to the operator. Same status across all four memory endpoints, so a single retry policy covers the disabled case.
+- `403` - the chat_id does not belong to your credential, or your credential lacks the permission scope for that operation. Not retryable: no change to the request will make it succeed. If you believe the chat_id is your own, surface the error to the user instead of retrying.
+- `503` - the memory system is disabled. Don't retry; surface to the operator. Same status across all three memory endpoints, so a single retry policy covers the disabled case.
 - `500` - on `/api/memory/add` only, the underlying store call failed despite memory being enabled. May be transient; retrying once with a short backoff is reasonable. Persistent 500s should be surfaced to the operator.
 
 ## Issue-First Workflow


### PR DESCRIPTION
Closes #1021.

## Decision

Remove the delete-all recipe rather than grant the missing scope. The blast radius of an agent-reachable full wipe outweighs its utility, and per-fact deletion already has a safe human-in-the-loop path through the `/memory` command. The endpoint itself is untouched (fail-closed, tested).

## What

- The `Deleting all memories` section is gone from `templates/AGENTS.md`, along with the confirm-token sentence in the 400 line that referenced it.
- An explicit note now states there is deliberately no delete endpoint and routes removal requests to `/memory` or the operator, so an agent cannot re-invent the recipe from the remaining endpoint docs or retry variations hoping for one.
- The 403 explanation now names both real causes (chat_id not owned by the credential, or missing permission scope) and says the error is not retryable; the old wording ("use your own chat_id") is what created the retry loop against a fail-closed gate.
- The 503 line's endpoint count is corrected to the three documented endpoints.

## Timeout sweep

The second acceptance criterion is a verification result rather than an edit: no file in the repo or the wiki claims a 90-second extraction timeout. The wiki's Memory and Configuration-Wizard pages document the actual 10-second stage-1 default with explicit raise-it-for-production guidance. The recorded 90-second belief therefore existed only in the memory corpus, which the curation pass already cleaned.

## Deployed copies

The template seeds per-user `AGENTS.md` files at install time, but existing per-user copies are operator-customizable and are not overwritten by reinstall, so they still carry the removed section. Those files are per-user-owned; updating them is an operator action, flagged in review.
