### PR TITLE
security: enforce audited dependency constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,11 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install --constraint requirements/constraints.txt -e '.[dev,totp]'
+        run: |
+          python -m pip install --upgrade \
+            --constraint requirements/constraints.txt pip setuptools
+          python -m pip install --upgrade \
+            --constraint requirements/constraints.txt -e '.[dev,totp]'
 
       - name: Install Workshop client dependencies
         run: npm ci --prefix workshop-client

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,13 +1,15 @@
 # Report known Python dependency vulnerabilities.
 #
-# This workflow is intentionally non-blocking while Kai still has an
-# existing vulnerability backlog. It runs on a schedule and on manual
-# dispatch so maintainers can see the current dependency risk without
-# breaking unrelated PRs. Convert it to blocking once the backlog is
-# cleared or an explicit ignore policy is in place.
+# This is a blocking dependency-policy check. The reviewed constraints must
+# resolve cleanly and the resulting environment must contain no known
+# vulnerabilities.
 name: Dependency audit
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "17 11 * * 1"
@@ -24,22 +26,11 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install --constraint requirements/constraints.txt -e '.[dev,memory,totp,tts]'
+        run: |
+          python -m pip install --upgrade \
+            --constraint requirements/constraints.txt pip setuptools
+          python -m pip install --upgrade \
+            --constraint requirements/constraints.txt -e '.[dev,memory,totp,tts]'
 
       - name: Run dependency audit
-        run: |
-          set +e
-          make BIN= audit-deps > pip-audit.txt
-          status=$?
-          pip-audit --local --skip-editable --format json --output pip-audit.json
-          echo "pip-audit exited with status ${status}" >> pip-audit.txt
-          cat pip-audit.txt
-          exit 0
-
-      - name: Upload audit report
-        uses: actions/upload-artifact@v7
-        with:
-          name: pip-audit-report
-          path: |
-            pip-audit.txt
-            pip-audit.json
+        run: make BIN= audit-deps

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ audit-deps:
 	$(BIN)pip-audit --local --skip-editable
 
 check-install-constraints:
+	$(BIN)python -m pip install --dry-run --upgrade \
+		--constraint requirements/constraints.txt pip setuptools
 	$(BIN)python -m pip install --dry-run --constraint requirements/constraints.txt -e '.[memory,totp,tts]'
 
 module-sizes:
@@ -36,7 +38,10 @@ test:
 
 # Development environment setup (editable install with dev tools)
 setup:
-	$(BIN)pip install -e '.[dev]'
+	$(BIN)python -m pip install --upgrade \
+		--constraint requirements/constraints.txt pip setuptools
+	$(BIN)python -m pip install --upgrade \
+		--constraint requirements/constraints.txt -e '.[dev]'
 
 # Protected installation targets
 config:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -3,9 +3,10 @@
 # The protected installer copies this file into /opt/kai and passes it to
 # `pip install --constraint` when installing `.[memory,totp,tts]`.
 #
-# Scope: direct runtime and optional-install dependencies only. Do not add
-# incidental transitive packages here unless a vulnerability, compatibility
-# issue, or reproducibility incident requires it.
+# Scope: direct runtime, optional-install, and development dependencies, plus
+# transitive or packaging-tool versions required by a vulnerability,
+# compatibility, or reproducibility incident. Keep this one reviewed set in
+# force for development, CI, and the protected install.
 
 python-telegram-bot==22.6
 aiosqlite==0.22.1
@@ -20,3 +21,25 @@ piper-tts==1.4.1
 
 pyotp==2.9.0
 qrcode==8.2
+
+# Development and audit tooling.
+ruff==0.15.1
+pyright==1.1.411
+pip-audit==2.10.1
+pytest==9.0.3
+pytest-asyncio==1.3.0
+
+# Security-constrained transitive dependencies and packaging tools. These
+# versions are the first reviewed releases that resolve every advisory in the
+# 2026-08-21 audit while remaining compatible with Kai's supported dependency
+# graph. They intentionally stay constrained until a later dependency review.
+click==8.3.3
+h2==4.4.1
+idna==3.15
+pip==26.2.1
+pygments==2.20.0
+requests==2.33.0
+setuptools==83.0.0
+torch==2.13.0
+tornado==6.5.7
+urllib3==2.7.0

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -7151,6 +7151,27 @@ def _apply_venv(install_path: Path, is_update: bool, dry_run: bool) -> None:
         shutil.rmtree(build_path)
         print(f"  Removed stale package build artifacts: {build_path}")
 
