### PR TITLE
fix: serialize Workshop memory reads

### DIFF
--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -2023,41 +2023,46 @@ def register_workshop_read_routes(
     if memory_queries is not None:
 
         async def handle_memory_stats(request: web.Request) -> web.Response:
-            return await _handle_memory_stats(
-                request,
-                authenticator=authenticator,
-                service=memory_queries,
-            )
+            async with request_lock:
+                return await _handle_memory_stats(
+                    request,
+                    authenticator=authenticator,
+                    service=memory_queries,
+                )
 
         async def handle_memory_records(request: web.Request) -> web.Response:
-            return await _handle_memory_records(
-                request,
-                authenticator=authenticator,
-                service=memory_queries,
-            )
+            async with request_lock:
+                return await _handle_memory_records(
+                    request,
+                    authenticator=authenticator,
+                    service=memory_queries,
+                )
 
         async def handle_memory_search(request: web.Request) -> web.Response:
-            return await _handle_memory_search(
-                request,
-                authenticator=authenticator,
-                service=memory_queries,
-            )
+            async with request_lock:
+                return await _handle_memory_search(
+                    request,
+                    authenticator=authenticator,
+                    service=memory_queries,
+                )
 
         async def handle_memory_detail(request: web.Request) -> web.Response:
-            return await _handle_memory_detail(
-                request,
-                authenticator=authenticator,
-                service=memory_queries,
-                source=False,
-            )
+            async with request_lock:
+                return await _handle_memory_detail(
+                    request,
+                    authenticator=authenticator,
+                    service=memory_queries,
+                    source=False,
+                )
 
         async def handle_memory_source(request: web.Request) -> web.Response:
-            return await _handle_memory_detail(
-                request,
-                authenticator=authenticator,
-                service=memory_queries,
-                source=True,
-            )
+            async with request_lock:
+                return await _handle_memory_detail(
+                    request,
+                    authenticator=authenticator,
+                    service=memory_queries,
+                    source=True,
+                )
 
         app.router.add_get(_MEMORY_STATS_PATH, handle_memory_stats)
         app.router.add_get(_MEMORY_RECORDS_PATH, handle_memory_records)

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -33,6 +33,10 @@ from kai.workshop.client_events import (
     ClientTimelineMessageEvent,
     read_client_channel_events,
 )
+from kai.workshop.client_sessions import (
+    WorkshopBearerSessionAuthenticator,
+    WorkshopClientSessionManager,
+)
 from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.domain import (
     ChannelId,
@@ -590,6 +594,36 @@ async def test_memory_api_rejects_owner_parameters_and_duplicate_values(
         ):
             response = await client.get(path, headers=headers)
             assert response.status == 400
+    finally:
+        await client.close()
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_memory_reads_share_the_client_request_transaction_boundary(
+    tmp_path: Path,
+) -> None:
+    store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+    sessions = WorkshopClientSessionManager(store)
+    device = await sessions.register_device(alice_id, "Alice browser")
+    issued = await sessions.issue_session(alice_id, device.device_id)
+    client = await _open_client(
+        store,
+        WorkshopBearerSessionAuthenticator(sessions),
+        memory_queries=_MemoryQueries(alice_id),
+    )
+    headers = {"Authorization": f"Bearer {issued.token}"}
+    try:
+        stats, records = await asyncio.gather(
+            client.get("/v1/memory/stats", headers=headers),
+            client.get(
+                "/v1/memory/records?source=extracted&limit=1&order=oldest",
+                headers=headers,
+            ),
+        )
+
+        assert stats.status == 200
+        assert records.status == 200
     finally:
         await client.close()
         await store.close()


### PR DESCRIPTION
## Summary

- serialize every authenticated Workshop memory route through the existing shared client request boundary
- prevent concurrent Memory explorer requests from overlapping SQLite client-session transactions
- add an HTTP regression test using a real Workshop bearer session and concurrent stats/records requests

## Production failure addressed

Opening the new Memory explorer starts multiple reads concurrently. Authentication updates session activity inside `BEGIN IMMEDIATE`; the unguarded memory routes could overlap that transaction with another memory or run-inspector request and fail with `sqlite3.OperationalError: cannot start a transaction within a transaction`.

## Validation

- `6125 passed in 73.64s`
- Workshop client API: `63 passed`
- `make check`
- `make typecheck`
