### PR TITLE
Fix generation-safe launchd service restarts

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -23,12 +23,14 @@ It's a JSON file with a version field for forward compatibility.
 
 import grp
 import hashlib
+import http.client
 import json
 import os
 import pwd
 import re
 import secrets
 import shutil
+import signal
 import sqlite3
 import stat
 import subprocess
@@ -144,6 +146,19 @@ _LAUNCHD_LABEL = "com.syrinx.kai"
 _SERVICE_START_MAX_ATTEMPTS = 3
 _SERVICE_START_SETTLE_SECONDS = 1
 _SERVICE_START_RETRY_SECONDS = 2
+_SERVICE_READY_TIMEOUT_SECONDS = 120.0
+_SERVICE_READY_POLL_SECONDS = 1.0
+_SERVICE_STOP_GRACE_SECONDS = 65.0
+_SERVICE_STOP_KILL_SECONDS = 5.0
+_SERVICE_STOP_POLL_SECONDS = 0.25
+_LAUNCHD_EXIT_TIMEOUT_SECONDS = 65
+
+# The launchd wrapper uses the same bounded grace period when it receives
+# TERM directly or discovers a previous service generation after `kickstart
+# -k`.  Half-second steps keep the generated shell portable on macOS.
+_LAUNCHER_SHUTDOWN_POLL_SECONDS = 0.5
+_LAUNCHER_SHUTDOWN_GRACE_STEPS = 120
+_LAUNCHER_STARTUP_SHUTDOWN_GRACE_STEPS = 20
 
 _PRIVATE_USER_ROOT_MODE = 0o711
 _PRIVATE_USER_DIR_MODE = 0o700
@@ -173,6 +188,18 @@ class ServiceStartError(Exception):
     original) or propagate (apply succeeded; the install has not
     produced a working system).
     """
+
+
+class ServiceStopError(Exception):
+    """Raised when the verified previous service generation cannot stop."""
+
+
+@dataclass(frozen=True, slots=True)
+class _DarwinServiceGeneration:
+    """Verified launchd wrapper process group for one Kai generation."""
+
+    pid: int
+    pgid: int
 
 
 # Files and directories to copy from source to the install location.
@@ -3912,7 +3939,11 @@ def _user_home(username: str) -> str:
         return f"/home/{username}"
 
 
-def _generate_launcher_script(install_dir: str, webhook_port: int = 8080) -> str:
+def _generate_launcher_script(
+    install_dir: str,
+    webhook_port: int = 8080,
+    data_dir: str = _DEFAULT_DATA_DIR,
+) -> str:
     """
     Generate a launcher script for launchd.
 
@@ -3927,32 +3958,97 @@ def _generate_launcher_script(install_dir: str, webhook_port: int = 8080) -> str
         # Keeps bash as the tracked PID so launchd can manage the service
         # even when Homebrew Python re-execs through the framework bundle.
         #
-        # Homebrew Python's framework binary fork+execs through Python.app,
-        # creating a grandchild process with a new PID. Launchd tracks this
-        # bash script instead, and we forward signals to the real Python.
+        # A generation file lets a replacement wrapper wait for a predecessor
+        # left behind by `launchctl kickstart -k`. The Python child also watches
+        # this wrapper PID and begins graceful shutdown if launchd kills only
+        # the shell.
+        GENERATION_FILE="{data_dir}/.service-generation"
+        PREVIOUS_GENERATION=""
+        [ -f "$GENERATION_FILE" ] && PREVIOUS_GENERATION=$(tr -d '[:space:]' < "$GENERATION_FILE")
+
+        wait_for_generation_exit() {{
+            local pgid="$1"
+            local steps="$2"
+            for _ in $(seq 1 "$steps"); do
+                if ! kill -0 -- "-$pgid" 2>/dev/null; then
+                    return 0
+                fi
+                sleep {_LAUNCHER_SHUTDOWN_POLL_SECONDS}
+            done
+            return 1
+        }}
+
+        if [[ "$PREVIOUS_GENERATION" =~ ^[0-9]+$ ]] \
+            && [ "$PREVIOUS_GENERATION" -gt 1 ] \
+            && [ "$PREVIOUS_GENERATION" != "$$" ] \
+            && kill -0 -- "-$PREVIOUS_GENERATION" 2>/dev/null; then
+            echo "kai launcher: waiting for previous generation $PREVIOUS_GENERATION to exit" >&2
+            if ! wait_for_generation_exit \
+                "$PREVIOUS_GENERATION" {_LAUNCHER_SHUTDOWN_GRACE_STEPS}; then
+                echo "kai launcher: previous generation exceeded shutdown grace; sending SIGKILL" >&2
+                kill -KILL -- "-$PREVIOUS_GENERATION" 2>/dev/null || true
+                if ! wait_for_generation_exit "$PREVIOUS_GENERATION" 10; then
+                    echo "kai launcher: previous generation still exists after SIGKILL" >&2
+                    exit 1
+                fi
+            fi
+        fi
+
+        umask 077
+        GENERATION_TMP="$GENERATION_FILE.$$"
+        printf '%s\\n' "$$" > "$GENERATION_TMP"
+        mv -f "$GENERATION_TMP" "$GENERATION_FILE"
+        export KAI_SERVICE_GENERATION="$$"
+
+        # Homebrew Python's framework binary fork+execs through Python.app.
+        # Launchd tracks this bash script while the generation PID and process
+        # group bind the wrapper and Python descendants together.
         {install_dir}/venv/bin/python3 -m kai &
         CHILD_PID=$!
