### PR TITLE
fix: preserve historical memory source views

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -514,21 +514,25 @@ def read_transcript_provenance(metadata: dict[str, Any] | None) -> TranscriptPro
     )
     assistant_ts = md.get(SOURCE_ASSISTANT_TS_KEY)
     date_end = md.get(SOURCE_DATE_END_KEY)
-    canonical_keys = (
+    canonical_owner_keys = (
         WORKSHOP_PRINCIPAL_ID_KEY,
         WORKSHOP_CHANNEL_ID_KEY,
         WORKSHOP_AGENT_ID_KEY,
         WORKSHOP_RUNTIME_PROFILE_ID_KEY,
+    )
+    canonical_source_keys = (
         WORKSHOP_RUN_ID_KEY,
         WORKSHOP_SOURCE_MESSAGE_ID_KEY,
         WORKSHOP_RESULT_MESSAGE_ID_KEY,
     )
+    canonical_keys = canonical_owner_keys + canonical_source_keys
     canonical_values = tuple(md.get(key) for key in canonical_keys)
-    canonical_any = any(value is not None for value in canonical_values)
+    canonical_source_values = tuple(md.get(key) for key in canonical_source_keys)
+    canonical_source_any = any(value is not None for value in canonical_source_values)
     canonical_present = all(isinstance(value, str) and bool(value) for value in canonical_values)
     legacy_values = (chat_id, date, user_ts, user_text_sha256)
     legacy_any = any(value is not None for value in legacy_values)
-    malformed = (canonical_any and not canonical_present) or (legacy_any and not required_present)
+    malformed = (canonical_source_any and not canonical_present) or (legacy_any and not required_present)
     return TranscriptProvenance(
         present=(canonical_present or required_present) and not malformed,
         chat_id=chat_id if isinstance(chat_id, int) else None,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6555,6 +6555,56 @@ class TestReadTranscriptProvenance:
         assert p.present is True
         assert p.assistant_ts is None
 
+    def test_workshop_owner_metadata_does_not_invalidate_historical_locator(self):
+        """Canonical ownership is not itself a canonical source pointer."""
+        from kai.memory import read_transcript_provenance
+
+        p = read_transcript_provenance(
+            self._md(
+                workshop_principal_id="prn_1",
+                workshop_channel_id="chn_1",
+                workshop_agent_id="agt_1",
+                workshop_runtime_profile_id="rtp_1",
+            )
+        )
+        assert p.present is True
+        assert p.canonical_present is False
+        assert p.malformed is False
+        assert p.chat_id == 100
+
+    def test_workshop_owner_metadata_without_locator_remains_legacy(self):
+        """Migrated owner stamps do not fabricate a source locator."""
+        from kai.memory import read_transcript_provenance
+
+        p = read_transcript_provenance(
+            {
+                "workshop_principal_id": "prn_1",
+                "workshop_channel_id": "chn_1",
+                "workshop_agent_id": "agt_1",
+                "workshop_runtime_profile_id": "rtp_1",
+            }
+        )
+        assert p.present is False
+        assert p.canonical_present is False
+        assert p.malformed is False
+
+    def test_partial_canonical_source_locator_is_malformed(self):
+        """A run/message pointer must never be resolved by guessing."""
+        from kai.memory import read_transcript_provenance
+
+        p = read_transcript_provenance(
+            {
+                "workshop_principal_id": "prn_1",
+                "workshop_channel_id": "chn_1",
+                "workshop_agent_id": "agt_1",
+                "workshop_runtime_profile_id": "rtp_1",
+                "workshop_run_id": "run_1",
+            }
+        )
+        assert p.present is False
+        assert p.canonical_present is False
+        assert p.malformed is True
+
     def test_date_end_populated_only_on_midnight_cross(self):
         from kai.memory import read_transcript_provenance
 

--- a/tests/test_workshop_transcript_export.py
+++ b/tests/test_workshop_transcript_export.py
@@ -231,6 +231,10 @@ def test_partial_canonical_provenance_never_falls_back_to_jsonl(monkeypatch):
     provenance = read_transcript_provenance(
         {
             "workshop_principal_id": "prn_incomplete",
+            "workshop_channel_id": "chn_incomplete",
+            "workshop_agent_id": "agt_incomplete",
+            "workshop_runtime_profile_id": "rtp_incomplete",
+            "workshop_run_id": "run_incomplete",
             "source_chat_id": 919191,
             "source_date": "2026-08-15",
             "source_user_ts": "2026-08-15T09:00:00Z",


### PR DESCRIPTION
## Summary

- distinguish canonical ownership stamps from canonical transcript source locators
- keep complete historical JSONL provenance usable after Workshop memory ownership migration
- continue to fail closed when any canonical run/message source pointer is partially written

## Installed finding

The Milestone 4 installed qualification found that the parser classified all
358 non-canonical rows as malformed because migrated ownership metadata shares
four field names with canonical source provenance. With this fix, the deployed
corpus classifies as 37 canonical locators, 247 historical locators, 111 rows
without a source locator, and zero malformed rows. Read-only resolution of a
representative canonical source and a representative historical source both
returned their exact owned user/assistant pair.

## Tests

- `make check`
- `make test` (6,104 passed, 1 skipped)
- focused provenance/history tests (66 passed)

Follow-up to #1047 and #1056.
