### PR TITLE
Close semantic memory cleanly during shutdown

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -372,6 +372,18 @@ async def _drain_pending_memory_work() -> None:
     )
 
 
+def _close_semantic_memory() -> None:
+    """Release Mem0/Qdrant resources and always clear canonical authority."""
+    from kai.memory import close_memory, configure_memory_authority
+
+    try:
+        close_memory()
+    except Exception:
+        logging.exception("Semantic memory stopped with an error")
+    finally:
+        configure_memory_authority(None)
+
+
 async def _memory_backup_loop() -> None:
     """
     Nightly snapshot of the semantic memory corpus.
@@ -754,9 +766,7 @@ def _start() -> None:
                 await _drain_pending_memory_work()
             except Exception:
                 logging.exception("Shutdown memory drain failed")
-            from kai.memory import configure_memory_authority
-
-            configure_memory_authority(None)
+            _close_semantic_memory()
             await sessions.close_db()
 
     try:

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1591,6 +1591,54 @@ def init_offline_memory(config: Config) -> None:
     init_memory(config)
 
 
+def _close_memory_instance(memory: object) -> None:
+    """Close every independently owned resource behind one Mem0 instance."""
+    errors: list[Exception] = []
+    close = getattr(memory, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception as exc:
+            errors.append(exc)
+
+    closed_clients: set[int] = set()
+    for attribute in ("vector_store", "_telemetry_vector_store"):
+        store = getattr(memory, attribute, None)
+        client = getattr(store, "client", None)
+        client_close = getattr(client, "close", None)
+        if client is None or not callable(client_close) or id(client) in closed_clients:
+            continue
+        closed_clients.add(id(client))
+        try:
+            client_close()
+        except Exception as exc:
+            errors.append(exc)
+
+    if errors:
+        raise ExceptionGroup("Semantic memory shutdown failed", errors)
+
+
+def close_memory() -> None:
+    """Close the process-owned Mem0 singleton and release embedded-store locks.
+
+    Mem0's public ``close()`` closes its history database but leaves both
+    Qdrant clients open. The primary and telemetry clients independently own
+    SQLite connections and local-storage locks, so production shutdown must
+    close all three resources explicitly. Singleton state is cleared first
+    to make repeated teardown safe even when one close operation fails.
+    """
+    global _memory, _config
+
+    memory = _memory
+    _memory = None
+    _config = None
+    if memory is None:
+        return
+
+    _close_memory_instance(memory)
+    log.info("Memory system stopped")
+
+
 def init_memory(config: Config, *, store_dir: Path | None = None) -> None:
     """
     Initialize the Mem0 memory instance with Qdrant embedded storage.
@@ -1815,19 +1863,27 @@ def init_memory(config: Config, *, store_dir: Path | None = None) -> None:
     mem0_cfg = _mem0_config(config, store_dir)
     m = Memory.from_config(mem0_cfg)
 
-    # Construction is the moment the store's files all exist
-    # (qdrant meta/collection tree, history db, mem0's migrations
-    # store), so tighten before anything else can run; deliberately
-    # ahead of the dims-mismatch bailout below so even that early
-    # return leaves the tree owner-only.
-    _tighten_store_permissions(store_dir if store_dir is not None else DATA_DIR / "memory")
+    try:
+        # Construction is the moment the store's files all exist
+        # (qdrant meta/collection tree, history db, mem0's migrations
+        # store), so tighten before anything else can run; deliberately
+        # ahead of the dims-mismatch bailout below so even that early
+        # return leaves the tree owner-only.
+        _tighten_store_permissions(store_dir if store_dir is not None else DATA_DIR / "memory")
 
