### PR TITLE
Fix Workshop artifact previews blocked by CSP

### DIFF
--- a/src/kai/workshop/client_shell.py
+++ b/src/kai/workshop/client_shell.py
@@ -19,7 +19,8 @@ _DOCUMENT_CSP = "; ".join(
         "base-uri 'none'",
         "form-action 'self'",
         "frame-ancestors 'none'",
-        "img-src 'none'",
+        "img-src blob:",
+        "media-src blob:",
         "font-src 'none'",
     )
 )

--- a/tests/test_workshop_client_shell.py
+++ b/tests/test_workshop_client_shell.py
@@ -26,11 +26,20 @@ class TestWorkshopClientShell:
             assert response.status == 200
             assert response.content_type == "text/html"
             assert response.headers["Cache-Control"] == "private, no-store"
-            assert "default-src 'none'" in response.headers["Content-Security-Policy"]
-            assert "script-src 'self'" in response.headers["Content-Security-Policy"]
-            assert "style-src 'self'" in response.headers["Content-Security-Policy"]
-            assert "connect-src 'self'" in response.headers["Content-Security-Policy"]
-            assert "frame-ancestors 'none'" in response.headers["Content-Security-Policy"]
+            assert response.headers["Content-Security-Policy"] == "; ".join(
+                (
+                    "default-src 'none'",
+                    "script-src 'self'",
+                    "style-src 'self'",
+                    "connect-src 'self'",
+                    "base-uri 'none'",
+                    "form-action 'self'",
+                    "frame-ancestors 'none'",
+                    "img-src blob:",
+                    "media-src blob:",
+                    "font-src 'none'",
+                )
+            )
             assert response.headers["Cross-Origin-Opener-Policy"] == "same-origin"
             assert response.headers["Cross-Origin-Resource-Policy"] == "same-origin"
             assert response.headers["Referrer-Policy"] == "no-referrer"


### PR DESCRIPTION
## Summary

- allow Workshop image previews to render from authenticated `blob:` URLs
- allow the existing audio preview path to use authenticated `blob:` URLs
- retain the shell's deny-by-default content security policy and pin the full policy in a regression test

## Security

- permits only `blob:` sources for `img-src` and `media-src`
- does not permit `data:`, `http:`, `https:`, `file:`, or cross-origin preview sources
- leaves artifact download authorization and artifact-response headers unchanged

## Validation

- `make client-check check-install-constraints check typecheck test`
- 44 client tests passed and the client production build completed
- 6,104 Python tests passed
- install constraints, Ruff, and Pyright passed

## Installed qualification

After merge and install, hard-refresh Workshop and confirm that an uploaded image renders inline while its download still works.

Closes #1069
