### PR TITLE
security: fail closed on legacy memory scope

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -8133,6 +8133,29 @@ def _check_service_status(platform: str) -> str:
     return f"Service: unknown platform '{platform}'"
 
 
+def _memory_scope_review_status(path: Path, *, memory_enabled: bool | None) -> str:
+    """Report content-free scope-review/quarantine counts."""
+    prefix = "Semantic memory scope review:"
+    if memory_enabled is False:
+        return f"{prefix} disabled by policy"
+    if not path.is_file() or path.is_symlink():
+        return f"{prefix} pending; no protected census"
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+        observed = document["observed"]
+        raw = int(observed["raw_legacy_default"])
+        quarantined = int(observed["quarantined"])
+        unreviewed = int(observed["unreviewed"])
+        invalid = int(observed["invalid_quarantined"])
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+    state = "active" if unreviewed == 0 else "INCOMPLETE"
+    return (
+        f"{prefix} {state}; raw legacy-default={raw}, reviewed quarantine={quarantined}, "
+        f"unreviewed={unreviewed}, invalid quarantine={invalid}; legacy/invalid retrieval=fail-closed"
+    )
+
+
 def _cmd_status() -> None:
     """
     Report the current installation state.
@@ -8219,6 +8242,12 @@ def _cmd_status() -> None:
     print(
         workshop_memory_authority_status(
             Path(data_dir) / "kai.db",
+            memory_enabled=_read_deployed_memory_enabled(_DEPLOYED_ENV_FILE),
+        )
+    )
+    print(
+        _memory_scope_review_status(
+            Path(data_dir) / "memory-scope-review.json",
             memory_enabled=_read_deployed_memory_enabled(_DEPLOYED_ENV_FILE),
         )
     )

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -584,6 +584,21 @@ def _start() -> None:
                     memory_migration.stamped,
                     memory_migration.total,
                 )
+                try:
+                    from kai.memory_scope_review import refresh_scope_review_status
+
+                    scope_status = await asyncio.to_thread(refresh_scope_review_status)
+                    observed = scope_status.get("observed", {})
+                    logging.info(
+                        "Semantic memory scope census ready "
+                        "(legacy_default=%d, reviewed_quarantine=%d, unreviewed=%d, invalid=%d)",
+                        int(observed.get("raw_legacy_default", 0)),
+                        int(observed.get("quarantined", 0)),
+                        int(observed.get("unreviewed", 0)),
+                        int(observed.get("invalid_quarantined", 0)),
+                    )
+                except Exception:
+                    logging.warning("Could not refresh semantic memory scope census", exc_info=True)
 
         try:
             core_host = KaiApplicationHost(

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -645,7 +645,7 @@ class MemoryStats:
     # needs to measure. Keys are stable bucket identifiers consumed
     # by the /memory stats renderer:
     #   "global"             - explicit valid global rows
-    #   "global_legacy"      - rows resolved global via legacy_default
+    #   "global_legacy"      - unresolved legacy rows quarantined from retrieval
     #   "invalid"            - rows flagged invalid_defaulted by the
     #                          resolver (corrupted scope or provenance)
     #   "project:<id>"       - valid project rows, one bucket per id
@@ -780,10 +780,9 @@ class ScopedRetrievalDebug:
         ok                     - at least one hit returned.
 
     `excluded_by_scope` counts only exclusions (admission reasons
-    from `_scoped_memory_admission_reason`). Admitted rows that
-    were resolved as legacy- or invalid-default are visible
-    through `ScopedMemoryHit.resolved_scope`; the spec prefers the
-    per-hit channel over a second audit dict.
+    from `_scoped_memory_admission_reason`). Legacy- and
+    invalid-default rows appear there because their unresolved
+    authority is quarantined before ranking.
     """
 
     active_project_id: str | None
@@ -1355,6 +1354,8 @@ _ADMISSION_PROJECT_SCOPE_NOT_ALLOWED = "project_scope_not_allowed"
 _ADMISSION_PROJECT_SCOPE_MISSING_PROJECT_ID = "project_scope_missing_project_id"
 _ADMISSION_PROJECT_ID_MISMATCH = "project_id_mismatch"
 _ADMISSION_TASK_SCOPE_NOT_SUPPORTED = "task_scope_not_supported"
+_ADMISSION_LEGACY_SCOPE_QUARANTINED = "legacy_scope_quarantined"
+_ADMISSION_INVALID_SCOPE_QUARANTINED = "invalid_scope_quarantined"
 _ADMISSION_UNKNOWN_SCOPE = "unknown_scope"
 
 
