### PR TITLE
Fix Workshop attribution for scheduled agent runs

### DIFF
--- a/src/kai/workshop/client_events.py
+++ b/src/kai/workshop/client_events.py
@@ -13,6 +13,7 @@ from kai.workshop.timeline import (
     TimelineAccessDeniedError,
     TimelineMessage,
     TimelineResumeError,
+    is_internal_scheduled_invocation,
 )
 
 _MAX_BATCH_SIZE = 100
@@ -158,7 +159,7 @@ async def read_client_channel_events(
         "m.id AS message_id, m.channel_id AS message_channel_id, "
         "m.author_principal_id, p.kind AS author_kind, p.display_name AS author_display_name, "
         "m.reply_to_message_id, m.body, m.created_at AS message_created_at, "
-        "r.id AS run_id "
+        "e.metadata_json AS message_metadata_json, r.id AS run_id "
         "FROM event_log e "
         "LEFT JOIN messages m ON m.created_event_position = e.position "
         "LEFT JOIN principals p ON p.id = m.author_principal_id "
@@ -172,9 +173,16 @@ async def read_client_channel_events(
         rows = list(await cursor.fetchall())
 
     events: list[ClientChannelEvent] = []
+    next_position = after_position
     for row in rows:
         position = int(row["position"])
+        next_position = position
         if row["message_id"] is not None:
+            if is_internal_scheduled_invocation(
+                row["message_metadata_json"],
+                row["author_kind"],
+            ):
+                continue
             events.append(
                 ClientTimelineMessageEvent(
                     TimelineMessage(
@@ -209,5 +217,4 @@ async def read_client_channel_events(
             )
         )
 
-    next_position = events[-1].event_position if events else after_position
     return ClientChannelEventBatch(tuple(events), next_position)

--- a/src/kai/workshop/timeline.py
+++ b/src/kai/workshop/timeline.py
@@ -18,6 +18,9 @@ _CURSOR_PREFIX = "v1."
 _MAX_CURSOR_LENGTH = 512
 _MAX_PAGE_SIZE = 100
 _MAX_SQLITE_INTEGER = 2**63 - 1
+_VISIBLE_MESSAGE_PREDICATE = (
+    "NOT (p.kind = 'human' AND COALESCE(json_extract(e.metadata_json, '$.source'), '') = 'scheduled_job')"
+)
 
 
 class TimelineAccessDeniedError(PermissionError):
@@ -168,6 +171,25 @@ def _parse_timestamp(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
 
 
+def is_internal_scheduled_invocation(metadata_json: object, author_kind: object) -> bool:
+    """Return whether a canonical message is an internal scheduled command.
+
+    Scheduled agent work is represented by a human-authored canonical message
+    so the run keeps durable ownership, context, and audit provenance. That
+    record is not a message the human sent from a client and must not be echoed
+    into client timelines. Scheduled reminders use the same source metadata
+    but are agent-authored user-visible output, so author kind is part of the
+    classification.
+    """
+    if str(author_kind) != "human":
+        return False
+    try:
+        metadata = json.loads(str(metadata_json))
+    except json.JSONDecodeError:
+        return False
+    return isinstance(metadata, dict) and metadata.get("source") == "scheduled_job"
+
+
 def _validate_request(principal_id: PrincipalId, channel_id: ChannelId, limit: int) -> None:
     if not isinstance(principal_id, PrincipalId):
         raise ValueError("principal_id must be a PrincipalId")
@@ -212,20 +234,24 @@ async def _latest_event_position(store: WorkshopEventStore) -> int:
 
 
 def _messages_from_rows(rows: list[aiosqlite.Row]) -> tuple[TimelineMessage, ...]:
-    return tuple(
-        TimelineMessage(
-            message_id=MessageId(str(row[0])),
-            channel_id=ChannelId(str(row[1])),
-            author_principal_id=PrincipalId(str(row[2])),
-            author_kind=str(row[3]),
-            author_display_name=str(row[4]),
-            reply_to_message_id=MessageId(str(row[5])) if row[5] is not None else None,
-            body=str(row[6]),
-            event_position=int(row[7]),
-            created_at=_parse_timestamp(str(row[8])),
+    messages: list[TimelineMessage] = []
+    for row in rows:
+        if is_internal_scheduled_invocation(row[9], row[3]):
+            continue
+        messages.append(
+            TimelineMessage(
+                message_id=MessageId(str(row[0])),
+                channel_id=ChannelId(str(row[1])),
+                author_principal_id=PrincipalId(str(row[2])),
+                author_kind=str(row[3]),
+                author_display_name=str(row[4]),
+                reply_to_message_id=MessageId(str(row[5])) if row[5] is not None else None,
+                body=str(row[6]),
+                event_position=int(row[7]),
+                created_at=_parse_timestamp(str(row[8])),
+            )
         )
-        for row in rows
-    )
+    return tuple(messages)
 
 
 async def _read_forward_page(
@@ -236,10 +262,12 @@ async def _read_forward_page(
 ) -> TimelinePage:
     async with store.connection.execute(
         "SELECT m.id, m.channel_id, m.author_principal_id, p.kind, p.display_name, "
-        "m.reply_to_message_id, m.body, m.created_event_position, m.created_at "
+        "m.reply_to_message_id, m.body, m.created_event_position, m.created_at, e.metadata_json "
         "FROM messages m JOIN principals p ON p.id = m.author_principal_id "
+        "JOIN event_log e ON e.position = m.created_event_position "
         "WHERE m.channel_id = ? AND m.created_event_position > ? "
-        "AND m.created_event_position <= ? ORDER BY m.created_event_position ASC LIMIT ?",
+        f"AND m.created_event_position <= ? AND {_VISIBLE_MESSAGE_PREDICATE} "
+        "ORDER BY m.created_event_position ASC LIMIT ?",
         (channel_id, state.after_position, state.through_position, limit + 1),
     ) as query_cursor:
         rows = list(await query_cursor.fetchall())
@@ -273,10 +301,11 @@ async def _read_tail_page(
     # in event order.
     async with store.connection.execute(
         "SELECT m.id, m.channel_id, m.author_principal_id, p.kind, p.display_name, "
-        "m.reply_to_message_id, m.body, m.created_event_position, m.created_at "
+        "m.reply_to_message_id, m.body, m.created_event_position, m.created_at, e.metadata_json "
         "FROM messages m JOIN principals p ON p.id = m.author_principal_id "
+        "JOIN event_log e ON e.position = m.created_event_position "
         "WHERE m.channel_id = ? AND m.created_event_position < ? "
-        "ORDER BY m.created_event_position DESC LIMIT ?",
+        f"AND {_VISIBLE_MESSAGE_PREDICATE} ORDER BY m.created_event_position DESC LIMIT ?",
         (channel_id, state.before_position, limit + 1),
     ) as query_cursor:
         rows = list(await query_cursor.fetchall())
@@ -380,8 +409,9 @@ async def read_channel_timeline_updates(
 
     async with store.connection.execute(
         "SELECT m.id, m.channel_id, m.author_principal_id, p.kind, p.display_name, "
-        "m.reply_to_message_id, m.body, m.created_event_position, m.created_at "
+        "m.reply_to_message_id, m.body, m.created_event_position, m.created_at, e.metadata_json "
         "FROM messages m JOIN principals p ON p.id = m.author_principal_id "
+        "JOIN event_log e ON e.position = m.created_event_position "
         "WHERE m.channel_id = ? AND m.created_event_position > ? "
         "ORDER BY m.created_event_position ASC LIMIT ?",
         (channel_id, after_position, limit),
@@ -389,5 +419,5 @@ async def read_channel_timeline_updates(
         rows = list(await query_cursor.fetchall())
 
     messages = _messages_from_rows(rows)
-    next_position = messages[-1].event_position if messages else after_position
+    next_position = int(rows[-1][7]) if rows else after_position
     return TimelineUpdateBatch(messages, next_position)

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -14,6 +14,7 @@ import pytest
 from kai import sessions
 from kai.backend import AgentResponse, StreamEvent
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.client_events import ClientTimelineMessageEvent, read_client_channel_events
 from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.domain import ChannelId, PrincipalId, RuntimeProfileId
@@ -31,6 +32,7 @@ from kai.workshop.scheduler import (
     _scheduled_success_outcome,
 )
 from kai.workshop.store import WorkshopEventStore
+from kai.workshop.timeline import read_channel_timeline
 from tests.workshop_profiles import profile_id, profile_registry
 
 
@@ -40,6 +42,12 @@ class _UnusedExecution:
 
 class _UnusedCompatibilityState:
     pass
+
+
+class _AllowRead:
+    async def can_read_channel(self, principal_id: PrincipalId, channel_id: ChannelId) -> bool:
+        del principal_id, channel_id
+        return True
 
 
 class _AgentExecution:
@@ -203,6 +211,16 @@ async def _install_owned_job(
     return store, job_id
 
 
+async def _job_owner(store: WorkshopEventStore, job_id: int) -> tuple[PrincipalId, ChannelId]:
+    async with store.connection.execute(
+        "SELECT principal_id, channel_id FROM workshop_job_owners WHERE job_id = ?",
+        (job_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return PrincipalId(str(row[0])), ChannelId(str(row[1]))
+
+
 @pytest.mark.parametrize(
     ("text", "notify", "expected_body", "expected_delivery", "condition_met"),
     [
@@ -285,6 +303,15 @@ async def test_workshop_only_reminder_fires_canonically_without_delivery(tmp_pat
             firing = await cursor.fetchone()
         assert tuple(firing[:2]) == ("succeeded", 1)
         assert str(firing[2]).startswith("msg_")
+        principal_id, channel_id = await _job_owner(source_store, job_id)
+        page = await read_channel_timeline(
+            source_store,
+            principal_id=principal_id,
+            channel_id=channel_id,
+            authorizer=_AllowRead(),
+        )
+        assert [message.body for message in page.messages] == ["Remember this"]
+        assert [message.author_kind for message in page.messages] == ["agent"]
     finally:
         await scheduler.stop()
         await source_store.close()
@@ -525,6 +552,36 @@ async def test_agent_firing_completes_through_real_canonical_coordinator(
             )
         async with source_store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
             assert (await cursor.fetchone())[0] == 0
+        principal_id, channel_id = await _job_owner(source_store, job_id)
+        page = await read_channel_timeline(
+            source_store,
+            principal_id=principal_id,
+            channel_id=channel_id,
+            authorizer=_AllowRead(),
+            limit=1,
+        )
+        assert [message.body for message in page.messages] == ["[Job: Canonical reminder]\nScheduled agent answer"]
+        hidden_only = await read_client_channel_events(
+            source_store,
+            principal_id=principal_id,
+            channel_id=channel_id,
+            authorizer=_AllowRead(),
+            after_position=0,
+            limit=1,
+        )
+        assert hidden_only.events == ()
+        assert hidden_only.next_position > 0
+        live = await read_client_channel_events(
+            source_store,
+            principal_id=principal_id,
+            channel_id=channel_id,
+            authorizer=_AllowRead(),
+            after_position=0,
+        )
+        visible_messages = [
+            event.message.body for event in live.events if isinstance(event, ClientTimelineMessageEvent)
+        ]
+        assert visible_messages == ["[Job: Canonical reminder]\nScheduled agent answer"]
     finally:
         await scheduler.stop()
         await execution.stop()


### PR DESCRIPTION
## Summary

- keep scheduled agent prompts as canonical run inputs for context and audit provenance
- exclude those internal human-attributed records from loaded and live Workshop client timelines
- preserve agent-authored scheduled reminders as visible messages
- advance live timeline cursors across hidden scheduler records to prevent replay loops

## Validation

- `make test` — 6,083 passed
- `make check`
- `make typecheck`

## Installed qualification

The defect was reproduced during the core-scheduler qualification: the scheduled
agent prompt appeared in Workshop as a new message from the owning human
immediately before the agent result. After merge and install, repeat a one-time
scheduled agent run and confirm that only the agent result appears in Workshop.