+        REAL_PID=""
+
+        clear_generation_file() {{
+            local recorded=""
+            [ -f "$GENERATION_FILE" ] && recorded=$(tr -d '[:space:]' < "$GENERATION_FILE")
+            if [ "$recorded" = "$$" ]; then
+                rm -f "$GENERATION_FILE"
+            fi
+        }}
+
+        terminate_generation() {{
+            local exit_code="$1"
+            local steps={_LAUNCHER_STARTUP_SHUTDOWN_GRACE_STEPS}
+            # Ignore further TERM/INT while tearing down so the group signal
+            # below does not re-enter this handler.
+            trap '' TERM INT
+            kill -TERM -- -$$ 2>/dev/null || kill -TERM "$CHILD_PID" 2>/dev/null
+
+            if [ -n "$REAL_PID" ]; then
+                steps={_LAUNCHER_SHUTDOWN_GRACE_STEPS}
+                for _ in $(seq 1 "$steps"); do
+                    if ! kill -0 "$REAL_PID" 2>/dev/null; then
+                        clear_generation_file
+                        exit "$exit_code"
+                    fi
+                    sleep {_LAUNCHER_SHUTDOWN_POLL_SECONDS}
+                done
+            else
+                # During the pre-bind re-exec window there is no stable child
+                # PID to await. TERM reached the complete process group; allow
+                # a short bounded grace before escalating the same group.
+                for _ in $(seq 1 "$steps"); do
+                    sleep {_LAUNCHER_SHUTDOWN_POLL_SECONDS}
+                done
+            fi
+
+            echo "kai launcher: generation $$ exceeded shutdown grace; sending SIGKILL" >&2
+            clear_generation_file
+            kill -KILL -- -$$ 2>/dev/null || kill -KILL "$CHILD_PID" 2>/dev/null
+            exit "$exit_code"
+        }}
 
         cleanup() {{
-            # Ignore further TERM/INT while tearing down so the group
-            # signal below does not re-enter this handler.
-            trap '' TERM INT
-            # Signal the launcher's whole process group: launchd runs
-            # this script as its own group leader and non-interactive
-            # bash creates no job-control groups, so the python child,
-            # its re-exec'd grandchild, and any helper sleeps all share
-            # the group (fork and exec both preserve the pgid). The
-            # group signal is the only handle that reaches a python
-            # that has re-exec'd but not yet bound the port; in that
-            # window it has no individually resolvable pid. Fall back
-            # to the direct child if this shell is somehow not a group
-            # leader.
-            kill -TERM -- -$$ 2>/dev/null || kill -TERM "$CHILD_PID" 2>/dev/null
-            # Wait for the webhook port to be released so the stop is
-            # not reported complete while a dying python still holds
-            # the port a successor will need.
-            while [ -n "$(/usr/sbin/lsof -ti :{webhook_port} -sTCP:LISTEN 2>/dev/null)" ]; do sleep 0.5; done
-            exit 0
+            terminate_generation 0
         }}
         # Installed BEFORE the bind poll: a service stop during the
         # (up to 120s) startup window must still tear the agent down;
@@ -3960,17 +4056,17 @@ def _generate_launcher_script(install_dir: str, webhook_port: int = 8080) -> str
         # orphan the starting python.
         trap cleanup TERM INT
 
-        # Find the actual Python process (the re-exec'd grandchild) by
-        # its listen port. lsof lives at /usr/sbin/ which may not be in
-        # the service PATH. Healthy startups bind in 15-25 seconds on
-        # this stack (the memory subsystem loads its embedding model
-        # before the webhook server starts), so poll for up to 120s.
-        # The direct child exits on the framework re-exec in normal
-        # operation, so child death alone is not a failure signal;
-        # only the port answers whether the agent came up.
-        REAL_PID=""
+        # Find the actual Python process by its listener, but accept only a PID
+        # in this wrapper's process group. A stale listener from a draining
+        # predecessor must never be adopted as the current generation.
         for _ in $(seq 1 60); do
-            REAL_PID=$(/usr/sbin/lsof -ti :{webhook_port} -sTCP:LISTEN 2>/dev/null)
+            for CANDIDATE_PID in $(/usr/sbin/lsof -ti :{webhook_port} -sTCP:LISTEN 2>/dev/null); do
+                CANDIDATE_PGID=$(/bin/ps -o pgid= -p "$CANDIDATE_PID" 2>/dev/null | /usr/bin/tr -d ' ')
+                if [ "$CANDIDATE_PGID" = "$$" ]; then
+                    REAL_PID="$CANDIDATE_PID"
+                    break
+                fi
+            done
             [ -n "$REAL_PID" ] && break
             sleep 2
         done
@@ -3985,15 +4081,14 @@ def _generate_launcher_script(install_dir: str, webhook_port: int = 8080) -> str
             # visible retry loop instead of an eternal sleep that
             # reports state=running with no agent behind it.
             echo "kai launcher: no listener on :{webhook_port} after 120s; exiting so launchd restarts the service" >&2
-            trap '' TERM INT
-            kill -TERM -- -$$ 2>/dev/null || kill -TERM "$CHILD_PID" 2>/dev/null
-            exit 1
+            terminate_generation 1
         fi
 
         # Poll for the real Python process to exit.
         # kill -0 checks if PID exists without sending a signal.
         # This is macOS-compatible (no GNU tail --pid needed).
         while kill -0 "$REAL_PID" 2>/dev/null; do sleep 1; done
+        clear_generation_file
     """)
 
 
@@ -4080,6 +4175,9 @@ def _generate_launchd_plist(install_dir: str, data_dir: str, service_user: str) 
 
             <key>ProcessType</key>
             <string>Background</string>
+
+            <key>ExitTimeOut</key>
+            <integer>{_LAUNCHD_EXIT_TIMEOUT_SECONDS}</integer>
         </dict>
         </plist>
     """)
