### PR TITLE
memory: close the session DB so reclassify-scope can exit

### DIFF
--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -376,6 +376,33 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+async def _run_and_close_sessions(coro):
+    """Await a reclassify entrypoint, then close the session DB.
+
+    `load_project_registry` (called by the dry-run and apply
+    entrypoints) opens the session DB the way daemon startup does,
+    and each aiosqlite connection runs a NON-DAEMON worker thread
+    that exits only when the connection is closed. The daemon closes
+    it in main.py's shutdown path; a CLI process has no shutdown
+    path, so the leaked worker thread pinned interpreter exit and
+    every reclassify invocation hung forever after finishing its
+    work. Closing here, at the process-lifetime boundary and inside
+    the same event loop that opened the connection (aiosqlite
+    futures are loop-bound, so a second asyncio.run cannot close
+    it), is what lets the process exit.
+
+    close_db() no-ops when nothing was opened, so wrapping the
+    rollback entrypoint (which never loads the registry) is safe
+    and keeps the three dispatch sites uniform.
+    """
+    from kai import sessions
+
+    try:
+        return await coro
+    finally:
+        await sessions.close_db()
+
+
 def _initialize_memory() -> Config | None:
     """Load config and call `init_memory()`; return the Config on success.
 
@@ -677,15 +704,17 @@ def _cmd_reclassify(args: argparse.Namespace) -> int:
 
     if not mutating:
         return asyncio.run(
-            memory_reclassify.run_dry_run(
-                config,
-                args.user_id,
-                backend=args.backend,
-                os_user=args.os_user,
-                provider=args.provider,
-                threshold=threshold,
-                sample=sample,
-                out_dir=out_dir,
+            _run_and_close_sessions(
+                memory_reclassify.run_dry_run(
+                    config,
+                    args.user_id,
+                    backend=args.backend,
+                    os_user=args.os_user,
+                    provider=args.provider,
+                    threshold=threshold,
+                    sample=sample,
+                    out_dir=out_dir,
+                )
             )
         )
 
@@ -717,9 +746,13 @@ def _cmd_reclassify(args: argparse.Namespace) -> int:
 
     if args.apply is not None:
         return asyncio.run(
-            memory_reclassify.run_apply(config, args.user_id, proposals_path=artifact_path, out_dir=out_dir)
+            _run_and_close_sessions(
+                memory_reclassify.run_apply(config, args.user_id, proposals_path=artifact_path, out_dir=out_dir)
+            )
         )
-    return asyncio.run(memory_reclassify.run_rollback(config, args.user_id, preimages_path=artifact_path))
+    return asyncio.run(
+        _run_and_close_sessions(memory_reclassify.run_rollback(config, args.user_id, preimages_path=artifact_path))
+    )
 
 
 def _cmd_backfill_provenance(args: argparse.Namespace) -> int:

--- a/tests/test_memory_admin.py
+++ b/tests/test_memory_admin.py
@@ -775,3 +775,64 @@ class TestReportDirectoryFallback:
         )
 
         assert result == tmp_path / "data" / "home" / "42" / "docs" / "reclassify"
+
+
+class TestRunAndCloseSessions:
+    """The exit-wedge fix: reclassify entrypoints open the session DB
+    (via load_project_registry) and aiosqlite's per-connection worker
+    thread is non-daemon, so a CLI process that never closes the
+    connection hangs forever at interpreter shutdown. The wrapper
+    closes at the process-lifetime boundary, inside the loop that
+    opened it."""
+
+    @pytest.mark.asyncio
+    async def test_returns_result_and_closes(self, monkeypatch):
+        closed = []
+
+        async def fake_close():
+            closed.append(True)
+
+        monkeypatch.setattr("kai.sessions.close_db", fake_close)
+
+        async def entrypoint():
+            return 7
+
+        assert await memory_admin._run_and_close_sessions(entrypoint()) == 7
+        assert closed == [True]
+
+    @pytest.mark.asyncio
+    async def test_closes_even_when_entrypoint_raises(self, monkeypatch):
+        closed = []
+
+        async def fake_close():
+            closed.append(True)
+
+        monkeypatch.setattr("kai.sessions.close_db", fake_close)
+
+        async def entrypoint():
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await memory_admin._run_and_close_sessions(entrypoint())
+        assert closed == [True]
+
+    def test_dry_run_dispatch_closes_sessions(self, monkeypatch):
+        """The dry-run dispatch site actually routes through the
+        wrapper: a stubbed run_dry_run must be followed by close_db
+        before the command returns."""
+        order = []
+
+        async def fake_dry_run(*args, **kwargs):
+            order.append("run")
+            return 0
+
+        async def fake_close():
+            order.append("close")
+
+        monkeypatch.setattr("kai.memory_reclassify.run_dry_run", fake_dry_run)
+        monkeypatch.setattr("kai.sessions.close_db", fake_close)
+        monkeypatch.setattr(memory_admin, "_initialize_memory", lambda: SimpleNamespace(session_db_path="x"))
+
+        args = memory_admin._build_parser().parse_args(["reclassify-scope", "100", "--out-dir", "/tmp/x"])
+        assert memory_admin._cmd_reclassify(args) == 0
+        assert order == ["run", "close"]


### PR DESCRIPTION
Closes #1029.

## Root cause

Found by reproducing against a throwaway store (an empty one wedges too, which ruled out the reasoner) and stack-sampling the hung process: the main thread sits in `wait_for_thread_shutdown` joining a non-daemon thread blocked on a queue get. Thread enumeration named it: aiosqlite's `_connection_worker_thread`. The dry-run and apply entrypoints open the session DB through `load_project_registry` (which deliberately mirrors daemon startup), and every aiosqlite connection runs a non-daemon worker thread that exits only when the connection is closed. The daemon closes it in `main.py`'s shutdown path; the CLI process had no equivalent, so every invocation finished its work and then hung forever in interpreter shutdown. The sibling admin commands never load the registry, which is why only `reclassify-scope` wedged.

## Fix

`_run_and_close_sessions`, a wrapper at the dispatch boundary: await the entrypoint, close the session DB in a `finally`. It runs inside the same event loop that opened the connection, which matters because aiosqlite futures are loop-bound and a second `asyncio.run` could not close it. All three modes route through it uniformly; `close_db` no-ops for rollback, which never opens the DB.

## Verification

The reproduction that previously hung indefinitely (dry run, throwaway store, claude backend) now exits with code 0 immediately after writing its artifacts. Unit tests pin the wrapper's result passthrough, its close-on-exception behavior, and that the dry-run dispatch site actually routes through it (run-then-close order asserted). Suite: 6053 passed, 1 skipped; ruff and pyright clean.

The acceptance sketch from the issue holds: the command exits on its own within seconds of its final artifact, in both dry-run and apply shapes.
