### PR TITLE
Make generic webhook routing explicitly canonical

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -8509,6 +8509,7 @@ def _cmd_status() -> None:
     print(_deployed_adapter_policy_status(_DEPLOYED_ENV_FILE))
     print(_core_schedule_status(Path(data_dir) / "kai.db"))
     print(_github_automation_status(Path(data_dir) / "kai.db"))
+    print(_integration_route_status(Path(data_dir) / "kai.db"))
     if conf_env is None:
         print("Client adapters (install.conf artifact): unavailable")
     else:
@@ -8889,6 +8890,40 @@ def _github_automation_status(db_path: Path) -> str:
         f"succeeded={succeeded}, failed={failed}, uncertain={uncertain}; "
         "subscription routing=canonical"
     )
+
+
+def _integration_route_status(db_path: Path) -> str:
+    """Report the explicit canonical destination for generic webhooks."""
+    prefix = "Workshop integration routing:"
+    if not db_path.is_file():
+        return f"{prefix} NOT VERIFIED (database unavailable)"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            table = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'workshop_integration_routes'"
+            ).fetchone()
+            if table is None:
+                return f"{prefix} pending; canonical route registry unavailable"
+            row = connection.execute(
+                "SELECT c.kind, COUNT(p.id) FROM workshop_integration_routes r "
+                "LEFT JOIN channels c ON c.id = r.channel_id "
+                "LEFT JOIN channel_agents ca ON ca.channel_id = c.id "
+                "LEFT JOIN agents a ON a.id = ca.agent_id AND a.workshop_id = c.workshop_id "
+                "LEFT JOIN principals p ON p.id = a.principal_id AND p.kind = 'agent' "
+                "WHERE r.source = 'generic' AND r.route_name = 'default' "
+                "GROUP BY r.source, r.route_name, c.id, c.kind"
+            ).fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        return f"{prefix} NOT VERIFIED ({exc})"
+    if row is None:
+        return f"{prefix} INCOMPLETE; generic/default=missing"
+    kind, agents = str(row[0] or "missing"), int(row[1] or 0)
+    if kind not in {"direct", "notification"} or agents != 1:
+        return f"{prefix} INCOMPLETE; generic/default=invalid, kind={kind}, agents={agents}"
+    return f"{prefix} active; generic/default={kind}, agents={agents}; transport lookup=disabled"
 
 
 def _deployed_webhook_secret_migration_status(env_path: Path) -> str:

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -97,6 +97,7 @@ from kai.workshop.github_automation import (
     WorkshopGitHubAutomationService,
 )
 from kai.workshop.integration_notifications import (
+    DEFAULT_INTEGRATION_ROUTE,
     IntegrationNotification,
     WorkshopIntegrationNotificationService,
 )