@@ -4127,20 +4225,100 @@ def _generate_systemd_unit(install_dir: str, data_dir: str, service_user: str) -
     """)
 
 
+def _capture_darwin_service_generation() -> _DarwinServiceGeneration | None:
+    """Return the verified launchd wrapper process group, if running."""
+    result = subprocess.run(
+        ["launchctl", "print", f"system/{_LAUNCHD_LABEL}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    match = re.search(r"(?m)^\s*pid = ([0-9]+)\s*$", result.stdout or "")
+    if match is None:
+        return None
+    pid = int(match.group(1))
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        return None
+    if pgid != pid:
+        raise ServiceStopError(
+            f"Refusing to stop launchd generation {pid}: expected process group {pid}, observed {pgid}"
+        )
+    return _DarwinServiceGeneration(pid=pid, pgid=pgid)
+
+
+def _darwin_generation_alive(generation: _DarwinServiceGeneration) -> bool:
+    """Return whether any process remains in a verified service generation."""
+    try:
+        os.killpg(generation.pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_for_darwin_generation_exit(
+    generation: _DarwinServiceGeneration,
+    *,
+    timeout: float,
+) -> bool:
+    """Wait a bounded interval for every process in one generation to exit."""
+    deadline = time.monotonic() + timeout
+    while _darwin_generation_alive(generation):
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_SERVICE_STOP_POLL_SECONDS)
+    return True
+
+
+def _finish_stopping_darwin_generation(generation: _DarwinServiceGeneration) -> None:
+    """Await graceful exit, then safely escalate the exact verified group."""
+    if _wait_for_darwin_generation_exit(
+        generation,
+        timeout=_SERVICE_STOP_GRACE_SECONDS,
+    ):
+        return
+    print(
+        f"  Service generation {generation.pid} exceeded "
+        f"{_SERVICE_STOP_GRACE_SECONDS:g}s shutdown grace; sending SIGKILL"
+    )
+    try:
+        os.killpg(generation.pgid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    except PermissionError as exc:
+        raise ServiceStopError(f"Could not terminate verified service generation {generation.pid}") from exc
+    if not _wait_for_darwin_generation_exit(
+        generation,
+        timeout=_SERVICE_STOP_KILL_SECONDS,
+    ):
+        raise ServiceStopError(f"Service generation {generation.pid} still exists after SIGKILL")
+
+
 def _stop_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
     """
     Stop the Kai service before applying changes.
 
-    Best-effort: uses check=False since the service may not be running
-    (first install) or may not exist yet. Failing to stop is not fatal.
+    A missing service is harmless on first install. A registered macOS service
+    is different: capture its verified wrapper process group before bootout,
+    then wait for the complete generation to exit. If graceful shutdown exceeds
+    its bounded deadline, SIGKILL is sent only to that verified group. Apply
+    must not continue while an old generation can retain Qdrant or listeners.
 
     Args:
         platform: "darwin" or "linux".
         dry_run: If True, print the command without executing.
     """
+    generation: _DarwinServiceGeneration | None = None
     if platform == "darwin":
         # Boot out from the system domain (LaunchDaemon, not LaunchAgent)
         cmd = ["launchctl", "bootout", f"system/{_LAUNCHD_LABEL}"]
+        if not dry_run:
+            generation = _capture_darwin_service_generation()
     elif platform == "linux":
         cmd = ["systemctl", "stop", "kai"]
     else:
@@ -4152,21 +4330,87 @@ def _stop_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
     else:
         result = subprocess.run(cmd, check=False, capture_output=True)
         if result.returncode == 0:
+            if generation is not None:
+                _finish_stopping_darwin_generation(generation)
             print(f"  Stopped service ({' '.join(cmd[:2])})")
-            # Give launchd time to fully release the service domain.
-            # Without this, a subsequent bootstrap can fail transiently
-            # on KeepAlive daemons.
-            if platform == "darwin":
-                time.sleep(2)
         else:
-            # Non-zero is expected on first install (service not yet registered)
+            if generation is not None and _darwin_generation_alive(generation):
+                detail = (result.stderr or b"").decode().strip()
+                suffix = f": {detail}" if detail else ""
+                raise ServiceStopError(f"launchctl bootout failed for running generation {generation.pid}{suffix}")
+            # Non-zero is expected on first install (service not yet registered).
             print(f"  Service not running ({' '.join(cmd[:2])})")
 
 
-def _start_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
+def _probe_service_readiness(
+    webhook_port: int,
+    *,
+    expected_generation: str | None,
+) -> tuple[bool, str]:
+    """Probe content-free readiness for the expected service generation."""
+    connection = http.client.HTTPConnection("127.0.0.1", webhook_port, timeout=1.0)
+    try:
+        connection.request("GET", "/health")
+        response = connection.getresponse()
+        body = response.read(65536)
+    except (OSError, http.client.HTTPException) as exc:
+        return False, type(exc).__name__
+    finally:
+        connection.close()
+    if response.status != 200:
+        return False, f"HTTP {response.status}"
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False, "invalid health payload"
+    if not isinstance(payload, dict):
+        return False, "invalid health payload"
+    if expected_generation is not None and payload.get("service_generation") != expected_generation:
+        return False, "health belongs to a different service generation"
+    core = payload.get("core")
+    if not isinstance(core, dict) or core.get("ready") is not True:
+        return False, "core is not ready"
+    adapters = payload.get("adapters")
+    if not isinstance(adapters, dict):
+        return False, "adapter readiness is unavailable"
+    http_adapter = adapters.get("http")
+    if not isinstance(http_adapter, dict) or http_adapter.get("ready") is not True:
+        return False, "HTTP adapter is not ready"
+    for adapter_name, readiness in adapters.items():
+        if not isinstance(readiness, dict) or readiness.get("ready") is not True:
+            return False, f"adapter {adapter_name!r} is not ready"
+    return True, "ready"
+
+
+def _wait_for_service_readiness(
+    webhook_port: int,
+    *,
+    expected_generation: str | None,
+) -> tuple[bool, str]:
+    """Wait until the expected service generation reports full readiness."""
+    deadline = time.monotonic() + _SERVICE_READY_TIMEOUT_SECONDS
+    detail = "health endpoint has not responded"
+    while True:
+        ready, detail = _probe_service_readiness(
+            webhook_port,
+            expected_generation=expected_generation,
+        )
+        if ready:
+            return True, detail
+        if time.monotonic() >= deadline:
+            return False, detail
+        time.sleep(_SERVICE_READY_POLL_SECONDS)
+
+
+def _start_service(
+    platform: str,
+    dry_run: bool,
+    *,
+    webhook_port: int = 8080,
+    **_kwargs: object,
+) -> None:
     """
