### PR TITLE
Fix Workshop SSE shutdown hang

### DIFF
--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -166,6 +166,7 @@ _webhook_registered: bool = False
 # Each task removes itself from the set via a done callback.
 _background_tasks: set[asyncio.Task] = set()
 _BACKGROUND_TASK_DRAIN_TIMEOUT = 30.0
+_HTTP_RUNNER_SHUTDOWN_TIMEOUT = 5.0
 _telegram_queue_worker_task: asyncio.Task | None = None
 _telegram_queue_worker_active_row_id: int | None = None
 _TELEGRAM_UPDATE_MAX_ATTEMPTS = 5
@@ -2741,7 +2742,11 @@ async def start(
             run_previews=core_services.run_previews,
         )
 
-    _runner = web.AppRunner(_app, access_log=None)
+    _runner = web.AppRunner(
+        _app,
+        access_log=None,
+        shutdown_timeout=_HTTP_RUNNER_SHUTDOWN_TIMEOUT,
+    )
     await _runner.setup()
     # The mixed webhook/internal API application remains loopback-only.  A
     # separately configured LAN listener below receives only Workshop client
@@ -2754,7 +2759,11 @@ async def start(
         assert register_workshop_routes is not None
         workshop_lan_app = web.Application()
         register_workshop_routes(workshop_lan_app)
-        _workshop_lan_runner = web.AppRunner(workshop_lan_app, access_log=None)
+        _workshop_lan_runner = web.AppRunner(
+            workshop_lan_app,
+            access_log=None,
+            shutdown_timeout=_HTTP_RUNNER_SHUTDOWN_TIMEOUT,
+        )
         await _workshop_lan_runner.setup()
         workshop_lan_site = web.TCPSite(
             _workshop_lan_runner,

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -626,6 +626,7 @@ async def _handle_channel_event_stream(
     heartbeat_interval: float,
     authentication_recheck_interval: float,
     stream_limiter: WorkshopEventStreamLimiter,
+    shutdown_event: asyncio.Event,
     run_previews: WorkshopRunPreviewRegistry | None = None,
 ) -> web.StreamResponse:
     try:
@@ -722,7 +723,11 @@ async def _handle_channel_event_stream(
             if now - last_heartbeat >= heartbeat_interval:
                 await response.write(b": keep-alive\n\n")
                 last_heartbeat = now
-            await asyncio.sleep(poll_interval)
+            try:
+                await asyncio.wait_for(shutdown_event.wait(), timeout=poll_interval)
+                break
+            except TimeoutError:
+                pass
 
             reauthenticate = time.monotonic() - last_authentication_check >= authentication_recheck_interval
             _, next_batch = await _authorized_update_batch(
@@ -1090,6 +1095,13 @@ def register_workshop_read_routes(
     if event_poll_interval <= 0 or event_heartbeat_interval <= 0 or event_authentication_recheck_interval <= 0:
         raise ValueError("Event-stream intervals must be positive")
     stream_limiter = event_stream_limiter or WorkshopEventStreamLimiter()
+    shutdown_event = asyncio.Event()
+
+    async def stop_event_streams(_app: web.Application) -> None:
+        """Release persistent SSE requests before aiohttp drains handlers."""
+        shutdown_event.set()
+
+    app.on_shutdown.append(stop_event_streams)
 
     async def handle_channel_timeline(request: web.Request) -> web.Response:
         async with request_lock:
@@ -1117,6 +1129,7 @@ def register_workshop_read_routes(
             heartbeat_interval=event_heartbeat_interval,
             authentication_recheck_interval=event_authentication_recheck_interval,
             stream_limiter=stream_limiter,
+            shutdown_event=shutdown_event,
             run_previews=run_previews,
         )
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2676,11 +2676,13 @@ class TestNotificationChatIdMutations:
         github_notifications = MagicMock(spec=WorkshopTelegramNotificationService)
 
         apps: list[web.Application] = []
+        runner_shutdown_timeouts: list[float] = []
         runners: list[MagicMock] = []
         sites: list[tuple[MagicMock, str, int]] = []
 
-        def fake_runner(app, *, access_log=None):
+        def fake_runner(app, *, access_log=None, shutdown_timeout):
             apps.append(app)
+            runner_shutdown_timeouts.append(shutdown_timeout)
             runner = MagicMock()
             runner.setup = AsyncMock()
             runner.cleanup = AsyncMock()
@@ -2710,6 +2712,10 @@ class TestNotificationChatIdMutations:
                 ("10.0.0.36", 8080),
             ]
             assert len(apps) == 2
+            assert runner_shutdown_timeouts == [
+                wh._HTTP_RUNNER_SHUTDOWN_TIMEOUT,
+                wh._HTTP_RUNNER_SHUTDOWN_TIMEOUT,
+            ]
             lan_paths = {resource.canonical for resource in apps[1].router.resources()}
             assert lan_paths == {
                 "/v1/client/enrollment/redeem",

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -1108,6 +1108,34 @@ class TestWorkshopTimelineEventStreamHTTPContract:
             await client.close()
             await store.close()
 
+    async def test_server_shutdown_closes_an_open_event_stream_promptly(self, tmp_path: Path):
+        store, alice_id, alice_channel, _, _ = await _open_store(tmp_path / "kai.db")
+        limiter = WorkshopEventStreamLimiter(per_principal_limit=1, global_limit=1)
+        client = await _open_client(
+            store,
+            _Authenticator({"alice-token": alice_id}),
+            event_poll_interval=30.0,
+            event_heartbeat_interval=30.0,
+            event_stream_limiter=limiter,
+        )
+        response = None
+        try:
+            response = await client.get(
+                f"/v1/channels/{alice_channel}/events",
+                headers={"Authorization": "Bearer alice-token"},
+            )
+            assert await response.content.readline() == b": connected\n"
+
+            await asyncio.wait_for(client.server.close(), timeout=1.0)
+
+            assert limiter.acquire(alice_id) is True
+            limiter.release(alice_id)
+        finally:
+            if response is not None:
+                response.close()
+            await client.close()
+            await store.close()
+
     async def test_unauthenticated_event_stream_is_rejected_before_input_or_storage(self, tmp_path: Path):
         store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
         client = await _open_client(store, _Authenticator({"alice-token": alice_id}))


### PR DESCRIPTION
## Summary

- signal active Workshop SSE handlers when their aiohttp application begins shutdown
- let persistent event streams exit promptly and release their capacity slots
- bound each HTTP runner's defensive graceful-request timeout below the service-generation watchdog
- cover shutdown with a real server holding an otherwise 30-second-idle SSE connection open

## Why

An open Workshop browser keeps a persistent SSE request active. During service shutdown, aiohttp waited its default 60-second handler timeout, while Kai's verified generation guard escalated to SIGKILL after 65 seconds. Installs and kickstarts therefore appeared hung and the old process did not complete its cleanup path.

## Validation

- `6084 passed in 73.62s`
- `make check`
- `make typecheck`
- focused HTTP/Workshop suite: `315 passed`
- real-server SSE shutdown regression completes in under one second