@@ -877,8 +878,8 @@ async def _handle_generic(request: web.Request) -> web.Response:
     Handle generic webhook notifications from any source.
 
     Extracts a "message" field from the JSON payload (or dumps the full
-    payload), records it in the canonical admin channel, and requests delivery
-    through any configured channel bindings.
+    payload), records it through the explicit canonical generic/default route,
+    and requests delivery through any configured channel bindings.
     """
     try:
         payload = await request.json()
@@ -921,18 +922,10 @@ async def _handle_generic(request: web.Request) -> web.Response:
     except ValueError as exc:
         return web.json_response({"error": str(exc)}, status=400)
     try:
-        fallback_chat_id = request.app.get(CHAT_ID_KEY)
-        recorded = (
-            await service.record_for_binding(
-                notification,
-                transport="telegram",
-                external_channel_id=str(fallback_chat_id),
-            )
-            if fallback_chat_id is not None
-            else None
+        recorded = await service.record_for_route(
+            notification,
+            route_name=DEFAULT_INTEGRATION_ROUTE,
         )
-        if recorded is None:
-            recorded = await service.record_for_default_admin(notification)
     except Exception:
         log.exception("Failed to record generic webhook notification")
         return web.json_response({"status": "unavailable"}, status=503)

--- a/src/kai/workshop/integration_notifications.py
+++ b/src/kai/workshop/integration_notifications.py
@@ -30,7 +30,10 @@ from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
 _DELIVERY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _SOURCE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
 _EVENT_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_ROUTE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 _REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+GENERIC_INTEGRATION_SOURCE = "generic"
+DEFAULT_INTEGRATION_ROUTE = "default"
 
 
 class IntegrationNotificationError(RuntimeError):
@@ -76,6 +79,17 @@ class IntegrationNotificationRecord:
     deliveries: tuple[DeliveryRequestResult, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class IntegrationRouteStatus:
+    """Persisted canonical routing state for one external integration."""
+
+    source: str
+    route_name: str
+    state: str
+    channel_id: ChannelId | None
+    detail: str
+
+
 class WorkshopIntegrationNotificationService:
     """Own canonical integration recording independently of client adapters."""
 
@@ -87,7 +101,13 @@ class WorkshopIntegrationNotificationService:
 
     @classmethod
     async def open(cls, database_path: Path) -> WorkshopIntegrationNotificationService:
-        return cls(await WorkshopEventStore.open(database_path))
+        service = cls(await WorkshopEventStore.open(database_path))
+        try:
+            await service.reconcile_default_generic_route()
+        except BaseException:
+            await service.close()
+            raise
+        return service
 
     async def close(self) -> None:
         if self._closed:
@@ -149,6 +169,114 @@ class WorkshopIntegrationNotificationService:
                 )
             return await self._record_locked(notification, ChannelId(str(rows[0][0])))
 
+    async def reconcile_default_generic_route(self) -> IntegrationRouteStatus:
+        """Seed the default generic route from canonical policy when unambiguous."""
+        async with self._lock:
+            self._ensure_open()
+            existing = await self._route_status_locked(
+                GENERIC_INTEGRATION_SOURCE,
+                DEFAULT_INTEGRATION_ROUTE,
+            )
+            if existing.state != "missing":
+                return existing
+
+            async with self._store.connection.execute(
+                "SELECT DISTINCT c.id FROM channels c "
+                "JOIN channel_memberships cm ON cm.channel_id = c.id "
+                "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+                "JOIN workshop_memberships wm ON wm.workshop_id = c.workshop_id "
+                "AND wm.principal_id = p.id AND wm.role = 'admin' "
+                "WHERE c.kind = 'direct' ORDER BY c.id"
+            ) as cursor:
+                rows = tuple(await cursor.fetchall())
+            if len(rows) != 1:
+                detail = (
+                    "no canonical admin direct channel is available"
+                    if not rows
+                    else "multiple canonical admin direct channels are available"
+                )
+                return IntegrationRouteStatus(
+                    source=GENERIC_INTEGRATION_SOURCE,
+                    route_name=DEFAULT_INTEGRATION_ROUTE,
+                    state="missing" if not rows else "ambiguous",
+                    channel_id=None,
+                    detail=detail,
+                )
+
+            channel_id = ChannelId(str(rows[0][0]))
+            await self._validate_channel_locked(channel_id)
+            try:
+                await self._store.connection.execute("BEGIN IMMEDIATE")
+                await self._store.connection.execute(
+                    "INSERT OR IGNORE INTO workshop_integration_routes "
+                    "(source, route_name, channel_id) VALUES (?, ?, ?)",
+                    (GENERIC_INTEGRATION_SOURCE, DEFAULT_INTEGRATION_ROUTE, channel_id),
+                )
+                await self._store.connection.commit()
+            except Exception:
+                await self._store.connection.rollback()
+                raise
+            return await self._route_status_locked(
+                GENERIC_INTEGRATION_SOURCE,
+                DEFAULT_INTEGRATION_ROUTE,
+            )
+
+    async def route_status(self, *, source: str, route_name: str) -> IntegrationRouteStatus:
+        """Inspect one canonical integration route without resolving a transport."""
+        self._validate_route_identity(source, route_name)
+        async with self._lock:
+            self._ensure_open()
+            return await self._route_status_locked(source, route_name)
+
+    async def set_route(
+        self,
+        *,
+        source: str,
+        route_name: str,
+        channel_id: ChannelId,
+    ) -> IntegrationRouteStatus:
+        """Explicitly assign one integration route to a canonical channel."""
+        self._validate_route_identity(source, route_name)
+        if not isinstance(channel_id, ChannelId):
+            raise ValueError("channel_id must be a ChannelId")
+        async with self._lock:
+            self._ensure_open()
+            await self._validate_channel_locked(channel_id)
+            try:
+                await self._store.connection.execute("BEGIN IMMEDIATE")
+                await self._store.connection.execute(
+                    "INSERT INTO workshop_integration_routes "
+                    "(source, route_name, channel_id) VALUES (?, ?, ?) "
+                    "ON CONFLICT(source, route_name) DO UPDATE SET "
+                    "channel_id = excluded.channel_id, "
+                    "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+                    (source, route_name, channel_id),
+                )
+                await self._store.connection.commit()
+            except Exception:
+                await self._store.connection.rollback()
+                raise
+            return await self._route_status_locked(source, route_name)
+
+    async def record_for_route(
+        self,
+        notification: IntegrationNotification,
+        *,
+        route_name: str,
+    ) -> IntegrationNotificationRecord:
+        """Record using explicit canonical routing policy for the integration source."""
+        if not isinstance(notification, IntegrationNotification):
+            raise ValueError("notification must be an IntegrationNotification")
+        self._validate_route_identity(notification.source, route_name)
+        async with self._lock:
+            self._ensure_open()
+            status = await self._route_status_locked(notification.source, route_name)
+            if status.state != "active" or status.channel_id is None:
+                raise IntegrationNotificationError(
+                    f"Integration route {notification.source}/{route_name} is {status.state}: {status.detail}"
+                )
+            return await self._record_locked(notification, status.channel_id)
+
     async def record_for_channel(
         self,
         notification: IntegrationNotification,
@@ -169,6 +297,69 @@ class WorkshopIntegrationNotificationService:
                     "Canonical notification destination is missing or unsupported"
                 )
             return await self._record_locked(notification, channel_id)
+
+    async def _route_status_locked(
+        self,
+        source: str,
+        route_name: str,
+    ) -> IntegrationRouteStatus:
+        async with self._store.connection.execute(
+            "SELECT channel_id FROM workshop_integration_routes WHERE source = ? AND route_name = ?",
+            (source, route_name),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return IntegrationRouteStatus(
+                source=source,
+                route_name=route_name,
+                state="missing",
+                channel_id=None,
+                detail="no canonical destination is configured",
+            )
+        channel_id = ChannelId(str(row[0]))
+        try:
+            await self._validate_channel_locked(channel_id)
+        except AmbiguousIntegrationNotificationDestinationError as exc:
+            return IntegrationRouteStatus(
+                source=source,
+                route_name=route_name,
+                state="invalid",
+                channel_id=channel_id,
+                detail=str(exc),
+            )
+        return IntegrationRouteStatus(
+            source=source,
+            route_name=route_name,
+            state="active",
+            channel_id=channel_id,
+            detail="canonical destination is configured",
+        )
+
+    async def _validate_channel_locked(self, channel_id: ChannelId) -> None:
+        async with self._store.connection.execute(
+            "SELECT c.kind, COUNT(p.id) FROM channels c "
+            "LEFT JOIN channel_agents ca ON ca.channel_id = c.id "
+            "LEFT JOIN agents a ON a.id = ca.agent_id AND a.workshop_id = c.workshop_id "
+            "LEFT JOIN principals p ON p.id = a.principal_id AND p.kind = 'agent' "
+            "WHERE c.id = ? GROUP BY c.id, c.kind",
+            (channel_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None or str(row[0]) not in {"direct", "notification"}:
+            raise AmbiguousIntegrationNotificationDestinationError(
+                "Canonical notification destination is missing or unsupported"
+            )
+        if int(row[1]) != 1:
+            raise AmbiguousIntegrationNotificationDestinationError(
+                "Canonical notification destination must have exactly one agent"
+            )
+
+    @staticmethod
+    def _validate_route_identity(source: str, route_name: str) -> None:
+        if not _SOURCE_PATTERN.fullmatch(source):
+            raise ValueError("source must be a lowercase integration identifier")
+        if not _ROUTE_PATTERN.fullmatch(route_name):
+            raise ValueError("route_name must be a bounded lowercase route identifier")
 
     async def _record_locked(
         self,

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 27
+WORKSHOP_SCHEMA_VERSION = 28
 
 
 @dataclass(frozen=True, slots=True)
@@ -1255,6 +1255,31 @@ _GITHUB_AUTOMATION_SCHEMA = SchemaMigration(
     ),
 )
 
+_INTEGRATION_ROUTE_SCHEMA = SchemaMigration(
+    version=28,
+    name="canonical_integration_routes",
+    statements=(
+        """
+        CREATE TABLE workshop_integration_routes (
+            source TEXT NOT NULL CHECK (
+                length(source) BETWEEN 1 AND 32
+                AND source NOT GLOB '*[^a-z0-9_]*'
+            ),
+            route_name TEXT NOT NULL CHECK (
+                length(route_name) BETWEEN 1 AND 64
+                AND route_name NOT GLOB '*[^a-z0-9_-]*'
+            ),
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            PRIMARY KEY (source, route_name)
+        )
+        """,
+        "CREATE INDEX workshop_integration_routes_channel_idx "
+        "ON workshop_integration_routes (channel_id, source, route_name)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1283,6 +1308,7 @@ _MIGRATIONS = (
     _CANONICAL_TRANSCRIPT_AUTHORITY_SCHEMA,
     _CORE_SCHEDULER_SCHEMA,
     _GITHUB_AUTOMATION_SCHEMA,
+    _INTEGRATION_ROUTE_SCHEMA,
 )
 
 

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -38,6 +38,12 @@ from kai.workshop.human_provisioning import (
     WorkshopHumanProvisioner,
     WorkshopHumanProvisioningError,
 )
+from kai.workshop.integration_notifications import (
+    DEFAULT_INTEGRATION_ROUTE,
+    GENERIC_INTEGRATION_SOURCE,
+    IntegrationNotificationError,
+    WorkshopIntegrationNotificationService,
+)
 from kai.workshop.runtime_assignments import (
     WorkshopRuntimeAssignmentError,
     WorkshopRuntimeAssignmentService,
@@ -162,6 +168,21 @@ def _parser() -> argparse.ArgumentParser:
         help="write one canonical channel transcript as NDJSON to standard output",
     )
     export.add_argument("--channel-id", required=True)
+    integration_route = commands.add_parser(
+        "integration-route",
+        help="inspect or assign the canonical generic-webhook destination",
+    )
+    integration_route_actions = integration_route.add_subparsers(dest="action", required=True)
+    integration_route_actions.add_parser("status")
+    integration_route_actions.add_parser(
+        "reconcile",
+        help="seed the route from canonical admin policy when unambiguous",
+    )
+    set_route = integration_route_actions.add_parser(
+        "set",
+        help="assign the generic/default route to a canonical channel",
+    )
+    set_route.add_argument("--channel-id", required=True)
     return parser
 
 
@@ -240,6 +261,31 @@ def _qualification_database(data_dir: Path) -> Path:
 async def _run(args: argparse.Namespace) -> int:
     store = await WorkshopEventStore.open(_qualification_database(DATA_DIR))
     try:
+        if args.command == "integration-route":
+            service = WorkshopIntegrationNotificationService(store)
+            if args.action == "set":
+                try:
+                    channel_id = ChannelId(args.channel_id)
+                except (TypeError, ValueError) as exc:
+                    raise IntegrationNotificationError("Invalid canonical channel ID") from exc
+                status = await service.set_route(
+                    source=GENERIC_INTEGRATION_SOURCE,
+                    route_name=DEFAULT_INTEGRATION_ROUTE,
+                    channel_id=channel_id,
+                )
+            elif args.action == "reconcile":
+                status = await service.reconcile_default_generic_route()
+            else:
+                status = await service.route_status(
+                    source=GENERIC_INTEGRATION_SOURCE,
+                    route_name=DEFAULT_INTEGRATION_ROUTE,
+                )
+            print(f"Integration route: {status.source}/{status.route_name}")
+            print(f"Status: {status.state}")
+            print(f"Channel: {status.channel_id or 'unavailable'}")
+            print(f"Detail: {status.detail}")
+            return 0 if status.state == "active" else 2
+
         if args.command == "transcript":
             export = await build_canonical_transcript_export(
                 store,
@@ -439,6 +485,8 @@ def cli(args: list[str]) -> None:
         raise SystemExit(f"Workshop runtime assignment failed: {exc}") from exc
     except WorkshopRuntimeProfileError as exc:
         raise SystemExit(f"Workshop runtime profile failed: {exc}") from exc
+    except IntegrationNotificationError as exc:
+        raise SystemExit(f"Workshop integration route failed: {exc}") from exc
     except CanonicalTranscriptExportError as exc:
         raise SystemExit(f"Workshop transcript export failed: {exc}") from exc
     except (DeliveryQualificationError, DeliveryTargetNotFoundError) as exc:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -64,6 +64,7 @@ from kai.install import (
     _generate_systemd_unit,
     _generate_users_yaml,
     _github_automation_status,
+    _integration_route_status,
     _log_security_status,
     _memory_scope_review_status,
     _migrate_identity_to_claude_md,
@@ -5013,6 +5014,41 @@ class TestCmdStatus:
     def test_status_reports_unavailable_github_automation_database(self, tmp_path):
         assert _github_automation_status(tmp_path / "missing.db") == (
             "Workshop GitHub automation: NOT VERIFIED (database unavailable)"
+        )
+
+    def test_status_reports_canonical_generic_integration_route(self, tmp_path):
+        db_path = tmp_path / "kai.db"
+        connection = sqlite3.connect(db_path)
+        connection.execute("CREATE TABLE channels (id TEXT PRIMARY KEY, kind TEXT NOT NULL, workshop_id TEXT)")
+        connection.execute("CREATE TABLE principals (id TEXT PRIMARY KEY, kind TEXT NOT NULL)")
+        connection.execute("CREATE TABLE agents (id TEXT PRIMARY KEY, workshop_id TEXT, principal_id TEXT)")
+        connection.execute("CREATE TABLE channel_agents (channel_id TEXT NOT NULL, agent_id TEXT NOT NULL)")
+        connection.execute("CREATE TABLE workshop_integration_routes (source TEXT, route_name TEXT, channel_id TEXT)")
+        connection.execute("INSERT INTO channels VALUES ('chn_direct', 'direct', 'wsp_one')")
+        connection.execute("INSERT INTO principals VALUES ('prn_agent', 'agent')")
+        connection.execute("INSERT INTO agents VALUES ('agt_kai', 'wsp_one', 'prn_agent')")
+        connection.execute("INSERT INTO channel_agents VALUES ('chn_direct', 'agt_kai')")
+        connection.execute("INSERT INTO workshop_integration_routes VALUES ('generic', 'default', 'chn_direct')")
+        connection.commit()
+        connection.close()
+
+        assert _integration_route_status(db_path) == (
+            "Workshop integration routing: active; generic/default=direct, agents=1; transport lookup=disabled"
+        )
+
+    def test_status_reports_missing_generic_integration_route(self, tmp_path):
+        db_path = tmp_path / "kai.db"
+        connection = sqlite3.connect(db_path)
+        connection.execute("CREATE TABLE workshop_integration_routes (source TEXT, route_name TEXT, channel_id TEXT)")
+        connection.execute("CREATE TABLE channels (id TEXT PRIMARY KEY, kind TEXT NOT NULL, workshop_id TEXT)")
+        connection.execute("CREATE TABLE principals (id TEXT PRIMARY KEY, kind TEXT NOT NULL)")
+        connection.execute("CREATE TABLE agents (id TEXT PRIMARY KEY, workshop_id TEXT, principal_id TEXT)")
+        connection.execute("CREATE TABLE channel_agents (channel_id TEXT NOT NULL, agent_id TEXT NOT NULL)")
+        connection.commit()
+        connection.close()
+
+        assert _integration_route_status(db_path) == (
+            "Workshop integration routing: INCOMPLETE; generic/default=missing"
         )
 
     def test_deployed_status_reports_named_secrets_without_values(self, tmp_path, monkeypatch):

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -1207,7 +1207,7 @@ def generic_request():
     """Create a mock request for the generic webhook endpoint."""
     request = MagicMock(spec=web.Request)
     notification_service = MagicMock()
-    notification_service.record_for_default_admin = AsyncMock(
+    notification_service.record_for_route = AsyncMock(
         return_value=MagicMock(message_id="msg_" + "2" * 32, inserted=True)
     )
     request.app = {
@@ -1227,8 +1227,21 @@ class TestGenericWebhook:
 
         assert resp.status == 200
         service = generic_request.app[WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY]
-        service.record_for_default_admin.assert_awaited_once()
-        assert service.record_for_default_admin.await_args.args[0].body == "Alert: disk full"
+        service.record_for_route.assert_awaited_once()
+        assert service.record_for_route.await_args.kwargs == {"route_name": "default"}
+        assert service.record_for_route.await_args.args[0].body == "Alert: disk full"
+
+    async def test_ignores_legacy_telegram_chat_destination(self, generic_request):
+        generic_request.app[CHAT_ID_KEY] = 12345
+        service = generic_request.app[WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY]
+        service.record_for_binding = AsyncMock()
+        generic_request.json = AsyncMock(return_value={"message": "Canonical only"})
+
+        resp = await _handle_generic(generic_request)
+
+        assert resp.status == 200
+        service.record_for_binding.assert_not_awaited()
+        service.record_for_route.assert_awaited_once()
 
     async def test_dumps_full_payload_when_no_message(self, generic_request):
         payload = {"key": "value", "count": 42}
@@ -1238,7 +1251,7 @@ class TestGenericWebhook:
 
         assert resp.status == 200
         service = generic_request.app[WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY]
-        sent_text = service.record_for_default_admin.await_args.args[0].body
+        sent_text = service.record_for_route.await_args.args[0].body
         # Should be a pretty-printed JSON dump
         assert '"key": "value"' in sent_text
         assert '"count": 42' in sent_text
@@ -1258,7 +1271,7 @@ class TestGenericWebhook:
 
         assert resp.status == 200
         service = generic_request.app[WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY]
-        sent_text = service.record_for_default_admin.await_args.args[0].body
+        sent_text = service.record_for_route.await_args.args[0].body
         assert sent_text == long_msg
 
     async def test_invalid_json_returns_400(self, generic_request):
@@ -1272,7 +1285,7 @@ class TestGenericWebhook:
     async def test_record_failure_returns_retryable_unavailable(self, generic_request):
         generic_request.json = AsyncMock(return_value={"message": "test"})
         service = generic_request.app[WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY]
-        service.record_for_default_admin = AsyncMock(side_effect=RuntimeError("database error"))
+        service.record_for_route = AsyncMock(side_effect=RuntimeError("database error"))
 
         resp = await _handle_generic(generic_request)
 
@@ -1298,7 +1311,7 @@ class TestGenericWebhook:
 
         assert resp.status == 401
         service = generic_request.app[WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY]
-        service.record_for_default_admin.assert_not_awaited()
+        service.record_for_route.assert_not_awaited()
 
 
 # ── GET /api/jobs ──────────────────────────────────────────────────

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -57,7 +57,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -187,6 +187,7 @@ class TestWorkshopSchema:
             "workshop_memory_authority_migrations",
             "workshop_schedule_firings",
             "workshop_github_automation_work",
+            "workshop_integration_routes",
             "messages",
             "artifacts",
             "deliveries",
@@ -201,7 +202,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 27
+        assert await workshop_store.schema_version() == 28
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -214,7 +215,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 27
+        assert await second.schema_version() == 28
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -235,7 +236,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -280,6 +281,7 @@ class TestWorkshopSchema:
                     25,
                     26,
                     27,
+                    28,
                 ]
         finally:
             await upgraded.close()
@@ -302,7 +304,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -343,7 +345,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -396,7 +398,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -440,7 +442,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -484,7 +486,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -528,7 +530,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -632,7 +634,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -759,7 +761,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_github_notifications.py
+++ b/tests/test_workshop_github_notifications.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from argparse import Namespace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+from kai import workshop_cli
 from kai.workshop.bootstrap import (
     BootstrapHuman,
     BootstrapNotificationChannel,
@@ -17,6 +19,7 @@ from kai.workshop.delivery_outbox import NOTIFICATION_PURPOSE
 from kai.workshop.domain import ChannelId
 from kai.workshop.integration_notifications import (
     IntegrationNotification,
+    IntegrationNotificationError,
     WorkshopIntegrationNotificationService,
 )
 from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
@@ -87,6 +90,131 @@ class TestIntegrationNotificationInput:
 
 
 class TestWorkshopIntegrationNotificationService:
+    async def test_open_seeds_default_generic_route_from_canonical_admin(self, tmp_path: Path):
+        path = tmp_path / "kai.db"
+        store = await _open_notification_store(path)
+        await store.close()
+
+        service = await WorkshopIntegrationNotificationService.open(path)
+        try:
+            status = await service.route_status(source="generic", route_name="default")
+
+            assert status.state == "active"
+            assert status.channel_id is not None
+            assert status.detail == "canonical destination is configured"
+        finally:
+            await service.close()
+
+    async def test_route_records_without_resolving_any_transport_binding(self, tmp_path: Path):
+        path = tmp_path / "kai.db"
+        store = await _open_notification_store(path)
+        await store.close()
+        service = await WorkshopIntegrationNotificationService.open(path)
+        try:
+            notification = IntegrationNotification(
+                delivery_id="generic-route-1",
+                source="generic",
+                event_type="notification",
+                body="Canonical route",
+                occurred_at=_NOW,
+            )
+
+            result = await service.record_for_route(notification, route_name="default")
+
+            assert result.inserted is True
+            assert len(result.deliveries) == 1
+        finally:
+            await service.close()
+
+    async def test_ambiguous_admin_policy_does_not_seed_or_deliver(self, tmp_path: Path):
+        store = await WorkshopEventStore.open(tmp_path / "kai.db")
+        await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman(
+                    display_name="Daniel",
+                    role="admin",
+                    transport="telegram",
+                    external_subject="101",
+                    external_channel_id="101",
+                ),
+                BootstrapHuman(
+                    display_name="Scott",
+                    role="admin",
+                    transport="telegram",
+                    external_subject="202",
+                    external_channel_id="202",
+                ),
+            ),
+        )
+        try:
+            service = WorkshopIntegrationNotificationService(store)
+            status = await service.reconcile_default_generic_route()
+
+            assert status.state == "ambiguous"
+            with pytest.raises(IntegrationNotificationError, match="is missing"):
+                await service.record_for_route(
+                    IntegrationNotification(
+                        delivery_id="generic-route-ambiguous",
+                        source="generic",
+                        event_type="notification",
+                        body="Do not route",
+                        occurred_at=_NOW,
+                    ),
+                    route_name="default",
+                )
+        finally:
+            await store.close()
+
+    async def test_operator_can_inspect_and_assign_default_route(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        capsys,
+    ):
+        path = tmp_path / "kai.db"
+        store = await _open_notification_store(path)
+        async with store.connection.execute("SELECT id FROM channels WHERE kind = 'notification'") as cursor:
+            channel_id = str((await cursor.fetchone())[0])
+        await store.close()
+        monkeypatch.setattr(workshop_cli, "DATA_DIR", tmp_path)
+
+        assert await workshop_cli._run(Namespace(command="integration-route", action="status")) == 2
+        assert "Status: missing" in capsys.readouterr().out
+
+        assert (
+            await workshop_cli._run(
+                Namespace(
+                    command="integration-route",
+                    action="set",
+                    channel_id=channel_id,
+                )
+            )
+            == 0
+        )
+        output = capsys.readouterr().out
+        assert "Integration route: generic/default" in output
+        assert "Status: active" in output
+        assert f"Channel: {channel_id}" in output
+
+    async def test_operator_can_set_route_to_canonical_notification_channel(self, tmp_path: Path):
+        store = await _open_notification_store(tmp_path / "kai.db")
+        try:
+            async with store.connection.execute("SELECT id FROM channels WHERE kind = 'notification'") as cursor:
+                channel_id = ChannelId(str((await cursor.fetchone())[0]))
+            service = WorkshopIntegrationNotificationService(store)
+
+            status = await service.set_route(
+                source="generic",
+                route_name="default",
+                channel_id=channel_id,
+            )
+
+            assert status.state == "active"
+            assert status.channel_id == channel_id
+        finally:
+            await store.close()
+
     async def test_records_directly_to_authorized_canonical_channel(self, tmp_path: Path):
         store = await _open_notification_store(tmp_path / "kai.db")
         try:

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -455,7 +455,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -404,7 +404,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -466,7 +466,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 27
+            assert await upgraded.schema_version() == 28
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"


### PR DESCRIPTION
Closes #1093.

## Summary

- add a persisted canonical integration-route registry and migrate the Workshop schema to version 28
- seed `generic/default` only from the unique canonical admin direct channel, without consulting Telegram identities or bindings
- route generic webhook notifications exclusively through that canonical route and fail with a retryable 503 when it is missing or invalid
- add operator `status`, `reconcile`, and `set` commands plus an authoritative install-status diagnostic

## Compatibility and safety

- existing unambiguous installs retain their current canonical destination automatically
- generic delivery identities remain stable because they continue to derive from the canonical channel, source, and external delivery ID
- all bindings on the selected canonical channel still receive durable outbox delivery
- a legacy `CHAT_ID_KEY` can no longer influence generic-webhook routing
- ambiguous admin policy does not guess a destination; it remains explicit and fail-closed

## Validation

- `make check`
- `make typecheck`
- focused integration, webhook, schema, install, host, and startup tests: 1,020 passed
- full suite: 6,084 passed in 78.90s