-    # Validate that the embedding model's output dimensions match the
-    # hardcoded 384 in the Qdrant config. A mismatch means the user
-    # configured a different model via MEMORY_EMBEDDING_MODEL but the
-    # Qdrant collection was created for 384-dim vectors. Catch this at
-    # startup rather than getting cryptic Qdrant errors at first use.
-    actual_dims = m.embedding_model.model.get_embedding_dimension()
+        # Validate that the embedding model's output dimensions match the
+        # hardcoded 384 in the Qdrant config. A mismatch means the user
+        # configured a different model via MEMORY_EMBEDDING_MODEL but the
+        # Qdrant collection was created for 384-dim vectors. Catch this at
+        # startup rather than getting cryptic Qdrant errors at first use.
+        actual_dims = m.embedding_model.model.get_embedding_dimension()
+    except BaseException:
+        _config = None
+        try:
+            _close_memory_instance(m)
+        except Exception:
+            log.exception("Could not close semantic memory after initialization failed")
+        raise
     if actual_dims != 384:
         log.error(
             "Embedding model '%s' outputs %d dimensions but Qdrant "
@@ -1838,6 +1894,10 @@ def init_memory(config: Config, *, store_dir: Path | None = None) -> None:
             actual_dims,
         )
         _config = None
+        try:
+            _close_memory_instance(m)
+        except Exception:
+            log.exception("Could not close semantic memory after dimension validation failed")
         return
 
     _memory = m

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,12 +17,13 @@ from datetime import UTC, datetime
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from kai.config import UserConfig
 from kai.main import (
+    _close_semantic_memory,
     _configured_launcher_pid,
     _file_age,
     _file_cleanup_loop,
@@ -778,3 +779,31 @@ class TestDrainPendingMemoryWork:
             await _drain_pending_memory_work()
 
         assert "Draining" not in caplog.text
+
+
+class TestCloseSemanticMemory:
+    def test_closes_memory_before_clearing_authority(self):
+        events: list[str] = []
+
+        with (
+            patch("kai.memory.close_memory", side_effect=lambda: events.append("close")),
+            patch(
+                "kai.memory.configure_memory_authority",
+                side_effect=lambda registry: events.append(f"authority:{registry}"),
+            ),
+        ):
+            _close_semantic_memory()
+
+        assert events == ["close", "authority:None"]
+
+    def test_close_failure_is_logged_and_authority_is_still_cleared(self, caplog):
+        configure = MagicMock()
+        with (
+            patch("kai.memory.close_memory", side_effect=RuntimeError("close failed")),
+            patch("kai.memory.configure_memory_authority", configure),
+            caplog.at_level(logging.ERROR),
+        ):
+            _close_semantic_memory()
+
+        configure.assert_called_once_with(None)
+        assert "Semantic memory stopped with an error" in caplog.text

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -82,32 +82,10 @@ def _reset_memory_module():
 
 
 def _close_init_memory() -> None:
-    """Close the singleton Memory created by a `TestInitMemory` test.
-
-    Mem0's own `close()` only closes the history SQLite db. The
-    Qdrant `vector_store` and `_telemetry_vector_store` hold separate
-    `QdrantClient` instances that own SQLite connections and embedded
-    storage locks; both need explicit `client.close()`. Each step is
-    wrapped in try/except because we may be tearing down a half-init
-    object and individual cleanup failures must not stop later steps.
-    """
+    """Close the singleton Memory created by a `TestInitMemory` test."""
     import kai.memory as mem_mod
 
-    memory = mem_mod._memory
-    if memory is None:
-        return
-    try:
-        memory.close()
-    except Exception:
-        pass
-    for attr in ("vector_store", "_telemetry_vector_store"):
-        store = getattr(memory, attr, None)
-        client = getattr(store, "client", None)
-        if client is not None and hasattr(client, "close"):
-            try:
-                client.close()
-            except Exception:
-                pass
+    mem_mod.close_memory()
 
 
 # ── Fixtures ────────────────────────────────────────────────────────
@@ -460,6 +438,49 @@ class TestInitMemory:
         init_memory(config)
         assert not is_enabled()
 
+    def test_close_releases_all_owned_resources_and_is_idempotent(self):
+        import kai.memory as mem_mod
+
+        primary_client = MagicMock()
+        telemetry_client = MagicMock()
+        memory = MagicMock(
+            vector_store=SimpleNamespace(client=primary_client),
+            _telemetry_vector_store=SimpleNamespace(client=telemetry_client),
+        )
+        mem_mod._memory = memory
+        mem_mod._config = _make_config()
+
+        mem_mod.close_memory()
+        mem_mod.close_memory()
+
+        memory.close.assert_called_once_with()
+        primary_client.close.assert_called_once_with()
+        telemetry_client.close.assert_called_once_with()
+        assert mem_mod._memory is None
+        assert mem_mod._config is None
+
+    def test_close_attempts_every_resource_and_clears_state_after_errors(self):
+        import kai.memory as mem_mod
+
+        primary_client = MagicMock()
+        telemetry_client = MagicMock()
+        memory = MagicMock(
+            vector_store=SimpleNamespace(client=primary_client),
+            _telemetry_vector_store=SimpleNamespace(client=telemetry_client),
+        )
+        memory.close.side_effect = RuntimeError("history close failed")
+        primary_client.close.side_effect = RuntimeError("primary close failed")
+        mem_mod._memory = memory
+        mem_mod._config = _make_config()
+
+        with pytest.raises(ExceptionGroup) as exc_info:
+            mem_mod.close_memory()
+
+        assert len(exc_info.value.exceptions) == 2
+        telemetry_client.close.assert_called_once_with()
+        assert mem_mod._memory is None
+        assert mem_mod._config is None
+
     def test_init_disabled_emits_config_log_with_null_fields(self, caplog):
         """Even when memory is disabled, init_memory emits exactly
         one structured `memory.config` log so an operator scanning
@@ -687,6 +708,18 @@ class TestInitMemory:
         assert is_enabled()
 
     @integration
+    def test_close_releases_qdrant_for_immediate_reinitialization(self, tmp_path):
+        from kai.memory import close_memory, init_memory, is_enabled
+
+        config = _make_config()
+        with patch("kai.memory.DATA_DIR", tmp_path):
+            init_memory(config)
+            close_memory()
+            init_memory(config)
+
+        assert is_enabled()
+
+    @integration
     def test_init_failure_propagates(self):
         """If Mem0 raises during init, the exception propagates and memory stays disabled."""
         from kai.memory import init_memory, is_enabled
@@ -739,6 +772,28 @@ class TestInitMemory:
 
         # Should be disabled due to dimension mismatch
         assert not is_enabled()
+        mock_memory.close.assert_called_once_with()
+        mock_memory.vector_store.client.close.assert_called_once_with()
+        mock_memory._telemetry_vector_store.client.close.assert_called_once_with()
+
+    @integration
+    def test_post_construction_init_failure_closes_all_resources(self, tmp_path):
+        from kai.memory import init_memory, is_enabled
+
+        mock_memory = MagicMock()
+        mock_memory.embedding_model.model.get_embedding_dimension.side_effect = RuntimeError("dimension failed")
+
+        with (
+            patch("kai.memory.DATA_DIR", tmp_path),
+            patch("mem0.Memory.from_config", return_value=mock_memory),
+            pytest.raises(RuntimeError, match="dimension failed"),
+        ):
+            init_memory(_make_config())
+
+        assert not is_enabled()
+        mock_memory.close.assert_called_once_with()
+        mock_memory.vector_store.client.close.assert_called_once_with()
+        mock_memory._telemetry_vector_store.client.close.assert_called_once_with()
 
 
 class TestSearch:


### PR DESCRIPTION
## Summary

- explicitly close Mem0's history database plus its primary and telemetry Qdrant clients during daemon shutdown
- clear singleton state before teardown so repeated or partially failing cleanup remains safe
- release constructed memory resources when post-construction initialization fails or rejects an embedding dimension
- replace the test suite's private cleanup workaround with the production lifecycle API

## Why

After the Workshop SSE shutdown fix, Kai exited promptly but Python emitted two `QdrantClient.__del__` exceptions during interpreter teardown. Mem0 2.x closes its history database but leaves two independently owned local Qdrant clients open. Production therefore relied on garbage collection to release SQLite connections and embedded-store locks.

## Validation

- `6090 passed in 73.18s`
- `301 passed` across the complete memory and main lifecycle suites
- real Mem0/Qdrant integration test closes and immediately reopens the same embedded store without garbage collection
- `make check`
- `make typecheck`
