### PR TITLE
security: bind internal APIs to canonical contexts

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -22,6 +22,7 @@ from kai.workshop.delivery_authority import (
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.github_automation import WorkshopGitHubAutomationService
 from kai.workshop.integration_notifications import WorkshopIntegrationNotificationService
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.run_previews import WorkshopRunPreviewRegistry
@@ -115,6 +116,7 @@ class KaiCoreServices:
     client_commands: WorkshopClientCommandExecutor
     client_store: WorkshopEventStore
     principal_storage: WorkshopPrincipalStorageRegistry
+    internal_api_contexts: WorkshopInternalAPIContextRegistry
     delivery_authority_epoch: DeliveryAuthorityEpoch
     run_previews: WorkshopRunPreviewRegistry
     scheduler: WorkshopCanonicalScheduler
@@ -140,6 +142,7 @@ class KaiApplicationHost:
         runtime_profiles: WorkshopRuntimeProfileRegistry,
         execution_state: WorkshopExecutionStateRegistry,
         principal_storage: WorkshopPrincipalStorageRegistry,
+        internal_api_contexts: WorkshopInternalAPIContextRegistry,
         services_info: list[dict],
         registered_backend_ids: frozenset[str],
     ) -> None:
@@ -147,6 +150,7 @@ class KaiApplicationHost:
         self._runtime_profiles = runtime_profiles
         self._execution_state = execution_state
         self._principal_storage = principal_storage
+        self._internal_api_contexts = internal_api_contexts
         self._services_info = services_info
         self._registered_backend_ids = registered_backend_ids
         self._state = KaiApplicationState.NEW
@@ -195,6 +199,7 @@ class KaiApplicationHost:
                 config=self._config,
                 services_info=self._services_info,
                 runtime_profiles=self._runtime_profiles,