@@ -1373,10 +1374,11 @@ def _scoped_memory_admission_reason(
     the project detector, or the singleton.
 
     Admission matrix:
-    - scope=global: admit. (Includes rows that resolved to global
-      via legacy_default and invalid_default branches in
-      `resolve_memory_scope`; the per-hit `resolved_scope` channel
-      preserves the audit trail.)
+    - Any row defaulted by the resolver because its scope is absent
+      or malformed: exclude. These rows have no reviewed authority to
+      cross workspace boundaries; treating their compatibility
+      fallback as an authorization decision would fail open.
+    - scope=global with explicit valid provenance: admit.
     - scope=project with allowed_project_id None: exclude as
       `project_scope_not_allowed`. Covers both "no active project
       detected" and "active project has memory_enabled=False"; the
@@ -1398,6 +1400,11 @@ def _scoped_memory_admission_reason(
       `unknown_scope`. Defensive belt for future schema drift; in
       practice the resolver never emits a non-recognized scope.
     """
+    if resolved_scope.legacy_defaulted:
+        return _ADMISSION_LEGACY_SCOPE_QUARANTINED
+    if resolved_scope.invalid_defaulted:
+        return _ADMISSION_INVALID_SCOPE_QUARANTINED
+
     scope = resolved_scope.scope
     if scope == SCOPE_GLOBAL:
         return None
@@ -3221,6 +3228,23 @@ def get_all(*, user_id: str, limit: int | None = 1000) -> list[MemoryResult]:
         return []
 
 
+def get_all_for_admin(*, user_id: str) -> list[MemoryResult]:
+    """Return the complete canonical-owner corpus, raising on read failure.
+
+    Interactive callers intentionally degrade to an empty result when Mem0
+    is unavailable. Administrative reconciliation must not: mistaking a
+    failed read for an empty census could authorize an incomplete review.
+    """
+    if _memory is None:
+        raise RuntimeError("Semantic memory is not initialized")
+    storage_user_id, namespace = _canonical_memory_owner(user_id)
+    result = _memory.get_all(filters={"user_id": storage_user_id}, top_k=100_000)
+    raw_results = result.get("results", []) if isinstance(result, dict) else result
+    return [
+        wrapped for raw in raw_results if _memory_result_belongs_to_principal((wrapped := _wrap_result(raw)), namespace)
+    ]
+
+
 def _get_all_raw(*, user_id: str) -> list[MemoryResult]:
     """Read one exact Mem0 namespace without applying canonical aliases."""
     if _memory is None:
@@ -3293,6 +3317,42 @@ def count_points_by_owner() -> dict[str, int]:
         if offset is None:
             break
     return counts
+
+
+def list_scope_census_points() -> list[tuple[str, str, dict[str, object]]]:
+    """Return collection-wide fields needed for scope status diagnostics.
+
+    The result contains ``(point_id, user_id, metadata_subset)`` and never
+    reads memory text or vectors. It uses the same isolated Qdrant scroll
+    boundary as the owner census because Mem0 has no collection-wide API.
+    """
+    if _memory is None:
+        raise RuntimeError("Semantic memory is not initialized")
+    vector_store = getattr(_memory, "vector_store", None)
+    client = getattr(vector_store, "client", None)
+    scroll = getattr(client, "scroll", None)
+    if not callable(scroll):
+        raise RuntimeError("Semantic-memory provider does not support a scope census")
+
+    fields = ["user_id", "source", "scope", "project_id", "workspace_root", "scope_confidence", "scope_source"]
+    found: list[tuple[str, str, dict[str, object]]] = []
+    offset = None
+    while True:
+        points, offset = scroll(
+            collection_name=vector_store.collection_name,
+            limit=1000,
+            offset=offset,
+            with_payload=fields,
+            with_vectors=False,
+        )
+        for point in points:
+            payload = dict(point.payload or {})
+            owner = payload.pop("user_id", "")
+            if isinstance(owner, str) and payload.get("source") in USER_VISIBLE_SOURCES:
+                found.append((str(point.id), owner, payload))
+        if offset is None:
+            break
+    return found
 
 
 def list_api_written_points() -> list[tuple[str, dict[str, object]]]:

--- a/src/kai/memory_admin.py
+++ b/src/kai/memory_admin.py
@@ -16,6 +16,9 @@ Scope (spec §16 + Phase 4 of spec 320):
   file. The pass logic lives in `src/kai/memory_reclassify.py`; this
   module owns only argument parsing, the authorization gates, and
   dispatch.
+- `review-legacy-scope <user_id> [...]`: export every residual
+  legacy-default row for an explicit operator disposition, then apply
+  the complete reviewed manifest with pre-images and rollback guards.
 - `backfill-provenance <user_id> [...]`: stamp transcript provenance
   on legacy rows via content-overlap matching against the JSONL
   history. Dry-run by default; `--apply` writes the four required
@@ -272,6 +275,47 @@ def _build_parser() -> argparse.ArgumentParser:
         "--yes",
         action="store_true",
         help="Confirm a mutating mode. Without it, --apply/--rollback print the planned change count and exit with status 2.",
+    )
+
+    review = sub.add_parser(
+        "review-legacy-scope",
+        help="Census and explicitly dispose every residual legacy-default row",
+        description=(
+            "Export every remaining legacy-default memory row into a protected "
+            "JSONL review manifest. Replace every review_required disposition "
+            "with global, project, delete, or quarantine. --apply requires a "
+            "fresh complete manifest and dumps pre-images before any write. "
+            "--rollback restores metadata changes guarded by the review id. "
+            "The daemon must be stopped."
+        ),
+    )
+    review.add_argument(
+        "user_id",
+        help="Memory owner key; protected runtime IDs resolve to their canonical principal.",
+    )
+    review.add_argument(
+        "--out-dir",
+        dest="out_dir",
+        default=None,
+        help="Artifact directory. Default: <DATA_DIR>/home/<principal>/docs/legacy-scope-review/.",
+    )
+    review_mode = review.add_mutually_exclusive_group()
+    review_mode.add_argument(
+        "--apply",
+        metavar="MANIFEST",
+        default=None,
+        help="Apply a complete operator-reviewed manifest (requires --yes).",
+    )
+    review_mode.add_argument(
+        "--rollback",
+        metavar="PREIMAGES",
+        default=None,
+        help="Restore metadata changes from a pre-image file (requires --yes).",
+    )
+    review.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm a mutating mode. Without it, --apply/--rollback print the plan and exit with status 2.",
     )
 
     bp = sub.add_parser(
@@ -755,6 +799,73 @@ def _cmd_reclassify(args: argparse.Namespace) -> int:
     )
 
 
+def _cmd_review_legacy_scope(args: argparse.Namespace) -> int:
+    """Execute the complete residual legacy-scope review workflow."""
+    config = _initialize_memory()
+    if config is None:
+        return 1
+    from kai import memory_scope_review
+
+    out_dir = (
+        Path(args.out_dir)
+        if args.out_dir
+        else _default_human_report_directory(config, args.user_id, "legacy-scope-review")
+    )
+    artifact_value = args.apply if args.apply is not None else args.rollback
+    if artifact_value is None:
+        return asyncio.run(
+            _run_and_close_sessions(memory_scope_review.run_census(config, args.user_id, out_dir=out_dir))
+        )
+
+    artifact_path = Path(artifact_value)
+    row_type = "review manifest" if args.apply is not None else "pre-image file"
+    try:
+        text = artifact_path.read_text(encoding="utf-8")
+        if args.apply is not None:
+            header, rows = memory_scope_review.parse_manifest(text, user_id=args.user_id)
+            pending = [row for row in rows if row.disposition == memory_scope_review.DISPOSITION_REVIEW_REQUIRED]
+            if pending:
+                print(
+                    f"memory admin: {len(pending)} row(s) still have disposition review_required; "
+                    "complete the manifest before --apply.",
+                    file=sys.stderr,
+                )
+                return 1
+        else:
+            header, rows = memory_scope_review.parse_preimages(text, user_id=args.user_id)
+    except (OSError, ValueError) as exc:
+        print(f"memory admin: cannot read {row_type}: {exc}", file=sys.stderr)
+        return 1
+    if not args.yes:
+        verb = "apply" if args.apply is not None else "roll back"
+        print(
+            f"memory admin: would {verb} {len(rows)} row(s) from review "
+            f"{header.get('review_id')} for user {args.user_id}."
+        )
+        print("memory admin: re-run with --yes to execute.")
+        return 2
+    if args.apply is not None:
+        return asyncio.run(
+            _run_and_close_sessions(
+                memory_scope_review.run_apply(
+                    config,
+                    args.user_id,
+                    manifest_path=artifact_path,
+                    out_dir=out_dir,
+                )
+            )
+        )
+    return asyncio.run(
+        _run_and_close_sessions(
+            memory_scope_review.run_rollback(
+                config,
+                args.user_id,
+                preimages_path=artifact_path,
+            )
+        )
+    )
+
+
 def _cmd_backfill_provenance(args: argparse.Namespace) -> int:
     """Execute the `backfill-provenance` subcommand. Returns an exit code.
 
@@ -932,6 +1043,8 @@ def cli(argv: list[str]) -> None:
         sys.exit(_cmd_backfill_explicit(args))
     if args.command == "reclassify-scope":
         sys.exit(_cmd_reclassify(args))
+    if args.command == "review-legacy-scope":
+        sys.exit(_cmd_review_legacy_scope(args))
     if args.command == "backfill-provenance":
         sys.exit(_cmd_backfill_provenance(args))
     # argparse's required=True on the subparsers guarantees a known

--- a/src/kai/memory_command.py
+++ b/src/kai/memory_command.py
@@ -451,7 +451,11 @@ def _build_scope_view(
     # in the registry is flagged rather than hidden, because the row
     # is still movable and the operator needs to see why it stopped
     # being retrievable anywhere.
-    if resolved.scope == memory.SCOPE_PROJECT:
+    if resolved.legacy_defaulted:
+        scope_label = "unresolved (quarantined)"
+    elif resolved.invalid_defaulted:
+        scope_label = f"{resolved.scope} (invalid, quarantined)"
+    elif resolved.scope == memory.SCOPE_PROJECT:
         pid = resolved.project_id
         if pid is None:
             scope_label = "project (no project id)"
@@ -1430,7 +1434,7 @@ def _build_search_results(
 # tiebreaker, matching the prompt-version table's determinism rule.
 _SCOPE_BUCKET_ORDER: list[tuple[str, str]] = [
     ("global", "global"),
-    ("global_legacy", "global (legacy)"),
+    ("global_legacy", "unresolved (quarantined)"),
     ("task", "task"),
     ("project_missing_id", "project (no project id)"),
     ("invalid", "invalid"),
@@ -1514,9 +1518,8 @@ def _build_stats(stats: MemoryStats) -> tuple[str, InlineKeyboardMarkup]:
     # Scope distribution over all user-visible rows. Sits right after
     # the headline because (unlike the extracted-only sections below)
     # it spans every user-visible source. The global_legacy row is
-    # the operator's running measure of reclassification debt - rows
-    # that retrieval treats as global only because nothing has
-    # classified them yet.
+    # the operator's running measure of reclassification debt: rows
+    # that retrieval quarantines until an operator classifies them.
     if stats.by_scope:
         lines.append("")
         lines.append("Scope:")

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1891,9 +1891,10 @@ def _scope_admitted(metadata: dict | None, allowed_project_id: str | None) -> bo
 
     Thin composition of the read side's resolver and admission helper
     so write-time reads (consolidation candidates, the dedup gate)
-    apply EXACTLY the rule retrieval uses: global always admitted
-    (including legacy rows), project rows only under a matching
-    allowed_project_id, task rows never. Write-time reads control
+    apply EXACTLY the rule retrieval uses: explicit global rows are
+    admitted, unresolved legacy and invalid rows are quarantined,
+    project rows require a matching allowed_project_id, and task rows
+    are never admitted. Write-time reads control
     deletion (`update_of`) and suppression (`skip_redundant`, dedup),
     so their candidate authority must be at least as scoped as the
     write authority they gate.

--- a/src/kai/memory_scope_review.py
+++ b/src/kai/memory_scope_review.py
@@ -1,0 +1,528 @@
+"""Complete operator review and fail-closed accounting for legacy scope.
+
+The earlier classifier pass deliberately left low-confidence rows untouched.
+This module provides the deterministic second pass: export every remaining
+legacy-default row, require an explicit operator disposition for every row,
+apply only the reviewed manifest, dump pre-images first, and retain unresolved
+rows as fail-closed quarantine.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from kai import memory
+from kai.config import DATA_DIR, Config, MemoryProjectConfig
+from kai.memory import MemoryResult
+from kai.memory_projects import load_project_registry
+
+log = logging.getLogger(__name__)
+
+_MANIFEST_KIND = "kai.memory_scope_review"
+_PREIMAGE_KIND = "kai.memory_scope_review_preimages"
+_FORMAT_VERSION = 1
+_STATUS_VERSION = 1
+STATUS_FILENAME = "memory-scope-review.json"
+SCOPE_REVIEW_ID_KEY = "scope_review_id"
+
+DISPOSITION_REVIEW_REQUIRED = "review_required"
+DISPOSITION_GLOBAL = "global"
+DISPOSITION_PROJECT = "project"
+DISPOSITION_DELETE = "delete"
+DISPOSITION_QUARANTINE = "quarantine"
+_DISPOSITIONS = frozenset(
+    {
+        DISPOSITION_REVIEW_REQUIRED,
+        DISPOSITION_GLOBAL,
+        DISPOSITION_PROJECT,
+        DISPOSITION_DELETE,
+        DISPOSITION_QUARANTINE,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewRow:
+    memory_id: str
+    text_sha256: str
+    text: str
+    source: str
+    created_at: str
+    disposition: str
+    project_id: str | None
+    operator_note: str
+
+
+@dataclass(frozen=True, slots=True)
+class PreImage:
+    memory_id: str
+    text: str
+    metadata: dict[str, Any]
+    disposition: str
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def select_legacy_rows(rows: list[MemoryResult]) -> list[MemoryResult]:
+    """Select every user-visible row with absent scope metadata."""
+    selected = [
+        row
+        for row in rows
+        if (row.metadata or {}).get("source") in memory.USER_VISIBLE_SOURCES
+        and memory.resolve_memory_scope(row.metadata).legacy_defaulted
+    ]
+    return sorted(selected, key=lambda row: row.id)
+
+
+def _header(
+    *, review_id: str, user_id: str, rows: list[MemoryResult], registry: dict[str, MemoryProjectConfig]
+) -> dict:
+    return {
+        "kind": _MANIFEST_KIND,
+        "version": _FORMAT_VERSION,
+        "review_id": review_id,
+        "user_id": user_id,
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "corpus_count": len(rows),
+        "legacy_default_count": len(select_legacy_rows(rows)),
+        "registered_projects": [
+            {
+                "project_id": project_id,
+                "display_name": cfg.display_name,
+                "memory_enabled": cfg.memory_enabled,
+            }
+            for project_id, cfg in sorted(registry.items())
+        ],
+    }
+
+
+def render_manifest(header: dict[str, Any], rows: list[ReviewRow]) -> str:
+    lines = [json.dumps({"header": header}, separators=(",", ":"), ensure_ascii=False)]
+    lines.extend(json.dumps({"row": asdict(row)}, separators=(",", ":"), ensure_ascii=False) for row in rows)
+    return "\n".join(lines) + "\n"
+
+
+def _validate_header(header: Any, *, user_id: str | None = None) -> dict[str, Any]:
+    if not isinstance(header, dict):
+        raise ValueError("manifest header must be an object")
+    if header.get("kind") != _MANIFEST_KIND or header.get("version") != _FORMAT_VERSION:
+        raise ValueError("not a supported memory scope review manifest")
+    for key in ("review_id", "user_id"):
+        if not isinstance(header.get(key), str) or not header[key]:
+            raise ValueError(f"manifest header {key} must be a non-empty string")
+    if user_id is not None and header["user_id"] != user_id:
+        raise ValueError(f"manifest belongs to user {header['user_id']}, not {user_id}")
+    return header
+
+
+def _parse_review_row(value: Any) -> ReviewRow:
+    if not isinstance(value, dict):
+        raise ValueError("manifest row must be an object")
+    required_strings = ("memory_id", "text_sha256", "text", "source", "created_at", "disposition", "operator_note")
+    for key in required_strings:
+        if not isinstance(value.get(key), str):
+            raise ValueError(f"manifest row {key} must be a string")
+    if not value["memory_id"] or not value["text_sha256"] or not value["text"]:
+        raise ValueError("manifest row memory_id, text_sha256, and text must be non-empty")
+    disposition = value["disposition"]
+    if disposition not in _DISPOSITIONS:
+        raise ValueError(f"unsupported disposition {disposition!r}")
+    project_id = value.get("project_id")
+    if project_id is not None and (not isinstance(project_id, str) or not project_id):
+        raise ValueError("manifest row project_id must be null or a non-empty string")
+    if disposition == DISPOSITION_PROJECT and project_id is None:
+        raise ValueError("project disposition requires project_id")
+    if disposition != DISPOSITION_PROJECT and project_id is not None:
+        raise ValueError(f"{disposition} disposition requires project_id=null")
+    if _sha256(value["text"]) != value["text_sha256"]:
+        raise ValueError(f"manifest row {value['memory_id']} text hash does not match")
+    return ReviewRow(**{key: value.get(key) for key in ReviewRow.__dataclass_fields__})
+
+
+def parse_manifest(text: str, *, user_id: str | None = None) -> tuple[dict[str, Any], list[ReviewRow]]:
+    try:
+        objects = [json.loads(line) for line in text.splitlines() if line.strip()]
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSONL: {exc}") from exc
+    if not objects or set(objects[0]) != {"header"}:
+        raise ValueError("manifest must begin with one header record")
+    header = _validate_header(objects[0]["header"], user_id=user_id)
+    rows: list[ReviewRow] = []
+    seen: set[str] = set()
+    for record in objects[1:]:
+        if not isinstance(record, dict) or set(record) != {"row"}:
+            raise ValueError("manifest may contain only row records after its header")
+        row = _parse_review_row(record["row"])
+        if row.memory_id in seen:
+            raise ValueError(f"duplicate memory_id {row.memory_id}")
+        seen.add(row.memory_id)
+        rows.append(row)
+    return header, rows
+
+
+def render_preimages(header: dict[str, Any], rows: list[PreImage]) -> str:
+    pre_header = dict(header)
+    pre_header["kind"] = _PREIMAGE_KIND
+    lines = [json.dumps({"header": pre_header}, separators=(",", ":"), ensure_ascii=False)]
+    lines.extend(json.dumps({"row": asdict(row)}, separators=(",", ":"), ensure_ascii=False) for row in rows)
+    return "\n".join(lines) + "\n"
+
+
+def parse_preimages(text: str, *, user_id: str | None = None) -> tuple[dict[str, Any], list[PreImage]]:
+    try:
+        objects = [json.loads(line) for line in text.splitlines() if line.strip()]
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSONL: {exc}") from exc
+    if not objects or set(objects[0]) != {"header"}:
+        raise ValueError("pre-image file must begin with one header record")
+    header = objects[0]["header"]
+    if not isinstance(header, dict) or header.get("kind") != _PREIMAGE_KIND or header.get("version") != _FORMAT_VERSION:
+        raise ValueError("not a supported memory scope review pre-image file")
+    if user_id is not None and header.get("user_id") != user_id:
+        raise ValueError(f"pre-image file belongs to user {header.get('user_id')}, not {user_id}")
+    rows: list[PreImage] = []
+    seen: set[str] = set()
+    for record in objects[1:]:
+        value = record.get("row") if isinstance(record, dict) and set(record) == {"row"} else None
+        if not isinstance(value, dict):
+            raise ValueError("invalid pre-image row")
+        if not isinstance(value.get("memory_id"), str) or not value["memory_id"]:
+            raise ValueError("pre-image memory_id must be non-empty")
+        if not isinstance(value.get("text"), str) or not value["text"]:
+            raise ValueError("pre-image text must be non-empty")
+        if not isinstance(value.get("metadata"), dict) or value.get("disposition") not in _DISPOSITIONS:
+            raise ValueError("invalid pre-image metadata or disposition")
+        row = PreImage(**{key: value.get(key) for key in PreImage.__dataclass_fields__})
+        if row.memory_id in seen:
+            raise ValueError(f"duplicate memory_id {row.memory_id}")
+        seen.add(row.memory_id)
+        rows.append(row)
+    return header, rows
+
+
+def _secure_write(path: Path, content: str, *, exclusive: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise OSError(f"refusing symlinked artifact path: {path}")
+    flags = os.O_WRONLY | os.O_CREAT | (os.O_EXCL if exclusive else os.O_TRUNC)
+    fd = os.open(path, flags, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8", closefd=False) as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        os.close(fd)
+
+
+def _status_path(data_dir: Path = DATA_DIR) -> Path:
+    return data_dir / STATUS_FILENAME
+
+
+def _read_status(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"version": _STATUS_VERSION, "reviews": {}}
+    if path.is_symlink():
+        raise OSError(f"refusing symlinked scope-review status: {path}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or value.get("version") != _STATUS_VERSION:
+        raise ValueError("unsupported scope-review status document")
+    if not isinstance(value.get("reviews", {}), dict):
+        raise ValueError("scope-review status reviews must be an object")
+    return value
+
+
+def _atomic_status_write(path: Path, document: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise OSError(f"refusing symlinked scope-review status: {path}")
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8", closefd=False) as stream:
+            json.dump(document, stream, sort_keys=True, separators=(",", ":"))
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(tmp_name, path)
+        os.chmod(path, 0o600)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    finally:
+        os.close(fd)
+
+
+def refresh_scope_review_status(data_dir: Path = DATA_DIR) -> dict[str, Any]:
+    """Refresh content-free legacy/quarantine counts from the live store."""
+    path = _status_path(data_dir)
+    document = _read_status(path)
+    reviews = document.setdefault("reviews", {})
+    by_owner: dict[str, dict[str, set[str]]] = {}
+    for point_id, owner, metadata in memory.list_scope_census_points():
+        resolved = memory.resolve_memory_scope(metadata)
+        owner_sets = by_owner.setdefault(owner, {"legacy": set(), "invalid": set()})
+        if resolved.legacy_defaulted:
+            owner_sets["legacy"].add(point_id)
+        elif resolved.invalid_defaulted:
+            owner_sets["invalid"].add(point_id)
+
+    owners = set(by_owner) | set(reviews)
+    principals: dict[str, Any] = {}
+    totals = {"raw_legacy_default": 0, "quarantined": 0, "unreviewed": 0, "invalid_quarantined": 0}
+    for owner in sorted(owners):
+        current = by_owner.get(owner, {"legacy": set(), "invalid": set()})
+        review = reviews.get(owner, {}) if isinstance(reviews.get(owner, {}), dict) else {}
+        reviewed_quarantine = set(review.get("quarantined_ids", []))
+        quarantined = current["legacy"] & reviewed_quarantine
+        unreviewed = current["legacy"] - reviewed_quarantine
+        values = {
+            "raw_legacy_default": len(current["legacy"]),
+            "quarantined": len(quarantined),
+            "unreviewed": len(unreviewed),
+            "invalid_quarantined": len(current["invalid"]),
+        }
+        principals[owner] = values
+        for key, value in values.items():
+            totals[key] += value
+    document["observed"] = {
+        "observed_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        **totals,
+        "principals": principals,
+    }
+    _atomic_status_write(path, document)
+    return document
+
+
+def _record_review(*, user_id: str, review_id: str, rows: list[ReviewRow], data_dir: Path = DATA_DIR) -> None:
+    path = _status_path(data_dir)
+    document = _read_status(path)
+    reviews = document.setdefault("reviews", {})
+    reviews[user_id] = {
+        "review_id": review_id,
+        "reviewed_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "quarantined_ids": sorted(row.memory_id for row in rows if row.disposition == DISPOSITION_QUARANTINE),
+        "global": sum(row.disposition == DISPOSITION_GLOBAL for row in rows),
+        "project": sum(row.disposition == DISPOSITION_PROJECT for row in rows),
+        "deleted": sum(row.disposition == DISPOSITION_DELETE for row in rows),
+        "quarantined": sum(row.disposition == DISPOSITION_QUARANTINE for row in rows),
+    }
+    _atomic_status_write(path, document)
+
+
+def _emit_scope_change(
+    *,
+    memory_id: str,
+    user_id: str,
+    from_metadata: dict[str, Any],
+    to_metadata: dict[str, Any],
+    review_id: str,
+    rollback: bool = False,
+) -> None:
+    """Emit a content-free audit event for an operator-reviewed change."""
+    before = memory.resolve_memory_scope(from_metadata)
+    after = memory.resolve_memory_scope(to_metadata)
+    payload: dict[str, Any] = {
+        "memory_id": memory_id,
+        "chat_id": user_id,
+        "from_scope": before.scope,
+        "from_project_id": before.project_id,
+        "from_scope_source": before.scope_source,
+        "to_scope": after.scope,
+        "to_project_id": after.project_id,
+        "run_id": review_id,
+        "operator_reviewed": True,
+    }
+    if rollback:
+        payload["rollback"] = True
+    log.info("%s %s", memory.SCOPE_CHANGE_EVENT, json.dumps(payload, separators=(",", ":")))
+
+
+async def run_census(config: Config, user_id: str, *, out_dir: Path) -> int:
+    registry = await load_project_registry(config)
+    rows = memory.get_all_for_admin(user_id=user_id)
+    selected = select_legacy_rows(rows)
+    review_id = datetime.now(UTC).strftime("lsr-%Y%m%d-%H%M%S")
+    header = _header(review_id=review_id, user_id=user_id, rows=rows, registry=registry)
+    review_rows = [
+        ReviewRow(
+            memory_id=row.id,
+            text_sha256=_sha256(row.text),
+            text=row.text,
+            source=str(row.metadata.get("source", "")),
+            created_at=row.created_at,
+            disposition=DISPOSITION_REVIEW_REQUIRED,
+            project_id=None,
+            operator_note="",
+        )
+        for row in selected
+    ]
+    out_path = out_dir / f"legacy-scope-{review_id}-review.jsonl"
+    _secure_write(out_path, render_manifest(header, review_rows), exclusive=True)
+    refresh_scope_review_status()
+    print(f"memory admin: legacy-scope census {review_id}: scanned {len(rows)}, legacy-default {len(selected)}.")
+    print(f"memory admin: review manifest: {out_path}")
+    print("memory admin: replace every review_required disposition before --apply.")
+    return 0
+
+
+def _validate_complete_review(
+    manifest_rows: list[ReviewRow], current_rows: list[MemoryResult], registry: dict[str, MemoryProjectConfig]
+) -> str | None:
+    pending = [row.memory_id for row in manifest_rows if row.disposition == DISPOSITION_REVIEW_REQUIRED]
+    if pending:
+        return f"{len(pending)} row(s) still have disposition review_required"
+    current = {row.id: row for row in select_legacy_rows(current_rows)}
+    manifest = {row.memory_id: row for row in manifest_rows}
+    missing = sorted(set(current) - set(manifest))
+    extra = sorted(set(manifest) - set(current))
+    if missing or extra:
+        return f"manifest is not a fresh complete census (missing={missing}, extra={extra})"
+    for memory_id, review in manifest.items():
+        row = current[memory_id]
+        if _sha256(row.text) != review.text_sha256 or row.text != review.text:
+            return f"row {memory_id} text drifted since census"
+        if str(row.metadata.get("source", "")) != review.source:
+            return f"row {memory_id} source drifted since census"
+        if review.disposition == DISPOSITION_PROJECT:
+            project = registry.get(review.project_id or "")
+            if project is None:
+                return f"row {memory_id} targets an unregistered project {review.project_id!r}"
+            if not project.memory_enabled:
+                return f"row {memory_id} targets memory-disabled project {review.project_id!r}"
+    return None
+
+
+async def run_apply(config: Config, user_id: str, *, manifest_path: Path, out_dir: Path) -> int:
+    try:
+        header, review_rows = parse_manifest(manifest_path.read_text(encoding="utf-8"), user_id=user_id)
+    except (OSError, ValueError) as exc:
+        print(f"memory admin: cannot read review manifest: {exc}")
+        return 1
+    registry = await load_project_registry(config)
+    current_rows = memory.get_all_for_admin(user_id=user_id)
+    error = _validate_complete_review(review_rows, current_rows, registry)
+    if error is not None:
+        print(f"memory admin: {error}")
+        return 1
+    current = {row.id: row for row in select_legacy_rows(current_rows)}
+    review_id = str(header["review_id"])
+    preimages = [
+        PreImage(row.memory_id, current[row.memory_id].text, dict(current[row.memory_id].metadata), row.disposition)
+        for row in review_rows
+    ]
+    preimage_path = out_dir / f"legacy-scope-{review_id}-preimages.jsonl"
+    _secure_write(preimage_path, render_preimages(header, preimages), exclusive=True)
+
+    applied = deleted = quarantined = failed = 0
+    for review in review_rows:
+        row = current[review.memory_id]
+        if review.disposition == DISPOSITION_QUARANTINE:
+            quarantined += 1
+            continue
+        if review.disposition == DISPOSITION_DELETE:
+            if memory.delete_by_id(user_id=user_id, memory_id=row.id):
+                deleted += 1
+            else:
+                failed += 1
+            continue
+        merged = dict(row.metadata)
+        merged.update(
+            memory.build_scope_metadata(
+                scope=review.disposition,
+                project_id=review.project_id,
+                scope_confidence=1.0,
+                scope_source=memory.SCOPE_SOURCE_OPERATOR,
+            )
+        )
+        merged[SCOPE_REVIEW_ID_KEY] = review_id
+        if memory.update_metadata(user_id=user_id, memory_id=row.id, data=row.text, metadata=merged):
+            applied += 1
+            _emit_scope_change(
+                memory_id=row.id,
+                user_id=user_id,
+                from_metadata=row.metadata,
+                to_metadata=merged,
+                review_id=review_id,
+            )
+        else:
+            failed += 1
+
+    if failed:
+        print(
+            f"memory admin: review {review_id} incomplete: applied={applied}, deleted={deleted}, "
+            f"quarantined={quarantined}, failed={failed}; pre-images: {preimage_path}"
+        )
+        return 1
+    remaining = select_legacy_rows(memory.get_all_for_admin(user_id=user_id))
+    expected_quarantine = {row.memory_id for row in review_rows if row.disposition == DISPOSITION_QUARANTINE}
+    if {row.id for row in remaining} != expected_quarantine:
+        print("memory admin: post-apply census does not match the reviewed quarantine set")
+        return 1
+    _record_review(user_id=user_id, review_id=review_id, rows=review_rows)
+    refresh_scope_review_status()
+    print(
+        f"memory admin: review {review_id} complete: applied={applied}, deleted={deleted}, "
+        f"quarantined={quarantined}, unreviewed=0."
+    )
+    print(f"memory admin: pre-images: {preimage_path}")
+    return 0
+
+
+async def run_rollback(config: Config, user_id: str, *, preimages_path: Path) -> int:
+    _ = config
+    try:
+        header, preimages = parse_preimages(preimages_path.read_text(encoding="utf-8"), user_id=user_id)
+    except (OSError, ValueError) as exc:
+        print(f"memory admin: cannot read pre-images: {exc}")
+        return 1
+    review_id = str(header.get("review_id", ""))
+    restored = skipped = failed = 0
+    for preimage in preimages:
+        current = memory.get_by_id(user_id=user_id, memory_id=preimage.memory_id)
+        if current is None:
+            skipped += 1  # Deleted rows remain recoverable through Mem0 history.
+            continue
+        if preimage.disposition == DISPOSITION_QUARANTINE:
+            skipped += 1
+            continue
+        if current.metadata.get(SCOPE_REVIEW_ID_KEY) != review_id:
+            skipped += 1  # A later operator correction is authoritative.
+            continue
+        if memory.update_metadata(
+            user_id=user_id,
+            memory_id=preimage.memory_id,
+            data=preimage.text,
+            metadata=preimage.metadata,
+        ):
+            restored += 1
+            _emit_scope_change(
+                memory_id=preimage.memory_id,
+                user_id=user_id,
+                from_metadata=current.metadata,
+                to_metadata=preimage.metadata,
+                review_id=review_id,
+                rollback=True,
+            )
+        else:
+            failed += 1
+    refresh_scope_review_status()
+    print(
+        f"memory admin: rollback {review_id}: restored={restored}, skipped={skipped}, failed={failed}; "
+        "deleted rows remain recorded in Mem0 history."
+    )
+    return 1 if failed else 0

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -59,6 +59,7 @@ from kai.install import (
     _generate_systemd_unit,
     _generate_users_yaml,
     _log_security_status,
+    _memory_scope_review_status,
     _migrate_identity_to_claude_md,
     _migrate_managed_home_database_paths,
     _optional_file_checksum,
@@ -5105,6 +5106,41 @@ class TestLogStorageSecurity:
         insecure = _log_security_status(log_dir, "kai")
         assert "Log security: INSECURE" in insecure
         assert "unsafe modes=1" in insecure
+
+
+class TestMemoryScopeReviewStatus:
+    def test_pending_without_protected_census(self, tmp_path):
+        assert "pending" in _memory_scope_review_status(
+            tmp_path / "missing.json",
+            memory_enabled=True,
+        )
+
+    def test_reports_incomplete_and_active_without_content(self, tmp_path):
+        path = tmp_path / "memory-scope-review.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "observed": {
+                        "raw_legacy_default": 45,
+                        "quarantined": 44,
+                        "unreviewed": 1,
+                        "invalid_quarantined": 2,
+                    }
+                }
+            )
+        )
+        incomplete = _memory_scope_review_status(path, memory_enabled=True)
+        assert "INCOMPLETE" in incomplete
+        assert "unreviewed=1" in incomplete
+        assert "reviewed quarantine=44" in incomplete
+
+        document = json.loads(path.read_text())
+        document["observed"]["quarantined"] = 45
+        document["observed"]["unreviewed"] = 0
+        path.write_text(json.dumps(document))
+        active = _memory_scope_review_status(path, memory_enabled=True)
+        assert "active" in active
+        assert "legacy/invalid retrieval=fail-closed" in active
 
 
 class TestApplyVenv:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4615,10 +4615,9 @@ class TestResolveMemoryScope:
 
     def test_defaults_invalid_scope_to_invalid_global(self):
         """A row carrying an unknown `scope` value is corrupted, not
-        legacy. The resolver still returns global so retrieval keeps
-        working, but uses `invalid_default` provenance and zero
-        confidence so audit queries can find these rows separately
-        from genuine legacy rows."""
+        legacy. The resolver retains its compatibility representation
+        as global, but admission quarantines it using `invalid_default`
+        provenance and zero confidence so it cannot affect retrieval."""
         from kai.memory import (
             SCOPE_GLOBAL,
             SCOPE_SOURCE_INVALID_DEFAULT,
@@ -5152,6 +5151,34 @@ class TestScopedMemoryAdmission:
         )
         assert reason is None
 
+    def test_scoped_admission_quarantines_legacy_default(self):
+        """A missing scope is compatibility metadata, not authority."""
+        from kai.memory import SCOPE_GLOBAL, _scoped_memory_admission_reason
+
+        reason = _scoped_memory_admission_reason(
+            _resolved_scope(
+                scope=SCOPE_GLOBAL,
+                scope_source="legacy_default",
+                legacy_defaulted=True,
+            ),
+            allowed_project_id="kai",
+        )
+        assert reason == "legacy_scope_quarantined"
+
+    def test_scoped_admission_quarantines_invalid_scope(self):
+        """Malformed scope provenance also fails closed before scope use."""
+        from kai.memory import SCOPE_GLOBAL, _scoped_memory_admission_reason
+
+        reason = _scoped_memory_admission_reason(
+            _resolved_scope(
+                scope=SCOPE_GLOBAL,
+                scope_source="invalid_default",
+                invalid_defaulted=True,
+            ),
+            allowed_project_id=None,
+        )
+        assert reason == "invalid_scope_quarantined"
+
     def test_scoped_admission_rejects_project_when_no_active_project(self):
         """When no project is active (allowed_project_id=None), a
         valid project-scoped row is excluded as
@@ -5301,6 +5328,28 @@ def _context(workspace: Path, *, message: str = "what is kai?", chat_id: int | s
         backend_name="claude",
         session_id="sess-1",
     )
+
+
+@pytest.mark.asyncio
+async def test_scoped_retrieval_quarantines_legacy_before_ranking(tmp_path):
+    """A high-scoring legacy row cannot outrank an explicit global row."""
+    import kai.memory as mem_mod
+    from kai.memory import retrieve_scoped_memories
+
+    mock_mem = MagicMock()
+    mock_mem.search.return_value = {
+        "results": [
+            _search_row("legacy", "unreviewed", 0.99),
+            _search_row("global", "reviewed", 0.70, scope="global"),
+        ]
+    }
+    mem_mod._memory = mock_mem
+    mem_mod._config = _mp_config()
+
+    result = await retrieve_scoped_memories(_context(tmp_path))
+
+    assert [hit.result.id for hit in result.hits] == ["global"]
+    assert result.debug.excluded_by_scope == {"legacy_scope_quarantined": 1}
 
 
 class TestRetrieveScopedMemories:
@@ -6645,6 +6694,41 @@ class TestCountPointsByOwner:
         # Pagination contract: first call starts at None, second call
         # resumes from the returned cursor.
         assert calls["offsets"] == [None, "cursor"]
+
+
+class TestScopeCensusPoints:
+    _fake_memory = staticmethod(TestCountPointsByOwner._fake_memory)
+
+    def test_reads_only_scope_fields_and_user_visible_sources(self):
+        from kai.memory import list_scope_census_points
+
+        calls = []
+
+        def scroll(**kwargs):
+            calls.append(kwargs)
+            return (
+                [
+                    SimpleNamespace(
+                        id="visible",
+                        payload={"user_id": "prn_1", "source": "extracted", "scope": "global"},
+                    ),
+                    SimpleNamespace(id="hidden", payload={"user_id": "prn_1", "source": "user_raw"}),
+                ],
+                None,
+            )
+
+        fake = SimpleNamespace(
+            vector_store=SimpleNamespace(
+                client=SimpleNamespace(scroll=scroll),
+                collection_name="kai_memory",
+            )
+        )
+        with patch("kai.memory._memory", fake):
+            points = list_scope_census_points()
+
+        assert points == [("visible", "prn_1", {"source": "extracted", "scope": "global"})]
+        assert calls[0]["with_vectors"] is False
+        assert "memory" not in calls[0]["with_payload"]
 
     def test_missing_payload_counts_as_empty_owner(self):
         from kai.memory import count_points_by_owner

--- a/tests/test_memory_admin.py
+++ b/tests/test_memory_admin.py
@@ -300,6 +300,62 @@ class TestCliDispatch:
         assert exc_info.value.code == 0
         assert cmd_mock.call_args[0][0].user_id == "100"
 
+    def test_dispatch_calls_review_legacy_scope(self):
+        with (
+            patch.object(memory_admin, "_cmd_review_legacy_scope", return_value=0) as cmd_mock,
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            memory_admin.cli(["review-legacy-scope", "100"])
+        assert exc_info.value.code == 0
+        assert cmd_mock.call_args[0][0].user_id == "100"
+
+
+class TestReviewLegacyScopeCLI:
+    def test_parser_modes_are_mutually_exclusive(self):
+        parser = memory_admin._build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["review-legacy-scope", "100", "--apply", "review.jsonl", "--rollback", "pre.jsonl"])
+
+    def test_census_dispatches_without_yes(self, tmp_path):
+        args = memory_admin._build_parser().parse_args(["review-legacy-scope", "100", "--out-dir", str(tmp_path)])
+        run = AsyncMock(return_value=0)
+        with (
+            patch.object(memory_admin, "_initialize_memory", return_value=MagicMock()),
+            patch("kai.memory_scope_review.run_census", run),
+        ):
+            assert memory_admin._cmd_review_legacy_scope(args) == 0
+        run.assert_awaited_once()
+
+    def test_apply_refuses_review_required_before_authorization_plan(self, tmp_path, capsys):
+        from kai import memory_scope_review as review
+
+        row = review.ReviewRow(
+            memory_id="m1",
+            text_sha256=review._sha256("text"),
+            text="text",
+            source="extracted",
+            created_at="",
+            disposition=review.DISPOSITION_REVIEW_REQUIRED,
+            project_id=None,
+            operator_note="",
+        )
+        path = tmp_path / "review.jsonl"
+        path.write_text(
+            review.render_manifest(
+                {
+                    "kind": "kai.memory_scope_review",
+                    "version": 1,
+                    "review_id": "lsr-1",
+                    "user_id": "100",
+                },
+                [row],
+            )
+        )
+        args = memory_admin._build_parser().parse_args(["review-legacy-scope", "100", "--apply", str(path)])
+        with patch.object(memory_admin, "_initialize_memory", return_value=MagicMock()):
+            assert memory_admin._cmd_review_legacy_scope(args) == 1
+        assert "review_required" in capsys.readouterr().err
+
 
 # ── reclassify-scope: parser ─────────────────────────────────────────
 

--- a/tests/test_memory_command.py
+++ b/tests/test_memory_command.py
@@ -3037,14 +3037,14 @@ class TestBuildScopeView:
 
     def test_legacy_row_defaults_global_with_legacy_source(self):
         view = memory_command._build_scope_view(_scoped_fact(None), {}, None)
-        assert view.scope_label == "global"
+        assert view.scope_label == "unresolved (quarantined)"
         assert view.resolved.legacy_defaulted is True
         assert "legacy_default" in view.source_label
-        assert view.retrievable_label == "yes"
+        assert view.retrievable_label == "no (legacy_scope_quarantined)"
 
     def test_invalid_scope_value_renders_invalid_source(self):
         view = memory_command._build_scope_view(_scoped_fact("bogus"), {}, None)
-        assert view.scope_label == "global"
+        assert view.scope_label == "global (invalid, quarantined)"
         assert view.resolved.invalid_defaulted is True
         assert "invalid_default" in view.source_label
 
@@ -3171,7 +3171,7 @@ class TestBuildScopeScreen:
         targets = memory_command._scope_change_targets(view.resolved, registry)
         text, kb = memory_command._build_scope_screen(fact, view, targets)
         assert '"Scoped fact text."' in text
-        assert "Scope:  global" in text
+        assert "Scope:  unresolved (quarantined)" in text
         assert "legacy_default" in text
         assert "Choose a new scope:" in text
         # One button per target row, then the nav row.
@@ -3226,9 +3226,9 @@ class TestFactViewScopeBlock:
         fact = _episode_fact()
         view = memory_command._build_scope_view(fact, {}, None)
         text, _ = memory_command._build_fact_view(fact, return_to=None, scope_view=view)
-        assert "Scope:  global" in text
+        assert "Scope:  unresolved (quarantined)" in text
         assert "Scope source:  legacy_default (confidence 1.00)" in text
-        assert "Retrievable here:  yes" in text
+        assert "Retrievable here:  no (legacy_scope_quarantined)" in text
 
     def test_no_scope_view_omits_block(self):
         text, _ = memory_command._build_fact_view(_fact("a", "x", ["t"]), return_to=None)
@@ -3500,7 +3500,7 @@ class TestStatsScopeSection:
         text, _ = memory_command._build_stats(stats)
         assert "Scope:" in text
         idx_global = text.index("global ")
-        idx_legacy = text.index("global (legacy)")
+        idx_legacy = text.index("unresolved (quarantined)")
         idx_project = text.index("project 'kai'")
         idx_invalid = text.index("invalid")
         assert idx_global < idx_legacy < idx_project < idx_invalid

--- a/tests/test_memory_extraction.py
+++ b/tests/test_memory_extraction.py
@@ -653,6 +653,7 @@ class TestParaphraseGate:
         monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
         fake = MagicMock()
         fake.score = 0.85
+        fake.metadata = {"scope": "global", "scope_source": "operator"}
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
         assert _paraphrase_neighbor("x", "user-1", threshold=0.9) is None
 
@@ -665,6 +666,7 @@ class TestParaphraseGate:
         fake = MagicMock()
         fake.score = 0.9
         fake.id = "neighbor-id"
+        fake.metadata = {"scope": "global", "scope_source": "operator"}
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
         result = _paraphrase_neighbor("x", "user-1", threshold=0.9)
         assert result is fake
@@ -677,6 +679,7 @@ class TestParaphraseGate:
         fake = MagicMock()
         fake.score = 0.95
         fake.id = "neighbor-id"
+        fake.metadata = {"scope": "global", "scope_source": "operator"}
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
         result = _paraphrase_neighbor("x", "user-1", threshold=0.9)
         assert result is fake
@@ -747,6 +750,7 @@ class TestParaphraseGate:
         fake = MagicMock()
         fake.score = 0.79  # 0.01 below the cfg'd threshold of 0.80
         fake.id = "neighbor"
+        fake.metadata = {"scope": "global", "scope_source": "operator"}
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
         add_calls: list = []
         monkeypatch.setattr(
@@ -767,6 +771,7 @@ class TestParaphraseGate:
         monkeypatch.setattr("kai.memory_extraction.memory.is_enabled", lambda: True)
         fake = MagicMock()
         fake.score = 1.0
+        fake.metadata = {"scope": "global", "scope_source": "operator"}
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
         assert _paraphrase_neighbor("x", "user-1", threshold=1.01) is None
 
@@ -793,6 +798,7 @@ class TestParaphraseGate:
         fake = MagicMock()
         fake.score = 0.9234567
         fake.id = "surviving-neighbor"
+        fake.metadata = {"scope": "global", "scope_source": "operator"}
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
         monkeypatch.setattr(
             "kai.memory_extraction.memory.add_structured",
@@ -1364,6 +1370,7 @@ class TestStoreFactsDedup:
             # JSON encoder must serialize; an auto-generated MagicMock
             # attribute is not serializable, so pin a real string here.
             fake.id = "neighbor-id"
+            fake.metadata = {"scope": "global", "scope_source": "operator"}
             return [fake]
 
         monkeypatch.setattr("kai.memory_extraction.memory.search", _fake_search)
@@ -1412,7 +1419,12 @@ def _candidate(
     focused on whatever they are actually exercising. Tests that care
     about source/confidence sentinels override `metadata` explicitly.
     """
-    md = {"source": "extracted", "confidence": 0.85}
+    md = {
+        "source": "extracted",
+        "confidence": 0.85,
+        "scope": "global",
+        "scope_source": "operator",
+    }
     if metadata is not None:
         md.update(metadata)
     return MemoryResult(
@@ -1927,6 +1939,7 @@ class TestStoreFactsIntent:
         # JSON-serializable id - the dedup-fire log line carries
         # neighbor.id verbatim and chokes on a default MagicMock.
         fake.id = "neighbor-id"
+        fake.metadata = {"scope": "global", "scope_source": "operator"}
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: [fake])
         # add_structured must NOT be called.
         monkeypatch.setattr(
@@ -4837,9 +4850,9 @@ class TestScopeAdmittedWriteReads:
     these tests pin the composition (which rows a write-time read may
     act on), not the helpers' internals."""
 
-    def test_legacy_row_admitted_everywhere(self):
-        assert memory_extraction._scope_admitted({}, None) is True
-        assert memory_extraction._scope_admitted({}, "kai") is True
+    def test_legacy_row_quarantined_everywhere(self):
+        assert memory_extraction._scope_admitted({}, None) is False
+        assert memory_extraction._scope_admitted({}, "kai") is False
 
     def test_matching_project_row_admitted(self):
         assert memory_extraction._scope_admitted(_KAI_PROJECT_META, "kai") is True
@@ -4889,7 +4902,7 @@ class TestConsolidationCandidateScope:
             },
         )
         candidates = [
-            _mem_result("legacy-row", {}),
+            _mem_result("global-row", {"scope": "global", "scope_source": "operator"}),
             _mem_result("kai-row", dict(_KAI_PROJECT_META)),
             _mem_result("other-row", dict(_OTHER_PROJECT_META)),
         ]
@@ -4918,7 +4931,7 @@ class TestConsolidationCandidateScope:
 
         # The wrong-project row is gone from both the citable id set
         # and the rendered payload; admissible rows survive.
-        assert seen["candidate_ids"] == {"legacy-row", "kai-row"}
+        assert seen["candidate_ids"] == {"global-row", "kai-row"}
         assert "other-row" not in seen["payload"]
         # The candidate log line reports the exclusion so an operator
         # can see scope filtering acting on write-time reads.
@@ -4930,12 +4943,12 @@ class TestConsolidationCandidateScope:
 
     @pytest.mark.asyncio
     async def test_no_project_excludes_all_project_candidates(self, monkeypatch):
-        """Outside any registered project, project-scoped rows from
-        EVERY project lose candidate authority; only global/legacy
-        rows remain citable."""
+        """Outside any registered project, project-scoped and unresolved
+        rows lose candidate authority; only reviewed global rows remain."""
         cfg = _cfg(memory_consolidation_candidates_n=8)
         candidates = [
             _mem_result("legacy-row", {}),
+            _mem_result("global-row", {"scope": "global", "scope_source": "operator"}),
             _mem_result("kai-row", dict(_KAI_PROJECT_META)),
         ]
         monkeypatch.setattr("kai.memory_extraction.memory.search", lambda *a, **kw: list(candidates))
@@ -4953,7 +4966,7 @@ class TestConsolidationCandidateScope:
 
         await extract_and_store(user_text="u", assistant_text="a", user_id="1", config=cfg)
 
-        assert seen["candidate_ids"] == {"legacy-row"}
+        assert seen["candidate_ids"] == {"global-row"}
 
 
 class TestDedupGateScope:
@@ -5000,13 +5013,11 @@ class TestDedupGateScope:
         neighbor = _paraphrase_neighbor("x", "u1", threshold=0.9, active_project=_active_project())
         assert neighbor is None
 
-    def test_legacy_neighbor_still_fires_without_project(self, monkeypatch):
-        """The pre-scoping behavior is preserved for the global-only
-        state: a legacy row above threshold suppresses the duplicate."""
+    def test_legacy_neighbor_is_quarantined_without_project(self, monkeypatch):
+        """An unresolved legacy row cannot suppress a new global write."""
         self._searches(monkeypatch, [_mem_result("legacy-row", {}, score=0.95)])
         neighbor = _paraphrase_neighbor("x", "u1", threshold=0.9)
-        assert neighbor is not None
-        assert neighbor.id == "legacy-row"
+        assert neighbor is None
 
 
 # ── Transcript provenance stamping ──────────────────────────────────

--- a/tests/test_memory_scope_review.py
+++ b/tests/test_memory_scope_review.py
@@ -1,0 +1,211 @@
+"""Residual legacy-scope review, apply, rollback, and status tests."""
+
+from __future__ import annotations
+
+import json
+import stat
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kai import memory
+from kai import memory_scope_review as review
+from kai.config import MemoryProjectConfig
+from kai.memory import MemoryResult
+
+
+def _row(memory_id: str, *, text: str | None = None, scope: str | None = None) -> MemoryResult:
+    metadata = {"source": "extracted", "type": "fact", "other": "preserved"}
+    if scope is not None:
+        metadata.update(memory.build_scope_metadata(scope=scope, scope_source=memory.SCOPE_SOURCE_OPERATOR))
+    return MemoryResult(
+        id=memory_id,
+        text=text or f"text {memory_id}",
+        score=0.0,
+        memory_type="fact",
+        metadata=metadata,
+        created_at="2026-08-21T00:00:00Z",
+    )
+
+
+def _project(project_id: str, *, enabled: bool = True) -> MemoryProjectConfig:
+    return MemoryProjectConfig(
+        project_id=project_id,
+        display_name=project_id,
+        workspace_roots=(Path("/work") / project_id,),
+        memory_enabled=enabled,
+        default_scope_for_new_facts="project",
+    )
+
+
+def _manifest_rows(*rows: MemoryResult) -> list[review.ReviewRow]:
+    return [
+        review.ReviewRow(
+            memory_id=row.id,
+            text_sha256=review._sha256(row.text),
+            text=row.text,
+            source=str(row.metadata["source"]),
+            created_at=row.created_at,
+            disposition=review.DISPOSITION_REVIEW_REQUIRED,
+            project_id=None,
+            operator_note="",
+        )
+        for row in rows
+    ]
+
+
+def _header(user_id: str = "prn_1", review_id: str = "lsr-1") -> dict:
+    return {
+        "kind": "kai.memory_scope_review",
+        "version": 1,
+        "review_id": review_id,
+        "user_id": user_id,
+    }
+
+
+def test_select_legacy_rows_is_complete_and_user_visible_only():
+    legacy = _row("legacy")
+    scoped = _row("scoped", scope="global")
+    hidden = _row("hidden")
+    hidden.metadata["source"] = "user_raw"
+    assert review.select_legacy_rows([scoped, hidden, legacy]) == [legacy]
+
+
+def test_manifest_round_trip_and_hash_tamper_rejection():
+    row = _row("m1")
+    text = review.render_manifest(_header(), _manifest_rows(row))
+    header, parsed = review.parse_manifest(text, user_id="prn_1")
+    assert header["review_id"] == "lsr-1"
+    assert parsed[0].memory_id == "m1"
+    with pytest.raises(ValueError, match="hash"):
+        review.parse_manifest(text.replace("text m1", "changed"), user_id="prn_1")
+
+
+def test_complete_review_rejects_pending_missing_and_disabled_project():
+    first, second = _row("a"), _row("b")
+    rows = _manifest_rows(first, second)
+    assert "review_required" in (review._validate_complete_review(rows, [first, second], {}) or "")
+
+    only_first = [replace(rows[0], disposition=review.DISPOSITION_GLOBAL)]
+    assert "missing=['b']" in (review._validate_complete_review(only_first, [first, second], {}) or "")
+
+    project_row = replace(rows[0], disposition=review.DISPOSITION_PROJECT, project_id="kai")
+    assert "memory-disabled" in (
+        review._validate_complete_review([project_row], [first], {"kai": _project("kai", enabled=False)}) or ""
+    )
+
+
+@pytest.mark.asyncio
+async def test_census_writes_complete_private_manifest(tmp_path, monkeypatch):
+    rows = [_row("b"), _row("a"), _row("scoped", scope="global")]
+    monkeypatch.setattr(review.memory, "get_all_for_admin", lambda *, user_id: rows)
+    monkeypatch.setattr(review, "load_project_registry", AsyncMock(return_value={"kai": _project("kai")}))
+    monkeypatch.setattr(review, "refresh_scope_review_status", lambda: {})
+
+    assert await review.run_census(MagicMock(), "prn_1", out_dir=tmp_path) == 0
+    manifests = list(tmp_path.glob("*-review.jsonl"))
+    assert len(manifests) == 1
+    header, manifest_rows = review.parse_manifest(manifests[0].read_text(), user_id="prn_1")
+    assert header["corpus_count"] == 3
+    assert header["legacy_default_count"] == 2
+    assert [row.memory_id for row in manifest_rows] == ["a", "b"]
+    assert all(row.disposition == review.DISPOSITION_REVIEW_REQUIRED for row in manifest_rows)
+    assert stat.S_IMODE(manifests[0].stat().st_mode) == 0o600
+
+
+@pytest.mark.asyncio
+async def test_apply_requires_fresh_complete_manifest_and_preserves_metadata(tmp_path, monkeypatch, caplog):
+    rows = [_row("global"), _row("project"), _row("delete"), _row("quarantine")]
+    manifest_rows = _manifest_rows(*rows)
+    manifest_rows = [
+        replace(
+            row,
+            disposition={
+                "global": review.DISPOSITION_GLOBAL,
+                "project": review.DISPOSITION_PROJECT,
+                "delete": review.DISPOSITION_DELETE,
+                "quarantine": review.DISPOSITION_QUARANTINE,
+            }[row.memory_id],
+            project_id="kai" if row.memory_id == "project" else None,
+        )
+        for row in manifest_rows
+    ]
+    manifest = tmp_path / "review.jsonl"
+    manifest.write_text(review.render_manifest(_header(), manifest_rows))
+    store = {row.id: row for row in rows}
+    updates: list[tuple[str, dict]] = []
+    deleted: list[str] = []
+
+    monkeypatch.setattr(review, "load_project_registry", AsyncMock(return_value={"kai": _project("kai")}))
+    monkeypatch.setattr(review.memory, "get_all_for_admin", lambda *, user_id: list(store.values()))
+
+    def update(*, user_id, memory_id, data, metadata):
+        updates.append((memory_id, metadata))
+        source = store[memory_id]
+        store[memory_id] = MemoryResult(
+            id=source.id,
+            text=data,
+            score=0,
+            memory_type=source.memory_type,
+            metadata=metadata,
+            created_at=source.created_at,
+        )
+        return True
+
+    monkeypatch.setattr(review.memory, "update_metadata", update)
+    monkeypatch.setattr(
+        review.memory,
+        "delete_by_id",
+        lambda *, user_id, memory_id: (deleted.append(memory_id), store.pop(memory_id), True)[2],
+    )
+    monkeypatch.setattr(review, "_record_review", lambda **kwargs: None)
+    monkeypatch.setattr(review, "refresh_scope_review_status", lambda: {})
+
+    with caplog.at_level("INFO", logger="kai.memory_scope_review"):
+        assert await review.run_apply(MagicMock(), "prn_1", manifest_path=manifest, out_dir=tmp_path) == 0
+    assert {memory_id for memory_id, _ in updates} == {"global", "project"}
+    assert deleted == ["delete"]
+    assert store["quarantine"].metadata.get("scope") is None
+    assert all(metadata["other"] == "preserved" for _, metadata in updates)
+    assert store["global"].metadata["scope"] == "global"
+    assert store["project"].metadata["project_id"] == "kai"
+    audit_events = [record for record in caplog.records if record.message.startswith(memory.SCOPE_CHANGE_EVENT)]
+    assert len(audit_events) == 2
+    assert all('"operator_reviewed":true' in record.message for record in audit_events)
+    preimages = list(tmp_path.glob("*-preimages.jsonl"))
+    assert len(preimages) == 1
+    assert stat.S_IMODE(preimages[0].stat().st_mode) == 0o600
+
+
+def test_refresh_status_distinguishes_reviewed_quarantine_and_unreviewed(tmp_path, monkeypatch):
+    status_path = tmp_path / review.STATUS_FILENAME
+    status_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "reviews": {"prn_1": {"quarantined_ids": ["reviewed"]}},
+            }
+        )
+    )
+    monkeypatch.setattr(
+        review.memory,
+        "list_scope_census_points",
+        lambda: [
+            ("reviewed", "prn_1", {"source": "extracted"}),
+            ("new", "prn_1", {"source": "episode"}),
+            (
+                "invalid",
+                "prn_2",
+                {"source": "explicit", "scope": "global", "scope_source": "bogus"},
+            ),
+        ],
+    )
+    document = review.refresh_scope_review_status(tmp_path)
+    observed = document["observed"]
+    assert observed["raw_legacy_default"] == 2
+    assert observed["quarantined"] == 1
+    assert observed["unreviewed"] == 1
+    assert observed["invalid_quarantined"] == 1
+    assert stat.S_IMODE(status_path.stat().st_mode) == 0o600


### PR DESCRIPTION
## Summary

Issue #1045 records the residual semantic-memory scope debt left after the
automated reclassification pass: rows with no authoritative scope were still
resolved as global and could therefore affect another workspace belonging to
the same canonical principal.

This PR makes unresolved authority fail closed and adds the complete,
operator-reviewed reconciliation path needed to finish the issue safely.

### Retrieval boundary

- quarantine legacy-default and invalid-default rows before ranking;
- apply the same admission rule to ordinary recall, extraction consolidation,
  and the semantic dedup gate;
- preserve explicit global and matching-project behavior;
- expose stable exclusion reasons in scoped retrieval diagnostics;
- label unresolved and invalid rows as quarantined in the `/memory` UI rather
  than presenting them as global.

### Complete review workflow

Add `python -m kai memory review-legacy-scope <owner>` with three modes:

- census/export: writes a mode-0600 JSONL manifest containing every remaining
  user-visible legacy-default row for that canonical owner;
- apply: requires a fresh, complete manifest with an explicit `global`,
  `project`, `delete`, or `quarantine` disposition for every row;
- rollback: restores guarded metadata changes from protected pre-images while
  leaving later operator corrections authoritative.

Apply rejects incomplete, stale, drifted, duplicate, cross-owner, unknown-
project, and memory-disabled-project manifests. It writes mode-0600 pre-images
before the first mutation, preserves all non-scope metadata, stamps an operator
review id, emits content-free scope-change audit events, and uses the normal
per-row Mem0 delete path so deletions remain in Mem0 history.

### Operator diagnostics

- maintain a protected, content-free scope-review receipt and live census;
- refresh aggregate counts when semantic memory starts;
- report raw legacy-default, reviewed quarantine, unreviewed, and invalid-
  quarantine counts from `make install-status`;
- continue to fail closed even before the operator completes the review.

## Security properties

- No missing or malformed scope is admitted as global.
- A high-scoring unresolved row cannot outrank or suppress an authorized row.
- Project-scoped candidates remain limited to the active, memory-enabled
  project.
- Canonical principal ownership checks remain unchanged.
- Review artifacts and rollback material are written with mode 0600.
- Diagnostics contain counts and identifiers only, never memory text.

## Verification

- `make check`
- `make typecheck`
- `make test` — 6,093 passed, 1 skipped
- focused review/retrieval/admin/status tests — 1,175 passed before the final
  full-suite run

## Post-merge qualification

This PR intentionally does **not** close #1045. After installation, the
operator must export and review the complete manifests for the deployed
canonical owners, apply every disposition, run cross-project retrieval probes,
and confirm `make install-status` reports `unreviewed=0` (with any retained
uncertain rows counted explicitly as reviewed quarantine). The issue can close
only after that deployed corpus review succeeds.

Advances #1045.
