### PR TITLE
feat: add canonical Workshop memory query API

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -20,6 +20,7 @@ from kai.workshop.delivery_authority import (
     WorkshopConversationDeliveryAuthority,
 )
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
+from kai.workshop.memory_queries import WorkshopMemoryQueryService
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.run_previews import WorkshopRunPreviewRegistry
 from kai.workshop.runtime_pool import WorkshopRuntimePool
@@ -108,6 +109,7 @@ class KaiCoreServices:
     scheduler: WorkshopCanonicalScheduler
     artifacts: WorkshopArtifactService
     settings_workspaces: WorkshopSettingsWorkspaceService
+    memory_queries: WorkshopMemoryQueryService
 
 
 class KaiApplicationHost:
@@ -219,6 +221,12 @@ class KaiApplicationHost:
                 runtime_pool,
                 self._execution_state,
             )
+            memory_queries = WorkshopMemoryQueryService(
+                self._config,
+                client_store,
+                runtime_pool,
+                self._execution_state,
+            )
 
             self._services = KaiCoreServices(
                 subprocess_pool=subprocess_pool,
@@ -234,6 +242,7 @@ class KaiApplicationHost:
                 scheduler=scheduler,
                 artifacts=artifacts,
                 settings_workspaces=settings_workspaces,
+                memory_queries=memory_queries,
             )
             self._state = KaiApplicationState.READY
             return self._services

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -1458,6 +1458,18 @@ def _scoped_memory_admission_reason(
     return _ADMISSION_UNKNOWN_SCOPE
 
 
+def memory_scope_admission_reason(
+    resolved_scope: ResolvedMemoryScope,
+    *,
+    allowed_project_id: str | None,
+) -> str | None:
+    """Expose the production scope-admission decision to trusted services."""
+    return _scoped_memory_admission_reason(
+        resolved_scope,
+        allowed_project_id=allowed_project_id,
+    )
+
+
 def _estimate_tokens(text: str) -> int:
     """Rough token count: ~4 chars per token for English text."""
     return len(text) // 4
@@ -2086,6 +2098,34 @@ def _format_memory_result_line(
     if outcome_quality is not None:
         record["outcome_quality"] = outcome_quality
     return encode_untrusted_json_record(record)
+
+
+def format_memory_result_for_recall(
+    result: MemoryResult,
+    *,
+    resolved_scope: ResolvedMemoryScope | None = None,
+    speaker: str | None = None,
+    confidence: float | None = None,
+) -> str:
+    """Return the exact compact record used by live memory recall.
+
+    Workshop read APIs use this public boundary instead of duplicating the
+    prompt-facing representation. The returned string remains untrusted data;
+    callers must not treat it as instructions.
+    """
+    return _format_memory_result_line(
+        result,
+        resolved_scope=resolved_scope,
+        speaker=speaker,
+        confidence=confidence,
+    )
+
+
+def read_time_memory_speaker(
+    metadata: dict[str, Any] | None,
+) -> tuple[str, float]:
+    """Expose the shared read-time speaker/confidence interpretation."""
+    return _read_time_speaker(metadata)
 
 
 async def format_context(

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -95,6 +95,7 @@ from kai.workshop.client_sessions import (
 )
 from kai.workshop.client_shell import register_workshop_shell_routes
 from kai.workshop.github_notifications import GitHubNotification
+from kai.workshop.memory_queries import WorkshopMemoryQueryService
 from kai.workshop.run_previews import WorkshopRunPreviewRegistry
 from kai.workshop.scheduler import WorkshopCanonicalScheduler
 from kai.workshop.settings_workspaces import WorkshopSettingsWorkspaceService
@@ -2579,6 +2580,7 @@ async def _register_workshop_client_api(
     run_previews: WorkshopRunPreviewRegistry | None = None,
     artifact_service: WorkshopArtifactService | None = None,
     settings_workspaces: WorkshopSettingsWorkspaceService | None = None,
+    memory_queries: WorkshopMemoryQueryService | None = None,
 ) -> Callable[[web.Application], None]:
     """Register the client API against the core-owned canonical store.
 
@@ -2612,6 +2614,7 @@ async def _register_workshop_client_api(
             run_previews=run_previews,
             artifact_service=artifact_service,
             settings_workspaces=settings_workspaces,
+            memory_queries=memory_queries,
         )
         if command_submitter is not None:
             register_workshop_command_routes(
@@ -2749,6 +2752,7 @@ async def start(
             run_previews=core_services.run_previews,
             artifact_service=core_services.artifacts,
             settings_workspaces=core_services.settings_workspaces,
+            memory_queries=core_services.memory_queries,
         )
 
     _runner = web.AppRunner(

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -42,6 +42,21 @@ from kai.workshop.conversation_commands import ConversationCommandAcceptanceErro
 from kai.workshop.domain import ArtifactId, ChannelId, PrincipalId, RunId
 from kai.workshop.execution_coordinator import CanonicalCancellationDisposition
 from kai.workshop.inbound import ClientInboundMessage, InboundBindingNotFoundError
+from kai.workshop.memory_queries import (
+    DEFAULT_PAGE_SIZE,
+    MemoryQueryAuthority,
+    MemoryQueryFilters,
+    MemoryRecordDetail,
+    MemoryRecordSummary,
+    MemorySourceContext,
+    MemorySourceMessage,
+    WorkshopMemoryAccessDenied,
+    WorkshopMemoryNotFound,
+    WorkshopMemoryQueryError,
+    WorkshopMemoryQueryService,
+    WorkshopMemoryResponseTooLarge,
+    WorkshopMemoryValidationError,
+)
 from kai.workshop.run_lifecycle import DurableRun, RunNotFoundError, RunStatus
 from kai.workshop.run_previews import RunPreview, WorkshopRunPreviewRegistry
 from kai.workshop.settings_workspaces import (
@@ -74,8 +89,16 @@ _RUN_CANCELLATION_PATH = "/v1/channels/{channel_id}/runs/{run_id}/cancel"
 _RUNTIME_SETTINGS_PATH = "/v1/channels/{channel_id}/settings"
 _ACTIVE_WORKSPACE_PATH = "/v1/channels/{channel_id}/workspace"
 _WORKSPACE_CONFIG_PATH = "/v1/channels/{channel_id}/workspace-config"
+_MEMORY_STATS_PATH = "/v1/memory/stats"
+_MEMORY_RECORDS_PATH = "/v1/memory/records"
+_MEMORY_SEARCH_PATH = "/v1/memory/search"
+_MEMORY_DETAIL_PATH = "/v1/memory/records/{memory_id}"
+_MEMORY_SOURCE_PATH = "/v1/memory/records/{memory_id}/source"
 _ALLOWED_TIMELINE_QUERY_PARAMETERS = frozenset({"cursor", "limit", "tail"})
 _ALLOWED_EVENT_QUERY_PARAMETERS = frozenset({"after_position"})
+_ALLOWED_MEMORY_FILTERS = frozenset({"kind", "source", "memory_type", "tag", "scope", "project_id"})
+_ALLOWED_MEMORY_LIST_PARAMETERS = _ALLOWED_MEMORY_FILTERS | {"cursor", "limit"}
+_ALLOWED_MEMORY_SEARCH_PARAMETERS = _ALLOWED_MEMORY_FILTERS | {"q", "limit"}
 _ENROLLMENT_REQUEST_FIELDS = frozenset({"enrollment_token", "device_display_name"})
 _COMMAND_REQUEST_FIELDS = frozenset({"client_message_id", "body"})
 _SETTINGS_REQUEST_FIELDS = frozenset({"model", "timeout_seconds", "reset"})
@@ -174,6 +197,251 @@ def _serialize_workspace_config(
         "prompt_source": snapshot.prompt_source,
         "override_fields": list(snapshot.override_fields),
     }
+
+
+def _serialize_memory_record(record: MemoryRecordSummary) -> dict[str, object]:
+    return {
+        "memory_id": record.memory_id,
+        "kind": record.kind,
+        "source": record.source,
+        "memory_type": record.memory_type,
+        "preview": record.preview,
+        "tags": list(record.tags),
+        "speaker": record.speaker,
+        "confidence": record.confidence,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+        "scope": {
+            "scope": record.scope.scope,
+            "project_id": record.scope.project_id,
+            "scope_confidence": record.scope.scope_confidence,
+            "scope_source": record.scope.scope_source,
+            "legacy_defaulted": record.scope.legacy_defaulted,
+            "invalid_defaulted": record.scope.invalid_defaulted,
+            "retrievable": record.scope.retrievable,
+            "exclusion_reason": record.scope.exclusion_reason,
+        },
+    }
+
+
+def _serialize_memory_detail(detail: MemoryRecordDetail) -> dict[str, object]:
+    return {
+        **_serialize_memory_record(detail.record),
+        "content": detail.content,
+        "compact_recall": detail.compact_recall,
+        "confirmation_quote": detail.confirmation_quote,
+        "prompt_version": detail.prompt_version,
+        "episode": detail.episode,
+    }
+
+
+def _serialize_memory_source(context: MemorySourceContext) -> dict[str, object]:
+    def serialize_message(message: MemorySourceMessage | None) -> dict[str, object] | None:
+        if message is None:
+            return None
+        return {
+            "message_id": str(message.message_id),
+            "channel_id": str(message.channel_id),
+            "author_principal_id": str(message.author_principal_id),
+            "author_kind": message.author_kind,
+            "author_display_name": message.author_display_name,
+            "body": message.body,
+            "created_at": message.created_at,
+        }
+
+    return {
+        "status": context.status,
+        "reason": context.reason,
+        "run_id": str(context.run_id) if context.run_id is not None else None,
+        "source": serialize_message(context.source),
+        "result": serialize_message(context.result),
+    }
+
+
+def _memory_filters(request: web.Request) -> MemoryQueryFilters:
+    values: dict[str, str | None] = {}
+    for field in _ALLOWED_MEMORY_FILTERS:
+        values[field] = _single_query_value(request, field)
+    return MemoryQueryFilters(**values)
+
+
+def _memory_limit(request: web.Request, *, default: int) -> int:
+    raw = _single_query_value(request, "limit")
+    if raw is None:
+        return default
+    if not _DECIMAL_INTEGER.fullmatch(raw):
+        raise WorkshopMemoryValidationError("Invalid memory limit")
+    return int(raw)
+
+
+async def _memory_authority(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopMemoryQueryService,
+) -> tuple[MemoryQueryAuthority | None, web.Response | None]:
+    principal_id = await authenticator.authenticate(request)
+    if not isinstance(principal_id, PrincipalId):
+        response = _error_response(
+            status=401,
+            code="authentication_required",
+            message="Authentication required",
+        )
+        response.headers["WWW-Authenticate"] = "Bearer"
+        return None, response
+    try:
+        return service.authority_for_principal(principal_id), None
+    except WorkshopMemoryAccessDenied:
+        return None, _error_response(
+            status=403,
+            code="access_denied",
+            message="Access denied",
+        )
+
+
+def _memory_error_response(exc: Exception) -> web.Response:
+    if isinstance(exc, WorkshopMemoryNotFound):
+        return _error_response(status=404, code="memory_not_found", message="Memory not found")
+    if isinstance(exc, WorkshopMemoryResponseTooLarge):
+        return _error_response(status=413, code="response_too_large", message=str(exc))
+    if isinstance(exc, WorkshopMemoryAccessDenied):
+        return _error_response(status=403, code="access_denied", message="Access denied")
+    if isinstance(exc, WorkshopMemoryValidationError):
+        return _error_response(status=400, code="invalid_memory_query", message=str(exc))
+    return _error_response(
+        status=400,
+        code="invalid_memory_query",
+        message="Invalid memory query",
+    )
+
+
+async def _handle_memory_stats(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopMemoryQueryService,
+) -> web.Response:
+    authority, error = await _memory_authority(request, authenticator=authenticator, service=service)
+    if error is not None:
+        return error
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid memory request")
+    assert authority is not None
+    stats = await service.stats(authority)
+    return _json_response(
+        {
+            "version": 1,
+            "stats": {
+                "total": stats.total,
+                "facts": stats.facts,
+                "episodes": stats.episodes,
+                "by_source": stats.by_source,
+                "by_type": stats.by_type,
+                "by_scope": stats.by_scope,
+            },
+        },
+        status=200,
+    )
+
+
+async def _handle_memory_records(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopMemoryQueryService,
+) -> web.Response:
+    authority, error = await _memory_authority(request, authenticator=authenticator, service=service)
+    if error is not None:
+        return error
+    if not set(request.query).issubset(_ALLOWED_MEMORY_LIST_PARAMETERS) or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid memory request")
+    assert authority is not None
+    try:
+        page = await service.list_records(
+            authority,
+            filters=_memory_filters(request),
+            limit=_memory_limit(request, default=DEFAULT_PAGE_SIZE),
+            cursor=_single_query_value(request, "cursor"),
+        )
+    except (ValueError, WorkshopMemoryValidationError) as exc:
+        return _memory_error_response(exc)
+    return _json_response(
+        {
+            "version": 1,
+            "records": [_serialize_memory_record(record) for record in page.records],
+            "next_cursor": page.next_cursor,
+        },
+        status=200,
+    )
+
+
+async def _handle_memory_search(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopMemoryQueryService,
+) -> web.Response:
+    authority, error = await _memory_authority(request, authenticator=authenticator, service=service)
+    if error is not None:
+        return error
+    if not set(request.query).issubset(_ALLOWED_MEMORY_SEARCH_PARAMETERS) or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid memory request")
+    assert authority is not None
+    try:
+        query = _single_query_value(request, "q")
+        if query is None:
+            raise WorkshopMemoryValidationError("Memory search query is required")
+        snapshot = await service.search(
+            authority,
+            query,
+            filters=_memory_filters(request),
+            limit=_memory_limit(request, default=10),
+        )
+    except (ValueError, WorkshopMemoryQueryError) as exc:
+        return _memory_error_response(exc)
+    return _json_response(
+        {
+            "version": 1,
+            "active_project_id": snapshot.active_project_id,
+            "reason": snapshot.reason,
+            "hits": [
+                {
+                    "record": _serialize_memory_record(hit.record),
+                    "raw_score": hit.raw_score,
+                    "adjusted_score": hit.adjusted_score,
+                    "compact_recall": hit.compact_recall,
+                }
+                for hit in snapshot.hits
+            ],
+        },
+        status=200,
+    )
+
+
+async def _handle_memory_detail(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopMemoryQueryService,
+    source: bool,
+) -> web.Response:
+    authority, error = await _memory_authority(request, authenticator=authenticator, service=service)
+    if error is not None:
+        return error
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid memory request")
+    assert authority is not None
+    try:
+        memory_id = request.match_info["memory_id"]
+        if source:
+            context = await service.source_context(authority, memory_id)
+            payload = {"version": 1, "source_context": _serialize_memory_source(context)}
+        else:
+            detail = await service.detail(authority, memory_id)
+            payload = {"version": 1, "record": _serialize_memory_detail(detail)}
+    except (KeyError, WorkshopMemoryQueryError) as exc:
+        return _memory_error_response(exc)
+    return _json_response(payload, status=200)
 
 
 async def _authenticate_settings_authority(
@@ -1629,6 +1897,7 @@ def register_workshop_read_routes(
     run_previews: WorkshopRunPreviewRegistry | None = None,
     artifact_service: WorkshopArtifactService | None = None,
     settings_workspaces: WorkshopSettingsWorkspaceService | None = None,
+    memory_queries: WorkshopMemoryQueryService | None = None,
 ) -> None:
     """Register the read-only contract on an explicitly supplied application."""
     if event_poll_interval <= 0 or event_heartbeat_interval <= 0 or event_authentication_recheck_interval <= 0:
@@ -1750,6 +2019,50 @@ def register_workshop_read_routes(
             _WORKSPACE_CONFIG_PATH,
             handle_workspace_config_update,
         )
+    if memory_queries is not None:
+
+        async def handle_memory_stats(request: web.Request) -> web.Response:
+            return await _handle_memory_stats(
+                request,
+                authenticator=authenticator,
+                service=memory_queries,
+            )
+
+        async def handle_memory_records(request: web.Request) -> web.Response:
+            return await _handle_memory_records(
+                request,
+                authenticator=authenticator,
+                service=memory_queries,
+            )
+
+        async def handle_memory_search(request: web.Request) -> web.Response:
+            return await _handle_memory_search(
+                request,
+                authenticator=authenticator,
+                service=memory_queries,
+            )
+
+        async def handle_memory_detail(request: web.Request) -> web.Response:
+            return await _handle_memory_detail(
+                request,
+                authenticator=authenticator,
+                service=memory_queries,
+                source=False,
+            )
+
+        async def handle_memory_source(request: web.Request) -> web.Response:
+            return await _handle_memory_detail(
+                request,
+                authenticator=authenticator,
+                service=memory_queries,
+                source=True,
+            )
+
+        app.router.add_get(_MEMORY_STATS_PATH, handle_memory_stats)
+        app.router.add_get(_MEMORY_RECORDS_PATH, handle_memory_records)
+        app.router.add_get(_MEMORY_SEARCH_PATH, handle_memory_search)
+        app.router.add_get(_MEMORY_DETAIL_PATH, handle_memory_detail)
+        app.router.add_get(_MEMORY_SOURCE_PATH, handle_memory_source)
 
 
 def register_workshop_enrollment_routes(

--- a/src/kai/workshop/memory_queries.py
+++ b/src/kai/workshop/memory_queries.py
@@ -1,0 +1,659 @@
+"""Canonical, principal-scoped read service for Workshop semantic memory."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from kai import memory
+from kai.config import Config
+from kai.workshop.authorization import CanonicalChannelAuthorizer
+from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId, RunId
+from kai.workshop.execution_state import (
+    WorkshopExecutionStateNamespace,
+    WorkshopExecutionStateRegistry,
+)
+from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.store import WorkshopEventStore
+
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 100
+MAX_SEARCH_LIMIT = 50
+MAX_QUERY_CHARACTERS = 2_000
+MAX_CURSOR_CHARACTERS = 2_048
+MAX_PREVIEW_CHARACTERS = 500
+MAX_CONTENT_CHARACTERS = 100_000
+MAX_COMPACT_RECALL_CHARACTERS = 120_000
+MAX_SOURCE_BODY_CHARACTERS = 50_000
+_CURSOR_VERSION = 1
+_VALID_KINDS = frozenset({"fact", "episode"})
+_VALID_SCOPES = frozenset({"global", "project", "task"})
+
+
+class WorkshopMemoryQueryError(RuntimeError):
+    """Base error for the Workshop memory read boundary."""
+
+
+class WorkshopMemoryAccessDenied(WorkshopMemoryQueryError):
+    """A canonical principal has no memory-query authority."""
+
+
+class WorkshopMemoryValidationError(WorkshopMemoryQueryError):
+    """A bounded memory query is malformed."""
+
+
+class WorkshopMemoryCursorError(WorkshopMemoryValidationError):
+    """A memory-page cursor is malformed or belongs to another query."""
+
+
+class WorkshopMemoryNotFound(WorkshopMemoryQueryError):
+    """A visible memory does not exist for the authenticated principal."""
+
+
+class WorkshopMemoryResponseTooLarge(WorkshopMemoryQueryError):
+    """A stored record exceeds the bounded client response contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryQueryAuthority:
+    principal_id: PrincipalId
+    search_namespace: WorkshopExecutionStateNamespace | None
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryQueryFilters:
+    kind: str | None = None
+    source: str | None = None
+    memory_type: str | None = None
+    tag: str | None = None
+    scope: str | None = None
+    project_id: str | None = None
+
+
+EMPTY_MEMORY_FILTERS = MemoryQueryFilters()
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryScopeSnapshot:
+    scope: str
+    project_id: str | None
+    scope_confidence: float
+    scope_source: str
+    legacy_defaulted: bool
+    invalid_defaulted: bool
+    retrievable: bool
+    exclusion_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRecordSummary:
+    memory_id: str
+    kind: str
+    source: str
+    memory_type: str
+    preview: str
+    tags: tuple[str, ...]
+    speaker: str
+    confidence: float
+    created_at: str
+    updated_at: str
+    scope: MemoryScopeSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRecordDetail:
+    record: MemoryRecordSummary
+    content: str
+    compact_recall: str
+    confirmation_quote: str | None
+    prompt_version: str | None
+    episode: dict[str, str] | None
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryRecordPage:
+    records: tuple[MemoryRecordSummary, ...]
+    next_cursor: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class MemorySearchHit:
+    record: MemoryRecordSummary
+    raw_score: float
+    adjusted_score: float
+    compact_recall: str
+
+
+@dataclass(frozen=True, slots=True)
+class MemorySearchSnapshot:
+    hits: tuple[MemorySearchHit, ...]
+    active_project_id: str | None
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class MemoryStatsSnapshot:
+    total: int
+    facts: int
+    episodes: int
+    by_source: dict[str, int]
+    by_type: dict[str, int]
+    by_scope: dict[str, int]
+
+
+@dataclass(frozen=True, slots=True)
+class MemorySourceMessage:
+    message_id: MessageId
+    channel_id: ChannelId
+    author_principal_id: PrincipalId
+    author_kind: str
+    author_display_name: str
+    body: str
+    created_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class MemorySourceContext:
+    status: Literal["available", "unavailable"]
+    reason: str | None
+    run_id: RunId | None
+    source: MemorySourceMessage | None
+    result: MemorySourceMessage | None
+
+
+def _bounded_text(value: object, *, maximum: int) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return value[:maximum]
+
+
+def _record_kind(result: memory.MemoryResult) -> str:
+    return "episode" if result.metadata.get("source") == "episode" else "fact"
+
+
+def _source(result: memory.MemoryResult) -> str:
+    source = result.metadata.get("source")
+    return str(source) if isinstance(source, str) and source else "legacy"
+
+
+def _tags(result: memory.MemoryResult) -> tuple[str, ...]:
+    raw = result.metadata.get("tags")
+    if not isinstance(raw, list):
+        return ()
+    return tuple(tag[:128] for tag in raw[:32] if isinstance(tag, str) and tag)
+
+
+def _sort_key(result: memory.MemoryResult) -> tuple[str, str]:
+    return (result.updated_at or result.created_at, result.id)
+
+
+def _compact_recall(
+    result: memory.MemoryResult,
+    *,
+    resolved_scope: memory.ResolvedMemoryScope | None = None,
+    speaker: str | None = None,
+    confidence: float | None = None,
+) -> str:
+    rendered = memory.format_memory_result_for_recall(
+        result,
+        resolved_scope=resolved_scope,
+        speaker=speaker,
+        confidence=confidence,
+    )
+    if len(rendered) > MAX_COMPACT_RECALL_CHARACTERS:
+        raise WorkshopMemoryResponseTooLarge("Memory recall representation is too large")
+    return rendered
+
+
+def _filter_fingerprint(filters: MemoryQueryFilters) -> str:
+    encoded = json.dumps(
+        {
+            "kind": filters.kind,
+            "source": filters.source,
+            "memory_type": filters.memory_type,
+            "tag": filters.tag,
+            "scope": filters.scope,
+            "project_id": filters.project_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _encode_cursor(filters: MemoryQueryFilters, result: memory.MemoryResult) -> str:
+    payload = {
+        "v": _CURSOR_VERSION,
+        "f": _filter_fingerprint(filters),
+        "t": _sort_key(result)[0],
+        "i": result.id,
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _decode_cursor(cursor: str, filters: MemoryQueryFilters) -> tuple[str, str]:
+    if not cursor or len(cursor) > MAX_CURSOR_CHARACTERS:
+        raise WorkshopMemoryCursorError("Invalid memory cursor")
+    try:
+        raw = base64.b64decode(
+            cursor + "=" * (-len(cursor) % 4),
+            altchars=b"-_",
+            validate=True,
+        )
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        raise WorkshopMemoryCursorError("Invalid memory cursor") from exc
+    if (
+        not isinstance(payload, dict)
+        or set(payload) != {"v", "f", "t", "i"}
+        or payload.get("v") != _CURSOR_VERSION
+        or payload.get("f") != _filter_fingerprint(filters)
+        or not isinstance(payload.get("t"), str)
+        or not isinstance(payload.get("i"), str)
+        or not payload["i"]
+    ):
+        raise WorkshopMemoryCursorError("Invalid memory cursor")
+    return payload["t"], payload["i"]
+
+
+class WorkshopMemoryQueryService:
+    """Read semantic memory through canonical Workshop authority only."""
+
+    def __init__(
+        self,
+        config: Config,
+        store: WorkshopEventStore,
+        runtime_pool: WorkshopRuntimePool,
+        execution_state: WorkshopExecutionStateRegistry,
+    ) -> None:
+        self._config = config
+        self._store = store
+        self._runtime_pool = runtime_pool
+        self._channel_authorizer = CanonicalChannelAuthorizer(store)
+        by_principal: dict[PrincipalId, list[WorkshopExecutionStateNamespace]] = {}
+        for namespace in execution_state.namespaces:
+            by_principal.setdefault(namespace.principal_id, []).append(namespace)
+        self._namespaces = {principal_id: tuple(namespaces) for principal_id, namespaces in by_principal.items()}
+
+    def authority_for_principal(
+        self,
+        principal_id: str | PrincipalId,
+    ) -> MemoryQueryAuthority:
+        try:
+            canonical = principal_id if isinstance(principal_id, PrincipalId) else PrincipalId(principal_id)
+        except (TypeError, ValueError) as exc:
+            raise WorkshopMemoryAccessDenied("Memory access denied") from exc
+        namespaces = self._namespaces.get(canonical)
+        if not namespaces:
+            raise WorkshopMemoryAccessDenied("Memory access denied")
+        return MemoryQueryAuthority(
+            principal_id=canonical,
+            search_namespace=namespaces[0] if len(namespaces) == 1 else None,
+        )
+
+    @staticmethod
+    def validate_filters(filters: MemoryQueryFilters) -> None:
+        for value in (
+            filters.kind,
+            filters.source,
+            filters.memory_type,
+            filters.tag,
+            filters.scope,
+            filters.project_id,
+        ):
+            if value is not None and (not value or len(value) > 128):
+                raise WorkshopMemoryValidationError("Invalid memory filter")
+        if filters.kind is not None and filters.kind not in _VALID_KINDS:
+            raise WorkshopMemoryValidationError("Invalid memory kind")
+        if filters.scope is not None and filters.scope not in _VALID_SCOPES:
+            raise WorkshopMemoryValidationError("Invalid memory scope")
+
+    async def _all_visible(
+        self,
+        authority: MemoryQueryAuthority,
+    ) -> list[memory.MemoryResult]:
+        rows = await asyncio.to_thread(
+            memory.get_all,
+            user_id=str(authority.principal_id),
+            limit=None,
+        )
+        return [row for row in rows if row.metadata.get("source") in memory.USER_VISIBLE_SOURCES]
+
+    async def _allowed_project_id(
+        self,
+        authority: MemoryQueryAuthority,
+    ) -> str | None:
+        namespace = authority.search_namespace
+        if namespace is None:
+            return None
+        workspace = await self._runtime_pool.get_effective_workspace(namespace.runtime_profile_id)
+        from kai.memory_projects import detect_active_memory_project, merged_registry
+
+        active = detect_active_memory_project(
+            Path(workspace),
+            merged_registry(self._config.memory_projects),
+        )
+        return active.project_id if active is not None and active.memory_enabled else None
+
+    @staticmethod
+    def _scope_snapshot(
+        result: memory.MemoryResult,
+        *,
+        allowed_project_id: str | None,
+    ) -> MemoryScopeSnapshot:
+        resolved = memory.resolve_memory_scope(result.metadata)
+        reason = memory.memory_scope_admission_reason(
+            resolved,
+            allowed_project_id=allowed_project_id,
+        )
+        return MemoryScopeSnapshot(
+            scope=resolved.scope,
+            project_id=resolved.project_id,
+            scope_confidence=float(resolved.scope_confidence),
+            scope_source=resolved.scope_source,
+            legacy_defaulted=resolved.legacy_defaulted,
+            invalid_defaulted=resolved.invalid_defaulted,
+            retrievable=reason is None,
+            exclusion_reason=reason,
+        )
+
+    @classmethod
+    def _summary(
+        cls,
+        result: memory.MemoryResult,
+        *,
+        allowed_project_id: str | None,
+    ) -> MemoryRecordSummary:
+        speaker, confidence = memory.read_time_memory_speaker(result.metadata)
+        return MemoryRecordSummary(
+            memory_id=result.id,
+            kind=_record_kind(result),
+            source=_source(result),
+            memory_type=result.memory_type,
+            preview=result.text[:MAX_PREVIEW_CHARACTERS],
+            tags=_tags(result),
+            speaker=speaker,
+            confidence=float(confidence),
+            created_at=result.created_at,
+            updated_at=result.updated_at,
+            scope=cls._scope_snapshot(
+                result,
+                allowed_project_id=allowed_project_id,
+            ),
+        )
+
+    @staticmethod
+    def _matches(
+        result: memory.MemoryResult,
+        filters: MemoryQueryFilters,
+    ) -> bool:
+        resolved = memory.resolve_memory_scope(result.metadata)
+        return all(
+            (
+                filters.kind is None or _record_kind(result) == filters.kind,
+                filters.source is None or _source(result) == filters.source,
+                filters.memory_type is None or result.memory_type == filters.memory_type,
+                filters.tag is None or filters.tag in _tags(result),
+                filters.scope is None or resolved.scope == filters.scope,
+                filters.project_id is None or resolved.project_id == filters.project_id,
+            )
+        )
+
+    async def list_records(
+        self,
+        authority: MemoryQueryAuthority,
+        *,
+        filters: MemoryQueryFilters = EMPTY_MEMORY_FILTERS,
+        limit: int = DEFAULT_PAGE_SIZE,
+        cursor: str | None = None,
+    ) -> MemoryRecordPage:
+        self.validate_filters(filters)
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= MAX_PAGE_SIZE:
+            raise WorkshopMemoryValidationError(f"Memory page size must be between 1 and {MAX_PAGE_SIZE}")
+        anchor = _decode_cursor(cursor, filters) if cursor is not None else None
+        rows = [row for row in await self._all_visible(authority) if self._matches(row, filters)]
+        rows.sort(key=_sort_key, reverse=True)
+        if anchor is not None:
+            rows = [row for row in rows if _sort_key(row) < anchor]
+        selected = rows[: limit + 1]
+        has_more = len(selected) > limit
+        selected = selected[:limit]
+        allowed_project_id = await self._allowed_project_id(authority)
+        return MemoryRecordPage(
+            records=tuple(self._summary(row, allowed_project_id=allowed_project_id) for row in selected),
+            next_cursor=(_encode_cursor(filters, selected[-1]) if has_more and selected else None),
+        )
+
+    async def stats(
+        self,
+        authority: MemoryQueryAuthority,
+    ) -> MemoryStatsSnapshot:
+        rows = await self._all_visible(authority)
+        by_source: dict[str, int] = {}
+        by_type: dict[str, int] = {}
+        by_scope: dict[str, int] = {}
+        facts = 0
+        episodes = 0
+        for row in rows:
+            source = _source(row)
+            by_source[source] = by_source.get(source, 0) + 1
+            by_type[row.memory_type] = by_type.get(row.memory_type, 0) + 1
+            resolved = memory.resolve_memory_scope(row.metadata)
+            scope_key = (
+                f"project:{resolved.project_id}"
+                if resolved.scope == "project" and resolved.project_id
+                else resolved.scope
+            )
+            if resolved.legacy_defaulted:
+                scope_key = "global_legacy"
+            elif resolved.invalid_defaulted:
+                scope_key = "invalid"
+            by_scope[scope_key] = by_scope.get(scope_key, 0) + 1
+            if _record_kind(row) == "episode":
+                episodes += 1
+            else:
+                facts += 1
+        return MemoryStatsSnapshot(
+            total=len(rows),
+            facts=facts,
+            episodes=episodes,
+            by_source=dict(sorted(by_source.items())),
+            by_type=dict(sorted(by_type.items())),
+            by_scope=dict(sorted(by_scope.items())),
+        )
+
+    async def detail(
+        self,
+        authority: MemoryQueryAuthority,
+        memory_id: str,
+    ) -> MemoryRecordDetail:
+        if not memory_id or len(memory_id) > 256:
+            raise WorkshopMemoryValidationError("Invalid memory identifier")
+        result = await asyncio.to_thread(
+            memory.get_by_id,
+            user_id=str(authority.principal_id),
+            memory_id=memory_id,
+        )
+        if result is None:
+            raise WorkshopMemoryNotFound("Memory not found")
+        if len(result.text) > MAX_CONTENT_CHARACTERS:
+            raise WorkshopMemoryResponseTooLarge("Memory content is too large")
+        allowed_project_id = await self._allowed_project_id(authority)
+        resolved = memory.resolve_memory_scope(result.metadata)
+        speaker, confidence = memory.read_time_memory_speaker(result.metadata)
+        episode = None
+        if _record_kind(result) == "episode":
+            episode = {
+                key: value
+                for key in ("goal", "approach", "outcome", "lessons", "actors", "outcome_quality")
+                if (value := _bounded_text(result.metadata.get(key), maximum=10_000)) is not None
+            }
+        return MemoryRecordDetail(
+            record=self._summary(
+                result,
+                allowed_project_id=allowed_project_id,
+            ),
+            content=result.text,
+            compact_recall=_compact_recall(
+                result,
+                resolved_scope=resolved,
+                speaker=speaker,
+                confidence=confidence,
+            ),
+            confirmation_quote=_bounded_text(
+                result.metadata.get("confirmation_quote"),
+                maximum=10_000,
+            ),
+            prompt_version=_bounded_text(
+                result.metadata.get("prompt_version"),
+                maximum=256,
+            ),
+            episode=episode,
+        )
+
+    async def search(
+        self,
+        authority: MemoryQueryAuthority,
+        query: str,
+        *,
+        filters: MemoryQueryFilters = EMPTY_MEMORY_FILTERS,
+        limit: int = 10,
+    ) -> MemorySearchSnapshot:
+        self.validate_filters(filters)
+        if not isinstance(query, str) or not query.strip() or len(query) > MAX_QUERY_CHARACTERS:
+            raise WorkshopMemoryValidationError("Invalid memory search query")
+        if isinstance(limit, bool) or not isinstance(limit, int) or not 1 <= limit <= MAX_SEARCH_LIMIT:
+            raise WorkshopMemoryValidationError(f"Memory search limit must be between 1 and {MAX_SEARCH_LIMIT}")
+        namespace = authority.search_namespace
+        if namespace is None:
+            raise WorkshopMemoryAccessDenied("Memory search requires one unambiguous runtime profile")
+        workspace = await self._runtime_pool.get_effective_workspace(namespace.runtime_profile_id)
+        scoped = await memory.retrieve_scoped_memories(
+            memory.ScopedRetrievalContext(
+                chat_id=str(authority.principal_id),
+                message=query,
+                workspace=Path(workspace),
+            ),
+            limit=limit,
+        )
+        hits: list[MemorySearchHit] = []
+        for hit in scoped.hits:
+            result = hit.result
+            if result.metadata.get("source") not in memory.USER_VISIBLE_SOURCES:
+                continue
+            if not self._matches(result, filters):
+                continue
+            hits.append(
+                MemorySearchHit(
+                    record=self._summary(
+                        result,
+                        allowed_project_id=scoped.debug.allowed_project_id,
+                    ),
+                    raw_score=float(result.score),
+                    adjusted_score=float(hit.adjusted_score),
+                    compact_recall=_compact_recall(
+                        result,
+                        resolved_scope=hit.resolved_scope,
+                        speaker=hit.speaker,
+                        confidence=hit.confidence,
+                    ),
+                )
+            )
+            if len(hits) >= limit:
+                break
+        return MemorySearchSnapshot(
+            hits=tuple(hits),
+            active_project_id=scoped.debug.active_project_id,
+            reason=scoped.debug.reason,
+        )
+
+    async def source_context(
+        self,
+        authority: MemoryQueryAuthority,
+        memory_id: str,
+    ) -> MemorySourceContext:
+        if not memory_id or len(memory_id) > 256:
+            raise WorkshopMemoryValidationError("Invalid memory identifier")
+        result = await asyncio.to_thread(
+            memory.get_by_id,
+            user_id=str(authority.principal_id),
+            memory_id=memory_id,
+        )
+        if result is None:
+            raise WorkshopMemoryNotFound("Memory not found")
+        provenance = memory.read_transcript_provenance(result.metadata)
+        if provenance.malformed:
+            return MemorySourceContext("unavailable", "invalid_provenance", None, None, None)
+        if not provenance.canonical_present:
+            return MemorySourceContext("unavailable", "legacy_source", None, None, None)
+        if provenance.principal_id != str(authority.principal_id):
+            return MemorySourceContext("unavailable", "source_not_authorized", None, None, None)
+        try:
+            channel_id = ChannelId(provenance.channel_id or "")
+            run_id = RunId(provenance.run_id or "")
+            source_id = MessageId(provenance.source_message_id or "")
+            result_id = MessageId(provenance.result_message_id or "")
+            provenance_agent_id = AgentId(provenance.agent_id or "")
+        except (TypeError, ValueError):
+            return MemorySourceContext("unavailable", "invalid_provenance", None, None, None)
+        if not await self._channel_authorizer.can_read_channel(
+            authority.principal_id,
+            channel_id,
+        ):
+            return MemorySourceContext("unavailable", "source_not_authorized", None, None, None)
+        async with self._store.connection.execute(
+            "SELECT r.requested_by_principal_id, r.agent_id, a.principal_id "
+            "FROM runs r JOIN agents a ON a.id = r.agent_id "
+            "WHERE r.id = ? AND r.channel_id = ? "
+            "AND r.inbound_message_id = ? AND r.result_message_id = ? LIMIT 1",
+            (run_id, channel_id, source_id, result_id),
+        ) as cursor:
+            run_row = await cursor.fetchone()
+            if run_row is None:
+                return MemorySourceContext("unavailable", "canonical_source_missing", run_id, None, None)
+        if str(run_row[0]) != str(authority.principal_id) or str(run_row[1]) != str(provenance_agent_id):
+            return MemorySourceContext("unavailable", "source_not_authorized", run_id, None, None)
+        agent_principal_id = PrincipalId(str(run_row[2]))
+        messages: list[MemorySourceMessage] = []
+        for message_id in (source_id, result_id):
+            async with self._store.connection.execute(
+                "SELECT m.id, m.channel_id, m.author_principal_id, p.kind, "
+                "p.display_name, m.body, m.created_at FROM messages m "
+                "JOIN principals p ON p.id = m.author_principal_id "
+                "WHERE m.id = ? AND m.channel_id = ?",
+                (message_id, channel_id),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None:
+                return MemorySourceContext("unavailable", "canonical_source_missing", run_id, None, None)
+            body = str(row[5])
+            if len(body) > MAX_SOURCE_BODY_CHARACTERS:
+                raise WorkshopMemoryResponseTooLarge("Memory source context is too large")
+            messages.append(
+                MemorySourceMessage(
+                    message_id=MessageId(str(row[0])),
+                    channel_id=ChannelId(str(row[1])),
+                    author_principal_id=PrincipalId(str(row[2])),
+                    author_kind=str(row[3]),
+                    author_display_name=str(row[4]),
+                    body=body,
+                    created_at=str(row[6]),
+                )
+            )
+        if messages[0].author_principal_id != authority.principal_id:
+            return MemorySourceContext("unavailable", "source_not_authorized", run_id, None, None)
+        if messages[1].author_principal_id != agent_principal_id or messages[1].author_kind != "agent":
+            return MemorySourceContext("unavailable", "source_not_authorized", run_id, None, None)
+        return MemorySourceContext(
+            status="available",
+            reason=None,
+            run_id=run_id,
+            source=messages[0],
+            result=messages[1],
+        )

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -179,6 +179,16 @@ def host_dependencies(monkeypatch):
         "WorkshopSettingsWorkspaceService",
         lambda config, pool, execution_state: (config, pool, execution_state),
     )
+    monkeypatch.setattr(
+        host_module,
+        "WorkshopMemoryQueryService",
+        lambda config, store, pool, execution_state: (
+            config,
+            store,
+            pool,
+            execution_state,
+        ),
+    )
     return events
 
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2539,6 +2539,7 @@ class TestNotificationChatIdMutations:
             run_previews=WorkshopRunPreviewRegistry(),
             artifacts=MagicMock(),
             settings_workspaces=MagicMock(),
+            memory_queries=MagicMock(),
         )
         core_host = MagicMock()
         github_notifications = MagicMock(spec=WorkshopTelegramNotificationService)
@@ -2607,6 +2608,7 @@ class TestNotificationChatIdMutations:
             run_previews=WorkshopRunPreviewRegistry(),
             artifacts=MagicMock(),
             settings_workspaces=MagicMock(),
+            memory_queries=MagicMock(),
         )
         fake_runner = MagicMock()
         fake_runner.setup = AsyncMock()
@@ -2677,6 +2679,7 @@ class TestNotificationChatIdMutations:
             run_previews=WorkshopRunPreviewRegistry(),
             artifacts=MagicMock(),
             settings_workspaces=MagicMock(),
+            memory_queries=MagicMock(),
         )
         core_host = MagicMock()
         github_notifications = MagicMock(spec=WorkshopTelegramNotificationService)
@@ -2737,6 +2740,11 @@ class TestNotificationChatIdMutations:
                 "/v1/channels/{channel_id}/settings",
                 "/v1/channels/{channel_id}/workspace",
                 "/v1/channels/{channel_id}/workspace-config",
+                "/v1/memory/stats",
+                "/v1/memory/records",
+                "/v1/memory/search",
+                "/v1/memory/records/{memory_id}",
+                "/v1/memory/records/{memory_id}/source",
                 "/workshop",
                 "/workshop/",
                 "/workshop/app.css",

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -43,6 +43,19 @@ from kai.workshop.domain import (
 )
 from kai.workshop.execution_coordinator import CanonicalCancellationDisposition
 from kai.workshop.inbound import ClientInboundMessage, InboundMessage, record_inbound_message
+from kai.workshop.memory_queries import (
+    MemoryQueryAuthority,
+    MemoryRecordDetail,
+    MemoryRecordPage,
+    MemoryRecordSummary,
+    MemoryScopeSnapshot,
+    MemorySearchHit,
+    MemorySearchSnapshot,
+    MemorySourceContext,
+    MemoryStatsSnapshot,
+    WorkshopMemoryAccessDenied,
+    WorkshopMemoryNotFound,
+)
 from kai.workshop.run_lifecycle import (
     DurableRun,
     RunNotFoundError,
@@ -232,6 +245,100 @@ class _SettingsWorkspaces:
         )
 
 
+@dataclass
+class _MemoryQueries:
+    principal_id: PrincipalId
+
+    def authority_for_principal(self, principal_id):
+        if principal_id != self.principal_id:
+            raise WorkshopMemoryAccessDenied("denied")
+        return MemoryQueryAuthority(principal_id, None)
+
+    async def stats(self, _authority):
+        return MemoryStatsSnapshot(
+            total=1,
+            facts=1,
+            episodes=0,
+            by_source={"extracted": 1},
+            by_type={"fact": 1},
+            by_scope={"global": 1},
+        )
+
+    async def list_records(self, _authority, *, filters, limit, cursor):
+        assert filters.source == "extracted"
+        assert limit == 1
+        assert cursor is None
+        return MemoryRecordPage(
+            records=(
+                MemoryRecordSummary(
+                    memory_id="memory-1",
+                    kind="fact",
+                    source="extracted",
+                    memory_type="fact",
+                    preview="Remember this",
+                    tags=("preference",),
+                    speaker="user",
+                    confidence=1.0,
+                    created_at="2026-08-24T10:00:00Z",
+                    updated_at="2026-08-24T10:00:00Z",
+                    scope=MemoryScopeSnapshot(
+                        scope="global",
+                        project_id=None,
+                        scope_confidence=1.0,
+                        scope_source="operator",
+                        legacy_defaulted=False,
+                        invalid_defaulted=False,
+                        retrievable=True,
+                        exclusion_reason=None,
+                    ),
+                ),
+            ),
+            next_cursor="next-page",
+        )
+
+    async def detail(self, _authority, memory_id):
+        if memory_id != "memory-1":
+            raise WorkshopMemoryNotFound("missing")
+        record = (
+            await self.list_records(
+                _authority,
+                filters=SimpleNamespace(source="extracted"),
+                limit=1,
+                cursor=None,
+            )
+        ).records[0]
+        return MemoryRecordDetail(
+            record=record,
+            content="Remember this",
+            compact_recall='{"record_type":"memory"}',
+            confirmation_quote=None,
+            prompt_version="v1",
+            episode=None,
+        )
+
+    async def search(self, _authority, query, *, filters, limit):
+        assert query == "remember"
+        assert limit == 10
+        record = (
+            await self.list_records(
+                _authority,
+                filters=SimpleNamespace(source="extracted"),
+                limit=1,
+                cursor=None,
+            )
+        ).records[0]
+        return MemorySearchSnapshot(
+            hits=(MemorySearchHit(record, 0.9, 0.9, '{"record_type":"memory"}'),),
+            active_project_id=None,
+            reason="ok",
+        )
+
+    async def source_context(self, _authority, memory_id):
+        if memory_id != "memory-1":
+            raise WorkshopMemoryNotFound("missing")
+        return MemorySourceContext("unavailable", "legacy_source", None, None, None)
+
+
 async def _identity_for(store: WorkshopEventStore, subject: str) -> tuple[PrincipalId, ChannelId]:
     async with store.connection.execute(
         "SELECT e.principal_id, b.channel_id FROM external_identities e "
@@ -301,6 +408,7 @@ async def _open_client(
     run_previews: WorkshopRunPreviewRegistry | None = None,
     artifact_service: WorkshopArtifactService | None = None,
     settings_workspaces=None,
+    memory_queries=None,
 ) -> TestClient:
     app = web.Application()
     register_workshop_read_routes(
@@ -315,6 +423,7 @@ async def _open_client(
         run_previews=run_previews,
         artifact_service=artifact_service,
         settings_workspaces=settings_workspaces,
+        memory_queries=memory_queries,
     )
     client = TestClient(TestServer(app))
     await client.start_server()
@@ -382,6 +491,105 @@ async def _read_sse_event(response) -> dict[str, object]:
             event_id = value
         elif field == "data":
             data_lines.append(value)
+
+
+@pytest.mark.asyncio
+async def test_memory_api_uses_bearer_principal_and_stable_read_schema(
+    tmp_path: Path,
+) -> None:
+    store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+    client = await _open_client(
+        store,
+        _Authenticator({"alice-token": alice_id}),
+        memory_queries=_MemoryQueries(alice_id),
+    )
+    try:
+        unauthorized = await client.get("/v1/memory/stats")
+        assert unauthorized.status == 401
+
+        stats = await client.get(
+            "/v1/memory/stats",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert stats.status == 200
+        assert await stats.json() == {
+            "version": 1,
+            "stats": {
+                "total": 1,
+                "facts": 1,
+                "episodes": 0,
+                "by_source": {"extracted": 1},
+                "by_type": {"fact": 1},
+                "by_scope": {"global": 1},
+            },
+        }
+
+        page = await client.get(
+            "/v1/memory/records?source=extracted&limit=1",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert page.status == 200
+        payload = await page.json()
+        assert payload["version"] == 1
+        assert payload["next_cursor"] == "next-page"
+        assert payload["records"][0]["memory_id"] == "memory-1"
+        assert payload["records"][0]["scope"]["retrievable"] is True
+        assert "principal_id" not in payload
+
+        search = await client.get(
+            "/v1/memory/search?q=remember",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert search.status == 200
+        assert (await search.json())["hits"][0]["raw_score"] == 0.9
+
+        detail = await client.get(
+            "/v1/memory/records/memory-1",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert detail.status == 200
+        assert (await detail.json())["record"]["compact_recall"] == '{"record_type":"memory"}'
+
+        source = await client.get(
+            "/v1/memory/records/memory-1/source",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert source.status == 200
+        assert (await source.json())["source_context"]["reason"] == "legacy_source"
+
+        foreign = await client.get(
+            "/v1/memory/records/foreign-memory-id",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert foreign.status == 404
+        assert await foreign.json() == {"error": {"code": "memory_not_found", "message": "Memory not found"}}
+    finally:
+        await client.close()
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_api_rejects_owner_parameters_and_duplicate_values(
+    tmp_path: Path,
+) -> None:
+    store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+    client = await _open_client(
+        store,
+        _Authenticator({"alice-token": alice_id}),
+        memory_queries=_MemoryQueries(alice_id),
+    )
+    headers = {"Authorization": "Bearer alice-token"}
+    try:
+        for path in (
+            "/v1/memory/records?principal_id=prn_" + "9" * 32,
+            "/v1/memory/records?source=extracted&source=episode",
+            "/v1/memory/search?q=hello&q=other",
+        ):
+            response = await client.get(path, headers=headers)
+            assert response.status == 400
+    finally:
+        await client.close()
+        await store.close()
 
 
 class TestWorkshopNavigationHTTPContract:

--- a/tests/test_workshop_memory_queries.py
+++ b/tests/test_workshop_memory_queries.py
@@ -1,0 +1,446 @@
+"""Canonical Workshop semantic-memory query service tests."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kai import memory
+from kai.config import Config
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.conversation_commands import WorkshopConversationCommandService
+from kai.workshop.domain import (
+    AgentId,
+    ChannelId,
+    EventEnvelope,
+    EventId,
+    MessageId,
+    PrincipalId,
+    WorkshopEventType,
+)
+from kai.workshop.execution_state import (
+    WorkshopExecutionStateNamespace,
+    WorkshopExecutionStateRegistry,
+)
+from kai.workshop.inbound import InboundMessage
+from kai.workshop.memory_queries import (
+    MemoryQueryFilters,
+    WorkshopMemoryAccessDenied,
+    WorkshopMemoryCursorError,
+    WorkshopMemoryNotFound,
+    WorkshopMemoryQueryService,
+    WorkshopMemoryResponseTooLarge,
+    WorkshopMemoryValidationError,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id
+
+
+class _RuntimePool:
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+
+    async def get_effective_workspace(self, _profile_id) -> Path:
+        return self.workspace
+
+
+def _result(
+    memory_id: str,
+    text: str,
+    *,
+    source: str = "extracted",
+    created_at: str = "2026-08-24T10:00:00Z",
+    score: float = 0.8,
+    scope: str = "global",
+    project_id: str | None = None,
+    tags: list[str] | None = None,
+) -> memory.MemoryResult:
+    metadata: dict[str, object] = {
+        "source": source,
+        "type": "episode" if source == "episode" else "fact",
+        "scope": scope,
+        "scope_source": "extraction_default",
+        "scope_confidence": 1.0,
+        "tags": tags or [],
+        "speaker": "episode_summary" if source == "episode" else "user",
+        "confidence": 1.0,
+    }
+    if project_id is not None:
+        metadata["project_id"] = project_id
+    return memory.MemoryResult(
+        id=memory_id,
+        text=text,
+        score=score,
+        memory_type=str(metadata["type"]),
+        metadata=metadata,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+def _service(tmp_path: Path):
+    principal_id = PrincipalId("prn_" + "1" * 32)
+    namespace = WorkshopExecutionStateNamespace(
+        principal_id=principal_id,
+        channel_id=ChannelId("chn_" + "2" * 32),
+        agent_id=AgentId("agt_" + "3" * 32),
+        runtime_profile_id=profile_id(101),
+        runtime_config_id=101,
+    )
+    runtime_pool = _RuntimePool(tmp_path)
+    service = WorkshopMemoryQueryService(
+        Config(
+            telegram_bot_token="unused",
+            allowed_user_ids=set(),
+            default_backend="codex",
+            default_model="gpt-5.6-sol",
+        ),
+        SimpleNamespace(),  # type: ignore[arg-type]
+        runtime_pool,  # type: ignore[arg-type]
+        WorkshopExecutionStateRegistry((namespace,)),
+    )
+    return service, service.authority_for_principal(principal_id), principal_id
+
+
+def test_authority_is_canonical_and_fails_closed(tmp_path: Path) -> None:
+    service, authority, principal_id = _service(tmp_path)
+
+    assert authority.principal_id == principal_id
+    with pytest.raises(WorkshopMemoryAccessDenied):
+        service.authority_for_principal(PrincipalId("prn_" + "9" * 32))
+    with pytest.raises(WorkshopMemoryAccessDenied):
+        service.authority_for_principal("101")
+
+
+async def test_list_is_visible_filtered_deterministic_and_cursor_bound(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    service, authority, principal_id = _service(tmp_path)
+    rows = [
+        _result("new", "Newest", created_at="2026-08-24T12:00:00Z", tags=["kai"]),
+        _result("old", "Older", created_at="2026-08-24T11:00:00Z", tags=["kai"]),
+        _result("hidden", "Hidden", source="legacy-internal"),
+    ]
+    calls: list[tuple[str, int | None]] = []
+    offloaded: list[object] = []
+    real_to_thread = asyncio.to_thread
+
+    async def observed_to_thread(function, /, *args, **kwargs):
+        offloaded.append(function)
+        return await real_to_thread(function, *args, **kwargs)
+
+    def get_all(*, user_id: str, limit: int | None):
+        calls.append((user_id, limit))
+        return rows
+
+    monkeypatch.setattr(memory, "get_all", get_all)
+    monkeypatch.setattr(asyncio, "to_thread", observed_to_thread)
+
+    first = await service.list_records(
+        authority,
+        filters=MemoryQueryFilters(tag="kai"),
+        limit=1,
+    )
+    assert [record.memory_id for record in first.records] == ["new"]
+    assert first.next_cursor is not None
+    second = await service.list_records(
+        authority,
+        filters=MemoryQueryFilters(tag="kai"),
+        limit=1,
+        cursor=first.next_cursor,
+    )
+    assert [record.memory_id for record in second.records] == ["old"]
+    assert second.next_cursor is None
+    assert calls == [(str(principal_id), None), (str(principal_id), None)]
+    assert offloaded == [get_all, get_all]
+
+    with pytest.raises(WorkshopMemoryCursorError):
+        await service.list_records(
+            authority,
+            filters=MemoryQueryFilters(source="episode"),
+            cursor=first.next_cursor,
+        )
+    with pytest.raises(WorkshopMemoryValidationError):
+        await service.list_records(authority, limit=101)
+
+
+async def test_stats_and_detail_expose_only_bounded_stable_fields(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    service, authority, principal_id = _service(tmp_path)
+    fact = _result("fact-1", "Daniel prefers concise output.", tags=["preference"])
+    episode = _result("episode-1", "Deploy succeeded.", source="episode")
+    episode.metadata.update(
+        {
+            "goal": "Deploy Kai",
+            "outcome": "Succeeded",
+            "private_unknown_field": "/secret/path",
+        }
+    )
+    monkeypatch.setattr(
+        memory,
+        "get_all",
+        lambda **_kwargs: [fact, episode, _result("hidden", "no", source="hidden")],
+    )
+    monkeypatch.setattr(
+        memory,
+        "get_by_id",
+        lambda *, user_id, memory_id: episode if user_id == str(principal_id) and memory_id == episode.id else None,
+    )
+
+    stats = await service.stats(authority)
+    assert (stats.total, stats.facts, stats.episodes) == (2, 1, 1)
+    assert stats.by_source == {"episode": 1, "extracted": 1}
+
+    detail = await service.detail(authority, episode.id)
+    assert detail.content == "Deploy succeeded."
+    assert detail.episode == {"goal": "Deploy Kai", "outcome": "Succeeded"}
+    assert "private_unknown_field" not in detail.compact_recall
+    assert '"record_type":"memory"' in detail.compact_recall
+    with pytest.raises(WorkshopMemoryNotFound):
+        await service.detail(authority, "someone-elses-memory")
+    with pytest.raises(WorkshopMemoryValidationError):
+        await service.detail(authority, "x" * 257)
+
+    oversized = _result("oversized", "x" * 100_001)
+    monkeypatch.setattr(memory, "get_by_id", lambda **_kwargs: oversized)
+    with pytest.raises(WorkshopMemoryResponseTooLarge):
+        await service.detail(authority, oversized.id)
+
+    oversized_episode = _result("oversized-episode", "short", source="episode")
+    oversized_episode.metadata["goal"] = "x" * 120_001
+    monkeypatch.setattr(memory, "get_by_id", lambda **_kwargs: oversized_episode)
+    with pytest.raises(WorkshopMemoryResponseTooLarge):
+        await service.detail(authority, oversized_episode.id)
+
+
+async def test_scope_interpretation_matches_production_admission(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    service, authority, _ = _service(tmp_path)
+    global_row = _result("global", "Global")
+    matching = _result(
+        "matching",
+        "Matching",
+        scope="project",
+        project_id="kai",
+    )
+    foreign = _result(
+        "foreign",
+        "Foreign",
+        scope="project",
+        project_id="other",
+    )
+    legacy = _result("legacy", "Legacy")
+    legacy.metadata.pop("scope")
+    legacy.metadata.pop("scope_source")
+    invalid = _result("invalid", "Invalid")
+    invalid.metadata["scope"] = "nonsense"
+    monkeypatch.setattr(
+        memory,
+        "get_all",
+        lambda **_kwargs: [global_row, matching, foreign, legacy, invalid],
+    )
+
+    async def allowed_project(_authority):
+        return "kai"
+
+    monkeypatch.setattr(service, "_allowed_project_id", allowed_project)
+    page = await service.list_records(authority)
+    scopes = {record.memory_id: record.scope for record in page.records}
+    assert scopes["global"].retrievable is True
+    assert scopes["matching"].retrievable is True
+    assert scopes["foreign"].exclusion_reason == "project_id_mismatch"
+    assert scopes["legacy"].exclusion_reason == "legacy_scope_quarantined"
+    assert scopes["invalid"].exclusion_reason == "invalid_scope_quarantined"
+
+    project_only = await service.list_records(
+        authority,
+        filters=MemoryQueryFilters(
+            memory_type="fact",
+            scope="project",
+            project_id="kai",
+        ),
+    )
+    assert [record.memory_id for record in project_only.records] == ["matching"]
+
+
+async def test_search_uses_live_scoped_retrieval_and_visible_sources(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    service, authority, principal_id = _service(tmp_path)
+    visible = _result("visible", "Remember this", score=0.9)
+    hidden = _result("hidden", "Do not expose", source="internal", score=0.99)
+    resolved = memory.resolve_memory_scope(visible.metadata)
+    contexts: list[memory.ScopedRetrievalContext] = []
+
+    async def retrieve(context, *, limit):
+        contexts.append(context)
+        return memory.ScopedRetrievalResult(
+            hits=[
+                memory.ScopedMemoryHit(hidden, resolved, "user", 1.0, 1.0, 0.99),
+                memory.ScopedMemoryHit(visible, resolved, "user", 1.0, 1.0, 0.9),
+            ],
+            debug=SimpleNamespace(
+                active_project_id=None,
+                allowed_project_id=None,
+                reason="ok",
+            ),
+        )
+
+    monkeypatch.setattr(memory, "retrieve_scoped_memories", retrieve)
+
+    result = await service.search(authority, "remember", limit=5)
+    assert [hit.record.memory_id for hit in result.hits] == ["visible"]
+    assert result.hits[0].compact_recall == memory.format_memory_result_for_recall(visible)
+    assert contexts[0].chat_id == str(principal_id)
+    assert contexts[0].workspace == tmp_path
+    with pytest.raises(WorkshopMemoryValidationError):
+        await service.search(authority, "")
+    with pytest.raises(WorkshopMemoryValidationError):
+        await service.search(authority, "x" * 2_001)
+
+
+async def test_source_context_requires_canonical_lineage_and_channel_membership(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = await WorkshopEventStore.open(tmp_path / "kai.db")
+    try:
+        await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    "Alice",
+                    "admin",
+                    "telegram",
+                    "101",
+                    "101",
+                    profile_id(101),
+                ),
+            ),
+        )
+        async with store.connection.execute(
+            "SELECT e.principal_id, b.channel_id FROM external_identities e "
+            "JOIN channel_bindings b ON b.transport = e.provider "
+            "AND b.external_channel_id = e.external_subject "
+            "WHERE e.external_subject = '101'",
+        ) as cursor:
+            identity = await cursor.fetchone()
+        assert identity is not None
+        principal_id = PrincipalId(str(identity[0]))
+        channel_id = ChannelId(str(identity[1]))
+        async with store.connection.execute(
+            "SELECT a.id, a.principal_id FROM channel_agents ca "
+            "JOIN agents a ON a.id = ca.agent_id WHERE ca.channel_id = ?",
+            (channel_id,),
+        ) as cursor:
+            agent_row = await cursor.fetchone()
+        assert agent_row is not None
+        agent_id = AgentId(str(agent_row[0]))
+        agent_principal_id = PrincipalId(str(agent_row[1]))
+        namespace = WorkshopExecutionStateNamespace(
+            principal_id=principal_id,
+            channel_id=channel_id,
+            agent_id=agent_id,
+            runtime_profile_id=profile_id(101),
+            runtime_config_id=101,
+        )
+        service = WorkshopMemoryQueryService(
+            Config(
+                telegram_bot_token="unused",
+                allowed_user_ids=set(),
+                default_backend="codex",
+                default_model="gpt-5.6-sol",
+            ),
+            store,
+            _RuntimePool(tmp_path),  # type: ignore[arg-type]
+            WorkshopExecutionStateRegistry((namespace,)),
+        )
+        authority = service.authority_for_principal(principal_id)
+        now = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
+        accepted = await WorkshopConversationCommandService(store).accept(
+            InboundMessage(
+                "telegram",
+                "update-1",
+                "message-1",
+                "101",
+                "101",
+                "What is the marker?",
+                now,
+            )
+        )
+        run = accepted.run
+        result_message_id = MessageId.new()
+        result_event = EventEnvelope.create(
+            event_id=EventId.new(),
+            event_type=WorkshopEventType.MESSAGE_CREATED,
+            event_version=1,
+            workshop_id=run.workshop_id,
+            aggregate_type="message",
+            aggregate_id=result_message_id,
+            actor_principal_id=agent_principal_id,
+            occurred_at=now,
+            idempotency_key="memory-source-result",
+            payload={
+                "channel_id": channel_id,
+                "author_principal_id": agent_principal_id,
+                "reply_to_message_id": run.inbound_message_id,
+                "body": "The marker is BLUE-LANTERN.",
+            },
+            metadata={"source": "agent"},
+        )
+        appended = await store.append(result_event)
+        await store.project_pending(CanonicalConversationProjection())
+        await store.connection.execute(
+            "UPDATE runs SET status = 'completed', started_at = ?, terminal_at = ?, "
+            "result_message_id = ?, last_event_position = ? WHERE id = ?",
+            (now.isoformat(), now.isoformat(), result_message_id, appended.event.position, run.run_id),
+        )
+        await store.connection.commit()
+        row = _result("canonical", "The marker is BLUE-LANTERN.")
+        row.metadata.update(
+            {
+                memory.WORKSHOP_PRINCIPAL_ID_KEY: str(principal_id),
+                memory.WORKSHOP_CHANNEL_ID_KEY: str(channel_id),
+                memory.WORKSHOP_AGENT_ID_KEY: str(agent_id),
+                memory.WORKSHOP_RUNTIME_PROFILE_ID_KEY: str(profile_id(101)),
+                memory.WORKSHOP_RUN_ID_KEY: str(run.run_id),
+                memory.WORKSHOP_SOURCE_MESSAGE_ID_KEY: str(run.inbound_message_id),
+                memory.WORKSHOP_RESULT_MESSAGE_ID_KEY: str(result_message_id),
+            }
+        )
+        monkeypatch.setattr(memory, "get_by_id", lambda **_kwargs: row)
+
+        context = await service.source_context(authority, row.id)
+        assert context.status == "available"
+        assert context.source is not None and context.source.body == "What is the marker?"
+        assert context.result is not None and context.result.body == "The marker is BLUE-LANTERN."
+
+        row.metadata[memory.WORKSHOP_PRINCIPAL_ID_KEY] = "prn_" + "9" * 32
+        denied = await service.source_context(authority, row.id)
+        assert (denied.status, denied.reason) == ("unavailable", "source_not_authorized")
+
+        row.metadata[memory.WORKSHOP_PRINCIPAL_ID_KEY] = str(principal_id)
+        row.metadata[memory.WORKSHOP_RUN_ID_KEY] = "run_" + "9" * 32
+        missing = await service.source_context(authority, row.id)
+        assert (missing.status, missing.reason) == (
+            "unavailable",
+            "canonical_source_missing",
+        )
+
+        row.metadata.clear()
+        row.metadata.update({"source": "extracted"})
+        legacy = await service.source_context(authority, row.id)
+        assert (legacy.status, legacy.reason) == ("unavailable", "legacy_source")
+    finally:
+        await store.close()

--- a/workshop-client/src/api.test.ts
+++ b/workshop-client/src/api.test.ts
@@ -5,10 +5,15 @@ import {
   cancelRun,
   loadArtifactBlob,
   loadEarlierTimeline,
+  loadMemoryDetail,
+  loadMemoryRecords,
+  loadMemorySource,
+  loadMemoryStats,
   loadNavigation,
   loadRun,
   loadTimeline,
   redeemEnrollment,
+  searchMemories,
   submitCommand,
   streamTimeline,
 } from "./api";
@@ -40,6 +45,31 @@ function run(status = "accepted"): Record<string, unknown> {
     status,
     terminal_at: null,
     terminal_code: null,
+  };
+}
+
+function memoryRecord(): Record<string, unknown> {
+  return {
+    memory_id: "memory-1",
+    kind: "fact",
+    source: "extracted",
+    memory_type: "fact",
+    preview: "Daniel prefers concise output.",
+    tags: ["preference"],
+    speaker: "user",
+    confidence: 1,
+    created_at: "2026-08-24T10:00:00Z",
+    updated_at: "2026-08-24T10:00:00Z",
+    scope: {
+      scope: "global",
+      project_id: null,
+      scope_confidence: 1,
+      scope_source: "operator",
+      legacy_defaulted: false,
+      invalid_defaulted: false,
+      retrievable: true,
+      exclusion_reason: null,
+    },
   };
 }
 
@@ -121,6 +151,102 @@ describe("Workshop client API", () => {
     const [path] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(path).toContain("cursor=earlier-page");
     expect(path).not.toContain("tail=");
+  });
+
+  it("parses the stable Workshop memory read contracts", async () => {
+    const responses = [
+      Response.json({
+        version: 1,
+        stats: {
+          total: 1,
+          facts: 1,
+          episodes: 0,
+          by_source: { extracted: 1 },
+          by_type: { fact: 1 },
+          by_scope: { global: 1 },
+        },
+      }),
+      Response.json({ version: 1, records: [memoryRecord()], next_cursor: null }),
+      Response.json({
+        version: 1,
+        active_project_id: "kai",
+        reason: "ok",
+        hits: [
+          {
+            record: memoryRecord(),
+            raw_score: 0.9,
+            adjusted_score: 0.8,
+            compact_recall: "{\"record_type\":\"memory\"}",
+          },
+        ],
+      }),
+      Response.json({
+        version: 1,
+        record: {
+          ...memoryRecord(),
+          content: "Daniel prefers concise output.",
+          compact_recall: "{\"record_type\":\"memory\"}",
+          confirmation_quote: null,
+          prompt_version: "v1",
+          episode: null,
+        },
+      }),
+      Response.json({
+        version: 1,
+        source_context: {
+          status: "unavailable",
+          reason: "legacy_source",
+          run_id: null,
+          source: null,
+          result: null,
+        },
+      }),
+    ];
+    const fetchMock = vi.fn().mockImplementation(() => responses.shift());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadMemoryStats("session-secret")).resolves.toMatchObject({
+      total: 1,
+      facts: 1,
+      bySource: { extracted: 1 },
+    });
+    await expect(
+      loadMemoryRecords("session-secret", {
+        kind: "fact",
+        projectId: "kai",
+        limit: 25,
+      }),
+    ).resolves.toMatchObject({
+      nextCursor: null,
+      records: [{ memoryId: "memory-1", source: "extracted" }],
+    });
+    await expect(
+      searchMemories("session-secret", "concise output", {
+        scope: "project",
+        tag: "preference",
+      }),
+    ).resolves.toMatchObject({
+      activeProjectId: "kai",
+      hits: [{ record: { memoryId: "memory-1" }, adjustedScore: 0.8 }],
+    });
+    await expect(loadMemoryDetail("session-secret", "memory-1")).resolves.toMatchObject({
+      memoryId: "memory-1",
+      content: "Daniel prefers concise output.",
+      promptVersion: "v1",
+    });
+    await expect(loadMemorySource("session-secret", "memory-1")).resolves.toEqual({
+      status: "unavailable",
+      reason: "legacy_source",
+      runId: null,
+      source: null,
+      result: null,
+    });
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "/v1/memory/records?kind=fact&project_id=kai&limit=25",
+    );
+    expect(fetchMock.mock.calls[2]?.[0]).toBe(
+      "/v1/memory/search?tag=preference&scope=project&q=concise+output",
+    );
   });
 
   it("rejects an earlier page whose snapshot bound does not match", async () => {

--- a/workshop-client/src/api.ts
+++ b/workshop-client/src/api.ts
@@ -14,6 +14,16 @@ import type {
   WorkshopRunTransition,
   WorkshopSession,
   WorkshopSettingsWorkspace,
+  WorkshopMemoryPage,
+  WorkshopMemoryFilters,
+  WorkshopMemoryListOptions,
+  WorkshopMemoryDetail,
+  WorkshopMemoryRecord,
+  WorkshopMemorySearch,
+  WorkshopMemorySearchOptions,
+  WorkshopMemorySourceContext,
+  WorkshopMemorySourceMessage,
+  WorkshopMemoryStats,
   WorkshopArtifactKind,
   WorkshopArtifactSummary,
 } from "./types";
@@ -429,6 +439,308 @@ function parseSettingsWorkspace(
     },
     workspace: payload.workspace,
     workspaces,
+  };
+}
+
+function parseCountMap(value: unknown): Record<string, number> | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const parsed: Record<string, number> = {};
+  for (const [key, count] of Object.entries(value)) {
+    if (!Number.isSafeInteger(count) || (count as number) < 0) {
+      return null;
+    }
+    parsed[key] = count as number;
+  }
+  return parsed;
+}
+
+function parseMemoryRecord(value: unknown): WorkshopMemoryRecord | null {
+  if (!isRecord(value) || !isRecord(value.scope)) {
+    return null;
+  }
+  const scope = value.scope;
+  if (
+    typeof value.memory_id !== "string" ||
+    typeof value.kind !== "string" ||
+    !["fact", "episode"].includes(value.kind) ||
+    typeof value.source !== "string" ||
+    typeof value.memory_type !== "string" ||
+    typeof value.preview !== "string" ||
+    !Array.isArray(value.tags) ||
+    !value.tags.every((tag) => typeof tag === "string") ||
+    typeof value.speaker !== "string" ||
+    typeof value.confidence !== "number" ||
+    typeof value.created_at !== "string" ||
+    typeof value.updated_at !== "string" ||
+    typeof scope.scope !== "string" ||
+    !["global", "project", "task"].includes(scope.scope) ||
+    (scope.project_id !== null && typeof scope.project_id !== "string") ||
+    typeof scope.scope_confidence !== "number" ||
+    typeof scope.scope_source !== "string" ||
+    typeof scope.legacy_defaulted !== "boolean" ||
+    typeof scope.invalid_defaulted !== "boolean" ||
+    typeof scope.retrievable !== "boolean" ||
+    (scope.exclusion_reason !== null && typeof scope.exclusion_reason !== "string")
+  ) {
+    return null;
+  }
+  return {
+    confidence: value.confidence,
+    createdAt: value.created_at,
+    kind: value.kind as "fact" | "episode",
+    memoryId: value.memory_id,
+    memoryType: value.memory_type,
+    preview: value.preview,
+    scope: {
+      exclusionReason: scope.exclusion_reason,
+      invalidDefaulted: scope.invalid_defaulted,
+      legacyDefaulted: scope.legacy_defaulted,
+      projectId: scope.project_id,
+      retrievable: scope.retrievable,
+      scope: scope.scope as "global" | "project" | "task",
+      scopeConfidence: scope.scope_confidence,
+      scopeSource: scope.scope_source,
+    },
+    source: value.source,
+    speaker: value.speaker,
+    tags: value.tags as string[],
+    updatedAt: value.updated_at,
+  };
+}
+
+export async function loadMemoryStats(token: string): Promise<WorkshopMemoryStats> {
+  const response = await authorizedFetch({ channelId: "", token }, "/v1/memory/stats");
+  const payload = await responsePayload(response);
+  if (!response.ok) {
+    throw new Error(safeErrorMessage(payload, "Could not load memory statistics."));
+  }
+  if (!isRecord(payload) || payload.version !== 1 || !isRecord(payload.stats)) {
+    throw new Error("Kai returned unsupported memory statistics.");
+  }
+  const stats = payload.stats;
+  const byScope = parseCountMap(stats.by_scope);
+  const bySource = parseCountMap(stats.by_source);
+  const byType = parseCountMap(stats.by_type);
+  if (
+    !Number.isSafeInteger(stats.total) ||
+    !Number.isSafeInteger(stats.facts) ||
+    !Number.isSafeInteger(stats.episodes) ||
+    !byScope || !bySource || !byType
+  ) {
+    throw new Error("Kai returned unsupported memory statistics.");
+  }
+  return {
+    byScope,
+    bySource,
+    byType,
+    episodes: stats.episodes as number,
+    facts: stats.facts as number,
+    total: stats.total as number,
+  };
+}
+
+function memoryQueryParameters(
+  options: WorkshopMemoryFilters & { limit?: number },
+): URLSearchParams {
+  const parameters = new URLSearchParams();
+  if (options.kind !== undefined) parameters.set("kind", options.kind);
+  if (options.source !== undefined) parameters.set("source", options.source);
+  if (options.memoryType !== undefined) {
+    parameters.set("memory_type", options.memoryType);
+  }
+  if (options.tag !== undefined) parameters.set("tag", options.tag);
+  if (options.scope !== undefined) parameters.set("scope", options.scope);
+  if (options.projectId !== undefined) {
+    parameters.set("project_id", options.projectId);
+  }
+  if (options.limit !== undefined) parameters.set("limit", String(options.limit));
+  return parameters;
+}
+
+export async function loadMemoryRecords(
+  token: string,
+  options: WorkshopMemoryListOptions = {},
+): Promise<WorkshopMemoryPage> {
+  const query = memoryQueryParameters(options);
+  if (options.cursor !== undefined) query.set("cursor", options.cursor);
+  const suffix = query.size ? `?${query}` : "";
+  const response = await authorizedFetch(
+    { channelId: "", token },
+    `/v1/memory/records${suffix}`,
+  );
+  const payload = await responsePayload(response);
+  if (!response.ok) {
+    throw new Error(safeErrorMessage(payload, "Could not load memories."));
+  }
+  if (
+    !isRecord(payload) || payload.version !== 1 ||
+    !Array.isArray(payload.records) ||
+    (payload.next_cursor !== null && typeof payload.next_cursor !== "string")
+  ) {
+    throw new Error("Kai returned an unsupported memory page.");
+  }
+  const records = payload.records.map(parseMemoryRecord);
+  if (records.some((record) => record === null)) {
+    throw new Error("Kai returned an unsupported memory record.");
+  }
+  return {
+    nextCursor: payload.next_cursor,
+    records: records as WorkshopMemoryRecord[],
+  };
+}
+
+export async function searchMemories(
+  token: string,
+  query: string,
+  options: WorkshopMemorySearchOptions = {},
+): Promise<WorkshopMemorySearch> {
+  const parameters = memoryQueryParameters(options);
+  parameters.set("q", query);
+  const response = await authorizedFetch(
+    { channelId: "", token },
+    `/v1/memory/search?${parameters}`,
+  );
+  const payload = await responsePayload(response);
+  if (!response.ok) {
+    throw new Error(safeErrorMessage(payload, "Could not search memories."));
+  }
+  if (
+    !isRecord(payload) || payload.version !== 1 ||
+    (payload.active_project_id !== null && typeof payload.active_project_id !== "string") ||
+    typeof payload.reason !== "string" || !Array.isArray(payload.hits)
+  ) {
+    throw new Error("Kai returned unsupported memory search results.");
+  }
+  const hits = payload.hits.map((value) => {
+    if (
+      !isRecord(value) || typeof value.raw_score !== "number" ||
+      typeof value.adjusted_score !== "number" ||
+      typeof value.compact_recall !== "string"
+    ) {
+      return null;
+    }
+    const record = parseMemoryRecord(value.record);
+    return record ? {
+      adjustedScore: value.adjusted_score,
+      compactRecall: value.compact_recall,
+      rawScore: value.raw_score,
+      record,
+    } : null;
+  });
+  if (hits.some((hit) => hit === null)) {
+    throw new Error("Kai returned unsupported memory search results.");
+  }
+  return {
+    activeProjectId: payload.active_project_id,
+    hits: hits as WorkshopMemorySearch["hits"],
+    reason: payload.reason,
+  };
+}
+
+export async function loadMemoryDetail(
+  token: string,
+  memoryId: string,
+): Promise<WorkshopMemoryDetail> {
+  const response = await authorizedFetch(
+    { channelId: "", token },
+    `/v1/memory/records/${encodeURIComponent(memoryId)}`,
+  );
+  const payload = await responsePayload(response);
+  if (!response.ok) {
+    throw new Error(safeErrorMessage(payload, "Could not load this memory."));
+  }
+  if (!isRecord(payload) || payload.version !== 1 || !isRecord(payload.record)) {
+    throw new Error("Kai returned an unsupported memory detail.");
+  }
+  const record = parseMemoryRecord(payload.record);
+  const episode = payload.record.episode;
+  if (
+    !record || typeof payload.record.content !== "string" ||
+    typeof payload.record.compact_recall !== "string" ||
+    (payload.record.confirmation_quote !== null &&
+      typeof payload.record.confirmation_quote !== "string") ||
+    (payload.record.prompt_version !== null &&
+      typeof payload.record.prompt_version !== "string") ||
+    (episode !== null &&
+      (!isRecord(episode) ||
+        !Object.values(episode).every((value) => typeof value === "string")))
+  ) {
+    throw new Error("Kai returned an unsupported memory detail.");
+  }
+  return {
+    ...record,
+    compactRecall: payload.record.compact_recall,
+    confirmationQuote: payload.record.confirmation_quote,
+    content: payload.record.content,
+    episode: episode as Record<string, string> | null,
+    promptVersion: payload.record.prompt_version,
+  };
+}
+
+function parseMemorySourceMessage(value: unknown): WorkshopMemorySourceMessage | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (
+    typeof value.message_id !== "string" ||
+    typeof value.channel_id !== "string" ||
+    !CHANNEL_PATTERN.test(value.channel_id) ||
+    typeof value.author_principal_id !== "string" ||
+    !PRINCIPAL_PATTERN.test(value.author_principal_id) ||
+    typeof value.author_kind !== "string" ||
+    typeof value.author_display_name !== "string" ||
+    typeof value.body !== "string" ||
+    typeof value.created_at !== "string"
+  ) {
+    return null;
+  }
+  return {
+    authorDisplayName: value.author_display_name,
+    authorKind: value.author_kind,
+    authorPrincipalId: value.author_principal_id,
+    body: value.body,
+    channelId: value.channel_id,
+    createdAt: value.created_at,
+    messageId: value.message_id,
+  };
+}
+
+export async function loadMemorySource(
+  token: string,
+  memoryId: string,
+): Promise<WorkshopMemorySourceContext> {
+  const response = await authorizedFetch(
+    { channelId: "", token },
+    `/v1/memory/records/${encodeURIComponent(memoryId)}/source`,
+  );
+  const payload = await responsePayload(response);
+  if (!response.ok) {
+    throw new Error(safeErrorMessage(payload, "Could not load memory source context."));
+  }
+  if (!isRecord(payload) || payload.version !== 1 || !isRecord(payload.source_context)) {
+    throw new Error("Kai returned unsupported memory source context.");
+  }
+  const context = payload.source_context;
+  const source = context.source === null ? null : parseMemorySourceMessage(context.source);
+  const result = context.result === null ? null : parseMemorySourceMessage(context.result);
+  if (
+    typeof context.status !== "string" ||
+    !["available", "unavailable"].includes(context.status) ||
+    (context.reason !== null && typeof context.reason !== "string") ||
+    (context.run_id !== null && typeof context.run_id !== "string") ||
+    (context.source !== null && source === null) ||
+    (context.result !== null && result === null)
+  ) {
+    throw new Error("Kai returned unsupported memory source context.");
+  }
+  return {
+    reason: context.reason,
+    result,
+    runId: context.run_id,
+    source,
+    status: context.status as "available" | "unavailable",
   };
 }
 

--- a/workshop-client/src/types.ts
+++ b/workshop-client/src/types.ts
@@ -72,6 +72,102 @@ export interface WorkshopSettingsWorkspace {
   workspaces: WorkshopWorkspaceOption[];
 }
 
+export interface WorkshopMemoryScope {
+  exclusionReason: string | null;
+  invalidDefaulted: boolean;
+  legacyDefaulted: boolean;
+  projectId: string | null;
+  retrievable: boolean;
+  scope: "global" | "project" | "task";
+  scopeConfidence: number;
+  scopeSource: string;
+}
+
+export interface WorkshopMemoryRecord {
+  confidence: number;
+  createdAt: string;
+  kind: "fact" | "episode";
+  memoryId: string;
+  memoryType: string;
+  preview: string;
+  scope: WorkshopMemoryScope;
+  source: string;
+  speaker: string;
+  tags: string[];
+  updatedAt: string;
+}
+
+export interface WorkshopMemoryPage {
+  nextCursor: string | null;
+  records: WorkshopMemoryRecord[];
+}
+
+export interface WorkshopMemoryFilters {
+  kind?: "fact" | "episode";
+  memoryType?: string;
+  projectId?: string;
+  scope?: "global" | "project" | "task";
+  source?: string;
+  tag?: string;
+}
+
+export interface WorkshopMemoryListOptions extends WorkshopMemoryFilters {
+  cursor?: string;
+  limit?: number;
+}
+
+export interface WorkshopMemorySearchOptions extends WorkshopMemoryFilters {
+  limit?: number;
+}
+
+export interface WorkshopMemoryDetail extends WorkshopMemoryRecord {
+  compactRecall: string;
+  confirmationQuote: string | null;
+  content: string;
+  episode: Record<string, string> | null;
+  promptVersion: string | null;
+}
+
+export interface WorkshopMemorySourceMessage {
+  authorDisplayName: string;
+  authorKind: string;
+  authorPrincipalId: string;
+  body: string;
+  channelId: string;
+  createdAt: string;
+  messageId: string;
+}
+
+export interface WorkshopMemorySourceContext {
+  reason: string | null;
+  result: WorkshopMemorySourceMessage | null;
+  runId: string | null;
+  source: WorkshopMemorySourceMessage | null;
+  status: "available" | "unavailable";
+}
+
+export interface WorkshopMemoryStats {
+  byScope: Record<string, number>;
+  bySource: Record<string, number>;
+  byType: Record<string, number>;
+  episodes: number;
+  facts: number;
+  total: number;
+}
+
+export interface WorkshopMemorySearchHit {
+  adjustedScore: number;
+  compactRecall: string;
+  rawScore: number;
+  record: WorkshopMemoryRecord;
+}
+
+export interface WorkshopMemorySearch {
+  activeProjectId: string | null;
+  hits: WorkshopMemorySearchHit[];
+  reason: string;
+}
+
 export interface TimelineMessage {
   artifacts: WorkshopArtifactSummary[];
   authorDisplayName: string;


### PR DESCRIPTION
## Summary

- add a canonical, principal-scoped Workshop semantic-memory read service
- expose authenticated stats, paginated records, semantic search, detail, and canonical source-context routes
- add stable TypeScript contracts and client loaders for the future Workshop memory editor
- reuse the live recall scope, ranking, speaker, confidence, and compact-record rules

## Security boundary

- derive the memory owner exclusively from the authenticated Workshop bearer session
- reject caller-supplied owner identifiers and ambiguous runtime-profile search authority
- enforce canonical channel membership and exact run/message lineage for source context
- keep legacy JSONL non-authoritative and provide no transcript fallback
- bound filters, cursors, page/search sizes, record bodies, source bodies, and compact recall output
- keep Mem0/Qdrant reads and semantic search off the event loop

## Validation

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q` — 6124 passed
- `npm test -- --run` — 48 passed
- `npm run build`

Closes #1052