-    Start the Kai service after applying changes and verify it actually
-    registered.
+    Start the Kai service and verify registration plus application readiness.
 
     The platform start commands (`launchctl bootstrap` on macOS,
     `systemctl start` on Linux) do not always report failures
@@ -4178,8 +4422,11 @@ def _start_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
     the daemon was actually unregistered, leaving the operator
     with a silently broken bot.
 
-    The bootstrap/start exit code is now treated as advisory; the
-    authoritative check is the post-condition verify query
+    The bootstrap/start exit code is treated as advisory. Registration is
+    checked through the service manager, then `/health` must report ready core
+    and adapters. On macOS, the health generation must match launchd's wrapper
+    PID so a stale listener cannot satisfy the new service's readiness gate.
+    The service-manager post-condition query is
     (`launchctl print system/<label>` on macOS, `systemctl
     is-active <unit>` on Linux). The cycle is retried up to
     _SERVICE_START_MAX_ATTEMPTS times with a brief settle delay
@@ -4215,6 +4462,8 @@ def _start_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
 
     last_start_stderr = ""
     last_verify_stderr = ""
+    expected_generation: str | None = None
+    registered = False
     for attempt in range(1, _SERVICE_START_MAX_ATTEMPTS + 1):
         # Exit code from the start command is advisory only. The
         # authoritative check is the verify query below.
@@ -4224,8 +4473,17 @@ def _start_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
         time.sleep(_SERVICE_START_SETTLE_SECONDS)
         verify = subprocess.run(verify_cmd, check=False, capture_output=True)
         if verify.returncode == 0:
-            print(f"  Started service ({' '.join(start_cmd[:2])})")
-            return
+            registered = True
+            if platform == "darwin":
+                verify_stdout = (verify.stdout or b"").decode()
+                match = re.search(r"(?m)^\s*pid = ([0-9]+)\s*$", verify_stdout)
+                if match is None:
+                    raise ServiceStartError(
+                        "launchctl registered Kai but did not report a generation PID; "
+                        "readiness cannot be attributed safely"
+                    )
+                expected_generation = match.group(1)
+            break
         # Verify failed. Capture both stderrs for the retry hint and
         # the eventual exhaustion error. Guard with `or b""` so a
         # CompletedProcess with stderr=None (only reachable via test
@@ -4246,18 +4504,31 @@ def _start_service(platform: str, dry_run: bool, **_kwargs: object) -> None:
             )
             time.sleep(_SERVICE_START_RETRY_SECONDS)
 
-    # Retry budget exhausted. Surface both the start stderr and the
-    # verify stderr so the operator sees the authoritative failure
-    # state rather than only the unreliable start exit code.
-    detail = (
-        f"verify command ({' '.join(verify_cmd)}) reported the service is not registered "
-        f"after {_SERVICE_START_MAX_ATTEMPTS} attempts"
+    if not registered:
+        # Retry budget exhausted. Surface both the start stderr and the
+        # verify stderr so the operator sees the authoritative failure
+        # state rather than only the unreliable start exit code.
+        detail = (
+            f"verify command ({' '.join(verify_cmd)}) reported the service is not registered "
+            f"after {_SERVICE_START_MAX_ATTEMPTS} attempts"
+        )
+        if last_verify_stderr:
+            detail += f"; verify stderr: {last_verify_stderr}"
+        if last_start_stderr:
+            detail += f"; last start stderr: {last_start_stderr}"
+        raise ServiceStartError(detail)
+
+    ready, readiness_detail = _wait_for_service_readiness(
+        webhook_port,
+        expected_generation=expected_generation,
     )
-    if last_verify_stderr:
-        detail += f"; verify stderr: {last_verify_stderr}"
-    if last_start_stderr:
-        detail += f"; last start stderr: {last_start_stderr}"
-    raise ServiceStartError(detail)
+    if not ready:
+        generation_detail = f" generation {expected_generation}" if expected_generation is not None else ""
+        raise ServiceStartError(
+            f"registered service{generation_detail} did not become ready within "
+            f"{_SERVICE_READY_TIMEOUT_SECONDS:g}s: {readiness_detail}"
+        )
+    print(f"  Started service ({' '.join(start_cmd[:2])}); readiness confirmed")
 
 
 def _secure_codex_turn_image_staging(data_path: Path, dry_run: bool) -> None:
@@ -5980,7 +6251,10 @@ def _cmd_apply() -> None:
         )
 
     # -- Stop service before making changes --
-    _stop_service(platform, dry_run)
+    try:
+        _stop_service(platform, dry_run)
+    except ServiceStopError as exc:
+        raise SystemExit(f"Service stop failed; no installation changes were made:\n{exc}") from exc
 
     # apply_succeeded is initialized BEFORE the try block so the
     # finally handler can always read it. Several apply-time
@@ -6167,7 +6441,11 @@ def _cmd_apply() -> None:
         # installation is better than an offline bot. Most steps are idempotent,
         # so re-running apply after fixing the cause will complete the update.
         try:
-            _start_service(platform, dry_run)
+            _start_service(
+                platform,
+                dry_run,
+                webhook_port=int(env.get("WEBHOOK_PORT", "8080")),
+            )
         except ServiceStartError as e:
             # Verify confirmed the service is not registered after the
             # retry budget. Two paths:
