### PR TITLE
security: protect memory telemetry logs

### DIFF
--- a/src/kai/eval/retrieval_scoped.py
+++ b/src/kai/eval/retrieval_scoped.py
@@ -651,6 +651,7 @@ async def _run_one_probe(
         backend_name=None,
         job_type="eval",
         session_id=None,
+        include_diagnostic_content=True,
     )
     payload = rendered.recall_payload
     payload_hits = payload.get("hits") or []

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -146,6 +146,7 @@ _SERVICE_START_RETRY_SECONDS = 2
 _PRIVATE_USER_ROOT_MODE = 0o711
 _PRIVATE_USER_DIR_MODE = 0o700
 _PRIVATE_USER_FILE_MODE = 0o600
+_SERVICE_LOG_NAMES = ("kai.log", "kai.stdout.log", "kai.stderr.log")
 _OPTIONAL_PROTECTED_YAML_CONFIGS: tuple[str, ...] = (
     "services.yaml",
     "workspaces.yaml",
@@ -2945,6 +2946,66 @@ def _set_private_user_tree_modes(path: Path) -> None:
         os.chmod(path, _PRIVATE_USER_FILE_MODE)
 
 
+def _secure_log_storage(
+    log_dir: Path,
+    svc_uid: int,
+    svc_gid: int,
+    *,
+    dry_run: bool,
+) -> None:
+    """Create or repair service-private log storage without following links."""
+    if log_dir.is_symlink():
+        raise ValueError(f"Refusing symlinked log directory: {log_dir}")
+    if log_dir.exists() and not log_dir.is_dir():
+        raise ValueError(f"Log path is not a directory: {log_dir}")
+
+    if log_dir.exists():
+        for root, dirs, files in os.walk(log_dir, followlinks=False):
+            root_path = Path(root)
+            for name in (*dirs, *files):
+                entry = root_path / name
+                entry_stat = entry.lstat()
+                if stat.S_ISLNK(entry_stat.st_mode):
+                    raise ValueError(f"Refusing symlink in log directory: {entry}")
+                if not (stat.S_ISDIR(entry_stat.st_mode) or stat.S_ISREG(entry_stat.st_mode)):
+                    raise ValueError(f"Refusing non-file log entry: {entry}")
+
+    if dry_run:
+        print(f"[DRY RUN] Would secure log storage: {log_dir} ({svc_uid}:{svc_gid}, directories 0700, files 0600)")
+        return
+
+    log_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
+    os.chmod(log_dir, _PRIVATE_USER_DIR_MODE)
+    os.chown(log_dir, svc_uid, svc_gid)
+
+    for root, dirs, files in os.walk(log_dir, followlinks=False):
+        root_path = Path(root)
+        os.chmod(root_path, _PRIVATE_USER_DIR_MODE)
+        os.chown(root_path, svc_uid, svc_gid)
+        for name in dirs:
+            child = root_path / name
+            os.chmod(child, _PRIVATE_USER_DIR_MODE)
+            os.chown(child, svc_uid, svc_gid)
+        for name in files:
+            child = root_path / name
+            os.chmod(child, _PRIVATE_USER_FILE_MODE)
+            os.chown(child, svc_uid, svc_gid)
+
+    # launchd opens stdout/stderr before Python starts. Pre-creating all
+    # service logs at 0600 makes those opens preserve the same contract as
+    # the rotating application log.
+    open_flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    open_flags |= getattr(os, "O_NOFOLLOW", 0)
+    for name in _SERVICE_LOG_NAMES:
+        path = log_dir / name
+        if path.is_symlink():
+            raise ValueError(f"Refusing symlinked service log: {path}")
+        descriptor = os.open(path, open_flags, _PRIVATE_USER_FILE_MODE)
+        os.close(descriptor)
+        os.chmod(path, _PRIVATE_USER_FILE_MODE)
+        os.chown(path, svc_uid, svc_gid)
+
+
 def _set_static_install_tree_modes(path: Path) -> bool:
     """Make root-owned installed code traversable and readable by the service.
 
@@ -4993,6 +5054,8 @@ def _apply_migrate(
                 # Set ownership on the entire logs directory
                 _set_ownership(logs_dst, svc_uid, svc_gid, recursive=True)
 
+    _secure_log_storage(logs_dst, svc_uid, svc_gid, dry_run=dry_run)
+
     # -- MEMORY.md migration --
     # One-time: land personal memory at the per-user path
     # DATA_DIR/memory/<principal_id>/MEMORY.md. The "primary operator"
@@ -6203,7 +6266,7 @@ def _apply_directories(
         (install_path, 0, 0, 0o755),  # root-owned install dir
         (home_path, svc_uid, svc_gid, 0o755),  # user-writable home workspace
         (data_path, svc_uid, svc_gid, 0o755),  # user-owned data dir
-        (data_path / "logs", svc_uid, svc_gid, 0o755),
+        (data_path / "logs", svc_uid, svc_gid, _PRIVATE_USER_DIR_MODE),
         (data_path / "files", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         (data_path / "history", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
         (data_path / "memory", svc_uid, svc_gid, _PRIVATE_USER_ROOT_MODE),
@@ -7930,6 +7993,66 @@ def _check_path(path: Path, label: str) -> str:
     return f"{label}: {path} (exists, {owner}:{group})"
 
 
+def _log_security_status(log_dir: Path, service_user: str) -> str:
+    """Report log ownership and modes without reading names or content."""
+    try:
+        service = pwd.getpwnam(service_user)
+    except KeyError:
+        return f"Log security: unavailable; service user {service_user!r} not found"
+
+    try:
+        root_stat = log_dir.lstat()
+        if stat.S_ISLNK(root_stat.st_mode) or not stat.S_ISDIR(root_stat.st_mode):
+            return "Log security: INSECURE; log root is not a real directory"
+
+        unsafe_modes = 0
+        unsafe_owners = 0
+        unsafe_types = 0
+        directory_count = 1
+        file_count = 0
+
+        if stat.S_IMODE(root_stat.st_mode) != _PRIVATE_USER_DIR_MODE:
+            unsafe_modes += 1
+        if (root_stat.st_uid, root_stat.st_gid) != (service.pw_uid, service.pw_gid):
+            unsafe_owners += 1
+
+        for root, dirs, files in os.walk(log_dir, followlinks=False):
+            root_path = Path(root)
+            for name in dirs:
+                directory_count += 1
+                entry_stat = (root_path / name).lstat()
+                if stat.S_ISLNK(entry_stat.st_mode) or not stat.S_ISDIR(entry_stat.st_mode):
+                    unsafe_types += 1
+                    continue
+                if stat.S_IMODE(entry_stat.st_mode) != _PRIVATE_USER_DIR_MODE:
+                    unsafe_modes += 1
+                if (entry_stat.st_uid, entry_stat.st_gid) != (service.pw_uid, service.pw_gid):
+                    unsafe_owners += 1
+            for name in files:
+                file_count += 1
+                entry_stat = (root_path / name).lstat()
+                if stat.S_ISLNK(entry_stat.st_mode) or not stat.S_ISREG(entry_stat.st_mode):
+                    unsafe_types += 1
+                    continue
+                if stat.S_IMODE(entry_stat.st_mode) != _PRIVATE_USER_FILE_MODE:
+                    unsafe_modes += 1
+                if (entry_stat.st_uid, entry_stat.st_gid) != (service.pw_uid, service.pw_gid):
+                    unsafe_owners += 1
+    except FileNotFoundError:
+        return f"Log security: {log_dir} (not found)"
+    except PermissionError:
+        return f"Log security: {log_dir} (permission denied; run status with sudo)"
+
+    summary = f"directories={directory_count}, files={file_count}"
+    if unsafe_modes or unsafe_owners or unsafe_types:
+        return (
+            "Log security: INSECURE; "
+            f"{summary}, unsafe modes={unsafe_modes}, "
+            f"unsafe owners={unsafe_owners}, unsafe entries={unsafe_types}"
+        )
+    return f"Log security: secure; {summary}, service-owned, directories=0700, files=0600"
+
+
 def _check_traversal(path: Path, service_user: str) -> str | None:
     """
     Check if every component of path is traversable by the service user.
@@ -8043,6 +8166,7 @@ def _cmd_status() -> None:
     print("=" * 30)
     print(_check_path(Path(install_dir), "Installation"))
     print(_check_path(Path(data_dir), "Data"))
+    print(_log_security_status(Path(data_dir) / "logs", service_user))
     print(_check_path(_DEPLOYED_ENV_FILE, "Secrets"))
     print(_check_path(Path("/etc/kai/services.yaml"), "Services"))
     print(_check_path(RUNTIME_PROFILES_YAML, "Runtime profiles"))

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -35,8 +35,10 @@ The shutdown sequence (in the finally block) reverses this order:
 
 import asyncio
 import logging
+import os
 import re
 import signal
+import stat
 from datetime import UTC, datetime, timedelta
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
@@ -50,6 +52,41 @@ from kai.memory_backup import run_memory_backup
 from kai.telegram_adapter import TelegramAdapter
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+
+
+class _PrivateTimedRotatingFileHandler(TimedRotatingFileHandler):
+    """Timed file handler whose active log is always service-private."""
+
+    def _open(self):
+        stream = super()._open()
+        os.chmod(self.baseFilename, 0o600)
+        return stream
+
+
+def _secure_runtime_log_tree(log_dir: Path) -> None:
+    """Create or repair Kai's log tree without following symlinks."""
+    if log_dir.is_symlink():
+        raise RuntimeError(f"Refusing symlinked log directory: {log_dir}")
+    log_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if not log_dir.is_dir():
+        raise RuntimeError(f"Log path is not a directory: {log_dir}")
+    os.chmod(log_dir, 0o700)
+
+    for root, dirs, files in os.walk(log_dir, followlinks=False):
+        root_path = Path(root)
+        for name in dirs:
+            child = root_path / name
+            if child.is_symlink():
+                raise RuntimeError(f"Refusing symlink in log directory: {child}")
+            os.chmod(child, 0o700)
+        for name in files:
+            child = root_path / name
+            child_stat = child.lstat()
+            if stat.S_ISLNK(child_stat.st_mode):
+                raise RuntimeError(f"Refusing symlink in log directory: {child}")
+            if not stat.S_ISREG(child_stat.st_mode):
+                raise RuntimeError(f"Refusing non-regular log entry: {child}")
+            os.chmod(child, 0o600)
 
 
 async def _warn_if_compatibility_jobs_are_dormant(config) -> int:
@@ -123,17 +160,17 @@ def setup_logging() -> None:
     - StreamHandler: writes to stderr for terminal visibility during `make run`
       (harmless under launchd since there's no terminal attached)
 
-    Creates the logs/ directory if it doesn't already exist.
+    Creates or repairs the service-private logs/ tree before opening a file.
     """
     # Logs go under DATA_DIR so they're writable even when source is read-only
     log_dir = DATA_DIR / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
+    _secure_runtime_log_tree(log_dir)
 
     formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
 
     # Daily rotation at midnight, keep 2 weeks of history, use UTF-8 for
     # emoji and non-ASCII content in Claude responses
-    file_handler = TimedRotatingFileHandler(
+    file_handler = _PrivateTimedRotatingFileHandler(
         filename=log_dir / "kai.log",
         when="midnight",
         backupCount=14,

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1444,24 +1444,13 @@ def _estimate_tokens(text: str) -> int:
     return len(text) // 4
 
 
-# Maximum characters of the query field to embed in the memory.recall
-# log line. The full query reaches the semantic search; this cap
-# applies only to the log copy. 256 covers the common single-message
-# user turn so an eval harness can reproduce the search input from
-# logs alone without joining against chat-history JSONL by timestamp.
-# Queries longer than 256 chars still hit the fallback path (the eval
-# harness reads the full text from chat history); the cap exists to
-# bound multi-paragraph paste cases that would otherwise inflate
-# every recall log line.
+# Maximum characters of the query field in explicit evaluation and
+# diagnostic recall payloads. Production recall telemetry omits the
+# field entirely. The full query still reaches semantic search.
 _RECALL_QUERY_TRUNC = 256
 
-# Maximum characters of each per-hit snippet in the memory.recall log
-# line. 80 is enough to fingerprint a hit for an eval harness, which
-# treats the snippet as an identifier rather than full retrieved
-# text. The snippet cap stays narrower than the query cap because a
-# single recall returns up to MEMORY_K hits; raising both together
-# would multiply the log-line length by the hit count for a use case
-# (full hit-text recovery) that the eval harness does not need.
+# Maximum characters of each per-hit snippet in explicit evaluation
+# and diagnostic recall payloads. Production telemetry omits snippets.
 _RECALL_SNIPPET_TRUNC = 80
 
 
@@ -1501,7 +1490,12 @@ _RECALL_REASON_ALL_BELOW_FLOOR = "all_below_floor"
 _RECALL_REASON_BUDGET_EXHAUSTED = "budget_exhausted"
 
 
-def _base_recall_payload(user_id: str, query: str) -> dict[str, object]:
+def _base_recall_payload(
+    user_id: str,
+    query: str,
+    *,
+    include_content: bool,
+) -> dict[str, object]:
     """
     Build a memory.recall payload with all uniform-shape fields set.
 
@@ -1516,8 +1510,9 @@ def _base_recall_payload(user_id: str, query: str) -> dict[str, object]:
     `returned_empty` defaults to True; the success path flips it to
     False just before emit. `reason` is the one non-uniform field:
     present only on short-circuit lines, omitted on success, so it's
-    not in the base payload. Real query and user_id are always
-    populated; they are never sentineled.
+    not in the base payload. ``include_content`` is reserved for
+    explicit evaluation and diagnostics. Production telemetry keeps
+    query length and structural signals but omits the raw query.
     """
     return {
         "user_id": user_id,
@@ -1528,7 +1523,6 @@ def _base_recall_payload(user_id: str, query: str) -> dict[str, object]:
         # the two identities agree.
         "resolved_user_id": canonical_memory_user_id(user_id),
         "query_len": len(query),
-        "query": _truncate(query, _RECALL_QUERY_TRUNC),
         "fetch_limit": 0,
         "hits_raw": 0,
         "hits_after_floor": 0,
@@ -1538,6 +1532,7 @@ def _base_recall_payload(user_id: str, query: str) -> dict[str, object]:
         "lines_used": 0,
         "budget_tokens": 0,
         "hits": [],
+        **({"query": _truncate(query, _RECALL_QUERY_TRUNC)} if include_content else {}),
     }
 
 
@@ -1550,15 +1545,11 @@ def _emit_recall_log(payload: dict[str, object]) -> None:
     output would break extraction. The "memory.recall " prefix is
     the stable greppable tag.
 
-    PII posture (recorded here so a future reviewer does not
-    re-litigate it): the query and per-hit snippets are logged in
-    their truncated form (80 chars), unhashed and unredacted. Target
-    log file is operator-local and already contains the full
-    conversation under other paths (CLAUDE_DEBUG=true, history
-    storage). Pattern-based redaction is fragile and creates a false
-    sense of safety; truncation is the only meaningful protection
-    here. Operators wanting stricter handling should rotate logs
-    aggressively or shift the log level for this module.
+    Content posture: live callers use content-free payloads. Raw query,
+    hit snippets, and exception messages appear only when an explicit
+    evaluation/diagnostic caller requests them. Filesystem protection
+    remains defense in depth, not permission to add conversation text
+    back to routine telemetry.
     """
     log.info("memory.recall %s", json.dumps(payload, separators=(",", ":")))
 
@@ -2041,7 +2032,7 @@ async def format_context(
     # fields it knows about. Centralizing construction here guarantees
     # that query and user_id (always-populated fields) cannot be
     # forgotten on any return path.
-    payload = _base_recall_payload(user_id, query)
+    payload = _base_recall_payload(user_id, query, include_content=True)
 
     if not is_enabled() or _config is None:
         payload["reason"] = _RECALL_REASON_DISABLED
@@ -2681,7 +2672,11 @@ def _scoped_debug_to_payload(debug: ScopedRetrievalDebug) -> dict[str, object]:
     }
 
 
-def _scoped_hit_to_payload(hit: ScopedMemoryHit) -> dict[str, object]:
+def _scoped_hit_to_payload(
+    hit: ScopedMemoryHit,
+    *,
+    include_content: bool,
+) -> dict[str, object]:
     """
     Convert a `ScopedMemoryHit` to a JSON-safe dict for the `hits`
     array on the `memory.recall` payload. Carries
@@ -2692,7 +2687,7 @@ def _scoped_hit_to_payload(hit: ScopedMemoryHit) -> dict[str, object]:
     consistent with the rest of the payload.
     """
     r = hit.result
-    return {
+    payload: dict[str, object] = {
         "id": r.id,
         "scope": hit.resolved_scope.scope,
         "project_id": hit.resolved_scope.project_id,
@@ -2701,8 +2696,10 @@ def _scoped_hit_to_payload(hit: ScopedMemoryHit) -> dict[str, object]:
         "confidence": hit.confidence,
         "score": round(r.score, 4),
         "adj": round(hit.adjusted_score, 4),
-        "snippet": _truncate(r.text, _RECALL_SNIPPET_TRUNC),
     }
+    if include_content:
+        payload["snippet"] = _truncate(r.text, _RECALL_SNIPPET_TRUNC)
+    return payload
 
 
 @dataclass(frozen=True)
@@ -2745,6 +2742,7 @@ async def format_scoped_context_with_recall_payload(
     job_type: str | None = None,
     session_id: str | None = None,
     token_budget: int | None = None,
+    include_diagnostic_content: bool = False,
 ) -> ScopedRecallResult:
     """
     Run the scoped recall pipeline for LIVE prompt injection.
@@ -2766,8 +2764,16 @@ async def format_scoped_context_with_recall_payload(
     `ScopedRetrievalContext.workspace`); unlike the shadow path there
     is no skip branch, because this IS the live content path and a
     workspace-less caller still deserves its global memories.
+
+    ``include_diagnostic_content`` is deliberately false by default.
+    Evaluation tooling opts in when it needs query and hit fingerprints;
+    live backend callers must retain the content-free default.
     """
-    payload = _base_recall_payload(user_id, query)
+    payload = _base_recall_payload(
+        user_id,
+        query,
+        include_content=include_diagnostic_content,
+    )
 
     try:
         context = ScopedRetrievalContext(
@@ -2792,7 +2798,8 @@ async def format_scoped_context_with_recall_payload(
     except Exception as exc:
         payload["reason"] = _RECALL_REASON_SCOPED_ERROR
         payload["scoped_error_type"] = type(exc).__name__
-        payload["scoped_error_message"] = _truncate(str(exc), _SCOPED_ERROR_MESSAGE_TRUNC)
+        if include_diagnostic_content:
+            payload["scoped_error_message"] = _truncate(str(exc), _SCOPED_ERROR_MESSAGE_TRUNC)
         payload["returned_empty"] = True
         return ScopedRecallResult(rendered_context="", recall_payload=payload)
 
@@ -2822,7 +2829,9 @@ async def format_scoped_context_with_recall_payload(
     # math depends on.
     rendered_ids = {h.result.id for h in rendered_hits}
     overflow_hits = [h for h in scoped_result.hits if h.result.id not in rendered_ids]
-    payload["hits"] = [_scoped_hit_to_payload(h) for h in rendered_hits + overflow_hits]
+    payload["hits"] = [
+        _scoped_hit_to_payload(h, include_content=include_diagnostic_content) for h in rendered_hits + overflow_hits
+    ]
     payload["lines_used"] = len(rendered_hits)
     return ScopedRecallResult(rendered_context=rendered, recall_payload=payload)
 

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -2225,15 +2225,11 @@ async def _run_extractor(
         )
         return ExtractionResult(facts=[], has_episode=False)
     except OneShotSubprocessError as e:
-        # stderr head AND stdout tail: codex `exec --json` reports its
-        # failure cause in error / turn.failed events streamed to
-        # stdout (stderr carries only the stdin banner), and the cause
-        # events arrive last, so the tail is the informative end.
         log.warning(
-            "Memory extraction subprocess exited %d: stderr=%s stdout_tail=%s",
+            "Memory extraction subprocess exited %d (stderr_bytes=%d, stdout_bytes=%d)",
             e.returncode,
-            e.stderr[:500].decode("utf-8", errors="replace"),
-            e.stdout[-500:].decode("utf-8", errors="replace"),
+            len(e.stderr),
+            len(e.stdout),
         )
         _consecutive_subprocess_failures += 1
         if _consecutive_subprocess_failures == _FAILURE_STREAK_ALARM_THRESHOLD:
@@ -2244,12 +2240,12 @@ async def _run_extractor(
             # every turn; the ERROR is the operator's signal to look.
             log.error(
                 "Memory extraction has failed %d consecutive times; every affected "
-                "turn's facts are being lost. See the stderr/stdout capture on the "
-                "preceding warnings for the provider's failure detail.",
+                "turn's facts are being lost. Check the backend authentication and "
+                "availability for the affected runtime profile.",
                 _consecutive_subprocess_failures,
             )
         return ExtractionResult(facts=[], has_episode=False)
-    except OneShotError:
+    except OneShotError as exc:
         # OneShotOutputError or any future OneShotError subclass the
         # reasoner adds. Collapse to empty extraction rather than
         # propagate; the broad outer handler in extract_and_store
@@ -2257,7 +2253,7 @@ async def _run_extractor(
         # exceptions, but typed reasoner failures are expected and
         # should produce the same zero-state result as the older
         # subprocess-error path.
-        log.warning("Memory extraction reasoner error", exc_info=True)
+        log.warning("Memory extraction reasoner error (type=%s)", type(exc).__name__)
         return ExtractionResult(facts=[], has_episode=False)
 
     # The subprocess ran to completion, so any failure streak is over;
@@ -2267,21 +2263,17 @@ async def _run_extractor(
     try:
         parsed = json.loads(result.text)
     except json.JSONDecodeError:
-        log.warning(
-            "Memory extraction produced invalid JSON: %r",
-            result.text[:500],
-        )
+        log.warning("Memory extraction produced invalid JSON (chars=%d)", len(result.text))
         return ExtractionResult(facts=[], has_episode=False)
     if not isinstance(parsed, dict):
-        log.warning("Memory extraction returned non-object JSON: %r", parsed)
+        log.warning("Memory extraction returned non-object JSON (type=%s)", type(parsed).__name__)
         return ExtractionResult(facts=[], has_episode=False)
     # Defense-in-depth: the CLI can exit 0 with is_error=true while the
     # envelope still parses. Treat that as extraction failure, not
     # silent success with partial data.
     if parsed.get("is_error") is True:
         log.warning(
-            "Memory extraction CLI envelope reports is_error=true (subtype=%s)",
-            parsed.get("subtype"),
+            "Memory extraction CLI envelope reports is_error=true",
         )
         return ExtractionResult(facts=[], has_episode=False)
     # The §13.2 step-5 smoke test revealed that `claude --print
@@ -2394,7 +2386,7 @@ async def _run_episode_extractor(
     effective_backend: str,
     effective_provider: str,
     os_user: str | None = None,
-) -> tuple[dict | None, float, str | None]:
+) -> tuple[dict | None, str | None]:
     """
     Spawn `claude --print` with the episode-generator prompt and parse.
 
@@ -2418,8 +2410,8 @@ async def _run_episode_extractor(
     # Stage 2 routes through the same reasoner as stage 1; the
     # caller-side mapping recovers the exact failure-reason strings
     # downstream telemetry depends on (`"timeout"` and
-    # `"exit_<code>: <stderr>"`). OneShotSubprocessError carries the
-    # returncode and stderr bytes precisely so this mapping works.
+    # `"exit_<code>"`). Provider output is intentionally excluded
+    # because it may echo private conversation content.
     # `os_user` is the routing target resolved once at the top of
     # `extract_and_store` (per-user OS routing); stage 2 inherits the
     # same target so the policy boundary is enforced consistently.
@@ -2442,10 +2434,7 @@ async def _run_episode_extractor(
     except OneShotTimeout:
         return None, "timeout"
     except OneShotSubprocessError as e:
-        return (
-            None,
-            f"exit_{e.returncode}: {e.stderr[:200].decode('utf-8', errors='replace')}",
-        )
+        return None, f"exit_{e.returncode}"
     except OneShotError:
         # Future-proof: any other reasoner-level failure collapses to
         # a parse-shaped reason rather than propagating. The outer
@@ -2456,11 +2445,11 @@ async def _run_episode_extractor(
     try:
         parsed = json.loads(result.text)
     except json.JSONDecodeError:
-        return None, f"invalid_json: {result.text[:200]}"
+        return None, "invalid_json"
     if not isinstance(parsed, dict):
         return None, "non_object_envelope"
     if parsed.get("is_error") is True:
-        return None, f"is_error subtype={parsed.get('subtype')}"
+        return None, "is_error"
     # Same nested/root resolution as stage 1: `claude --print
     # --output-format json --json-schema ...` puts the schema-validated
     # payload under `structured_output`. Fall back to root for tests

--- a/src/kai/oneshot.py
+++ b/src/kai/oneshot.py
@@ -266,11 +266,10 @@ class OneShotSubprocessError(OneShotError):
     """
     The provider subprocess exited with a non-zero return code.
 
-    Carries `returncode` and raw `stderr` bytes because stage 2's
-    episode-extraction failure-reason string is
-    `f"exit_{returncode}: {stderr[:200].decode('utf-8', errors='replace')}"`.
-    Preserving that string is part of Acceptance 4 (stage 2 failure-
-    reason shape). The fields are dataclass attributes, not
+    Carries `returncode` and raw output bytes so trusted callers can
+    classify provider failures. Memory telemetry records only the exit
+    code and byte counts; it never copies these buffers into logs. The
+    fields are dataclass attributes, not
     constructor args, because Python's stdlib `Exception` does not
     play nicely with `__init__` parameter capture in subclasses;
     `@dataclass(eq=False)` on the subclass would also work but is not
@@ -282,14 +281,12 @@ class OneShotSubprocessError(OneShotError):
     # Captured stdout, for backends whose CLIs report failure detail
     # there rather than on stderr: codex `exec --json` streams its
     # error and turn.failed events to stdout as JSONL while stderr
-    # carries only the "Reading prompt from stdin..." banner, so a
-    # stderr-only capture logs the banner and discards the cause.
+    # carries only the "Reading prompt from stdin..." banner.
     # Defaulted so raise sites with no captured output stay valid.
     # Deliberately absent from __str__: that rendering's shape is
     # pinned by its own tests and embedded verbatim by callers that
     # fold str(e) into their error messages, and a stdout tail there
-    # would bloat every such message. Callers that want the stdout
-    # detail (the stage-1 extraction warning) read the field directly.
+    # would bloat every such message.
     stdout: bytes = b""
 
     def __str__(self) -> str:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -58,6 +58,7 @@ from kai.install import (
     _generate_sudoers,
     _generate_systemd_unit,
     _generate_users_yaml,
+    _log_security_status,
     _migrate_identity_to_claude_md,
     _migrate_managed_home_database_paths,
     _optional_file_checksum,
@@ -73,6 +74,7 @@ from kai.install import (
     _runtime_storage_targets,
     _secure_codex_turn_image_staging,
     _secure_history_directories,
+    _secure_log_storage,
     _secure_upload_directories,
     _set_ownership,
     _set_static_install_tree_modes,
@@ -5043,6 +5045,66 @@ class TestCmdStatus:
 
 
 # ── Venv creation ────────────────────────────────────────────────────
+
+
+class TestLogStorageSecurity:
+    def test_repairs_existing_tree_and_precreates_service_logs(self, tmp_path, monkeypatch):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(mode=0o755)
+        rotated = log_dir / "kai.log.2026-08-20"
+        rotated.write_text("private recalled memory")
+        rotated.chmod(0o644)
+        monkeypatch.setattr("kai.install.os.chown", lambda *args: None)
+
+        _secure_log_storage(log_dir, 503, 20, dry_run=False)
+
+        assert stat.S_IMODE(log_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(rotated.stat().st_mode) == 0o600
+        for name in ("kai.log", "kai.stdout.log", "kai.stderr.log"):
+            assert stat.S_IMODE((log_dir / name).stat().st_mode) == 0o600
+
+    def test_dry_run_reports_policy_without_reading_content(self, tmp_path, capsys):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        log_file = log_dir / "kai.log"
+        log_file.write_text("SECRET MEMORY TEXT")
+        log_file.chmod(0o644)
+
+        _secure_log_storage(log_dir, 503, 20, dry_run=True)
+
+        output = capsys.readouterr().out
+        assert "directories 0700, files 0600" in output
+        assert "SECRET MEMORY TEXT" not in output
+        assert stat.S_IMODE(log_file.stat().st_mode) == 0o644
+
+    def test_rejects_symlink_in_log_tree(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        target = tmp_path / "outside"
+        target.write_text("outside")
+        (log_dir / "kai.log").symlink_to(target)
+
+        with pytest.raises(ValueError, match="Refusing symlink"):
+            _secure_log_storage(log_dir, 503, 20, dry_run=False)
+
+    def test_status_reports_secure_and_insecure_modes(self, tmp_path, monkeypatch):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(mode=0o700)
+        log_file = log_dir / "kai.log"
+        log_file.write_text("SECRET MEMORY TEXT")
+        log_file.chmod(0o600)
+        owner = log_dir.stat()
+        account = MagicMock(pw_uid=owner.st_uid, pw_gid=owner.st_gid)
+        monkeypatch.setattr("kai.install.pwd.getpwnam", lambda _name: account)
+
+        secure = _log_security_status(log_dir, "kai")
+        assert "Log security: secure" in secure
+        assert "SECRET MEMORY TEXT" not in secure
+
+        log_file.chmod(0o644)
+        insecure = _log_security_status(log_dir, "kai")
+        assert "Log security: INSECURE" in insecure
+        assert "unsafe modes=1" in insecure
 
 
 class TestApplyVenv:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,6 +11,8 @@ coverage for that path now lives in tests/test_backend.py.
 
 import asyncio
 import logging
+import os
+import stat
 from datetime import UTC, datetime
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
@@ -129,6 +131,49 @@ class TestSetupLogging:
         with patch("kai.main.DATA_DIR", tmp_path):
             setup_logging()
         assert (tmp_path / "logs").is_dir()
+        assert stat.S_IMODE((tmp_path / "logs").stat().st_mode) == 0o700
+
+    def test_repairs_existing_log_file_modes(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(mode=0o755)
+        old_log = log_dir / "kai.log.older"
+        old_log.write_text("private memory text")
+        old_log.chmod(0o644)
+
+        with patch("kai.main.DATA_DIR", tmp_path):
+            setup_logging()
+
+        assert stat.S_IMODE(log_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(old_log.stat().st_mode) == 0o600
+        assert stat.S_IMODE((log_dir / "kai.log").stat().st_mode) == 0o600
+
+    def test_rotation_keeps_every_log_private(self, tmp_path):
+        with patch("kai.main.DATA_DIR", tmp_path):
+            setup_logging()
+
+        handler = next(h for h in logging.getLogger().handlers if isinstance(h, TimedRotatingFileHandler))
+        handler.doRollover()
+        handler.emit(logging.LogRecord("test", logging.INFO, __file__, 1, "after", (), None))
+
+        log_files = list((tmp_path / "logs").iterdir())
+        assert len(log_files) >= 2
+        assert all(stat.S_IMODE(path.stat().st_mode) == 0o600 for path in log_files)
+
+    def test_rejects_symlinked_log_entries(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        target = tmp_path / "outside.log"
+        target.write_text("outside")
+        os.symlink(target, log_dir / "kai.log.older")
+
+        with (
+            patch("kai.main.DATA_DIR", tmp_path),
+            pytest.raises(
+                RuntimeError,
+                match="Refusing symlink",
+            ),
+        ):
+            setup_logging()
 
     def test_adds_file_handler(self, tmp_path):
         """Adds a TimedRotatingFileHandler to the root logger."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6140,6 +6140,27 @@ class TestFormatScopedContextWithRecallPayload:
         # the 0.9 project row first).
         assert payload["lines_used"] == 2
         assert [h["id"] for h in payload["hits"]] == ["g1", "p1"]
+        assert "query" not in payload
+        assert all("snippet" not in hit for hit in payload["hits"])
+
+    async def test_explicit_diagnostic_mode_retains_eval_content(self, tmp_path):
+        import kai.memory as mem_mod
+        from kai.memory import format_scoped_context_with_recall_payload
+
+        mock_mem = MagicMock()
+        mock_mem.search.return_value = {"results": [_search_row("g1", "diagnostic fact", 0.8, scope="global")]}
+        mem_mod._memory = mock_mem
+        mem_mod._config = _mp_config()
+
+        result = await format_scoped_context_with_recall_payload(
+            "diagnostic query",
+            user_id="123",
+            workspace=tmp_path,
+            include_diagnostic_content=True,
+        )
+
+        assert result.recall_payload["query"] == "diagnostic query"
+        assert result.recall_payload["hits"][0]["snippet"] == "diagnostic fact"
 
     async def test_global_cap_drops_rows_out_of_prompt_prefix(self, tmp_path):
         """With both sections populated, the renderer caps the global
@@ -6273,7 +6294,7 @@ class TestFormatScopedContextWithRecallPayload:
         payload = result.recall_payload
         assert payload["reason"] == "scoped_error"
         assert payload["scoped_error_type"] == "RuntimeError"
-        assert "qdrant exploded" in str(payload["scoped_error_message"])
+        assert "scoped_error_message" not in payload
         assert payload["returned_empty"] is True
 
     async def test_disabled_memory_short_circuits(self, tmp_path):

--- a/tests/test_memory_episodes.py
+++ b/tests/test_memory_episodes.py
@@ -618,10 +618,10 @@ class TestStage2Isolation:
         assert len(records) == 1
         payload = json.loads(records[0].message[len("memory.episode ") :])
         assert payload["outcome"] == "subprocess_error"
-        # The subtype detail survives in the reason field so operators
-        # can distinguish failure classes.
-        assert payload["reason"] is not None
-        assert "error_during_execution" in payload["reason"]
+        # Provider-controlled subtype text may echo prompt content, so
+        # production telemetry retains only the content-free class.
+        assert payload["reason"] == "is_error"
+        assert "error_during_execution" not in records[0].message
 
     @pytest.mark.asyncio
     async def test_stage2_unexpected_exception_caught(self, monkeypatch, caplog):
@@ -1193,11 +1193,8 @@ class TestRunEpisodeExtractorViaReasoner:
         assert reason == "timeout"
 
     @pytest.mark.asyncio
-    async def test_subprocess_error_preserves_exit_reason_format(self):
-        """OneShotSubprocessError must carry returncode and stderr; the
-        stage-2 mapping recomposes them into the `exit_<code>: <stderr>`
-        reason format that telemetry has used since the original
-        subprocess path."""
+    async def test_subprocess_error_reason_omits_stderr_content(self):
+        """Stage-2 telemetry keeps the exit code but not provider output."""
         from kai.oneshot import OneShotSubprocessError
 
         class _FailingReasoner:
@@ -1214,9 +1211,8 @@ class TestRunEpisodeExtractorViaReasoner:
             )
 
         assert episode is None
-        assert reason is not None
-        assert reason.startswith("exit_2: ")
-        assert "oauth refused" in reason
+        assert reason == "exit_2"
+        assert "oauth refused" not in reason
 
 
 class TestRunEpisodeExtractorWithCodexEnvelope:

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -5096,11 +5096,7 @@ class TestProvenanceStamping:
 
 
 class TestSubprocessFailureCaptureAlarm:
-    """Stage 1's OneShotSubprocessError handler must log the stdout
-    tail (codex exec --json reports its failure cause there, not on
-    stderr) and must escalate to one ERROR-level line when consecutive
-    failures cross the streak threshold, since observed bursts are
-    sustained conditions during which every turn's facts are lost."""
+    """Stage 1 failures retain useful counters without provider content."""
 
     @staticmethod
     def _failing_reasoner(stdout: bytes = b"", stderr: bytes = b"banner"):
@@ -5136,7 +5132,7 @@ class TestSubprocessFailureCaptureAlarm:
             )
 
     @pytest.mark.asyncio
-    async def test_warning_includes_stdout_tail(self, caplog, monkeypatch):
+    async def test_warning_omits_stdout_and_stderr_content(self, caplog, monkeypatch):
         monkeypatch.setattr(memory_extraction, "_consecutive_subprocess_failures", 0)
         stdout = b'{"type":"turn.failed","error":{"message":"usage limit reached"}}'
 
@@ -5147,8 +5143,47 @@ class TestSubprocessFailureCaptureAlarm:
             r for r in caplog.records if "subprocess exited" in r.message or "subprocess exited" in r.getMessage()
         ]
         rendered = warning.getMessage()
-        assert "usage limit reached" in rendered
-        assert "banner" in rendered
+        assert "usage limit reached" not in rendered
+        assert "banner" not in rendered
+        assert "stdout_bytes=" in rendered
+        assert "stderr_bytes=6" in rendered
+
+    @pytest.mark.asyncio
+    async def test_invalid_output_log_omits_provider_content(self, caplog, monkeypatch):
+        monkeypatch.setattr(memory_extraction, "_consecutive_subprocess_failures", 0)
+
+        class _InvalidReasoner:
+            async def run(self, **kwargs):
+                return type("Result", (), {"text": "SECRET USER CONTENT not-json"})()
+
+        with caplog.at_level(logging.WARNING, logger="kai.memory_extraction"):
+            await self._run(_InvalidReasoner())
+
+        assert "invalid JSON" in caplog.text
+        assert "SECRET USER CONTENT" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_episode_failure_reason_omits_stderr_content(self):
+        from kai.oneshot import OneShotSubprocessError
+
+        class _Failing:
+            async def run(self, **kwargs):
+                raise OneShotSubprocessError(
+                    returncode=9,
+                    stderr=b"SECRET USER CONTENT",
+                )
+
+        with patch("kai.memory_extraction._build_memory_reasoner", return_value=_Failing()):
+            episode, reason = await memory_extraction._run_episode_extractor(
+                payload_text="payload",
+                config=_cfg(),
+                user_id="u1",
+                effective_backend="codex",
+                effective_provider="openai",
+            )
+
+        assert episode is None
+        assert reason == "exit_9"
 
     @pytest.mark.asyncio
     async def test_alarm_fires_at_threshold_crossing_only(self, caplog, monkeypatch):


### PR DESCRIPTION
## Summary

Closes #1042 by making Kai's memory-related logs private at both the
filesystem and telemetry layers.

- create and repair `/var/lib/kai/logs` as service-owned `0700`
- normalize every existing log file to service-owned `0600` during upgrade
- pre-create the application, launchd stdout, and launchd stderr logs at
  `0600` before the service starts
- enforce `0700`/`0600` again at runtime and preserve `0600` across daily
  application-log rotation
- reject symlinked and non-regular entries instead of following them during
  privileged repair or runtime startup
- add a content-free log-security result to `kai install status`
- remove raw queries, recalled-memory snippets, and scoped exception messages
  from live `memory.recall` telemetry
- retain query length, identifiers, scores, scope decisions, timing, counts,
  and other content-free operational signals
- preserve query/snippet fingerprints only through an explicit diagnostic
  opt-in used by the scoped retrieval evaluation harness
- remove provider stdout, stderr, invalid JSON, and provider-controlled error
  strings from memory extraction and episode telemetry while retaining exit
  codes, byte counts, failure classes, and streak alarms

## Security properties

The installer now repairs existing installations as well as creating secure
new ones. Agent OS users cannot traverse the service-owned `0700` log root,
and individual files are also `0600` as defense in depth. The runtime repeats
the mode repair before logging starts, while the rotating handler applies
`0600` whenever it opens a new active log after rollover.

Routine production telemetry no longer depends on filesystem privacy to make
conversation excerpts safe: it is content-free by construction. Evaluation
remains supported through an explicit call-site opt-in and does not weaken the
live backend default.

## Operator-visible behavior

After `make install`, `make install-status` reports a non-secret line such as:

```text
Log security: secure; directories=1, files=17, service-owned, directories=0700, files=0600
```

An unsafe tree is reported as `INSECURE` with counts only; no filenames or log
contents are printed. A subsequent install repairs unsafe ownership and modes.

## Verification

- focused installer/logging/memory/evaluation suite: `1197 passed`
- full suite: `6063 passed, 1 skipped`
- `make check`
- `make typecheck`

## Deployment qualification

After merge:

1. Run `make install` to repair the deployed log tree before restarting Kai.
2. Run `make install-status` and confirm `Log security: secure`.
3. Send one normal request that exercises memory recall and confirm Kai
   responds normally.
4. Inspect a new `memory.recall` record as the operator and confirm it retains
   structural telemetry but has no `query`, per-hit `snippet`, or scoped error
   message in the normal live path.
