### PR TITLE
Explain installer startup readiness waits

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -4460,6 +4460,8 @@ def _start_service(
         print(f"[DRY RUN] Would run: {' '.join(start_cmd)}")
         return
 
+    print(f"  Starting service ({' '.join(start_cmd[:2])})...")
+
     last_start_stderr = ""
     last_verify_stderr = ""
     expected_generation: str | None = None
@@ -4518,6 +4520,10 @@ def _start_service(
             detail += f"; last start stderr: {last_start_stderr}"
         raise ServiceStartError(detail)
 
+    print(
+        "  Service registered; waiting for full application readiness "
+        f"(including configured semantic memory, up to {_SERVICE_READY_TIMEOUT_SECONDS:g}s)..."
+    )
     ready, readiness_detail = _wait_for_service_readiness(
         webhook_port,
         expected_generation=expected_generation,

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7338,7 +7338,7 @@ class TestStartService:
             lambda _port, *, expected_generation: (True, f"ready:{expected_generation}"),
         )
 
-    def test_darwin(self, monkeypatch):
+    def test_darwin(self, monkeypatch, capsys):
         """Calls launchctl bootstrap then launchctl print to verify on
         macOS. Two calls per attempt because the bootstrap exit code is
         treated as advisory; verify is the authoritative check."""
@@ -7358,8 +7358,14 @@ class TestStartService:
         assert len(calls) == 2
         assert calls[0][:3] == ["launchctl", "bootstrap", "system"]
         assert calls[1] == ["launchctl", "print", "system/com.syrinx.kai"]
+        output = capsys.readouterr().out
+        assert "Starting service (launchctl bootstrap)..." in output
+        assert (
+            "Service registered; waiting for full application readiness "
+            "(including configured semantic memory, up to 120s)..."
+        ) in output
 
-    def test_linux(self, monkeypatch):
+    def test_linux(self, monkeypatch, capsys):
         """Calls systemctl start then systemctl is-active to verify on
         Linux. Mirrors the macOS verify-after-start shape so an
         operator does not see different success contracts per platform."""
@@ -7378,6 +7384,9 @@ class TestStartService:
             ["systemctl", "start", "kai"],
             ["systemctl", "is-active", "kai"],
         ]
+        output = capsys.readouterr().out
+        assert "Starting service (systemctl start)..." in output
+        assert "including configured semantic memory, up to 120s" in output
 
     def test_dry_run(self, monkeypatch, capsys):
         """Dry run prints the command without executing."""
@@ -7391,6 +7400,8 @@ class TestStartService:
 
         output = capsys.readouterr().out
         assert "[DRY RUN]" in output
+        assert "Starting service" not in output
+        assert "waiting for full application readiness" not in output
         assert len(calls) == 0
 
     def test_succeeds_when_bootstrap_returns_nonzero_but_verify_passes(self, monkeypatch):


### PR DESCRIPTION
## Summary

- announce when the installer begins the service-manager startup phase
- announce when registration is complete and Kai is waiting for full application readiness
- identify configured semantic-memory initialization and the 120-second readiness ceiling in operator output

## Why

After the installer writes the service definition, launchd startup and local semantic-memory initialization can leave the terminal silent for tens of seconds. The readiness gate is intentional and should remain authoritative, but the silence makes a healthy installation look stalled.

## Validation

- `6090 passed in 73.60s`
- `10 passed` for the focused cross-platform service-start tests
- `make check`
- `make typecheck`