+    # Keep the venv's packaging tools inside the same reviewed constraint set
+    # as Kai itself. They are installed into (and audited as part of) the
+    # protected environment, but ordinary package installation does not
+    # otherwise upgrade the copies originally seeded by ``venv``.
+    if constraints_dst.is_file():
+        subprocess.run(
+            [
+                str(venv_python),
+                "-m",
+                "pip",
+                "install",
+                "--upgrade",
+                "--constraint",
+                str(constraints_dst),
+                "pip",
+                "setuptools",
+            ],
+            check=True,
+        )
+        print("  Updated constrained packaging tools")
+
     # Install the package with optional dependencies.
     # Uses a non-editable install (not -e) so the venv is self-contained
     # and doesn't depend on the source directory being writable.

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5443,10 +5443,22 @@ class TestApplyVenv:
             "-m",
             "pip",
             "install",
+            "--upgrade",
+            "--constraint",
+            str(constraints),
+            "pip",
+            "setuptools",
+        ] in commands
+        assert [
+            str(install / "venv" / "bin" / "python"),
+            "-m",
+            "pip",
+            "install",
             "--constraint",
             str(constraints),
             f"{install}[memory,totp,tts]",
         ] in commands
+        assert "Updated constrained packaging tools" in output
         assert (install / ".constraints.sha256").read_text().strip() == _file_checksum(constraints)
 
     def test_dry_run_reports_constraints_change(self, tmp_path, monkeypatch, capsys):
@@ -7998,6 +8010,32 @@ class TestOptionalFileChecksum:
         path = tmp_path / "constraints.txt"
         path.write_text("aiohttp==3.13.4\n")
         assert _optional_file_checksum(path) == _file_checksum(path)
+
+
+class TestReviewedDependencyConstraints:
+    """Pin the security-reviewed packages shared by dev, CI, and install."""
+
+    def test_audit_remediations_remain_constrained(self):
+        constraints = {
+            line.strip()
+            for line in (kai.install.PROJECT_ROOT / "requirements" / "constraints.txt").read_text().splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+
+        assert {
+            "click==8.3.3",
+            "h2==4.4.1",
+            "idna==3.15",
+            "pip==26.2.1",
+            "pygments==2.20.0",
+            "pytest==9.0.3",
+            "python-dotenv==1.2.2",
+            "requests==2.33.0",
+            "setuptools==83.0.0",
+            "torch==2.13.0",
+            "tornado==6.5.7",
+            "urllib3==2.7.0",
+        } <= constraints
 
 
 # ── _retire_install_home_claude ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- replace the known-vulnerable dependency set with one reviewed constraint policy shared by development, CI, and protected installs
- make the protected installer upgrade constrained `pip` and `setuptools` before installing Kai
- make development setup and both CI workflows honor the same packaging-tool and dependency constraints
- convert the dependency audit from a non-blocking weekly report into a blocking pull-request, main-branch, manual, and scheduled check
- pin the remediation contract in installer tests so the vulnerable versions cannot silently return

## Security impact

The 2026-08-21 audit reported 51 advisories across 13 packages in the development environment and 20 advisories across 8 packages in the protected environment. This change constrains the first reviewed fixed releases for every finding:

- `aiohttp 3.14.3`
- `click 8.3.3`
- `h2 4.4.1`
- `idna 3.15`
- `pip 26.2.1`
- `Pygments 2.20.0`
- `pytest 9.0.3`
- `python-dotenv 1.2.2`
- `requests 2.33.0`
- `setuptools 83.0.0`
- `torch 2.13.0`
- `tornado 6.5.7`
- `urllib3 2.7.0`

There are no vulnerability ignores or exceptions. A clean audit is now required.

## Installer behavior

`requirements/constraints.txt` remains the authoritative reviewed input copied into `/opt/kai`. When its checksum changes, the protected installer now:

1. upgrades `pip` and `setuptools` under that constraint set;
2. installs Kai with the memory, TOTP, and TTS extras under the same set;
3. records checksums only after both operations succeed.

This closes the prior gap where packaging tools installed inside the protected venv were audited but never deliberately upgraded.

## Verification

- `make check`
- `make typecheck`
- `make client-check` — 40 client tests passed and generated assets matched
- `make check-install-constraints`
- `.venv/bin/python -m pip check` — no broken requirements
- `make audit-deps` — no known vulnerabilities
- memory-critical suite — 548 passed, covering real Mem0 initialization/local embeddings, retrieval, extraction, authority, and snapshots
- full suite — 6,094 passed, 1 skipped
- workflow YAML parsed successfully
- `git diff --check`

## Post-merge qualification

After `make install`, audit `/opt/kai/venv` and confirm normal Kai startup, memory status, recall, and extraction. The constraints checksum change guarantees that the installer refreshes the protected dependency set.

Closes #1043