@@ -7953,7 +8231,11 @@ def _apply_service(
         # Launcher script keeps bash as the tracked PID so launchd can
         # manage the service even when Homebrew Python re-execs.
         launcher_path = Path(install_dir) / "run.sh"
-        launcher_content = _generate_launcher_script(install_dir, webhook_port)
+        launcher_content = _generate_launcher_script(
+            install_dir,
+            webhook_port=webhook_port,
+            data_dir=data_dir,
+        )
 
         if dry_run:
             print(f"[DRY RUN] Would write: {launcher_path}")

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -300,13 +300,39 @@ _MEMORY_BACKUP_INTERVAL = 86400  # 24 hours
 _MEMORY_BACKUP_STARTUP_DELAY = 300
 
 
-# Budget for finishing in-flight memory work at shutdown. Bounded by
-# launchd's SIGTERM-to-SIGKILL grace, which defaults to 20 seconds
-# (ExitTimeOut is not set in the service plist): the drain must fit
-# inside that window alongside adapter teardown and the launcher's
-# port-release wait, or the whole process group is SIGKILLed
-# mid-drain and the warning below never lands in the log.
+# Budget for finishing in-flight memory work at shutdown. The installed
+# launchd wrapper and ExitTimeOut provide a larger bounded generation grace;
+# this inner budget remains deliberately short so memory cannot consume it all.
 _MEMORY_DRAIN_TIMEOUT_S = 10.0
+_LAUNCHER_PARENT_POLL_SECONDS = 0.5
+
+
+def _configured_launcher_pid() -> int | None:
+    """Return the root-owned launcher's generation PID when configured."""
+    raw = os.environ.get("KAI_SERVICE_GENERATION", "").strip()
+    if not raw.isdigit():
+        return None
+    pid = int(raw)
+    return pid if pid > 1 else None
+
+
+async def _watch_launcher_parent(parent_pid: int, stop_requested: asyncio.Event) -> None:
+    """Request graceful shutdown if launchd kills only the wrapper shell."""
+    while not stop_requested.is_set():
+        if os.getppid() != parent_pid:
+            logging.warning(
+                "Kai launcher generation %d disappeared; beginning graceful shutdown",
+                parent_pid,
+            )
+            stop_requested.set()
+            return
+        try:
+            await asyncio.wait_for(
+                stop_requested.wait(),
+                timeout=_LAUNCHER_PARENT_POLL_SECONDS,
+            )
+        except TimeoutError:
+            continue
 
 
 async def _drain_pending_memory_work() -> None:
@@ -499,6 +525,7 @@ def _start() -> None:
         telegram_adapter: TelegramAdapter | None = None
         cleanup_task: asyncio.Task[None] | None = None
         memory_backup_task: asyncio.Task[None] | None = None
+        launcher_watch_task: asyncio.Task[None] | None = None
 
         # Determine the default compatibility user (admin or first user) for
         # legacy per-user migrations. Workshop-only installations may have no
@@ -695,6 +722,11 @@ def _start() -> None:
             # stop, memory drain, db close) actually executes.
             stop_requested = asyncio.Event()
             asyncio.get_running_loop().add_signal_handler(signal.SIGTERM, stop_requested.set)
+            if launcher_pid := _configured_launcher_pid():
+                launcher_watch_task = asyncio.create_task(
+                    _watch_launcher_parent(launcher_pid, stop_requested),
+                    name="kai-launcher-parent-watch",
+                )
             host_supervision = asyncio.create_task(core_host.wait())
             sigterm_wait = asyncio.create_task(stop_requested.wait())
             done, pending = await asyncio.wait(
@@ -716,6 +748,9 @@ def _start() -> None:
                     raise supervision_error
         finally:
             # Shutdown in reverse order of startup
+            if launcher_watch_task is not None:
+                launcher_watch_task.cancel()
+                await asyncio.gather(launcher_watch_task, return_exceptions=True)
             if core_host is not None:
                 try:
                     await core_host.stop()

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -53,6 +53,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import time
 from collections.abc import Callable
@@ -720,6 +721,9 @@ async def _handle_health(request: web.Request) -> web.Response:
         "status": "ok",
         "memory_enabled": memory.is_enabled(),
     }
+    service_generation = os.environ.get("KAI_SERVICE_GENERATION", "").strip()
+    if service_generation.isdigit():
+        response["service_generation"] = service_generation
     host = request.app.get(CORE_HOST_KEY)
     if host is not None:
         response["core"] = host.readiness.as_dict()

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,6 +6,7 @@ import os
 import pwd
 import shutil
 import signal
+import socket
 import sqlite3
 import stat
 import subprocess
@@ -22,6 +23,7 @@ import kai.install
 from kai.install import (
     _LAUNCHD_LABEL,
     ServiceStartError,
+    ServiceStopError,
     _adapter_policy_status,
     _apply_backend_registry,
     _apply_directories,
@@ -36,6 +38,7 @@ from kai.install import (
     _apply_venv,
     _backend_command_trust_issues,
     _build_migrated_runtime_profiles,
+    _capture_darwin_service_generation,
     _check_path,
     _check_service_status,
     _check_traversal,
@@ -47,10 +50,12 @@ from kai.install import (
     _collect_user_memory_owners,
     _copy_managed_home_tree,
     _copy_tree,
+    _DarwinServiceGeneration,
     _deployed_adapter_policy_status,
     _deployed_webhook_secret_migration_status,
     _dormant_compatibility_schedule_status,
     _file_checksum,
+    _finish_stopping_darwin_generation,
     _generate_env_file,
     _generate_launchd_plist,
     _generate_launcher_script,
@@ -63,6 +68,7 @@ from kai.install import (
     _migrate_identity_to_claude_md,
     _migrate_managed_home_database_paths,
     _optional_file_checksum,
+    _probe_service_readiness,
     _prompt_choice,
     _prompt_optional_choice,
     _read_users_yaml_text,
@@ -1154,6 +1160,11 @@ class TestGenerateLaunchdPlist:
         result = _generate_launchd_plist("/opt/kai", "/srv/kai", "kai")
         assert "<string>/srv/kai/logs/kai.stderr.log</string>" in result
         assert "<string>/srv/kai/logs/kai.stdout.log</string>" in result
+
+    def test_exit_timeout_covers_bounded_launcher_shutdown(self):
+        result = _generate_launchd_plist("/opt/kai", "/var/lib/kai", "kai")
+        assert "<key>ExitTimeOut</key>" in result
+        assert "<integer>65</integer>" in result
 
 
 class TestGenerateSystemdUnit:
@@ -7207,22 +7218,53 @@ class TestGitignoreRuntimePreferencesDir:
 
 
 class TestStopService:
+    def test_captures_only_group_leader_launchd_generation(self, monkeypatch):
+        monkeypatch.setattr(
+            "kai.install.subprocess.run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="\tpid = 4321\n",
+            ),
+        )
+        monkeypatch.setattr("kai.install.os.getpgid", lambda pid: pid)
+
+        assert _capture_darwin_service_generation() == _DarwinServiceGeneration(
+            pid=4321,
+            pgid=4321,
+        )
+
+    def test_refuses_non_leader_launchd_generation(self, monkeypatch):
+        monkeypatch.setattr(
+            "kai.install.subprocess.run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="\tpid = 4321\n",
+            ),
+        )
+        monkeypatch.setattr("kai.install.os.getpgid", lambda _pid: 4000)
+
+        with pytest.raises(ServiceStopError, match="expected process group 4321, observed 4000"):
+            _capture_darwin_service_generation()
+
     def test_darwin(self, monkeypatch, tmp_path):
         """Calls launchctl bootout on macOS with system domain."""
         calls: list[list[str]] = []
 
         def mock_run(cmd, **kwargs):
             calls.append(list(cmd))
+            if cmd[:2] == ["launchctl", "print"]:
+                return subprocess.CompletedProcess(args=cmd, returncode=1)
             return subprocess.CompletedProcess(args=cmd, returncode=0)
 
         monkeypatch.setattr("kai.install.subprocess.run", mock_run)
 
         _stop_service("darwin", svc_uid=501, service_user="kai", dry_run=False)
 
-        assert len(calls) == 1
-        assert calls[0][0] == "launchctl"
-        assert calls[0][1] == "bootout"
-        assert calls[0][2] == "system/com.syrinx.kai"
+        assert len(calls) == 2
+        assert calls[0] == ["launchctl", "print", "system/com.syrinx.kai"]
+        assert calls[1] == ["launchctl", "bootout", "system/com.syrinx.kai"]
 
     def test_linux(self, monkeypatch):
         """Calls systemctl stop on Linux."""
@@ -7252,8 +7294,51 @@ class TestStopService:
         assert "[DRY RUN]" in output
         assert len(calls) == 0
 
+    def test_waits_for_complete_verified_generation(self, monkeypatch):
+        generation = _DarwinServiceGeneration(pid=4321, pgid=4321)
+        states = iter((True, True, False))
+        monkeypatch.setattr("kai.install._darwin_generation_alive", lambda _generation: next(states))
+        monkeypatch.setattr("kai.install.time.sleep", lambda _seconds: None)
+
+        _finish_stopping_darwin_generation(generation)
+
+    def test_escalates_only_verified_generation_after_grace(self, monkeypatch):
+        generation = _DarwinServiceGeneration(pid=4321, pgid=4321)
+        states = iter((True, False))
+        signals: list[tuple[int, int]] = []
+        monkeypatch.setattr("kai.install._SERVICE_STOP_GRACE_SECONDS", 0)
+        monkeypatch.setattr("kai.install._darwin_generation_alive", lambda _generation: next(states))
+        monkeypatch.setattr("kai.install.os.killpg", lambda pgid, sig: signals.append((pgid, sig)))
+
+        _finish_stopping_darwin_generation(generation)
+
+        assert signals == [(4321, signal.SIGKILL)]
+
+    def test_refuses_apply_when_bootout_fails_for_live_generation(self, monkeypatch):
+        generation = _DarwinServiceGeneration(pid=4321, pgid=4321)
+        monkeypatch.setattr("kai.install._capture_darwin_service_generation", lambda: generation)
+        monkeypatch.setattr("kai.install._darwin_generation_alive", lambda _generation: True)
+        monkeypatch.setattr(
+            "kai.install.subprocess.run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                args=cmd,
+                returncode=1,
+                stderr=b"bootout failed",
+            ),
+        )
+
+        with pytest.raises(ServiceStopError, match="bootout failed for running generation 4321"):
+            _stop_service("darwin", dry_run=False)
+
 
 class TestStartService:
+    @pytest.fixture(autouse=True)
+    def _ready_service(self, monkeypatch):
+        monkeypatch.setattr(
+            "kai.install._wait_for_service_readiness",
+            lambda _port, *, expected_generation: (True, f"ready:{expected_generation}"),
+        )
+
     def test_darwin(self, monkeypatch):
         """Calls launchctl bootstrap then launchctl print to verify on
         macOS. Two calls per attempt because the bootstrap exit code is
@@ -7262,6 +7347,8 @@ class TestStartService:
 
         def mock_run(cmd, **kwargs):
             calls.append(list(cmd))
+            if cmd[:2] == ["launchctl", "print"]:
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"\tpid = 4321\n")
             return subprocess.CompletedProcess(args=cmd, returncode=0)
 
         monkeypatch.setattr("kai.install.subprocess.run", mock_run)
@@ -7324,7 +7411,7 @@ class TestStartService:
                     returncode=5,
                     stderr=b"Bootstrap failed: 5: Input/output error",
                 )
-            return subprocess.CompletedProcess(args=cmd, returncode=0)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"\tpid = 4321\n")
 
         monkeypatch.setattr("kai.install.subprocess.run", mock_run)
         monkeypatch.setattr("kai.install.time.sleep", lambda _s: None)
@@ -7344,7 +7431,8 @@ class TestStartService:
             if cmd[:2] == ["launchctl", "print"]:
                 verify_calls += 1
                 rc = 0 if verify_calls >= 2 else 1
-                return subprocess.CompletedProcess(args=cmd, returncode=rc)
+                stdout = b"\tpid = 4321\n" if rc == 0 else b""
+                return subprocess.CompletedProcess(args=cmd, returncode=rc, stdout=stdout)
             return subprocess.CompletedProcess(args=cmd, returncode=0)
 
         monkeypatch.setattr("kai.install.subprocess.run", mock_run)
@@ -7406,6 +7494,72 @@ class TestStartService:
             _start_service("linux", svc_uid=1000, service_user="kai", dry_run=False)
 
         assert "systemctl is-active" in str(excinfo.value)
+
+    def test_requires_readiness_from_registered_darwin_generation(self, monkeypatch):
+        observed: list[tuple[int, str | None]] = []
+
+        def mock_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "print"]:
+                return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"\tpid = 9876\n")
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        def not_ready(port: int, *, expected_generation: str | None):
+            observed.append((port, expected_generation))
+            return False, "not ready"
+
+        monkeypatch.setattr("kai.install.subprocess.run", mock_run)
+        monkeypatch.setattr("kai.install.time.sleep", lambda _seconds: None)
+        monkeypatch.setattr("kai.install._wait_for_service_readiness", not_ready)
+
+        with pytest.raises(ServiceStartError, match=r"generation 9876.*did not become ready"):
+            _start_service("darwin", dry_run=False, webhook_port=9090)
+
+        assert observed == [(9090, "9876")]
+
+    def test_refuses_registered_darwin_service_without_generation_pid(self, monkeypatch):
+        monkeypatch.setattr(
+            "kai.install.subprocess.run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"state = running\n"),
+        )
+        monkeypatch.setattr("kai.install.time.sleep", lambda _seconds: None)
+
+        with pytest.raises(ServiceStartError, match="did not report a generation PID"):
+            _start_service("darwin", dry_run=False)
+
+    def test_health_probe_accepts_only_ready_expected_generation(self, monkeypatch):
+        payload = {
+            "status": "ok",
+            "service_generation": "9876",
+            "core": {"ready": True},
+            "adapters": {
+                "http": {"ready": True},
+                "telegram": {"ready": True},
+            },
+        }
+
+        class Response:
+            status = 200
+
+            def read(self, _limit):
+                return json.dumps(payload).encode()
+
+        class Connection:
+            def request(self, _method, _path):
+                return None
+
+            def getresponse(self):
+                return Response()
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr("kai.install.http.client.HTTPConnection", lambda *args, **kwargs: Connection())
+
+        assert _probe_service_readiness(8080, expected_generation="9876") == (True, "ready")
+        assert _probe_service_readiness(8080, expected_generation="1234") == (
+            False,
+            "health belongs to a different service generation",
+        )
 
 
 # ── CLI dispatch ─────────────────────────────────────────────────────
@@ -7690,6 +7844,26 @@ class TestGenerateLauncherScript:
         script = _generate_launcher_script("/opt/kai", webhook_port=9090)
         assert "9090" in script
 
+    def test_records_and_exports_service_generation(self):
+        script = _generate_launcher_script(
+            "/opt/kai",
+            data_dir="/var/lib/kai",
+        )
+        assert 'GENERATION_FILE="/var/lib/kai/.service-generation"' in script
+        assert '[ "$PREVIOUS_GENERATION" -gt 1 ]' in script
+        assert 'export KAI_SERVICE_GENERATION="$$"' in script
+
+    def test_listener_must_belong_to_current_process_group(self):
+        script = _generate_launcher_script("/opt/kai")
+        assert '/bin/ps -o pgid= -p "$CANDIDATE_PID"' in script
+        assert '[ "$CANDIDATE_PGID" = "$$" ]' in script
+
+    def test_shutdown_and_previous_generation_waits_are_bounded(self):
+        script = _generate_launcher_script("/opt/kai")
+        assert "previous generation exceeded shutdown grace" in script
+        assert "generation $$ exceeded shutdown grace" in script
+        assert "kill -KILL" in script
+
     def test_starts_with_shebang(self):
         script = _generate_launcher_script("/opt/kai")
         assert script.startswith("#!/bin/bash")
@@ -7729,7 +7903,7 @@ class TestGenerateLauncherScript:
         script = _generate_launcher_script("/opt/kai")
         assert script.index("trap cleanup TERM INT") < script.index("seq 1 60")
 
-    def test_sigterm_during_bind_poll_tears_down_the_child(self, tmp_path):
+    def test_sigterm_during_bind_poll_tears_down_the_child(self, tmp_path, monkeypatch):
         """Behavioral check on the generated script: SIGTERM arriving
         while the launcher is still polling for the listener must
         tear the spawned python down, not exit the wrapper alone. The
@@ -7749,9 +7923,16 @@ class TestGenerateLauncherScript:
         fake.write_text(f"#!/bin/bash\necho $$ > {pid_file}\nexec sleep 30\n")
         fake.chmod(0o755)
 
+        monkeypatch.setattr("kai.install._LAUNCHER_STARTUP_SHUTDOWN_GRACE_STEPS", 2)
         script_path = tmp_path / "run.sh"
         # Port 1 is never listened on, so the poll cannot succeed.
-        script_path.write_text(_generate_launcher_script(str(tmp_path), webhook_port=1))
+        script_path.write_text(
+            _generate_launcher_script(
+                str(tmp_path),
+                webhook_port=1,
+                data_dir=str(tmp_path),
+            )
+        )
         script_path.chmod(0o755)
 
         # New session mirrors launchd: the wrapper is its own process
@@ -7784,6 +7965,71 @@ class TestGenerateLauncherScript:
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(proc.pid, signal.SIGKILL)
             proc.wait(timeout=5)
+
+    @pytest.mark.skipif(not Path("/usr/sbin/lsof").is_file(), reason="requires macOS lsof path")
+    def test_foreign_listener_is_not_adopted_as_current_generation(self, tmp_path, monkeypatch):
+        with socket.socket() as reservation:
+            reservation.bind(("127.0.0.1", 0))
+            port = reservation.getsockname()[1]
+
+        foreign = subprocess.Popen(
+            [sys.executable, "-m", "http.server", str(port), "--bind", "127.0.0.1"],
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        wrapper: subprocess.Popen | None = None
+        try:
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                        break
+                except OSError:
+                    time.sleep(0.05)
+            else:
+                pytest.fail("foreign listener did not start")
+
+            venv_bin = tmp_path / "venv" / "bin"
+            venv_bin.mkdir(parents=True)
+            fake_pid_file = tmp_path / "fake.pid"
+            fake = venv_bin / "python3"
+            fake.write_text(f"#!/bin/bash\necho $$ > {fake_pid_file}\nexec sleep 30\n")
+            fake.chmod(0o755)
+            monkeypatch.setattr("kai.install._LAUNCHER_STARTUP_SHUTDOWN_GRACE_STEPS", 2)
+            script_path = tmp_path / "run.sh"
+            script_path.write_text(
+                _generate_launcher_script(
+                    str(tmp_path),
+                    webhook_port=port,
+                    data_dir=str(tmp_path),
+                )
+            )
+            script_path.chmod(0o755)
+
+            wrapper = subprocess.Popen(
+                ["/bin/bash", str(script_path)],
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            deadline = time.time() + 5
+            while time.time() < deadline and not fake_pid_file.exists():
+                time.sleep(0.05)
+            assert fake_pid_file.exists()
+
+            wrapper.send_signal(signal.SIGTERM)
+            wrapper.wait(timeout=6)
+            assert foreign.poll() is None
+        finally:
+            if wrapper is not None and wrapper.poll() is None:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(wrapper.pid, signal.SIGKILL)
+                wrapper.wait(timeout=5)
+            if foreign.poll() is None:
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(foreign.pid, signal.SIGKILL)
+            foreign.wait(timeout=5)
 
 
 # ── _apply_source ────────────────────────────────────────────────────

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,15 +23,44 @@ import pytest
 
 from kai.config import UserConfig
 from kai.main import (
+    _configured_launcher_pid,
     _file_age,
     _file_cleanup_loop,
     _memory_backup_loop,
     _warn_if_compatibility_jobs_are_dormant,
+    _watch_launcher_parent,
     _workshop_bootstrap_humans,
     _workshop_bootstrap_notification_channels,
     setup_logging,
 )
 from tests.workshop_profiles import profile_id, profile_registry
+
+
+class TestLauncherParentWatch:
+    def test_configured_launcher_pid_is_strictly_positive(self, monkeypatch):
+        monkeypatch.setenv("KAI_SERVICE_GENERATION", "4321")
+        assert _configured_launcher_pid() == 4321
+
+        for invalid in ("", "not-a-pid", "0", "1", "-2"):
+            monkeypatch.setenv("KAI_SERVICE_GENERATION", invalid)
+            assert _configured_launcher_pid() is None
+
+    async def test_missing_launcher_requests_graceful_shutdown(self, monkeypatch):
+        stop_requested = asyncio.Event()
+        monkeypatch.setattr("kai.main.os.getppid", lambda: 1)
+
+        await _watch_launcher_parent(4321, stop_requested)
+
+        assert stop_requested.is_set()
+
+    async def test_live_launcher_watch_exits_when_shutdown_is_requested(self, monkeypatch):
+        stop_requested = asyncio.Event()
+        monkeypatch.setattr("kai.main.os.getppid", lambda: 4321)
+        task = asyncio.create_task(_watch_launcher_parent(4321, stop_requested))
+
+        await asyncio.sleep(0)
+        stop_requested.set()
+        await task
 
 
 class TestWorkshopBootstrapMapping:

--- a/tests/test_webhook_routes.py
+++ b/tests/test_webhook_routes.py
@@ -98,11 +98,25 @@ def test_workshop_only_omits_telegram_owned_routes() -> None:
 
 async def test_health_reports_non_sensitive_memory_mode(monkeypatch) -> None:
     monkeypatch.setattr("kai.webhook.memory.is_enabled", lambda: True)
+    monkeypatch.delenv("KAI_SERVICE_GENERATION", raising=False)
 
     request = SimpleNamespace(app=web.Application())
     response = await _handle_health(request)  # type: ignore[arg-type]
 
     assert json.loads(response.body) == {"status": "ok", "memory_enabled": True}
+
+
+async def test_health_reports_non_sensitive_service_generation(monkeypatch) -> None:
+    monkeypatch.setattr("kai.webhook.memory.is_enabled", lambda: False)
+    monkeypatch.setenv("KAI_SERVICE_GENERATION", "4321")
+
+    response = await _handle_health(SimpleNamespace(app=web.Application()))  # type: ignore[arg-type]
+
+    assert json.loads(response.body) == {
+        "status": "ok",
+        "memory_enabled": False,
+        "service_generation": "4321",
+    }
 
 
 async def test_health_reports_typed_core_component_readiness(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- treat each macOS launchd wrapper and its descendants as one service generation
- refuse to modify the installation until the verified prior generation exits, with bounded and group-scoped escalation
- prevent a replacement launcher from adopting a listener owned by a stale generation
- make the Python service drain when `launchctl kickstart -k` removes only its wrapper
- require `/health` readiness from the newly registered launchd generation before reporting install success

## Root cause

The launchd wrapper started Python in the background, then inferred the real Python PID from the process listening on the HTTP port. During shutdown, `launchctl bootout` could unregister the wrapper before the draining Python process exited. A replacement wrapper could then observe the old listener, adopt its PID, and report a stale generation as the new service while the actual replacement failed on held resources such as Qdrant or the HTTP port.

## Safety properties

- launchd's reported wrapper PID is accepted for stop escalation only when it is also the process-group leader
- stop escalation targets only that verified process group
- recorded generation IDs must be numeric and greater than 1
- listener discovery accepts only a PID in the current wrapper's process group
- launcher shutdown and predecessor waits are bounded
- health readiness must identify the exact newly registered launchd generation
- a failed stop aborts before installation changes begin

## Validation

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q`
  - 6,121 passed, 1 skipped
- generated launcher validated with Bash syntax checking
- behavioral launcher tests cover pre-bind termination and refusal to adopt a foreign listener

## Installed qualification after merge

1. Run `make install` and confirm it reports service readiness, not merely launchd registration.
2. Confirm `make install-status` reports the service loaded and all Workshop authority checks remain healthy.
3. Send a normal Kai request and confirm the configured backend responds.
4. Restart with `sudo launchctl kickstart -k system/com.syrinx.kai`.
5. Confirm the browser reconnects, Kai responds after restart, and no interrupted-generation message appears for a new request.
6. Verify only one live Kai service generation remains.

Closes #1058