+                internal_api_contexts=self._internal_api_contexts,
             )
             runtime_pool = WorkshopRuntimePool(subprocess_pool, self._runtime_profiles)
             conversation_runs = WorkshopConversationRunService(
@@ -265,6 +270,7 @@ class KaiApplicationHost:
                 client_commands=client_commands,
                 client_store=client_store,
                 principal_storage=self._principal_storage,
+                internal_api_contexts=self._internal_api_contexts,
                 delivery_authority_epoch=delivery_authority_epoch,
                 run_previews=run_previews,
                 scheduler=scheduler,

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -584,7 +584,9 @@ def build_session_context(
         home_workspace: Kai's home workspace (identity + memory source).
         api: Webhook port, secret, and services info.
         workspace_config: Per-workspace config (for system_prompt).
-        chat_id: Telegram chat ID for history scoping and API routing.
+        chat_id: Private compatibility runtime key used by transitional
+            history and storage adapters. Internal API authorization and
+            routing derive from the credential-bound canonical context.
         data_dir: Root data directory (memory, history, files live here).
         backend_name: Canonical backend identifier used to validate explicit
             identity routing. Required whenever the active workspace differs
@@ -879,16 +881,13 @@ def build_session_context(
         )
         parts.append("\n".join(svc_lines))
 
-    # Include chat_id so the inner agent can pass it back in API
-    # calls for correct multi-user routing. Without this, all
-    # API calls route to the default admin user.
-    if chat_id is not None:
+    # Internal API authority is carried only by the short-lived credential.
+    # Explicit identity selectors are rejected at the HTTP boundary.
+    if api.webhook_secret:
         parts.append(
-            f"[Your chat_id for API calls: {chat_id}. Include "
-            f'"chat_id": {chat_id} in the JSON body of all '
-            f"POST requests to /api/schedule, /api/send-message, "
-            f"and /api/send-file so responses route to the "
-            f"correct user.]"
+            "[Internal API identity: $KAI_WEBHOOK_SECRET already binds your "
+            "canonical human, channel, agent, and runtime context. Never include "
+            "chat_id or another identity selector in an internal API request.]"
         )
 
     # No trailing \n\n here - prepend_to_prompt() adds the separator

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -5860,6 +5860,13 @@ def _apply_migrate(
             elif claude_content is not None:
                 migration_source = claude_path
             if migration_source is not None and home_template_exists:
+                api_migration = _migrate_internal_api_instructions(
+                    migration_source,
+                    home_template,
+                    dry_run=True,
+                )
+                if api_migration is True:
+                    print(f"[DRY RUN] Would replace legacy chat-routed internal API instructions in {agents_path}")
                 migration_result = _migrate_recalled_memory_section(
                     migration_source,
                     home_template,
@@ -5900,6 +5907,16 @@ def _apply_migrate(
                 and _migrate_recalled_memory_section(agents_path, home_template, dry_run=False) is True
             ):
                 print(f"  Appended Reading Recalled Memory section to {agents_path}")
+            if (
+                home_template_exists
+                and _migrate_internal_api_instructions(
+                    agents_path,
+                    home_template,
+                    dry_run=False,
+                )
+                is True
+            ):
+                print(f"  Replaced legacy chat-routed internal API instructions in {agents_path}")
 
             if backend_name == "claude":
                 claude_path.parent.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
@@ -6759,6 +6776,40 @@ def _migrate_identity_to_claude_md(
 # string would let the migration re-append on every install (sentinel
 # always missing) and silently double-write the section.
 _RECALLED_MEMORY_SECTION_HEADER = "## Reading Recalled Memory"
+_INTERNAL_API_SECTION_START = "## Scheduling Jobs"
+_INTERNAL_API_SECTION_END = "## Issue-First Workflow"
+_LEGACY_INTERNAL_API_ROUTING = '**Routing:** Always include `"chat_id": <your chat_id>`'
+
+
+def _migrate_internal_api_instructions(
+    identity_dst: Path,
+    template_path: Path,
+    *,
+    dry_run: bool,
+) -> bool | None:
+    """Replace the retired caller-routed API block in managed identities."""
+    if not identity_dst.is_file() or not template_path.is_file():
+        return None
+    try:
+        current = identity_dst.read_text()
+        template = template_path.read_text()
+    except OSError:
+        return None
+    if _LEGACY_INTERNAL_API_ROUTING not in current:
+        return False
+
+    current_start = current.find(_INTERNAL_API_SECTION_START)
+    current_end = current.find(_INTERNAL_API_SECTION_END, current_start)
+    template_start = template.find(_INTERNAL_API_SECTION_START)
+    template_end = template.find(_INTERNAL_API_SECTION_END, template_start)
+    if min(current_start, current_end, template_start, template_end) < 0:
+        return None
+    replacement = template[template_start:template_end]
+    migrated = current[:current_start] + replacement + current[current_end:]
+    if dry_run:
+        return True
+    _write_managed_identity_atomic(identity_dst, migrated)
+    return True
 
 
 def _migrate_recalled_memory_section(
@@ -8510,6 +8561,7 @@ def _cmd_status() -> None:
     print(_core_schedule_status(Path(data_dir) / "kai.db"))
     print(_github_automation_status(Path(data_dir) / "kai.db"))
     print(_integration_route_status(Path(data_dir) / "kai.db"))
+    print(_internal_api_authority_status(Path(data_dir) / "kai.db"))
     if conf_env is None:
         print("Client adapters (install.conf artifact): unavailable")
     else:
@@ -8924,6 +8976,42 @@ def _integration_route_status(db_path: Path) -> str:
     if kind not in {"direct", "notification"} or agents != 1:
         return f"{prefix} INCOMPLETE; generic/default=invalid, kind={kind}, agents={agents}"
     return f"{prefix} active; generic/default={kind}, agents={agents}; transport lookup=disabled"
+
+
+def _internal_api_authority_status(db_path: Path) -> str:
+    """Report canonical protected-runtime credential context coverage."""
+    prefix = "Workshop internal API authority:"
+    if not db_path.is_file():
+        return f"{prefix} NOT VERIFIED (database unavailable)"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            profiles = int(connection.execute("SELECT COUNT(*) FROM channel_agent_runtime_assignments").fetchone()[0])
+            contexts = int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM ("
+                    "SELECT ra.runtime_profile_id "
+                    "FROM channel_agent_runtime_assignments ra "
+                    "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+                    "JOIN agents a ON a.id = ra.agent_id AND a.workshop_id = c.workshop_id "
+                    "JOIN channel_agents ca ON ca.channel_id = c.id AND ca.agent_id = a.id "
+                    "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
+                    "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+                    "JOIN workshop_memberships wm ON wm.principal_id = p.id "
+                    "AND wm.workshop_id = c.workshop_id "
+                    "GROUP BY ra.runtime_profile_id HAVING COUNT(DISTINCT cm.principal_id) = 1"
+                    ")"
+                ).fetchone()[0]
+            )
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        return f"{prefix} NOT VERIFIED ({exc})"
+    status = "active" if profiles > 0 and profiles == contexts else "INCOMPLETE"
+    return (
+        f"{prefix} {status}; profiles={profiles}, canonical contexts={contexts}, "
+        f"missing={profiles - contexts}; caller identity selectors=disabled"
+    )
 
 
 def _deployed_webhook_secret_migration_status(env_path: Path) -> str:

--- a/src/kai/internal_api_auth.py
+++ b/src/kai/internal_api_auth.py
@@ -14,6 +14,9 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
+
 
 class InternalAPIScope(StrEnum):
     """Operations an internal API credential may perform."""
@@ -49,7 +52,11 @@ _NOTIFICATION_SCOPES = frozenset({InternalAPIScope.MESSAGES_SEND})
 class InternalAPIPrincipal:
     """Identity and authority resolved from an internal API credential."""
 
-    chat_id: int
+    principal_id: PrincipalId
+    channel_id: ChannelId
+    agent_id: AgentId
+    runtime_profile_id: RuntimeProfileId
+    _runtime_config_id: int
     scopes: frozenset[InternalAPIScope]
     allowed_services: frozenset[str] = frozenset()
 
@@ -61,6 +68,10 @@ class InternalAPIPrincipal:
         """Return whether this principal may call one named service."""
         return self.allows(InternalAPIScope.SERVICES_CALL) and service_name in self.allowed_services
 
+    def compatibility_runtime_config_id(self) -> int:
+        """Return the server-private key for compatibility persistence adapters."""
+        return self._runtime_config_id
+
 
 class InternalAPIAuth:
     """Issue and resolve random credentials for internal API principals.
@@ -70,52 +81,52 @@ class InternalAPIAuth:
     credential whenever they start and do not require an at-rest token store.
 
     Args:
-        agent_credentials: Optional fixed per-user credentials. Production code
+        agent_credentials: Optional fixed per-context credentials. Production code
             leaves this unset and receives cryptographically random tokens; the
             explicit form keeps direct handler tests deterministic.
-        allowed_services_by_user: Explicit service names each persistent user
-            agent may call. Omitted users receive no service-call scope.
+        allowed_services_by_profile: Explicit service names each protected
+            runtime may call. Omitted profiles receive no service-call scope.
     """
 
     def __init__(
         self,
-        agent_credentials: Mapping[int, str] | None = None,
+        agent_credentials: Mapping[WorkshopInternalAPIExecutionContext, str] | None = None,
         *,
-        allowed_services_by_user: Mapping[int, Iterable[str]] | None = None,
+        allowed_services_by_profile: Mapping[RuntimeProfileId, Iterable[str]] | None = None,
     ) -> None:
         self._principals_by_credential: dict[str, InternalAPIPrincipal] = {}
         self._credentials_by_principal: dict[InternalAPIPrincipal, str] = {}
-        self._allowed_services_by_user = {
-            chat_id: frozenset(name for name in names if name)
-            for chat_id, names in (allowed_services_by_user or {}).items()
+        self._allowed_services_by_profile = {
+            profile_id: frozenset(name for name in names if name)
+            for profile_id, names in (allowed_services_by_profile or {}).items()
         }
 
-        for chat_id, credential in (agent_credentials or {}).items():
+        for context, credential in (agent_credentials or {}).items():
             self._register(
                 credential,
-                self._agent_principal(chat_id),
+                self._agent_principal(context),
             )
 
     @classmethod
-    def for_users(
+    def for_execution_contexts(
         cls,
-        user_ids: Iterable[int],
+        contexts: Iterable[WorkshopInternalAPIExecutionContext],
         *,
-        allowed_services_by_user: Mapping[int, Iterable[str]] | None = None,
+        allowed_services_by_profile: Mapping[RuntimeProfileId, Iterable[str]] | None = None,
     ) -> InternalAPIAuth:
-        """Create an auth store with a persistent-agent credential for each user."""
-        auth = cls(allowed_services_by_user=allowed_services_by_user)
-        for chat_id in sorted(set(user_ids)):
-            auth.agent_credential_for(chat_id)
+        """Create one credential for every canonical execution context."""
+        auth = cls(allowed_services_by_profile=allowed_services_by_profile)
+        for context in sorted(set(contexts), key=lambda item: item.runtime_profile_id):
+            auth.agent_credential_for(context)
         return auth
 
-    def agent_credential_for(self, chat_id: int) -> str:
-        """Return the scoped internal API credential for a persistent user agent."""
-        return self._credential_for(self._agent_principal(chat_id))
+    def agent_credential_for(self, context: WorkshopInternalAPIExecutionContext) -> str:
+        """Return the scoped credential for one canonical agent context."""
+        return self._credential_for(self._agent_principal(context))
 
-    def notification_credential_for(self, chat_id: int) -> str:
+    def notification_credential_for(self, context: WorkshopInternalAPIExecutionContext) -> str:
         """Return a send-message-only credential for a notification agent."""
-        return self._credential_for(InternalAPIPrincipal(chat_id=chat_id, scopes=_NOTIFICATION_SCOPES))
+        return self._credential_for(self._principal(context, _NOTIFICATION_SCOPES))
 
     def authenticate(self, credential: str) -> InternalAPIPrincipal | None:
         """Resolve a credential to its server-owned principal, if valid.
@@ -134,15 +145,34 @@ class InternalAPIAuth:
                 matched = principal
         return matched
 
-    def _agent_principal(self, chat_id: int) -> InternalAPIPrincipal:
-        """Build the configured persistent-agent principal for one user."""
-        allowed_services = self._allowed_services_by_user.get(chat_id, frozenset())
+    def _agent_principal(
+        self,
+        context: WorkshopInternalAPIExecutionContext,
+    ) -> InternalAPIPrincipal:
+        """Build the persistent-agent principal for one canonical context."""
+        allowed_services = self._allowed_services_by_profile.get(context.runtime_profile_id, frozenset())
         scopes = set(_PERSISTENT_AGENT_BASE_SCOPES)
         if allowed_services:
             scopes.add(InternalAPIScope.SERVICES_CALL)
+        return self._principal(
+            context,
+            frozenset(scopes),
+            allowed_services,
+        )
+
+    @staticmethod
+    def _principal(
+        context: WorkshopInternalAPIExecutionContext,
+        scopes: frozenset[InternalAPIScope],
+        allowed_services: frozenset[str] = frozenset(),
+    ) -> InternalAPIPrincipal:
         return InternalAPIPrincipal(
-            chat_id=chat_id,
-            scopes=frozenset(scopes),
+            principal_id=context.principal_id,
+            channel_id=context.channel_id,
+            agent_id=context.agent_id,
+            runtime_profile_id=context.runtime_profile_id,
+            _runtime_config_id=context.compatibility_runtime_config_id(),
+            scopes=scopes,
             allowed_services=allowed_services,
         )
 

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -500,6 +500,11 @@ def _start() -> None:
             "Workshop principal storage ready (namespaces=%d)",
             len(principal_storage.namespaces),
         )
+        internal_api_contexts = await sessions.load_workshop_internal_api_context_registry(runtime_profiles)
+        logging.info(
+            "Workshop internal API authority ready (contexts=%d)",
+            len(internal_api_contexts.contexts),
+        )
         channel_history = await sessions.load_workshop_channel_history_registry(runtime_profiles)
         from kai.history import configure_channel_history_namespaces
 
@@ -629,6 +634,7 @@ def _start() -> None:
                 runtime_profiles=runtime_profiles,
                 execution_state=execution_state,
                 principal_storage=principal_storage,
+                internal_api_contexts=internal_api_contexts,
                 services_info=services.get_available_services(),
                 registered_backend_ids=_workshop_registered_backend_ids(config),
             )

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -45,6 +45,7 @@ from kai.internal_api_auth import InternalAPIAuth
 from kai.workspace_utils import is_workspace_allowed
 
 if TYPE_CHECKING:
+    from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
     from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
 
 log = logging.getLogger(__name__)
@@ -148,13 +149,14 @@ class SubprocessPool:
         config: Config,
         services_info: list[dict],
         runtime_profiles: WorkshopRuntimeProfileRegistry | None = None,
+        internal_api_contexts: WorkshopInternalAPIContextRegistry | None = None,
     ):
         self._config = config
         self._runtime_profiles = runtime_profiles
         available_service_names = {
             service["name"] for service in services_info if isinstance(service.get("name"), str) and service["name"]
         }
-        allowed_services_by_user: dict[int, frozenset[str]] = {}
+        allowed_services_by_profile = {}
         self._services_info_by_user: dict[int, list[dict]] = {}
         runtime_config_ids = (
             {profile.runtime_config_id for profile in runtime_profiles.profiles}
@@ -185,11 +187,17 @@ class SubprocessPool:
                     ", ".join(sorted(unavailable)),
                 )
             allowed = requested & available_service_names
-            allowed_services_by_user[chat_id] = allowed
+            if protected_profile is not None:
+                service_profile_id = protected_profile.profile_id
+            else:
+                from kai.workshop.runtime_profiles import runtime_profile_id_for_config_id
+
+                service_profile_id = runtime_profile_id_for_config_id(chat_id)
+            allowed_services_by_profile[service_profile_id] = allowed
             self._services_info_by_user[chat_id] = [
                 service for service in services_info if service.get("name") in allowed
             ]
-        if available_service_names and not any(allowed_services_by_user.values()):
+        if available_service_names and not any(allowed_services_by_profile.values()):
             log.warning(
                 "External services are loaded but no user has an allowed_services grant; "
                 "the agent service proxy is disabled for every user"
@@ -197,9 +205,33 @@ class SubprocessPool:
         # Tokens are random and process-local. The pool owns the store because
         # it creates every persistent backend; webhook.start() receives this
         # same object through bot_data so credential resolution cannot drift.
-        self._internal_api_auth = InternalAPIAuth.for_users(
-            runtime_config_ids,
-            allowed_services_by_user=allowed_services_by_user,
+        if internal_api_contexts is None:
+            if config.protected_install:
+                raise RuntimeError("Protected runtime requires canonical internal API execution contexts")
+            from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
+            from kai.workshop.runtime_profiles import runtime_profile_id_for_config_id
+
+            contexts = tuple(
+                WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
+                    runtime_config_id,
+                    (
+                        protected_profiles_by_config_id[runtime_config_id].profile_id
+                        if runtime_config_id in protected_profiles_by_config_id
+                        else runtime_profile_id_for_config_id(runtime_config_id)
+                    ),
+                )
+                for runtime_config_id in runtime_config_ids
+            )
+        else:
+            contexts = internal_api_contexts.contexts
+        self._internal_api_contexts = internal_api_contexts
+        self._protected_internal_api_contexts = config.protected_install
+        self._contexts_by_runtime_config_id = {
+            context.compatibility_runtime_config_id(): context for context in contexts
+        }
+        self._internal_api_auth = InternalAPIAuth.for_execution_contexts(
+            contexts,
+            allowed_services_by_profile=allowed_services_by_profile,
         )
         self._pool: dict[int, AgentBackend] = {}
         self._last_activity: dict[int, float] = {}
@@ -474,7 +506,19 @@ class SubprocessPool:
         # Internal API availability is independent of public webhook ingress.
         # Agents receive only their random principal credential, never an
         # external webhook signing secret.
-        internal_api_credential = self._internal_api_auth.agent_credential_for(chat_id)
+        internal_api_context = self._contexts_by_runtime_config_id.get(chat_id)
+        if internal_api_context is None:
+            if self._protected_internal_api_contexts:
+                raise RuntimeError("Runtime has no canonical internal API execution context")
+            from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
+            from kai.workshop.runtime_profiles import runtime_profile_id_for_config_id
+
+            internal_api_context = WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
+                chat_id,
+                runtime_profile_id_for_config_id(abs(chat_id)),
+            )
+            self._contexts_by_runtime_config_id[chat_id] = internal_api_context
+        internal_api_credential = self._internal_api_auth.agent_credential_for(internal_api_context)
         services_info = self._services_info_by_user.get(chat_id, [])
 
         if backend == "goose":

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -62,6 +62,7 @@ from kai.workshop.execution_state import (
     reconcile_legacy_execution_state,
 )
 from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_authority import (
     WorkshopMemoryAuthorityMigration,
     reconcile_workshop_memory_authority,
@@ -376,6 +377,20 @@ async def load_workshop_principal_storage_registry(
     async with _workshop_event_lock:
         store = WorkshopEventStore.from_initialized_connection(_get_db())
         return await WorkshopPrincipalStorageRegistry.from_store(
+            store,
+            runtime_profiles,
+        )
+
+
+async def load_workshop_internal_api_context_registry(
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
+) -> WorkshopInternalAPIContextRegistry:
+    """Resolve canonical internal API authority on the initialized database."""
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        store = WorkshopEventStore.from_initialized_connection(_get_db())
+        return await WorkshopInternalAPIContextRegistry.from_store(
             store,
             runtime_profiles,
         )

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -155,10 +155,6 @@ WORKSHOP_GITHUB_AUTOMATION_KEY: web.AppKey[WorkshopGitHubAutomationService] = we
 )
 
 
-class UnauthorizedChatIdError(Exception):
-    """Raised when a request targets a chat_id other than its principal."""
-
-
 # Module-level server state, managed by start() and stop()
 _app: web.Application | None = None
 _runner: web.AppRunner | None = None
@@ -444,9 +440,9 @@ def _require_internal_api(scope: InternalAPIScope):
                 return web.Response(status=401, text="Invalid credential")
             if not principal.allows(scope):
                 log.warning(
-                    "Internal API scope denial on %s for principal %d",
+                    "Internal API scope denial on %s for principal %s",
                     request.path,
-                    principal.chat_id,
+                    principal.principal_id,
                 )
                 return web.Response(status=403, text="Credential is not authorized for this operation")
             return await handler(request, principal)
@@ -456,35 +452,41 @@ def _require_internal_api(scope: InternalAPIScope):
     return decorator
 
 
-def _resolve_chat_id(principal: InternalAPIPrincipal, payload: dict) -> int:
-    """
-    Resolve identity from the authenticated principal, not request data.
+_INTERNAL_API_IDENTITY_SELECTORS = frozenset(
+    {
+        "chat_id",
+        "user_id",
+        "principal_id",
+        "channel_id",
+        "agent_id",
+        "runtime_profile_id",
+        "runtime_config_id",
+    }
+)
 
-    A caller may include chat_id for clarity and compatibility, but it must
-    match the server-resolved credential owner. Omitting chat_id uses that
-    owner directly; there is no admin or application-default fallback.
+
+def _resolve_internal_runtime_config_id(
+    principal: InternalAPIPrincipal,
+    payload: dict,
+) -> int:
+    """
+    Resolve the private compatibility key from authenticated authority.
+
+    Canonical identity is bound to the process-lifetime credential. Request
+    bodies and query strings may not repeat or select the retired ``chat_id``
+    identity field. The returned integer is confined to this server adapter
+    while legacy persistence primitives are being replaced.
 
     Raises:
-        ValueError: If chat_id is present but not a valid integer.
-        UnauthorizedChatIdError: If chat_id differs from the principal.
+        ValueError: If the retired caller-supplied identity field is present.
     """
-    explicit = payload.get("chat_id")
-    if explicit is not None:
-        # Reject bools (int(True) == 1) and non-integer floats
-        if isinstance(explicit, bool):
-            raise ValueError(f"chat_id must be an integer, got {explicit!r}")
-        if isinstance(explicit, float) and not float(explicit).is_integer():
-            raise ValueError(f"chat_id must be an integer, got {explicit!r}")
-        try:
-            resolved = int(explicit)
-        except (TypeError, ValueError):
-            raise ValueError(f"chat_id must be an integer, got {explicit!r}") from None
-        if resolved != principal.chat_id:
-            raise UnauthorizedChatIdError(
-                f"chat_id {resolved} does not match authenticated principal {principal.chat_id}"
-            )
-        return resolved
-    return principal.chat_id
+    supplied = sorted(_INTERNAL_API_IDENTITY_SELECTORS.intersection(payload))
+    if supplied:
+        raise ValueError(
+            f"Identity selector {supplied[0]} is not accepted; the internal API credential already binds "
+            "the canonical execution context"
+        )
+    return principal.compatibility_runtime_config_id()
 
 
 # ── GitHub event formatters ───────────────────────────────────────────
@@ -1086,11 +1088,9 @@ async def _handle_schedule(request: web.Request, principal: InternalAPIPrincipal
     auto_remove = payload.get("auto_remove", False)
     notify_on_check = payload.get("notify_on_check", False)
     try:
-        chat_id = _resolve_chat_id(principal, payload)
+        chat_id = _resolve_internal_runtime_config_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
 
     # Validate schedule_data structure before persisting. Catches malformed
     # JSON strings and wrong-shape payloads (e.g., interval keys on a daily
@@ -1144,15 +1144,11 @@ async def _handle_get_jobs(request: web.Request, principal: InternalAPIPrincipal
     without needing to parse Telegram bot command output.
     """
 
-    # Resolve the caller's identity. Query params are passed as the payload
-    # dict so _resolve_chat_id can extract and validate chat_id the same
-    # way it does for POST endpoints with JSON bodies.
+    # Query parameters cannot select identity; the credential owns routing.
     try:
-        chat_id = _resolve_chat_id(principal, dict(request.query))
+        chat_id = _resolve_internal_runtime_config_id(principal, dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
     jobs = await sessions.get_jobs(chat_id)
     return web.json_response(jobs)
 
@@ -1172,15 +1168,13 @@ async def _handle_get_job(request: web.Request, principal: InternalAPIPrincipal)
 
     # Resolve caller identity for ownership check
     try:
-        chat_id = _resolve_chat_id(principal, dict(request.query))
+        chat_id = _resolve_internal_runtime_config_id(principal, dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
 
     job = await sessions.get_job_by_id(job_id)
     # Return 404 for missing OR wrong-owner jobs (don't leak existence).
-    # Both sides are ints: _resolve_chat_id always returns int, and
+    # Both sides are ints: _resolve_internal_runtime_config_id always returns int, and
     # chat_id is stored as INTEGER in the jobs table.
     if not job or job["chat_id"] != chat_id:
         return web.json_response({"error": "Job not found"}, status=404)
@@ -1201,14 +1195,11 @@ async def _handle_delete_job(request: web.Request, principal: InternalAPIPrincip
     except ValueError:
         return web.json_response({"error": "Invalid job ID"}, status=400)
 
-    # Resolve caller identity from its server-owned principal. A query-string
-    # chat_id is accepted only when it repeats that identity.
+    # Resolve compatibility storage only from server-owned authority.
     try:
-        chat_id = _resolve_chat_id(principal, dict(request.query))
+        chat_id = _resolve_internal_runtime_config_id(principal, dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
     deleted = await sessions.delete_job(job_id, chat_id=chat_id)
     if not deleted:
         return web.json_response({"error": "Job not found"}, status=404)
@@ -1278,17 +1269,11 @@ async def _handle_update_job(request: web.Request, principal: InternalAPIPrincip
         if error:
             return web.json_response({"error": error}, status=400)
 
-    # Resolve caller identity from the JSON body (e.g., {"chat_id": 456, ...}).
-    # Falls back to admin chat_id when omitted. The chat_id field is used
-    # solely for authorization (WHERE clause filter in update_job), not as
-    # an updatable column - update_job only writes explicitly named fields
-    # (name, prompt, schedule_type, etc.) to the SET clause.
+    # The credential selects authority; request data cannot choose identity.
     try:
-        chat_id = _resolve_chat_id(principal, payload)
+        chat_id = _resolve_internal_runtime_config_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
 
     # If the schedule changes, keep the previous row so a failed scheduler
     # re-registration can be compensated. Without this, PATCH can leave the DB
@@ -1390,8 +1375,8 @@ async def _handle_service_call(request: web.Request, principal: InternalAPIPrinc
     service_name = request.match_info["name"]
     if not principal.allows_service(service_name):
         log.warning(
-            "Internal API service denial for principal %d: %s",
-            principal.chat_id,
+            "Internal API service denial for principal %s: %s",
+            principal.principal_id,
             service_name,
         )
         return web.json_response({"error": "Service is not authorized for this principal"}, status=403)
@@ -1467,11 +1452,9 @@ async def _handle_send_message(request: web.Request, principal: InternalAPIPrinc
 
     bot = request.app[TELEGRAM_BOT_KEY]
     try:
-        chat_id = _resolve_chat_id(principal, payload)
+        chat_id = _resolve_internal_runtime_config_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
 
     try:
         for part in chunk_text(text):
@@ -1525,11 +1508,9 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
 
     # Resolve chat_id first - needed for per-user workspace confinement
     try:
-        chat_id = _resolve_chat_id(principal, payload)
+        chat_id = _resolve_internal_runtime_config_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
 
     path = Path(file_path).resolve()
 
@@ -1552,7 +1533,7 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     if storage_registry is None:
         return web.json_response({"error": "Principal storage unavailable"}, status=403)
     try:
-        storage_namespace = storage_registry.for_runtime_config_id(principal.chat_id)
+        storage_namespace = storage_registry.for_runtime_config_id(principal.compatibility_runtime_config_id())
     except WorkshopStorageNamespaceError:
         return web.json_response({"error": "Principal storage unavailable"}, status=403)
     allowed_roots = (
@@ -1598,7 +1579,7 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
 #     "no data" and inner Claude could not pick a retry policy from the
 #     status code alone.
 #
-#   - Memory primitives take user_id as a string; _resolve_chat_id returns
+#   - Memory primitives take user_id as a string; _resolve_internal_runtime_config_id returns
 #     int. Stringify at the boundary in every handler. Removing the cast
 #     is a load-bearing bug: Mem0 keys are stored under the string form,
 #     so a missed cast would silently isolate the caller's memories from
@@ -1647,8 +1628,6 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
         tags: list[str], optional
         metadata: dict, optional (keys "type" and "tags" are reserved by
             add_structured; user values for those will be overwritten)
-        chat_id: int, optional, defaults to the authenticated principal
-
     Provenance is stamped server-side: `source` is always "explicit"
     (a caller-supplied value is overridden, so the convention cannot
     drift per caller), the scope fields are routed from the caller's
@@ -1659,9 +1638,8 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
 
     Responses:
         200 {"id": "<mem0-uuid>"} on success
-        400 on bad input (invalid JSON, missing/empty content, bad chat_id)
+        400 on bad input or a retired caller identity selector
         401 on bad/missing internal API credential (handled by the decorator)
-        403 on a chat_id that differs from the authenticated principal
         503 when memory is disabled (precheck; do not retry, escalate)
         500 when add_structured() returns None despite memory being enabled
             (the underlying store call failed; may be transient)
@@ -1736,11 +1714,9 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
             return web.json_response({"error": "metadata.confidence must be a number in [0.0, 1.0]"}, status=400)
 
     try:
-        chat_id = _resolve_chat_id(principal, payload)
+        chat_id = _resolve_internal_runtime_config_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
 
     # Symmetric is_enabled() precheck. Runs after auth + 400-level
     # validation but before the primitive call. See the §Memory API
@@ -1834,14 +1810,11 @@ async def _handle_memory_search(request: web.Request, principal: InternalAPIPrin
     Request body (JSON):
         query: str, required, non-empty after strip
         limit: int, optional (defaults to config.memory_search_limit)
-        chat_id: int, optional, defaults to the authenticated principal
-
     Responses:
         200 {"results": [<MemoryResult-dict>, ...]} on success (empty list
             is a valid 200 result for "no matches")
         400 on bad input
         401 on bad secret
-        403 on unauthorized chat_id
         503 when memory is disabled
     """
     try:
@@ -1875,11 +1848,9 @@ async def _handle_memory_search(request: web.Request, principal: InternalAPIPrin
         return web.json_response({"error": "limit must be a positive integer"}, status=400)
 
     try:
-        chat_id = _resolve_chat_id(principal, payload)
+        chat_id = _resolve_internal_runtime_config_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
 
     # search() degrades to [] when memory is disabled, but returning []
     # at the API layer would be indistinguishable from "no matches".
@@ -1917,10 +1888,7 @@ async def _handle_memory_stats(request: web.Request, principal: InternalAPIPrinc
     """
     Return memory statistics via memory.get_stats().
 
-    GET endpoint reads chat_id from query params, mirroring _handle_get_jobs.
-
-    Query params:
-        chat_id: int, optional (defaults to the authenticated principal)
+    GET endpoint derives its scope from the authenticated execution context.
 
     Response is the MemoryStats object at the top level, NOT wrapped in
     {"results": ...} - single-object reads return the object bare per
@@ -1934,19 +1902,15 @@ async def _handle_memory_stats(request: web.Request, principal: InternalAPIPrinc
 
     Responses:
         200 <MemoryStats-dict> on success
-        400 on bad chat_id
+        400 on a retired caller identity selector
         401 on bad secret
-        403 on unauthorized chat_id
         503 when memory is disabled
     """
-    # GET handlers feed query params to _resolve_chat_id; established
-    # pattern at _handle_get_jobs.
+    # Query parameters cannot select identity; the credential owns routing.
     try:
-        chat_id = _resolve_chat_id(principal, dict(request.query))
+        chat_id = _resolve_internal_runtime_config_id(principal, dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
 
     # get_stats() returns zeroed MemoryStats when memory is disabled,
     # but - same as search - "memory off" and "user has no facts yet"
@@ -1984,21 +1948,13 @@ async def _handle_memory_delete_all(request: web.Request, principal: InternalAPI
     well-known token (not per-request UUID) because the threat model
     is typo + prompt-injection defense, not replay protection.
 
-    Convention divergence (deliberate): _handle_delete_job reads chat_id
-    from query params, but this handler reads chat_id from the body
-    alongside the confirm token, since the body already exists for the
-    confirm field. Splitting confirm into the body and chat_id into the
-    query would be inconsistent within the same endpoint.
-
     Request body (JSON):
         confirm: str, required, must equal "delete-all-memories"
-        chat_id: int, optional, defaults to the authenticated principal
 
     Responses:
         200 {"status": "deleted"} on success
-        400 on missing/wrong confirm or bad chat_id
+        400 on missing/wrong confirm or a retired caller identity selector
         401 on bad secret
-        403 on unauthorized chat_id
         503 when memory is disabled
 
     Caveat: delete_all() swallows internal errors (memory.py:1066-1069).
@@ -2019,10 +1975,10 @@ async def _handle_memory_delete_all(request: web.Request, principal: InternalAPI
     if not isinstance(payload, dict):
         return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 
-    # Confirm-token check before chat_id resolution: a request with the
+    # Confirm-token check before compatibility storage resolution: a request with the
     # wrong token is structurally bad input regardless of which user it
     # was aimed at, and rejecting it first means we don't waste a
-    # _resolve_chat_id call on requests we will reject anyway.
+    # _resolve_internal_runtime_config_id call on requests we will reject anyway.
     if payload.get("confirm") != _DELETE_ALL_CONFIRM_TOKEN:
         return web.json_response(
             {"error": f'Missing or incorrect confirm field; expected "{_DELETE_ALL_CONFIRM_TOKEN}"'},
@@ -2030,11 +1986,9 @@ async def _handle_memory_delete_all(request: web.Request, principal: InternalAPI
         )
 
     try:
-        chat_id = _resolve_chat_id(principal, payload)
+        chat_id = _resolve_internal_runtime_config_id(principal, payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    except UnauthorizedChatIdError as e:
-        return web.json_response({"error": str(e)}, status=403)
 
     # Symmetric precheck. delete_all() is a no-op when disabled, but
     # callers asking the API to wipe their memories deserve to know the

--- a/src/kai/workshop/internal_api_contexts.py
+++ b/src/kai/workshop/internal_api_contexts.py
@@ -1,0 +1,156 @@
+"""Canonical execution authority for Kai's protected internal HTTP API."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.store import WorkshopEventStore
+
+
+class WorkshopInternalAPIContextError(RuntimeError):
+    """Protected runtime policy cannot resolve one canonical API context."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopInternalAPIExecutionContext:
+    """Canonical authority attached to one protected agent runtime."""
+
+    principal_id: PrincipalId
+    channel_id: ChannelId
+    agent_id: AgentId
+    runtime_profile_id: RuntimeProfileId
+    _runtime_config_id: int = field(repr=False)
+
+    def compatibility_runtime_config_id(self) -> int:
+        """Return the private compatibility key used behind server adapters."""
+        return self._runtime_config_id
+
+    @classmethod
+    def for_unprotected_runtime(
+        cls,
+        runtime_config_id: int,
+        runtime_profile_id: RuntimeProfileId,
+    ) -> WorkshopInternalAPIExecutionContext:
+        """Build deterministic development-only identity outside protected installs."""
+        digest = hashlib.sha256(f"kai-unprotected:{runtime_config_id}".encode()).hexdigest()
+        return cls(
+            principal_id=PrincipalId(f"prn_{digest[:32]}"),
+            channel_id=ChannelId(f"chn_{digest[1:33]}"),
+            agent_id=AgentId(f"agt_{digest[2:34]}"),
+            runtime_profile_id=runtime_profile_id,
+            _runtime_config_id=runtime_config_id,
+        )
+
+
+class WorkshopInternalAPIContextRegistry:
+    """Resolve every protected runtime to one canonical execution context."""
+
+    def __init__(
+        self,
+        contexts: tuple[WorkshopInternalAPIExecutionContext, ...],
+    ) -> None:
+        by_profile: dict[RuntimeProfileId, WorkshopInternalAPIExecutionContext] = {}
+        by_config_id: dict[int, WorkshopInternalAPIExecutionContext] = {}
+        for context in contexts:
+            if not isinstance(context, WorkshopInternalAPIExecutionContext):
+                raise TypeError("contexts must contain WorkshopInternalAPIExecutionContext values")
+            if context.runtime_profile_id in by_profile:
+                raise WorkshopInternalAPIContextError("Duplicate internal API runtime profile")
+            if context._runtime_config_id in by_config_id:
+                raise WorkshopInternalAPIContextError("Duplicate internal API runtime configuration")
+            by_profile[context.runtime_profile_id] = context
+            by_config_id[context._runtime_config_id] = context
+        if not by_profile:
+            raise WorkshopInternalAPIContextError("At least one internal API execution context is required")
+        self._by_profile = by_profile
+        self._by_config_id = by_config_id
+
+    @classmethod
+    async def from_store(
+        cls,
+        store: WorkshopEventStore,
+        runtime_profiles: WorkshopRuntimeProfileRegistry,
+    ) -> WorkshopInternalAPIContextRegistry:
+        """Load complete, same-workshop direct-channel execution contexts."""
+        async with store.connection.execute(
+            "SELECT ra.runtime_profile_id, cm.principal_id, ra.channel_id, ra.agent_id "
+            "FROM channel_agent_runtime_assignments ra "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN agents a ON a.id = ra.agent_id AND a.workshop_id = c.workshop_id "
+            "JOIN channel_agents ca ON ca.channel_id = c.id AND ca.agent_id = a.id "
+            "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
+            "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+            "JOIN workshop_memberships wm ON wm.principal_id = p.id "
+            "AND wm.workshop_id = c.workshop_id "
+            "ORDER BY ra.runtime_profile_id, cm.principal_id"
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+
+        rows_by_profile: dict[
+            RuntimeProfileId,
+            set[tuple[PrincipalId, ChannelId, AgentId]],
+        ] = {}
+        for row in rows:
+            try:
+                profile_id = RuntimeProfileId(str(row[0]))
+                identity = (
+                    PrincipalId(str(row[1])),
+                    ChannelId(str(row[2])),
+                    AgentId(str(row[3])),
+                )
+            except (TypeError, ValueError) as exc:
+                raise WorkshopInternalAPIContextError(
+                    "Canonical internal API context contains an invalid opaque identifier"
+                ) from exc
+            rows_by_profile.setdefault(profile_id, set()).add(identity)
+
+        contexts: list[WorkshopInternalAPIExecutionContext] = []
+        for profile in runtime_profiles.profiles:
+            identities = rows_by_profile.get(profile.profile_id, set())
+            if len(identities) != 1:
+                raise WorkshopInternalAPIContextError(
+                    "Protected runtime profile must resolve to exactly one canonical internal API context"
+                )
+            principal_id, channel_id, agent_id = next(iter(identities))
+            contexts.append(
+                WorkshopInternalAPIExecutionContext(
+                    principal_id=principal_id,
+                    channel_id=channel_id,
+                    agent_id=agent_id,
+                    runtime_profile_id=profile.profile_id,
+                    _runtime_config_id=profile.runtime_config_id,
+                )
+            )
+        return cls(tuple(contexts))
+
+    @property
+    def contexts(self) -> tuple[WorkshopInternalAPIExecutionContext, ...]:
+        return tuple(sorted(self._by_profile.values(), key=lambda context: context.runtime_profile_id))
+
+    def for_runtime_profile(
+        self,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> WorkshopInternalAPIExecutionContext:
+        try:
+            normalized = (
+                runtime_profile_id
+                if isinstance(runtime_profile_id, RuntimeProfileId)
+                else RuntimeProfileId(runtime_profile_id)
+            )
+        except (TypeError, ValueError) as exc:
+            raise WorkshopInternalAPIContextError("Runtime profile ID is invalid") from exc
+        context = self._by_profile.get(normalized)
+        if context is None:
+            raise WorkshopInternalAPIContextError("Runtime profile has no canonical internal API context")
+        return context
+
+    def for_runtime_config_id(self, runtime_config_id: int) -> WorkshopInternalAPIExecutionContext:
+        if isinstance(runtime_config_id, bool) or not isinstance(runtime_config_id, int):
+            raise WorkshopInternalAPIContextError("Runtime configuration ID must be an integer")
+        context = self._by_config_id.get(runtime_config_id)
+        if context is None:
+            raise WorkshopInternalAPIContextError("Runtime configuration has no canonical internal API context")
+        return context

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -94,7 +94,9 @@ Use the scheduling API to create reminders and scheduled tasks. The API endpoint
 
 **Timezones:** All times in `schedule_data` must be UTC. If the user's timezone is known from memory, convert their stated local time to UTC before creating the job. Confirm the conversion in your reply so they can catch any error.
 
-**Routing:** Always include `"chat_id": <your chat_id>` in the POST body. Your chat_id is provided in your session context.
+**Routing:** Do not include a user, chat, channel, agent, or runtime identity in
+internal API requests. `$KAI_WEBHOOK_SECRET` is a short-lived scoped credential
+that already binds the canonical execution context server-side.
 
 ### Examples:
 ```bash
@@ -102,19 +104,19 @@ Use the scheduling API to create reminders and scheduled tasks. The API endpoint
 curl -s -X POST http://localhost:8080/api/schedule \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "name": "Laundry", "prompt": "Time to do the laundry!", "schedule_type": "once", "schedule_data": {"run_at": "2026-02-08T19:00:00+00:00"}}'
+  -d '{"name": "Laundry", "prompt": "Time to do the laundry!", "schedule_type": "once", "schedule_data": {"run_at": "2026-02-08T19:00:00+00:00"}}'
 
 # Agent job (you process the prompt each time it fires)
 curl -s -X POST http://localhost:8080/api/schedule \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "name": "Weather", "prompt": "What is the weather today?", "job_type": "agent", "schedule_type": "daily", "schedule_data": {"times": ["08:00"]}}'
+  -d '{"name": "Weather", "prompt": "What is the weather today?", "job_type": "agent", "schedule_type": "daily", "schedule_data": {"times": ["08:00"]}}'
 
 # Auto-remove job (deactivates when condition is met, with progress updates)
 curl -s -X POST http://localhost:8080/api/schedule \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "name": "Package tracker", "prompt": "Has my package arrived? Give a brief status update.", "job_type": "agent", "auto_remove": true, "notify_on_check": true, "schedule_type": "interval", "schedule_data": {"seconds": 3600}}'
+  -d '{"name": "Package tracker", "prompt": "Has my package arrived? Give a brief status update.", "job_type": "agent", "auto_remove": true, "notify_on_check": true, "schedule_type": "interval", "schedule_data": {"seconds": 3600}}'
 ```
 
 For auto-remove jobs, start your response with `CONDITION_MET: <message>` when the condition is satisfied, or `CONDITION_NOT_MET` to silently continue. If `notify_on_check` is enabled, use `CONDITION_NOT_MET: <status message>` to send progress updates while continuing to monitor.
@@ -130,7 +132,6 @@ For auto-remove jobs, start your response with `CONDITION_MET: <message>` when t
 - `job_type` - `reminder` (default) or `agent`
 - `auto_remove` - deactivate when condition met (agent jobs only)
 - `notify_on_check` - send CONDITION_NOT_MET messages to user (auto_remove only, default false)
-- `chat_id` - integer; required for correct routing in multi-user setups
 
 ### Managing jobs:
 ```bash
@@ -158,10 +159,10 @@ To proactively send a message to the user (background task results, notification
 curl -s -X POST http://localhost:8080/api/send-message \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "text": "Your build finished successfully."}'
+  -d '{"text": "Your build finished successfully."}'
 ```
 
-Fields: `chat_id` (integer, required), `text` (string, required). Long messages are automatically split at Telegram's 4096-character limit.
+Fields: `text` (string, required).
 
 ## Sending Files
 
@@ -171,10 +172,9 @@ To send a file from the filesystem to the user:
 curl -s -X POST http://localhost:8080/api/send-file \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "path": "/absolute/path/to/file.png", "caption": "Here is your chart."}'
+  -d '{"path": "/absolute/path/to/file.png", "caption": "Here is your chart."}'
 ```
 
-- `chat_id` - integer; required for routing
 - `path` - required; absolute path within the current workspace
 - `caption` - string; optional
 - Images (png, jpg, webp) are sent as photos (rendered inline). Everything else is sent as a document attachment.
@@ -202,10 +202,10 @@ There is deliberately no delete endpoint in this API. When the user asks to remo
 curl -s -X POST http://localhost:8080/api/memory/add \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "content": "User prefers Earl Grey over English Breakfast", "memory_type": "preference", "tags": ["beverage", "preference"]}'
+  -d '{"content": "User prefers Earl Grey over English Breakfast", "memory_type": "preference", "tags": ["beverage", "preference"]}'
 ```
 
-Fields: `content` (string, required), `memory_type` (string, default `"fact"`), `tags` (list of strings, optional), `metadata` (dict, optional), `chat_id` (integer, required for routing). Response: `{"id": "<mem0-uuid>"}`.
+Fields: `content` (string, required), `memory_type` (string, default `"fact"`), `tags` (list of strings, optional), `metadata` (dict, optional). Response: `{"id": "<mem0-uuid>"}`.
 
 Provenance is stamped by the server: `source` and scope are set automatically (your value would be overridden), and `speaker`/`confidence` default to `"assistant"`/`0.9`. Override the defaults via `metadata` only when you know better, e.g. `"metadata": {"speaker": "user"}` for a fact the user stated directly.
 
@@ -215,15 +215,15 @@ Provenance is stamped by the server: `source` and scope are set automatically (y
 curl -s -X POST http://localhost:8080/api/memory/search \
   -H 'Content-Type: application/json' \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET" \
-  -d '{"chat_id": <chat_id>, "query": "what tea does the user like"}'
+  -d '{"query": "what tea does the user like"}'
 ```
 
-Fields: `query` (string, required), `limit` (integer, optional), `chat_id` (integer, required). Response: `{"results": [{"id": ..., "text": ..., "score": ..., "memory_type": ..., "metadata": {...}, "created_at": ...}, ...]}`. Empty `results` means no matches above the relevance threshold; this is a normal 200, not an error.
+Fields: `query` (string, required), `limit` (integer, optional). Response: `{"results": [{"id": ..., "text": ..., "score": ..., "memory_type": ..., "metadata": {...}, "created_at": ...}, ...]}`. Empty `results` means no matches above the relevance threshold; this is a normal 200, not an error.
 
 ### Stats
 
 ```bash
-curl -s "http://localhost:8080/api/memory/stats?chat_id=<chat_id>" \
+curl -s "http://localhost:8080/api/memory/stats" \
   -H "X-Webhook-Secret: $KAI_WEBHOOK_SECRET"
 ```
 
@@ -241,7 +241,7 @@ For a fresh user with no extracted facts (`extracted_count == 0`), the confidenc
 
 - `400` - your request was bad (missing field, invalid JSON). Fix the request and retry.
 - `401` - wrong webhook secret. Configuration bug; surface to the operator.
-- `403` - the chat_id does not belong to your credential, or your credential lacks the permission scope for that operation. Not retryable: no change to the request will make it succeed. If you believe the chat_id is your own, surface the error to the user instead of retrying.
+- `403` - your credential lacks the permission scope for that operation. Not retryable: no change to the request will make it succeed.
 - `503` - the memory system is disabled. Don't retry; surface to the operator. Same status across all three memory endpoints, so a single retry policy covers the disabled case.
 - `500` - on `/api/memory/add` only, the underlying store call failed despite memory being enabled. May be transient; retrying once with a short backoff is reasonable. Persistent 500s should be surfaced to the operator.
 

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -22,6 +22,10 @@ from kai.workshop.execution_state import (
     WorkshopExecutionStateRegistry,
 )
 from kai.workshop.inbound import InboundMessage
+from kai.workshop.internal_api_contexts import (
+    WorkshopInternalAPIContextRegistry,
+    WorkshopInternalAPIExecutionContext,
+)
 from kai.workshop.run_execution_authority import (
     RunAttemptStatus,
     RunExecutionSelection,
@@ -243,6 +247,7 @@ def _host() -> KaiApplicationHost:
         runtime_profiles=SimpleNamespace(),  # type: ignore[arg-type]
         execution_state=SimpleNamespace(),  # type: ignore[arg-type]
         principal_storage=SimpleNamespace(),  # type: ignore[arg-type]
+        internal_api_contexts=SimpleNamespace(contexts=()),  # type: ignore[arg-type]
         services_info=[],
         registered_backend_ids=frozenset({"codex"}),
     )
@@ -257,6 +262,20 @@ def _execution_state(principal_id: PrincipalId, runtime_config_id: int):
                 agent_id=AgentId(f"agt_{runtime_config_id:032x}"),
                 runtime_profile_id=profile_id(runtime_config_id),
                 runtime_config_id=runtime_config_id,
+            ),
+        )
+    )
+
+
+def _internal_contexts(principal_id: PrincipalId, runtime_config_id: int):
+    return WorkshopInternalAPIContextRegistry(
+        (
+            WorkshopInternalAPIExecutionContext(
+                principal_id=principal_id,
+                channel_id=ChannelId(f"chn_{runtime_config_id:032x}"),
+                agent_id=AgentId(f"agt_{runtime_config_id:032x}"),
+                runtime_profile_id=profile_id(runtime_config_id),
+                _runtime_config_id=runtime_config_id,
             ),
         )
     )
@@ -421,6 +440,7 @@ async def test_real_core_lifecycle_uses_workshop_identity_without_telegram_appli
         runtime_profiles=profiles,
         execution_state=_execution_state(PrincipalId(str(principal_id)), 101),
         principal_storage=principal_storage,
+        internal_api_contexts=_internal_contexts(PrincipalId(str(principal_id)), 101),
         services_info=[],
         registered_backend_ids=frozenset({"codex"}),
     )
@@ -515,6 +535,7 @@ async def test_core_activates_delivery_authority_before_recovering_expired_start
                 ),
             )
         ),
+        internal_api_contexts=_internal_contexts(PrincipalId(str(principal_id)), 101),
         services_info=[],
         registered_backend_ids=frozenset({"codex"}),
     )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -65,9 +65,11 @@ from kai.install import (
     _generate_users_yaml,
     _github_automation_status,
     _integration_route_status,
+    _internal_api_authority_status,
     _log_security_status,
     _memory_scope_review_status,
     _migrate_identity_to_claude_md,
+    _migrate_internal_api_instructions,
     _migrate_managed_home_database_paths,
     _optional_file_checksum,
     _probe_service_readiness,
@@ -5051,6 +5053,34 @@ class TestCmdStatus:
             "Workshop integration routing: INCOMPLETE; generic/default=missing"
         )
 
+    def test_status_reports_canonical_internal_api_context_coverage(self, tmp_path):
+        db_path = tmp_path / "kai.db"
+        connection = sqlite3.connect(db_path)
+        connection.executescript(
+            "CREATE TABLE channel_agent_runtime_assignments "
+            "(runtime_profile_id TEXT, channel_id TEXT, agent_id TEXT);"
+            "CREATE TABLE channels (id TEXT, kind TEXT, workshop_id TEXT);"
+            "CREATE TABLE agents (id TEXT, workshop_id TEXT);"
+            "CREATE TABLE channel_agents (channel_id TEXT, agent_id TEXT);"
+            "CREATE TABLE channel_memberships (channel_id TEXT, principal_id TEXT, role TEXT);"
+            "CREATE TABLE principals (id TEXT, kind TEXT);"
+            "CREATE TABLE workshop_memberships (principal_id TEXT, workshop_id TEXT);"
+            "INSERT INTO channel_agent_runtime_assignments VALUES ('rtp_one','chn_one','agt_one');"
+            "INSERT INTO channels VALUES ('chn_one','direct','wsp_one');"
+            "INSERT INTO agents VALUES ('agt_one','wsp_one');"
+            "INSERT INTO channel_agents VALUES ('chn_one','agt_one');"
+            "INSERT INTO channel_memberships VALUES ('chn_one','prn_one','owner');"
+            "INSERT INTO principals VALUES ('prn_one','human');"
+            "INSERT INTO workshop_memberships VALUES ('prn_one','wsp_one');"
+        )
+        connection.commit()
+        connection.close()
+
+        assert _internal_api_authority_status(db_path) == (
+            "Workshop internal API authority: active; profiles=1, "
+            "canonical contexts=1, missing=0; caller identity selectors=disabled"
+        )
+
     def test_deployed_status_reports_named_secrets_without_values(self, tmp_path, monkeypatch):
         env_path = tmp_path / "env"
         env_path.write_text(
@@ -8827,6 +8857,45 @@ class TestApplyMigrateManagedIdentity:
         )
         assert (home / "AGENTS.md").read_text() == "# Identity\n"
         assert not (home / ".claude" / "CLAUDE.md").exists()
+
+    def test_replaces_legacy_internal_api_block_without_touching_custom_identity(
+        self,
+        tmp_path,
+    ):
+        identity = tmp_path / "AGENTS.md"
+        template = tmp_path / "template.md"
+        identity.write_text(
+            "# Personal identity\nKeep me.\n\n"
+            "## Scheduling Jobs\n"
+            '**Routing:** Always include `"chat_id": <your chat_id>` in every call.\n\n'
+            "## Sending Messages\nOld examples.\n\n"
+            "## Issue-First Workflow\nKeep this too.\n"
+        )
+        template.write_text(
+            "# Template\n\n"
+            "## Scheduling Jobs\n"
+            "**Routing:** The credential binds canonical identity.\n\n"
+            "## Sending Messages\nNew examples.\n\n"
+            "## Issue-First Workflow\nTemplate tail.\n"
+        )
+
+        assert _migrate_internal_api_instructions(identity, template, dry_run=False) is True
+        migrated = identity.read_text()
+        assert "# Personal identity\nKeep me." in migrated
+        assert "The credential binds canonical identity" in migrated
+        assert "Old examples" not in migrated
+        assert "## Issue-First Workflow\nKeep this too." in migrated
+        assert "chat_id" not in migrated
+
+    def test_internal_api_instruction_migration_is_idempotent(self, tmp_path):
+        identity = tmp_path / "AGENTS.md"
+        template = tmp_path / "template.md"
+        current = "## Scheduling Jobs\nCanonical.\n\n## Issue-First Workflow\nTail.\n"
+        identity.write_text(current)
+        template.write_text(current)
+
+        assert _migrate_internal_api_instructions(identity, template, dry_run=False) is False
+        assert identity.read_text() == current
 
 
 # ── _migrate_identity_to_claude_md ───────────────────────────────────

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -3,29 +3,48 @@
 import pytest
 
 from kai.internal_api_auth import InternalAPIAuth, InternalAPIScope
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
+from tests.workshop_profiles import profile_id
+
+
+def _context(runtime_config_id: int) -> WorkshopInternalAPIExecutionContext:
+    return WorkshopInternalAPIExecutionContext(
+        principal_id=PrincipalId(f"prn_{runtime_config_id:032x}"),
+        channel_id=ChannelId(f"chn_{runtime_config_id:032x}"),
+        agent_id=AgentId(f"agt_{runtime_config_id:032x}"),
+        runtime_profile_id=profile_id(runtime_config_id),
+        _runtime_config_id=runtime_config_id,
+    )
 
 
 def test_agent_credentials_are_unique_and_resolve_server_side() -> None:
     """Each user receives a distinct token that resolves to only that user."""
-    auth = InternalAPIAuth.for_users({123, 456})
+    context_123 = _context(123)
+    context_456 = _context(456)
+    auth = InternalAPIAuth.for_execution_contexts({context_123, context_456})
 
-    token_123 = auth.agent_credential_for(123)
-    token_456 = auth.agent_credential_for(456)
+    token_123 = auth.agent_credential_for(context_123)
+    token_456 = auth.agent_credential_for(context_456)
     principal_123 = auth.authenticate(token_123)
     principal_456 = auth.authenticate(token_456)
 
     assert token_123 != token_456
     assert principal_123 is not None
     assert principal_456 is not None
-    assert principal_123.chat_id == 123
-    assert principal_456.chat_id == 456
+    assert principal_123.principal_id == context_123.principal_id
+    assert principal_123.channel_id == context_123.channel_id
+    assert principal_123.agent_id == context_123.agent_id
+    assert principal_123.runtime_profile_id == context_123.runtime_profile_id
+    assert principal_456.principal_id == context_456.principal_id
     assert auth.authenticate("not-a-token") is None
 
 
 def test_persistent_agent_profile_is_explicit_and_excludes_delete_all() -> None:
     """Persistent agents retain normal APIs but cannot wipe all memory."""
-    auth = InternalAPIAuth.for_users({123})
-    principal = auth.authenticate(auth.agent_credential_for(123))
+    context = _context(123)
+    auth = InternalAPIAuth.for_execution_contexts({context})
+    principal = auth.authenticate(auth.agent_credential_for(context))
 
     assert principal is not None
     assert principal.scopes == frozenset(
@@ -45,13 +64,15 @@ def test_persistent_agent_profile_is_explicit_and_excludes_delete_all() -> None:
 
 def test_persistent_agent_service_scope_requires_explicit_names() -> None:
     """Service scope and resources are issued only from the per-user allowlist."""
-    auth = InternalAPIAuth.for_users(
-        {123, 456},
-        allowed_services_by_user={123: {"perplexity", "weather"}},
+    context_123 = _context(123)
+    context_456 = _context(456)
+    auth = InternalAPIAuth.for_execution_contexts(
+        {context_123, context_456},
+        allowed_services_by_profile={context_123.runtime_profile_id: {"perplexity", "weather"}},
     )
 
-    principal_123 = auth.authenticate(auth.agent_credential_for(123))
-    principal_456 = auth.authenticate(auth.agent_credential_for(456))
+    principal_123 = auth.authenticate(auth.agent_credential_for(context_123))
+    principal_456 = auth.authenticate(auth.agent_credential_for(context_456))
 
     assert principal_123 is not None
     assert principal_123.allows(InternalAPIScope.SERVICES_CALL)
@@ -66,10 +87,11 @@ def test_persistent_agent_service_scope_requires_explicit_names() -> None:
 def test_notification_credential_has_only_message_scope() -> None:
     """One-shot notification agents cannot access jobs, files, services, or memory."""
     auth = InternalAPIAuth()
-    principal = auth.authenticate(auth.notification_credential_for(-100123))
+    context = _context(123)
+    principal = auth.authenticate(auth.notification_credential_for(context))
 
     assert principal is not None
-    assert principal.chat_id == -100123
+    assert principal.principal_id == context.principal_id
     assert principal.allowed_services == frozenset()
     assert principal.allows(InternalAPIScope.MESSAGES_SEND)
     assert not principal.allows(InternalAPIScope.JOBS_READ)
@@ -84,4 +106,4 @@ def test_notification_credential_has_only_message_scope() -> None:
 def test_fixed_test_credentials_must_be_unique() -> None:
     """Ambiguous credential-to-principal mappings are rejected."""
     with pytest.raises(ValueError, match="unique"):
-        InternalAPIAuth({123: "same", 456: "same"})
+        InternalAPIAuth({_context(123): "same", _context(456): "same"})

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -22,7 +22,11 @@ from kai.config import Config, ModelRole, UserConfig, WorkspaceConfig, get_model
 from kai.goose import GooseBackend
 from kai.internal_api_auth import InternalAPIScope
 from kai.pool import SubprocessPool
-from tests.workshop_profiles import profile_registry
+from kai.workshop.internal_api_contexts import (
+    WorkshopInternalAPIContextRegistry,
+    WorkshopInternalAPIExecutionContext,
+)
+from tests.workshop_profiles import profile_id, profile_registry
 
 
 def _make_config(**overrides) -> Config:
@@ -55,10 +59,33 @@ def _make_config(**overrides) -> Config:
     return Config(**defaults)
 
 
+def _internal_api_contexts(*runtime_config_ids: int) -> WorkshopInternalAPIContextRegistry:
+    return WorkshopInternalAPIContextRegistry(
+        tuple(
+            WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
+                runtime_config_id,
+                profile_id(runtime_config_id),
+            )
+            for runtime_config_id in runtime_config_ids
+        )
+    )
+
+
 # ── Instance creation ───────────────────────────────────────────────
 
 
 class TestInstanceCreation:
+    def test_protected_install_requires_canonical_internal_api_contexts(self):
+        """Protected runtimes must never synthesize API authority from config IDs."""
+        with pytest.raises(
+            RuntimeError,
+            match="Protected runtime requires canonical internal API execution contexts",
+        ):
+            SubprocessPool(
+                config=_make_config(protected_install=True),
+                services_info=[],
+            )
+
     def test_get_creates_instance(self):
         """First get(chat_id) creates an instance; second returns same one."""
         pool = SubprocessPool(config=_make_config(), services_info=[])
@@ -90,7 +117,8 @@ class TestInstanceCreation:
         assert credential
         principal = pool.internal_api_auth.authenticate(credential)
         assert principal is not None
-        assert principal.chat_id == 111
+        assert principal.compatibility_runtime_config_id() == 111
+        assert principal.runtime_profile_id == profile_id(111)
 
     def test_services_are_filtered_per_user_and_bound_to_principal(self):
         """Only explicitly allowed, available services reach each agent."""
@@ -500,7 +528,11 @@ class TestPerUserBackendRouting:
         for chat_id in users:
             (tmp_path / "home" / str(chat_id)).mkdir(parents=True)
         config = _make_config(protected_install=True, user_configs=users)
-        pool = SubprocessPool(config=config, services_info=[])
+        pool = SubprocessPool(
+            config=config,
+            services_info=[],
+            internal_api_contexts=_internal_api_contexts(*users),
+        )
         for chat_id, expected_type in [
             (111, ClaudeCodeBackend),
             (222, CodexBackend),

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -37,8 +37,9 @@ from kai.webhook import (
     add_notification_chat_id,
     remove_notification_chat_id,
 )
-from kai.workshop.domain import PrincipalId
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId
 from kai.workshop.integration_notifications import WorkshopIntegrationNotificationService
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.run_previews import WorkshopRunPreviewRegistry
 from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageNamespace,
@@ -46,6 +47,17 @@ from kai.workshop.storage_namespaces import (
 )
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id
+
+
+def _internal_api_auth() -> InternalAPIAuth:
+    context = WorkshopInternalAPIExecutionContext(
+        principal_id=PrincipalId("prn_" + "1" * 32),
+        channel_id=ChannelId("chn_" + "1" * 32),
+        agent_id=AgentId("agt_" + "1" * 32),
+        runtime_profile_id=profile_id(111),
+        _runtime_config_id=111,
+    )
+    return InternalAPIAuth({context: "secret"})
 
 
 def _principal_storage_registry() -> WorkshopPrincipalStorageRegistry:
@@ -664,7 +676,7 @@ class TestNotificationChatIdMutations:
         telegram_app = MagicMock()
         telegram_app.bot = AsyncMock()
         core_services = SimpleNamespace(
-            subprocess_pool=MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
+            subprocess_pool=MagicMock(internal_api_auth=_internal_api_auth()),
             principal_storage=_principal_storage_registry(),
             client_store=MagicMock(),
             client_commands=MagicMock(),
@@ -734,7 +746,7 @@ class TestNotificationChatIdMutations:
 
         store = await WorkshopEventStore.open(config.session_db_path)
         core_services = SimpleNamespace(
-            subprocess_pool=MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
+            subprocess_pool=MagicMock(internal_api_auth=_internal_api_auth()),
             principal_storage=_principal_storage_registry(),
             client_store=store,
             client_commands=MagicMock(),
@@ -806,7 +818,7 @@ class TestNotificationChatIdMutations:
         telegram_app.bot = AsyncMock()
         core_store = await WorkshopEventStore.open(config.session_db_path)
         core_services = SimpleNamespace(
-            subprocess_pool=MagicMock(internal_api_auth=InternalAPIAuth({111: "secret"})),
+            subprocess_pool=MagicMock(internal_api_auth=_internal_api_auth()),
             principal_storage=_principal_storage_registry(),
             client_store=core_store,
             client_commands=MagicMock(),

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -29,7 +29,6 @@ from kai.webhook import (
     WORKSHOP_GITHUB_AUTOMATION_KEY,
     WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY,
     WORKSHOP_PRINCIPAL_STORAGE_KEY,
-    UnauthorizedChatIdError,
     _handle_delete_job,
     _handle_generic,
     _handle_get_job,
@@ -45,10 +44,11 @@ from kai.webhook import (
     _handle_service_call,
     _handle_telegram_update,
     _handle_update_job,
-    _resolve_chat_id,
+    _resolve_internal_runtime_config_id,
     stop,
 )
-from kai.workshop.domain import PrincipalId
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageNamespace,
     WorkshopPrincipalStorageRegistry,
@@ -58,9 +58,21 @@ from tests.workshop_profiles import profile_id
 
 def _make_internal_api_auth() -> InternalAPIAuth:
     """Create deterministic credentials for the two API test principals."""
+    context_123 = _internal_api_context(123)
+    context_456 = _internal_api_context(456)
     return InternalAPIAuth(
-        {123: "test-secret", 456: "other-secret"},
-        allowed_services_by_user={123: {"perplexity"}},
+        {context_123: "test-secret", context_456: "other-secret"},
+        allowed_services_by_profile={context_123.runtime_profile_id: {"perplexity"}},
+    )
+
+
+def _internal_api_context(runtime_config_id: int) -> WorkshopInternalAPIExecutionContext:
+    return WorkshopInternalAPIExecutionContext(
+        principal_id=PrincipalId(f"prn_{runtime_config_id:032x}"),
+        channel_id=ChannelId(f"chn_{runtime_config_id:032x}"),
+        agent_id=AgentId(f"agt_{runtime_config_id:032x}"),
+        runtime_profile_id=profile_id(runtime_config_id),
+        _runtime_config_id=runtime_config_id,
     )
 
 
@@ -83,8 +95,13 @@ def _principal_storage_registry() -> WorkshopPrincipalStorageRegistry:
 
 async def _call_memory_delete_all_as_authorized(request, *, chat_id: int = 123):
     """Exercise delete-all handler behavior with an explicitly privileged principal."""
+    context = _internal_api_context(chat_id)
     principal = InternalAPIPrincipal(
-        chat_id=chat_id,
+        principal_id=context.principal_id,
+        channel_id=context.channel_id,
+        agent_id=context.agent_id,
+        runtime_profile_id=context.runtime_profile_id,
+        _runtime_config_id=context.compatibility_runtime_config_id(),
         scopes=frozenset({InternalAPIScope.MEMORY_DELETE_ALL}),
     )
     return await _handle_memory_delete_all.__wrapped__(request, principal)
@@ -1898,10 +1915,10 @@ class TestServiceCall:
         mock_call.assert_not_called()
 
 
-# ── _resolve_chat_id ────────────────────────────────────────────────
+# ── _resolve_internal_runtime_config_id ────────────────────────────────────────────────
 
 
-class TestResolveChatId:
+class TestResolveInternalRuntimeConfigId:
     def _principal(self, chat_id: int = 123) -> InternalAPIPrincipal:
         """Resolve a deterministic test principal from its credential."""
         auth = _make_internal_api_auth()
@@ -1910,50 +1927,34 @@ class TestResolveChatId:
         assert principal is not None
         return principal
 
-    def test_mismatched_explicit_chat_id_rejected(self):
-        """Rejects a request-supplied identity that differs from the principal."""
+    @pytest.mark.parametrize(
+        "selector",
+        [
+            "chat_id",
+            "user_id",
+            "principal_id",
+            "channel_id",
+            "agent_id",
+            "runtime_profile_id",
+            "runtime_config_id",
+        ],
+    )
+    def test_any_explicit_identity_selector_is_rejected(self, selector):
+        """Request data can never repeat or select execution identity."""
         principal = self._principal()
-        with pytest.raises(UnauthorizedChatIdError, match="does not match authenticated principal"):
-            _resolve_chat_id(principal, {"chat_id": 42})
+        with pytest.raises(ValueError, match=f"Identity selector {selector} is not accepted"):
+            _resolve_internal_runtime_config_id(principal, {selector: "anything"})
 
     def test_omitted_chat_id_uses_principal(self):
         """Omitted chat_id resolves to the authenticated principal."""
         principal = self._principal()
-        assert _resolve_chat_id(principal, {}) == 123
-
-    def test_invalid_non_numeric(self):
-        """Raises ValueError for non-numeric chat_id."""
-        principal = self._principal()
-        with pytest.raises(ValueError, match="must be an integer"):
-            _resolve_chat_id(principal, {"chat_id": "abc"})
-
-    def test_invalid_float(self):
-        """Raises ValueError for non-integer float chat_id."""
-        principal = self._principal()
-        with pytest.raises(ValueError, match="must be an integer"):
-            _resolve_chat_id(principal, {"chat_id": 12345.6})
-
-    def test_invalid_bool(self):
-        """Raises ValueError for boolean chat_id."""
-        principal = self._principal()
-        with pytest.raises(ValueError, match="must be an integer"):
-            _resolve_chat_id(principal, {"chat_id": True})
-
-    def test_integer_like_float_accepted(self):
-        """Integer-like float (e.g. 42.0) is accepted."""
-        principal = self._principal(chat_id=456)
-        assert _resolve_chat_id(principal, {"chat_id": 456.0}) == 456
-
-    def test_string_integer_accepted(self):
-        """String-encoded integer (e.g. from JSON) is accepted."""
-        principal = self._principal(chat_id=456)
-        assert _resolve_chat_id(principal, {"chat_id": "456"}) == 456
+        assert _resolve_internal_runtime_config_id(principal, {}) == 123
 
 
-class TestGetJobsChatIdRouting:
+class TestGetJobsCredentialRouting:
     @pytest.mark.asyncio
-    async def test_query_param_routes_to_user(self, db, mock_request):
-        """GET /api/jobs?chat_id=456 returns jobs for that user."""
+    async def test_query_identity_selector_is_rejected(self, db, mock_request):
+        """GET /api/jobs rejects the retired query identity selector."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.app[CHAT_ID_KEY] = 123
         mock_request.query = {"chat_id": "456"}
@@ -1969,13 +1970,12 @@ class TestGetJobsChatIdRouting:
         )
 
         resp = await _handle_get_jobs(mock_request)
-        body = json.loads(resp.body.decode())
-        assert len(body) == 1
-        assert body[0]["name"] == "User 456 Job"
+        assert resp.status == 400
+        assert "Identity selector chat_id is not accepted" in resp.text
 
     @pytest.mark.asyncio
     async def test_invalid_query_param_returns_400(self, db, mock_request):
-        """GET /api/jobs?chat_id=abc returns 400."""
+        """Any query identity selector returns 400."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.app[CHAT_ID_KEY] = 123
         mock_request.query = {"chat_id": "abc"}
@@ -1984,10 +1984,10 @@ class TestGetJobsChatIdRouting:
         assert resp.status == 400
 
 
-class TestScheduleChatIdRouting:
+class TestScheduleCredentialRouting:
     @pytest.mark.asyncio
-    async def test_explicit_chat_id_in_body(self, db, mock_request):
-        """POST /api/schedule with chat_id routes job to that user."""
+    async def test_explicit_chat_id_in_body_is_rejected(self, db, mock_request):
+        """POST /api/schedule rejects caller-selected identity."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.app[CHAT_ID_KEY] = 123
         mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
@@ -2004,16 +2004,8 @@ class TestScheduleChatIdRouting:
         )
 
         resp = await _handle_schedule(mock_request)
-        assert resp.status == 200
-
-        # Verify the job was created for user 456, not 123
-        jobs = await sessions.get_jobs(456)
-        assert len(jobs) == 1
-        assert jobs[0]["name"] == "Routed Job"
-
-        # User 123 should have no jobs
-        jobs_123 = await sessions.get_jobs(123)
-        assert len(jobs_123) == 0
+        assert resp.status == 400
+        assert await sessions.get_jobs(456) == []
 
 
 # ── chat_id authorization ──────────────────────────────────────────
@@ -2035,7 +2027,7 @@ class TestChatIdAuthorization:
     async def test_notification_credential_cannot_manage_jobs(self, mock_request):
         """A review/triage notification credential is limited to sending messages."""
         auth = mock_request.app[INTERNAL_API_AUTH_KEY]
-        credential = auth.notification_credential_for(123)
+        credential = auth.notification_credential_for(_internal_api_context(123))
         mock_request.headers = {"X-Webhook-Secret": credential}
 
         mock_request.json = AsyncMock(return_value={"text": "review complete"})
@@ -2046,8 +2038,8 @@ class TestChatIdAuthorization:
         assert schedule_resp.status == 403
 
     @pytest.mark.asyncio
-    async def test_unauthorized_chat_id_returns_403(self, db, mock_request):
-        """POST /api/schedule with chat_id differing from the principal returns 403."""
+    async def test_caller_selected_chat_id_returns_400(self, db, mock_request):
+        """POST /api/schedule rejects the retired identity selector."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.app[TELEGRAM_APP_KEY].job_queue = MagicMock()
         mock_request.app[TELEGRAM_APP_KEY].job_queue.jobs.return_value = []
@@ -2063,7 +2055,7 @@ class TestChatIdAuthorization:
         )
 
         resp = await _handle_schedule(mock_request)
-        assert resp.status == 403
+        assert resp.status == 400
 
     @pytest.mark.asyncio
     async def test_other_authorized_chat_id_rejected(self, db, mock_request):
@@ -2083,40 +2075,41 @@ class TestChatIdAuthorization:
         )
 
         resp = await _handle_schedule(mock_request)
-        assert resp.status == 403
+        assert resp.status == 400
         assert await sessions.get_jobs(456) == []
 
     @pytest.mark.asyncio
-    async def test_send_message_unauthorized_returns_403(self, db, mock_request):
-        """POST /api/send-message with unauthorized chat_id returns 403."""
+    async def test_send_message_identity_selector_returns_400(self, db, mock_request):
+        """POST /api/send-message rejects caller-selected identity."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.json = AsyncMock(return_value={"text": "hello", "chat_id": 999999})
 
         resp = await _handle_send_message(mock_request)
-        assert resp.status == 403
+        assert resp.status == 400
 
     @pytest.mark.asyncio
-    async def test_send_file_unauthorized_returns_403(self, db, mock_request):
-        """POST /api/send-file with unauthorized chat_id returns 403."""
+    async def test_send_file_identity_selector_returns_400(self, db, mock_request):
+        """POST /api/send-file rejects caller-selected identity."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.json = AsyncMock(return_value={"path": "/tmp/test.txt", "chat_id": 999999})
 
         resp = await _handle_send_file(mock_request)
-        assert resp.status == 403
+        assert resp.status == 400
 
-    def test_resolve_chat_id_unauthorized(self):
-        """_resolve_chat_id rejects any identity other than the principal."""
+    def test_resolve_internal_runtime_config_id_rejects_selector(self):
+        """The server-private resolver rejects request identity fields."""
         principal = _make_internal_api_auth().authenticate("test-secret")
         assert principal is not None
 
-        with pytest.raises(UnauthorizedChatIdError):
-            _resolve_chat_id(principal, {"chat_id": 999999})
+        with pytest.raises(ValueError, match="Identity selector chat_id is not accepted"):
+            _resolve_internal_runtime_config_id(principal, {"chat_id": 999999})
 
-    def test_resolve_chat_id_accepts_matching_principal(self):
-        """_resolve_chat_id accepts an explicit repetition of the principal."""
+    def test_resolve_internal_runtime_config_id_rejects_matching_selector(self):
+        """Even a matching repeated identity is rejected."""
         principal = _make_internal_api_auth().authenticate("test-secret")
         assert principal is not None
-        assert _resolve_chat_id(principal, {"chat_id": 123}) == 123
+        with pytest.raises(ValueError, match="Identity selector chat_id is not accepted"):
+            _resolve_internal_runtime_config_id(principal, {"chat_id": 123})
 
 
 # ── Job ownership ──────────────────────────────────────────────────
@@ -2235,19 +2228,19 @@ class TestGetJobsAuth:
         assert body[0]["name"] == "Principal Job"
 
     @pytest.mark.asyncio
-    async def test_unauthorized_chat_id_returns_403(self, db, mock_request):
-        """GET /api/jobs?chat_id=999 returns 403 for unauthorized users."""
+    async def test_identity_selector_returns_400(self, db, mock_request):
+        """GET /api/jobs rejects caller-supplied identity."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.query = {"chat_id": "999"}
 
         resp = await _handle_get_jobs(mock_request)
-        assert resp.status == 403
+        assert resp.status == 400
 
     @pytest.mark.asyncio
-    async def test_authorized_chat_id_returns_only_their_jobs(self, db, mock_request):
-        """GET /api/jobs?chat_id=456 returns only user 456's jobs."""
+    async def test_credential_returns_only_its_jobs(self, db, mock_request):
+        """GET /api/jobs uses only the authenticated canonical context."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
-        mock_request.query = {"chat_id": "456"}
+        mock_request.query = {}
 
         await sessions.create_job(
             chat_id=123,
@@ -2300,7 +2293,7 @@ class TestGetJobAuth:
         """GET /api/jobs/{id} returns 404 when job belongs to another user."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         # Caller is user 456, job belongs to user 123
-        mock_request.query = {"chat_id": "456"}
+        mock_request.query = {}
         job_id = await sessions.create_job(
             chat_id=123,
             name="Admin Job",
@@ -2316,9 +2309,9 @@ class TestGetJobAuth:
 
     @pytest.mark.asyncio
     async def test_owner_can_view_own_job(self, db, mock_request):
-        """GET /api/jobs/{id}?chat_id=456 returns the job when owned by 456."""
+        """The credential owner can view its own job."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
-        mock_request.query = {"chat_id": "456"}
+        mock_request.query = {}
         job_id = await sessions.create_job(
             chat_id=456,
             name="User Job",
@@ -2335,14 +2328,14 @@ class TestGetJobAuth:
         assert body["name"] == "User Job"
 
     @pytest.mark.asyncio
-    async def test_unauthorized_chat_id_returns_403(self, db, mock_request):
-        """GET /api/jobs/{id}?chat_id=999 returns 403 for unauthorized user."""
+    async def test_identity_selector_returns_400(self, db, mock_request):
+        """GET /api/jobs/{id} rejects caller-supplied identity."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.query = {"chat_id": "999"}
         mock_request.match_info = {"id": "1"}
 
         resp = await _handle_get_job(mock_request)
-        assert resp.status == 403
+        assert resp.status == 400
 
 
 class TestDeleteJobAuth:
@@ -2369,9 +2362,9 @@ class TestDeleteJobAuth:
 
     @pytest.mark.asyncio
     async def test_user_can_delete_own_job(self, db, mock_request):
-        """DELETE /api/jobs/{id}?chat_id=456 deletes user 456's job."""
+        """A credential can delete its own job."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
-        mock_request.query = {"chat_id": "456"}
+        mock_request.query = {}
         job_id = await sessions.create_job(
             chat_id=456,
             name="User Job",
@@ -2388,9 +2381,9 @@ class TestDeleteJobAuth:
 
     @pytest.mark.asyncio
     async def test_cannot_delete_other_users_job(self, db, mock_request):
-        """DELETE /api/jobs/{id}?chat_id=456 returns 404 for admin's job."""
+        """A credential cannot delete another context's job."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
-        mock_request.query = {"chat_id": "456"}
+        mock_request.query = {}
         job_id = await sessions.create_job(
             chat_id=123,
             name="Admin Job",
@@ -2407,14 +2400,14 @@ class TestDeleteJobAuth:
         assert await sessions.get_job_by_id(job_id) is not None
 
     @pytest.mark.asyncio
-    async def test_unauthorized_chat_id_returns_403(self, db, mock_request):
-        """DELETE /api/jobs/{id}?chat_id=999 returns 403."""
+    async def test_identity_selector_returns_400(self, db, mock_request):
+        """DELETE /api/jobs/{id} rejects caller-supplied identity."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.query = {"chat_id": "999"}
         mock_request.match_info = {"id": "1"}
 
         resp = await _handle_delete_job(mock_request)
-        assert resp.status == 403
+        assert resp.status == 400
 
 
 class TestUpdateJobAuth:
@@ -2445,7 +2438,7 @@ class TestUpdateJobAuth:
 
     @pytest.mark.asyncio
     async def test_user_can_update_own_job(self, db, mock_request):
-        """PATCH with chat_id in body updates the user's own job."""
+        """PATCH uses the authenticated context to update its own job."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         job_id = await sessions.create_job(
             chat_id=456,
@@ -2456,7 +2449,7 @@ class TestUpdateJobAuth:
             schedule_data='{"run_at": "2026-06-01T12:00:00+00:00"}',
         )
         mock_request.match_info = {"id": str(job_id)}
-        mock_request.json = AsyncMock(return_value={"chat_id": 456, "name": "Updated"})
+        mock_request.json = AsyncMock(return_value={"name": "Updated"})
 
         resp = await _handle_update_job(mock_request)
         assert resp.status == 200
@@ -2466,7 +2459,7 @@ class TestUpdateJobAuth:
 
     @pytest.mark.asyncio
     async def test_cannot_update_other_users_job(self, db, mock_request):
-        """PATCH with chat_id=456 returns 404 for admin's job."""
+        """PATCH returns 404 for another context's job."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         job_id = await sessions.create_job(
             chat_id=123,
@@ -2477,7 +2470,7 @@ class TestUpdateJobAuth:
             schedule_data='{"run_at": "2026-06-01T12:00:00+00:00"}',
         )
         mock_request.match_info = {"id": str(job_id)}
-        mock_request.json = AsyncMock(return_value={"chat_id": 456, "name": "Hacked"})
+        mock_request.json = AsyncMock(return_value={"name": "Hacked"})
 
         resp = await _handle_update_job(mock_request)
         assert resp.status == 404
@@ -2487,14 +2480,14 @@ class TestUpdateJobAuth:
         assert job["name"] == "Admin Job"
 
     @pytest.mark.asyncio
-    async def test_unauthorized_chat_id_returns_403(self, db, mock_request):
-        """PATCH with unauthorized chat_id returns 403."""
+    async def test_identity_selector_returns_400(self, db, mock_request):
+        """PATCH rejects caller-supplied identity."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.match_info = {"id": "1"}
         mock_request.json = AsyncMock(return_value={"chat_id": 999, "name": "Nope"})
 
         resp = await _handle_update_job(mock_request)
-        assert resp.status == 403
+        assert resp.status == 400
 
 
 # ── Filename sanitization ──────────────────────────────────────────
@@ -2800,7 +2793,7 @@ class TestMemoryAdd:
         succeed).
         """
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
-        mock_request.json = AsyncMock(return_value={"content": "x", "chat_id": 456})
+        mock_request.json = AsyncMock(return_value={"content": "x"})
 
         with (
             patch("kai.memory.is_enabled", return_value=True),
@@ -2812,8 +2805,8 @@ class TestMemoryAdd:
         assert kwargs["user_id"] == "456"
         assert isinstance(kwargs["user_id"], str)
 
-    async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
-        """chat_id differing from the principal -> 403, primitive not called."""
+    async def test_returns_400_on_identity_selector(self, mock_request):
+        """Caller-supplied identity is rejected before the primitive."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         # The credential resolves to principal 123, not the requested 999.
         mock_request.json = AsyncMock(return_value={"content": "x", "chat_id": 999})
@@ -2821,7 +2814,7 @@ class TestMemoryAdd:
         with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.add_structured") as mock_add:
             resp = await _handle_memory_add(mock_request)
 
-        assert resp.status == 403
+        assert resp.status == 400
         mock_add.assert_not_called()
 
     async def test_returns_500_when_add_structured_raises(self, mock_request):
@@ -3144,8 +3137,8 @@ class TestMemorySearch:
         body = json.loads(resp.body.decode())
         assert body == {"error": "Memory search failed"}
 
-    async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
-        """chat_id differing from the principal -> 403, primitive not called."""
+    async def test_returns_400_on_identity_selector(self, mock_request):
+        """Caller-supplied identity is rejected before the primitive."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.json = AsyncMock(return_value={"query": "x", "chat_id": 999})
 
@@ -3155,7 +3148,7 @@ class TestMemorySearch:
         ):
             resp = await _handle_memory_search(mock_request)
 
-        assert resp.status == 403
+        assert resp.status == 400
         mock_search.assert_not_called()
 
 
@@ -3231,8 +3224,7 @@ class TestMemoryStats:
         from kai.memory import MemoryStats
 
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
-        # The user-456 credential matches the string query parameter.
-        mock_request.query = {"chat_id": "456"}
+        mock_request.query = {}
 
         with (
             patch("kai.memory.is_enabled", return_value=True),
@@ -3252,15 +3244,15 @@ class TestMemoryStats:
 
         assert resp.status == 401
 
-    async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
-        """Query-string chat_id differing from the principal -> 403."""
+    async def test_returns_400_on_identity_selector(self, mock_request):
+        """Query-string identity selectors are rejected."""
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.query = {"chat_id": "999"}
 
         with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.get_stats") as mock_get_stats:
             resp = await _handle_memory_stats(mock_request)
 
-        assert resp.status == 403
+        assert resp.status == 400
         mock_get_stats.assert_not_called()
 
     async def test_returns_500_when_get_stats_raises(self, mock_request):
@@ -3366,7 +3358,7 @@ class TestMemoryDeleteAll:
     async def test_calls_delete_all_with_stringified_user_id(self, mock_request):
         """int -> str cast at the memory boundary, same as add."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
-        mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM, "chat_id": 456})
+        mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM})
 
         with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.delete_all") as mock_del:
             await _call_memory_delete_all_as_authorized(mock_request, chat_id=456)
@@ -3403,10 +3395,10 @@ class TestMemoryDeleteAll:
         body = json.loads(resp.body.decode())
         assert body == {"error": "Memory delete failed"}
 
-    async def test_returns_403_on_unauthorized_chat_id(self, mock_request):
-        """chat_id differing from the principal -> 403, primitive not called.
+    async def test_returns_400_on_identity_selector(self, mock_request):
+        """Caller-supplied identity is rejected before the primitive.
 
-        Verifies the 403 path runs even when the confirm token is
+        Verifies the 400 path runs even when the confirm token is
         correct: an unauthorized caller with the right token should
         still be blocked at the chat_id resolution step.
         """
@@ -3419,7 +3411,7 @@ class TestMemoryDeleteAll:
         ):
             resp = await _call_memory_delete_all_as_authorized(mock_request)
 
-        assert resp.status == 403
+        assert resp.status == 400
         mock_del.assert_not_called()
 
     async def test_persistent_agent_scope_cannot_delete_all(self, mock_request):

--- a/tests/test_workshop_internal_api_contexts.py
+++ b/tests/test_workshop_internal_api_contexts.py
@@ -1,0 +1,164 @@
+"""Canonical execution contexts for protected internal API credentials."""
+
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.internal_api_contexts import (
+    WorkshopInternalAPIContextError,
+    WorkshopInternalAPIContextRegistry,
+    WorkshopInternalAPIExecutionContext,
+)
+from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
+
+
+async def _store(path: Path) -> WorkshopEventStore:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman("Alice", "admin", "telegram", "101", "101", profile_id(101)),
+            BootstrapHuman("Bob", "member", "telegram", "202", "202", profile_id(202)),
+        ),
+    )
+    return store
+
+
+async def test_resolves_complete_canonical_context_for_every_profile(tmp_path: Path) -> None:
+    store = await _store(tmp_path / "kai.db")
+    try:
+        registry = await WorkshopInternalAPIContextRegistry.from_store(
+            store,
+            profile_registry(101, 202),
+        )
+        context = registry.for_runtime_config_id(101)
+
+        assert context.principal_id.startswith("prn_")
+        assert context.channel_id.startswith("chn_")
+        assert context.agent_id.startswith("agt_")
+        assert context.runtime_profile_id == profile_id(101)
+        assert context.compatibility_runtime_config_id() == 101
+        assert registry.for_runtime_profile(profile_id(101)) is context
+    finally:
+        await store.close()
+
+
+async def test_missing_profile_assignment_fails_closed(tmp_path: Path) -> None:
+    store = await _store(tmp_path / "kai.db")
+    try:
+        with pytest.raises(
+            WorkshopInternalAPIContextError,
+            match="exactly one canonical internal API context",
+        ):
+            await WorkshopInternalAPIContextRegistry.from_store(
+                store,
+                profile_registry(101, 202, 303),
+            )
+    finally:
+        await store.close()
+
+
+async def test_missing_channel_agent_attachment_fails_closed(tmp_path: Path) -> None:
+    store = await _store(tmp_path / "kai.db")
+    try:
+        await store.connection.execute(
+            "DELETE FROM channel_agents WHERE agent_id = ("
+            "SELECT agent_id FROM channel_agent_runtime_assignments WHERE runtime_profile_id = ?)",
+            (profile_id(101),),
+        )
+        await store.connection.commit()
+        with pytest.raises(
+            WorkshopInternalAPIContextError,
+            match="exactly one canonical internal API context",
+        ):
+            await WorkshopInternalAPIContextRegistry.from_store(
+                store,
+                profile_registry(101, 202),
+            )
+    finally:
+        await store.close()
+
+
+async def test_ambiguous_direct_channel_ownership_fails_closed(tmp_path: Path) -> None:
+    store = await _store(tmp_path / "kai.db")
+    try:
+        channel_id, workshop_id = await (
+            await store.connection.execute(
+                "SELECT channel_id, workshop_id FROM channel_agent_runtime_assignments ra "
+                "JOIN channels c ON c.id = ra.channel_id WHERE ra.runtime_profile_id = ?",
+                (profile_id(101),),
+            )
+        ).fetchone()
+        second_principal = "prn_" + "f" * 32
+        await store.connection.execute(
+            "INSERT INTO principals (id, kind, display_name, created_at) VALUES (?, 'human', 'Other', ?)",
+            (second_principal, "2026-01-01T00:00:00Z"),
+        )
+        await store.connection.execute(
+            "INSERT INTO workshop_memberships "
+            "(id, workshop_id, principal_id, role, created_at) VALUES (?, ?, ?, 'member', ?)",
+            ("wsm_" + "f" * 32, workshop_id, second_principal, "2026-01-01T00:00:00Z"),
+        )
+        await store.connection.execute(
+            "INSERT INTO channel_memberships "
+            "(id, channel_id, principal_id, role, created_at) VALUES (?, ?, ?, 'owner', ?)",
+            ("cmm_" + "f" * 32, channel_id, second_principal, "2026-01-01T00:00:00Z"),
+        )
+        await store.connection.commit()
+
+        with pytest.raises(
+            WorkshopInternalAPIContextError,
+            match="exactly one canonical internal API context",
+        ):
+            await WorkshopInternalAPIContextRegistry.from_store(
+                store,
+                profile_registry(101, 202),
+            )
+    finally:
+        await store.close()
+
+
+async def test_cross_workshop_agent_assignment_fails_closed(tmp_path: Path) -> None:
+    store = await _store(tmp_path / "kai.db")
+    try:
+        other_workshop = "wsp_" + "f" * 32
+        await store.connection.execute(
+            "INSERT INTO workshops (id, name, created_at) VALUES (?, 'Other', ?)",
+            (other_workshop, "2026-01-01T00:00:00Z"),
+        )
+        await store.connection.execute(
+            "UPDATE agents SET workshop_id = ? WHERE id = ("
+            "SELECT agent_id FROM channel_agent_runtime_assignments WHERE runtime_profile_id = ?)",
+            (other_workshop, profile_id(101)),
+        )
+        await store.connection.commit()
+
+        with pytest.raises(
+            WorkshopInternalAPIContextError,
+            match="exactly one canonical internal API context",
+        ):
+            await WorkshopInternalAPIContextRegistry.from_store(
+                store,
+                profile_registry(101, 202),
+            )
+    finally:
+        await store.close()
+
+
+def test_duplicate_runtime_profile_contexts_are_rejected() -> None:
+    context = WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
+        101,
+        profile_id(101),
+    )
+    duplicate_assignment = WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
+        202,
+        profile_id(101),
+    )
+
+    with pytest.raises(
+        WorkshopInternalAPIContextError,
+        match="Duplicate internal API runtime profile",
+    ):
+        WorkshopInternalAPIContextRegistry((context, duplicate_assignment))

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -12,6 +12,10 @@ from kai.backend import AgentResponse, StreamEvent
 from kai.config import Config, UserConfig
 from kai.internal_api_auth import InternalAPIScope
 from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.internal_api_contexts import (
+    WorkshopInternalAPIContextRegistry,
+    WorkshopInternalAPIExecutionContext,
+)
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.runtime_profiles import (
     ProtectedRuntimeProfile,
@@ -26,6 +30,20 @@ async def _events():
         text_so_far="Done.",
         done=True,
         response=AgentResponse(text="Done.", success=True),
+    )
+
+
+def _contexts_for_profiles(
+    profiles: WorkshopRuntimeProfileRegistry,
+) -> WorkshopInternalAPIContextRegistry:
+    return WorkshopInternalAPIContextRegistry(
+        tuple(
+            WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
+                profile.runtime_config_id,
+                profile.profile_id,
+            )
+            for profile in profiles.profiles
+        )
     )
 
 
@@ -209,7 +227,7 @@ def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, mon
 
     assert instance.backend_name == "codex"
     assert principal is not None
-    assert principal.chat_id == runtime_config_id
+    assert principal.compatibility_runtime_config_id() == runtime_config_id
     assert principal.allowed_services == frozenset({"perplexity"})
     assert instance._api_context.services_info == services_info
     assert instance.workspace == tmp_path / "home" / str(runtime_config_id)
@@ -322,7 +340,12 @@ def test_unavailable_explicit_profile_home_fails_only_that_runtime(tmp_path, mon
             ),
         )
     )
-    pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
+    pool = SubprocessPool(
+        config=config,
+        services_info=[],
+        runtime_profiles=profiles,
+        internal_api_contexts=_contexts_for_profiles(profiles),
+    )
 
     with pytest.raises(RuntimeError, match="Mount or create it, or update the protected runtime profile"):
         pool.get(runtime_config_id)
@@ -360,7 +383,12 @@ def test_profile_only_canonical_home_error_has_actionable_remediation(tmp_path, 
             ),
         )
     )
-    pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
+    pool = SubprocessPool(
+        config=config,
+        services_info=[],
+        runtime_profiles=profiles,
+        internal_api_contexts=_contexts_for_profiles(profiles),
+    )
 
     with pytest.raises(RuntimeError, match="profile-only runtimes require an explicit home_workspace"):
         pool.get(runtime_config_id)
@@ -446,7 +474,7 @@ def test_negative_group_key_retains_legacy_compatibility_runtime(tmp_path, monke
     assert instance.backend_name == "codex"
     principal = pool.internal_api_auth.authenticate(instance._api_context.webhook_secret)
     assert principal is not None
-    assert principal.chat_id == -100999
+    assert principal.compatibility_runtime_config_id() == -100999
     assert principal.allowed_services == frozenset()
 
 


### PR DESCRIPTION
## Summary

- bind every protected backend credential to a canonical human, direct channel,
  agent, and runtime profile resolved from Workshop state at startup
- reject caller-supplied identity selectors across the internal job, message,
  file, and memory APIs while preserving least-privilege scopes and service
  grants
- fail protected startup when canonical authority is missing or ambiguous, and
  keep the remaining integer persistence key behind a private server adapter
- migrate managed backend instructions away from `chat_id` routing and report
  canonical credential coverage in `install status`

## Security properties

- request data cannot select a principal, channel, agent, runtime profile,
  transport identity, OS user, or compatibility key
- credentials remain distinct per canonical execution context
- missing, ambiguous, cross-workshop, and duplicate runtime authority fails
  closed
- protected runtimes cannot synthesize compatibility-only credentials
- no credential or opaque canonical identifier is exposed by diagnostics

## Validation

- `make test` — 6,095 passed
- focused internal API and registry suite — 267 passed
- `make check`
- `make typecheck`
- `make client-check` — 6 files / 54 tests passed; generated client clean
- `git diff --check`

## Follow-up boundary

The underlying integer-keyed persistence APIs are intentionally not replaced in
this PR. They are now reachable only through the credential-derived private
compatibility adapter, which a subsequent Milestone 6 issue can retire without
changing the public internal API contract again.

Closes #1095
