### PR TITLE
memory: contract fixes plus dead-code hygiene from the audit sweep

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -139,6 +139,13 @@ _LEGACY_CONFIDENCE = 0.5
 def build_migration_metadata(*, section: str, subsection: str) -> dict[str, Any]:
     """Return the metadata dict used by the MEMORY.md -> Qdrant migration.
 
+    No production caller: the migration writer is the hyphenated
+    operator script, not module code, so within the package this
+    helper is exercised only by the migration-metadata tests.
+    Retained deliberately as the single authority on migration-row
+    shape; see the next paragraph for why the script and tests must
+    share it.
+
     Centralizes the speaker / confidence / source / section /
     subsection assignment so the migration writer (the
     migrate-memory-md script) and the test that pins migration-row
@@ -1514,6 +1521,12 @@ def _base_recall_payload(user_id: str, query: str) -> dict[str, object]:
     """
     return {
         "user_id": user_id,
+        # The caller-facing id above is often the legacy numeric chat
+        # id while retrieval actually filters on the resolved
+        # canonical principal; logging both makes the mapping
+        # verifiable on every line instead of leaving readers to wonder whether
+        # the two identities agree.
+        "resolved_user_id": canonical_memory_user_id(user_id),
         "query_len": len(query),
         "query": _truncate(query, _RECALL_QUERY_TRUNC),
         "fetch_limit": 0,
@@ -2457,9 +2470,13 @@ def format_scoped_context(
     Render a ScopedRetrievalResult into a two-section prompt block.
 
     Pure formatting layer. Does NOT search memory, detect projects,
-    emit log lines, or call `retrieve_scoped_memories`. Consumed by
-    `format_scoped_context_with_recall_payload` for live prompt
-    injection.
+    emit log lines, or call `retrieve_scoped_memories`. No production
+    caller: the live path (`format_scoped_context_with_recall_payload`)
+    renders through the shared `_render_scoped_sections`
+    implementation directly, and this public wrapper survives as the
+    payload-free entry point the rendering tests drive. Deleting it
+    would force those tests through the recall-payload plumbing they
+    are not about.
 
     Section shape (D3 / D4):
 
@@ -2857,12 +2874,18 @@ def count_by_source(user_id: str, source: str) -> int:
 
     # Single fetch: top_k bounds the result; no looping. See docstring
     # for why a paged loop is unsafe here even though it works in
-    # delete_by_source.
-    storage_user_id, namespace = _canonical_memory_owner(user_id)
-    result = _memory.get_all(
-        filters={"user_id": storage_user_id},
-        top_k=_DELETE_PAGE_SIZE,
-    )
+    # delete_by_source. Guarded like every sibling read helper: a
+    # Mem0 failure degrades to a zero count with a warning rather
+    # than propagating out of a counting utility.
+    try:
+        storage_user_id, namespace = _canonical_memory_owner(user_id)
+        result = _memory.get_all(
+            filters={"user_id": storage_user_id},
+            top_k=_DELETE_PAGE_SIZE,
+        )
+    except Exception:
+        log.warning("count_by_source failed (user_id=%s)", user_id, exc_info=True)
+        return 0
     rows = result.get("results", []) if isinstance(result, dict) else result or []
 
     # Match logic mirrors delete_by_source: empty-source means legacy
@@ -3088,16 +3111,23 @@ def add_structured(
     if not content.strip():
         return None
 
-    storage_user_id, namespace = _canonical_memory_owner(user_id)
-
-    # Build the metadata dict. Caller-provided metadata comes first so
-    # the reserved keys (type, tags) can override caller values.
-    final_metadata: dict = _metadata_for_owner(metadata, namespace)
-    final_metadata["type"] = memory_type
-    if tags is not None:
-        final_metadata["tags"] = tags
-
     try:
+        # Owner resolution and metadata merge sit INSIDE the guard:
+        # `_metadata_for_owner` raises on a provenance conflict with
+        # the canonical owner, and this function documents a
+        # never-raise contract; a conflicting caller must get the
+        # same None-plus-warning failure surface as a store error,
+        # not an exception the caller was told cannot happen.
+        storage_user_id, namespace = _canonical_memory_owner(user_id)
+
+        # Build the metadata dict. Caller-provided metadata comes
+        # first so the reserved keys (type, tags) can override
+        # caller values.
+        final_metadata: dict = _metadata_for_owner(metadata, namespace)
+        final_metadata["type"] = memory_type
+        if tags is not None:
+            final_metadata["tags"] = tags
+
         # infer=False means no LLM call; Mem0 only embeds + stores.
         # This is the entire point of the Track 2 primitive.
         raw = _memory.add(

--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -93,20 +93,31 @@ def _default_human_report_directory(config: Config, user_id: str, report_name: s
     finally:
         connection.close()
     if len(rows) != 1:
-        raise RuntimeError("Memory admin user has no unique canonical Workshop principal")
+        # Unmapped user (zero rows) or ambiguous mapping (several):
+        # fall back to the literal-user-id path exactly like every
+        # other unresolvable branch above. This helper picks a
+        # DEFAULT artifact directory; failing the whole admin command
+        # over a missing identity mapping punished the operator for a
+        # condition --out-dir already handles.
+        return DATA_DIR / "home" / user_id / "docs" / report_name
     return DATA_DIR / "home" / str(rows[0][0]) / "docs" / report_name
 
 
 # ── Known source values ─────────────────────────────────────────────
 #
-# Accepted values for --source. The empty-string option covers LEGACY
-# rows (pre-Phase-1 entries whose metadata dict has no "source" key).
-# `delete_by_source(user_id, source="")` deliberately matches both the
-# key-absent and key-empty cases, per the implementation in memory.py.
+# Accepted values for --source: every source the live system mints
+# (mirrors memory.USER_VISIBLE_SOURCES; the literal copy exists
+# because this module keeps kai.memory imports lazy so --help stays
+# fast, and a test pins the two sets against drift) plus two
+# purge-only extras: "user_raw" targets Track-1-era legacy rows that
+# survive only as purge candidates, and the empty string covers
+# LEGACY rows whose metadata dict has no "source" key at all
+# (`delete_by_source(user_id, source="")` deliberately matches both
+# the key-absent and key-empty cases, per memory.py).
 #
 # We enumerate explicitly so a typo ("user-raw" vs "user_raw") fails
 # at arg-parse time rather than silently no-op'ing against every row.
-_KNOWN_SOURCES = frozenset({"extracted", "user_raw", ""})
+_KNOWN_SOURCES = frozenset({"extracted", "episode", "migration", "explicit", "user_raw", ""})
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -180,13 +180,6 @@ _EPISODE_PROMPT_VERSION: str = "2"
 _FAILURE_STREAK_ALARM_THRESHOLD = 3
 _consecutive_subprocess_failures = 0
 
-# Memory `type` values this module writes. Track 1 writes "exchange"
-# from memory.py; Track 2 writes "fact" from here. Any other type value
-# in add_structured() metadata produced by this module is a bug.
-# NOTE: metadata["type"] is NOT the same namespace as metadata["tags"]
-# ("fact" happens to appear in both but the semantics differ).
-_ALLOWED_TYPES: frozenset[str] = frozenset({"exchange", "fact"})
-
 # Minimum length for a valid confirmation_quote on a confirmed_action
 # fact. Matches the "20 characters" rule in the extractor prompt.
 _CONFIRMATION_QUOTE_MIN_CHARS = 20
@@ -3526,7 +3519,6 @@ async def extract_and_store(
 # assembly directly without going through subprocess. Kept explicit
 # at module level rather than via __all__ for grep discoverability.
 __all__ = [
-    "_ALLOWED_TYPES",
     "_CONFIRMATION_QUOTE_MIN_CHARS",
     "_CONSOLIDATION_INTENTS",
     "_DEDUP_NEIGHBOR_FETCH_N",

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -5648,6 +5648,7 @@ class TestFormatContextUnchangedByScopedHelper:
         # docstring); short-circuit lines add it.
         expected_keys = {
             "user_id",
+            "resolved_user_id",
             "query_len",
             "query",
             "fetch_limit",
@@ -6644,3 +6645,54 @@ class TestExplicitSourceVisibility:
         assert "explicit" in _FACT_BUCKET_SOURCES
         # Episodes keep their own browser; the bucket must not gain them.
         assert "episode" not in _FACT_BUCKET_SOURCES
+
+
+class TestNeverRaiseContracts:
+    """The audit's L2 contract nits: add_structured documents a
+    never-raise contract but the owner-conflict check sat outside its
+    exception shell, and count_by_source lacked the guard every
+    sibling read helper has."""
+
+    def test_add_structured_swallows_provenance_conflict(self):
+        """A caller-supplied owner key that conflicts with the
+        canonical namespace must produce the documented None-plus-
+        warning failure, not a CanonicalMemoryAuthorityError escaping
+        a function that promises not to raise."""
+        import kai.memory as mem_mod
+        from kai.memory import WORKSHOP_PRINCIPAL_ID_KEY, add_structured
+        from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
+        from kai.workshop.execution_state import (
+            WorkshopExecutionStateNamespace,
+            WorkshopExecutionStateRegistry,
+        )
+
+        namespace = WorkshopExecutionStateNamespace(
+            principal_id=PrincipalId.new(),
+            channel_id=ChannelId.new(),
+            agent_id=AgentId.new(),
+            runtime_profile_id=RuntimeProfileId.new(),
+            runtime_config_id=424242,
+        )
+        mem_mod._memory = MagicMock()
+        try:
+            mem_mod.configure_memory_authority(WorkshopExecutionStateRegistry((namespace,)))
+            result = add_structured(
+                "conflicting fact",
+                user_id=str(namespace.runtime_config_id),
+                metadata={WORKSHOP_PRINCIPAL_ID_KEY: "prn_" + "f" * 32},
+            )
+        finally:
+            mem_mod.configure_memory_authority(None)
+
+        assert result is None
+        mem_mod._memory.add.assert_not_called()
+
+    def test_count_by_source_returns_zero_on_store_error(self):
+        import kai.memory as mem_mod
+        from kai.memory import count_by_source
+
+        mock_mem = MagicMock()
+        mock_mem.get_all.side_effect = RuntimeError("mem0 down")
+        mem_mod._memory = mock_mem
+
+        assert count_by_source(user_id="123", source="extracted") == 0

--- a/tests/test_memory_admin.py
+++ b/tests/test_memory_admin.py
@@ -693,3 +693,85 @@ class TestBackfillExplicit:
             memory_admin.cli(["backfill-explicit"])
         assert exc.value.code == 0
         cmd.assert_called_once()
+
+
+class TestBackfillProvenanceParser:
+    """Parser pins for backfill-provenance, previously the only
+    subcommand with no parser tests (audit test-gap item). Shapes
+    mirror the reclassify pins: required user_id, None defaults that
+    the mutating-mode rejection depends on, exclusive modes."""
+
+    def test_requires_user_id(self):
+        parser = memory_admin._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["backfill-provenance"])
+
+    def test_flags_default_to_none(self):
+        """None defaults are load-bearing: the mutating-mode rejection
+        distinguishes explicitly-passed flags from defaults by None,
+        including the store_const shape of --no-assistant-pass."""
+        parser = memory_admin._build_parser()
+        args = parser.parse_args(["backfill-provenance", "100"])
+        assert args.window_seconds is None
+        assert args.min_overlap is None
+        assert args.strong_overlap_ratio is None
+        assert args.overlap_shingle_n is None
+        assert args.no_assistant_pass is None
+        assert args.assistant_max_user_gap_seconds is None
+        assert args.sample is None
+        assert args.out_dir is None
+        assert args.apply is None
+        assert args.rollback is None
+        assert args.yes is False
+
+    def test_modes_are_mutually_exclusive(self):
+        parser = memory_admin._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["backfill-provenance", "100", "--apply", "a.jsonl", "--rollback", "b.jsonl"])
+
+    def test_dispatch_calls_backfill_provenance(self):
+        with (
+            patch.object(memory_admin, "_cmd_backfill_provenance", return_value=0) as cmd_mock,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            memory_admin.cli(["backfill-provenance", "100"])
+        assert exc_info.value.code == 0
+        assert cmd_mock.call_args[0][0].user_id == "100"
+
+
+class TestKnownSourcesDrift:
+    def test_known_sources_track_user_visible_sources(self):
+        """_KNOWN_SOURCES is a literal copy (this module keeps
+        kai.memory imports lazy so --help stays fast); this pin is
+        the drift guard the literal relies on. The two purge-only
+        extras are the Track-1 legacy source and the empty string
+        for rows with no source key."""
+        from kai.memory import USER_VISIBLE_SOURCES
+
+        expected = frozenset(USER_VISIBLE_SOURCES) | {"user_raw", ""}
+        assert expected == memory_admin._KNOWN_SOURCES
+
+
+class TestReportDirectoryFallback:
+    def test_unmapped_user_falls_back_to_literal_path(self, tmp_path, monkeypatch):
+        """An unmapped user (no external-identity row) lands on the
+        literal-user-id path like every other unresolvable branch,
+        instead of raising and killing the whole admin command over
+        a default that --out-dir can override anyway."""
+        db_path = tmp_path / "kai.db"
+        connection = sqlite3.connect(db_path)
+        connection.execute(
+            "CREATE TABLE external_identities ("
+            "principal_id TEXT NOT NULL, provider TEXT NOT NULL, external_subject TEXT NOT NULL)"
+        )
+        connection.commit()
+        connection.close()
+        monkeypatch.setattr("kai.config.DATA_DIR", tmp_path / "data")
+
+        result = memory_admin._default_human_report_directory(
+            SimpleNamespace(session_db_path=db_path),
+            "42",
+            "reclassify",
+        )
+
+        assert result == tmp_path / "data" / "home" / "42" / "docs" / "reclassify"

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -206,18 +206,27 @@ class TestCanonicalMemoryNamespace:
         assert memory.get_by_id(user_id="101", memory_id=memory_id) is None
 
     def test_conflicting_owner_metadata_fails_closed(self):
+        """Fail-closed means the misowned row is never stored. The
+        refusal surfaces as the documented never-raise failure shape
+        (None plus a warning) rather than an escaping
+        CanonicalMemoryAuthorityError; the audit flagged the old
+        raise as a contract violation, and callers of add_structured
+        are written against the None contract."""
         namespace = _namespace()
-        memory._memory = _FakeMem0()
+        fake = _FakeMem0()
+        memory._memory = fake
         memory._config = SimpleNamespace(memory_search_limit=10)
         memory.configure_memory_authority(WorkshopExecutionStateRegistry((namespace,)))
 
-        with pytest.raises(memory.CanonicalMemoryAuthorityError, match="conflicts"):
-            memory.add_structured(
-                "Misowned fact",
-                user_id="101",
-                memory_type="fact",
-                metadata={memory.WORKSHOP_PRINCIPAL_ID_KEY: str(PrincipalId.new())},
-            )
+        result = memory.add_structured(
+            "Misowned fact",
+            user_id="101",
+            memory_type="fact",
+            metadata={memory.WORKSHOP_PRINCIPAL_ID_KEY: str(PrincipalId.new())},
+        )
+
+        assert result is None
+        assert memory.get_all(user_id="101") == []
 
     def test_partial_external_store_move_resumes_without_duplication(self):
         namespace = _namespace()


### PR DESCRIPTION
Closes #1022.

Per the acceptance criteria, every item is listed here as fixed, done operationally, or waived with a reason. No silent skips.

## Code fixes (this PR)

- **`add_structured` never-raise contract**: owner resolution and the metadata merge move inside the exception shell; a provenance conflict now yields the documented None-plus-warning failure, still fail-closed (nothing stored, verified by test). The authority test pinning the old raise now pins refusal-without-storage.
- **`count_by_source` guard**: gains the exception guard every sibling read helper has; store failure degrades to a zero count with a warning. Test-pinned.
- **`_KNOWN_SOURCES`**: expanded to every source the live system mints (`extracted`, `episode`, `migration`, `explicit`) plus the two purge-only extras (`user_raw`, empty string). A drift-guard test pins the set against `USER_VISIBLE_SOURCES`; the literal copy preserves this module's lazy `kai.memory` imports.
- **`_ALLOWED_TYPES`**: deleted. It referenced the removed Track 1, was enforced nowhere, and had no callers in code or tests.
- **Zero-caller functions**: `build_migration_metadata` and `format_scoped_context` are marked with their no-production-caller rationale (single authority on migration-row shape; payload-free test entry point over the shared renderer). `canonical_memory_user_id` gained a production caller via the telemetry fix below. `migrate_memory_namespace` turned out to be live (passed as a callable by the workshop authority), so no mark.
- **Admin report-directory helper**: unmapped or ambiguous users fall back to the literal-user-id path like every other unresolvable branch instead of raising an uncaught RuntimeError.
- **Recall telemetry**: the payload now carries `resolved_user_id` beside the caller-facing id, making the legacy-id-to-principal mapping verifiable on every line (strictly more useful than the suggested one-line assertion, and it cannot crash the recall path). The payload-schema pin test is updated for the new key.
- **Test gap**: `backfill-provenance` gains parser and dispatch tests (required user id, None-default flags the mutating-mode rejection depends on, mutually exclusive modes, CLI dispatch).

## Waived

- **`delete_by_source` pagination** (under-delete past 10,000 rows, O(n) per page): waived. The behavior is documented at the definition, the corpus is under 400 rows and bounded by single-operator scale, and the fix (offset pagination against an API that does not guarantee ordering) would add complexity for a limit three orders of magnitude away.

## Data hygiene (operational, done outside the PR)

- Stale eval snapshot archived to the backups tree (its production collection name made a misconfigured `DATA_DIR` hazard); nothing deleted.
- Legacy-numeric MEMORY.md duplication confirmed by checksum against the canonical principal dirs for both principals, via the root-owned reader. The two foreign-owned legacy dirs need operator deletion (modes block the service user); exact paths handed over in review. The kai-owned group-chat dir has no canonical counterpart, is not a duplicate, and stays.
- Empty repo-local `memory/` scaffold deleted.
- The previously unenumerable subdirectory listing is complete: five foreign-owned dirs enumerated via the reader, one kai-owned; all accounted for as the two confirmed duplicates, three canonical principal dirs, and the non-duplicate group-chat dir.

Suite: 6050 passed, 1 skipped; ruff and pyright clean.
