### PR TITLE
Make scheduled jobs canonically owned

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -103,6 +103,7 @@ from kai.workshop.execution_coordinator import (
 )
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.outbound import DeliveryObservation, OutboundMessage
+from kai.workshop.scheduled_jobs import WorkshopScheduledJobAuthority
 from kai.workshop.settings_workspaces import (
     SettingsWorkspaceAuthority,
     WorkshopSettingsWorkspaceAccessDenied,
@@ -1153,16 +1154,34 @@ async def handle_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     )
 
 
-async def _list_jobs(update: Update, chat_id: int) -> None:
+def _scheduled_job_authority(
+    context: ContextTypes.DEFAULT_TYPE,
+    runtime_config_id: int,
+) -> WorkshopScheduledJobAuthority:
+    canonical = _get_core_services(context).internal_api_contexts.for_runtime_config_id(runtime_config_id)
+    return WorkshopScheduledJobAuthority(
+        canonical.principal_id,
+        canonical.channel_id,
+        canonical.agent_id,
+        canonical.runtime_profile_id,
+    )
+
+
+async def _list_jobs(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    runtime_config_id: int,
+) -> None:
     """
-    List all active scheduled jobs for a chat.
+    List all active scheduled jobs for a Telegram-authenticated human.
 
     Formats each job with an emoji tag (bell for reminders, robot for Claude
     jobs), the job ID, name, and a human-readable schedule description.
     Shared by /job (list branch) and /jobs (alias).
     """
     assert update.message is not None
-    jobs = await sessions.get_jobs(chat_id)
+    services = _get_core_services(context)
+    jobs = await services.scheduler.list_jobs(_scheduled_job_authority(context, runtime_config_id))
     if not jobs:
         await update.message.reply_text("No active scheduled jobs.")
         return
@@ -1208,13 +1227,13 @@ async def handle_job(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         /job cancel <id> - cancel (delete) a job
     """
     assert update.message is not None
-    chat_id = _chat_id(update)
+    runtime_config_id = _user_id(update)
     args = context.args or []
     subcommand = args[0].lower() if args else None
 
     # No subcommand or "list": show all jobs
     if subcommand is None or subcommand == "list":
-        await _list_jobs(update, chat_id)
+        await _list_jobs(update, context, runtime_config_id)
         return
 
     if subcommand == "info":
@@ -1226,9 +1245,11 @@ async def handle_job(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         except ValueError:
             await update.message.reply_text("Job ID must be a number.")
             return
-        job = await sessions.get_job_by_id(job_id)
-        # Ownership check: only show jobs belonging to this chat
-        if not job or job["chat_id"] != chat_id:
+        job = await _get_core_services(context).scheduler.get_job(
+            job_id,
+            _scheduled_job_authority(context, runtime_config_id),
+        )
+        if job is None:
             await update.message.reply_text(f"Job #{job_id} not found.")
             return
         auto_remove = "yes" if job["auto_remove"] else "no"
@@ -1252,13 +1273,13 @@ async def handle_job(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         except ValueError:
             await update.message.reply_text("Job ID must be a number.")
             return
-        # Pass user's chat_id for ownership check - users can only cancel
-        # their own jobs (prevents cross-user job manipulation).
-        deleted = await sessions.delete_job(job_id, chat_id=chat_id)
+        deleted = await _get_core_services(context).scheduler.delete_job(
+            job_id,
+            _scheduled_job_authority(context, runtime_config_id),
+        )
         if not deleted:
             await update.message.reply_text(f"Job #{job_id} not found.")
             return
-        await _get_core_services(context).scheduler.remove_job(job_id)
         await update.message.reply_text(f"Job #{job_id} cancelled.")
         return
 
@@ -1272,7 +1293,7 @@ async def handle_job(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
 async def handle_jobs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Alias for /job list. Kept for backward compatibility."""
     assert update.message is not None
-    await _list_jobs(update, _chat_id(update))
+    await _list_jobs(update, context, _user_id(update))
 
 
 @_require_auth

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -8881,8 +8881,15 @@ def _core_schedule_status(db_path: Path) -> str:
         connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
         try:
             ownership = connection.execute(
-                "SELECT COUNT(*), COUNT(o.job_id) FROM jobs j "
-                "LEFT JOIN workshop_job_owners o ON o.job_id = j.id WHERE j.active = 1"
+                "SELECT COUNT(*), SUM(CASE WHEN EXISTS ("
+                "SELECT 1 FROM channels c "
+                "JOIN channel_memberships cm ON cm.channel_id = c.id "
+                "AND cm.principal_id = j.principal_id AND cm.role = 'owner' "
+                "JOIN agents a ON a.id = j.agent_id AND a.workshop_id = c.workshop_id "
+                "JOIN channel_agent_runtime_assignments ra ON ra.channel_id = c.id "
+                "AND ra.agent_id = a.id AND ra.runtime_profile_id = j.runtime_profile_id "
+                "WHERE c.id = j.channel_id AND c.kind = 'direct') THEN 1 ELSE 0 END) "
+                "FROM workshop_scheduled_jobs j WHERE j.active = 1"
             ).fetchone()
             firings = connection.execute(
                 "SELECT "

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -103,7 +103,11 @@ from kai.workshop.integration_notifications import (
 )
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
 from kai.workshop.run_previews import WorkshopRunPreviewRegistry
-from kai.workshop.scheduler import WorkshopCanonicalScheduler
+from kai.workshop.scheduled_jobs import (
+    WorkshopScheduledJobAuthority,
+    WorkshopScheduledJobUpdate,
+)
+from kai.workshop.scheduler import WorkshopScheduledJobRegistrationError
 from kai.workshop.settings_workspaces import WorkshopSettingsWorkspaceService
 from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageRegistry,
@@ -465,28 +469,32 @@ _INTERNAL_API_IDENTITY_SELECTORS = frozenset(
 )
 
 
-def _resolve_internal_runtime_config_id(
-    principal: InternalAPIPrincipal,
-    payload: dict,
-) -> int:
-    """
-    Resolve the private compatibility key from authenticated authority.
-
-    Canonical identity is bound to the process-lifetime credential. Request
-    bodies and query strings may not repeat or select the retired ``chat_id``
-    identity field. The returned integer is confined to this server adapter
-    while legacy persistence primitives are being replaced.
-
-    Raises:
-        ValueError: If the retired caller-supplied identity field is present.
-    """
+def _reject_internal_identity_selectors(payload: dict) -> None:
+    """Reject identity fields whose authority is already bound to a credential."""
     supplied = sorted(_INTERNAL_API_IDENTITY_SELECTORS.intersection(payload))
     if supplied:
         raise ValueError(
             f"Identity selector {supplied[0]} is not accepted; the internal API credential already binds "
             "the canonical execution context"
         )
+
+
+def _resolve_internal_runtime_config_id(
+    principal: InternalAPIPrincipal,
+    payload: dict,
+) -> int:
+    """Resolve the remaining private key for handlers not yet cut over."""
+    _reject_internal_identity_selectors(payload)
     return principal.compatibility_runtime_config_id()
+
+
+def _scheduled_job_authority(principal: InternalAPIPrincipal) -> WorkshopScheduledJobAuthority:
+    return WorkshopScheduledJobAuthority(
+        principal.principal_id,
+        principal.channel_id,
+        principal.agent_id,
+        principal.runtime_profile_id,
+    )
 
 
 # ── GitHub event formatters ───────────────────────────────────────────
@@ -1075,9 +1083,8 @@ async def _handle_schedule(request: web.Request, principal: InternalAPIPrincipal
             status=400,
         )
 
-    # Normalize the compatibility alias at ingress so all new rows use the
-    # backend-neutral identifier. sessions.create_job repeats this validation
-    # as the persistence boundary for non-HTTP callers.
+    # Normalize the retired job-type alias at ingress so canonical storage
+    # never records a backend-specific scheduler identifier.
     try:
         job_type = normalize_job_type(payload.get("job_type", "reminder"))
     except ValueError:
@@ -1088,7 +1095,7 @@ async def _handle_schedule(request: web.Request, principal: InternalAPIPrincipal
     auto_remove = payload.get("auto_remove", False)
     notify_on_check = payload.get("notify_on_check", False)
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, payload)
+        _reject_internal_identity_selectors(payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
 
@@ -1100,10 +1107,10 @@ async def _handle_schedule(request: web.Request, principal: InternalAPIPrincipal
         return web.json_response({"error": error}, status=400)
     assert schedule_data_str is not None  # guaranteed when error is None
 
-    # Persist to database
+    scheduler = request.app[CORE_HOST_KEY].services.scheduler
     try:
-        job_id = await sessions.create_job(
-            chat_id=chat_id,
+        job_id = await scheduler.create_job(
+            _scheduled_job_authority(principal),
             name=name,
             job_type=job_type,
             prompt=prompt,
@@ -1112,21 +1119,12 @@ async def _handle_schedule(request: web.Request, principal: InternalAPIPrincipal
             auto_remove=auto_remove,
             notify_on_check=notify_on_check,
         )
+    except WorkshopScheduledJobRegistrationError:
+        log.exception("Failed to register created job")
+        return web.json_response({"error": "Failed to register job"}, status=500)
     except Exception:
         log.exception("Failed to create job")
         return web.json_response({"error": "Failed to create job"}, status=500)
-
-    scheduler = request.app[CORE_HOST_KEY].services.scheduler
-    try:
-        registered = await scheduler.register_job(job_id)
-    except Exception:
-        log.exception("Failed to register job %d with scheduler", job_id)
-        await sessions.deactivate_job(job_id, chat_id=chat_id)
-        return web.json_response({"error": "Failed to register job"}, status=500)
-    if not registered:
-        log.error("Failed to register job %d with scheduler", job_id)
-        await sessions.deactivate_job(job_id, chat_id=chat_id)
-        return web.json_response({"error": "Failed to register job"}, status=500)
 
     log.info("Scheduled job %d '%s' via API (%s)", job_id, name, schedule_type)
     return web.json_response({"job_id": job_id, "name": name})
@@ -1144,12 +1142,11 @@ async def _handle_get_jobs(request: web.Request, principal: InternalAPIPrincipal
     without needing to parse Telegram bot command output.
     """
 
-    # Query parameters cannot select identity; the credential owns routing.
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, dict(request.query))
+        _reject_internal_identity_selectors(dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    jobs = await sessions.get_jobs(chat_id)
+    jobs = await request.app[CORE_HOST_KEY].services.scheduler.list_jobs(_scheduled_job_authority(principal))
     return web.json_response(jobs)
 
 
@@ -1166,17 +1163,15 @@ async def _handle_get_job(request: web.Request, principal: InternalAPIPrincipal)
     except ValueError:
         return web.json_response({"error": "Invalid job ID"}, status=400)
 
-    # Resolve caller identity for ownership check
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, dict(request.query))
+        _reject_internal_identity_selectors(dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-
-    job = await sessions.get_job_by_id(job_id)
-    # Return 404 for missing OR wrong-owner jobs (don't leak existence).
-    # Both sides are ints: _resolve_internal_runtime_config_id always returns int, and
-    # chat_id is stored as INTEGER in the jobs table.
-    if not job or job["chat_id"] != chat_id:
+    job = await request.app[CORE_HOST_KEY].services.scheduler.get_job(
+        job_id,
+        _scheduled_job_authority(principal),
+    )
+    if job is None:
         return web.json_response({"error": "Job not found"}, status=404)
     return web.json_response(job)
 
@@ -1195,16 +1190,14 @@ async def _handle_delete_job(request: web.Request, principal: InternalAPIPrincip
     except ValueError:
         return web.json_response({"error": "Invalid job ID"}, status=400)
 
-    # Resolve compatibility storage only from server-owned authority.
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, dict(request.query))
+        _reject_internal_identity_selectors(dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
-    deleted = await sessions.delete_job(job_id, chat_id=chat_id)
+    scheduler = request.app[CORE_HOST_KEY].services.scheduler
+    deleted = await scheduler.delete_job(job_id, _scheduled_job_authority(principal))
     if not deleted:
         return web.json_response({"error": "Job not found"}, status=404)
-
-    await request.app[CORE_HOST_KEY].services.scheduler.remove_job(job_id)
 
     log.info("Deleted job %d via API", job_id)
     return web.json_response({"deleted": job_id})
@@ -1261,7 +1254,10 @@ async def _handle_update_job(request: web.Request, principal: InternalAPIPrincip
         # Otherwise, fetch the current job to get its existing schedule_type.
         effective_type = new_schedule_type
         if effective_type is None:
-            existing_job = await sessions.get_job_by_id(job_id)
+            existing_job = await request.app[CORE_HOST_KEY].services.scheduler.get_job(
+                job_id,
+                _scheduled_job_authority(principal),
+            )
             if existing_job is None:
                 return web.json_response({"error": "Job not found or inactive"}, status=404)
             effective_type = existing_job["schedule_type"]
@@ -1269,9 +1265,8 @@ async def _handle_update_job(request: web.Request, principal: InternalAPIPrincip
         if error:
             return web.json_response({"error": error}, status=400)
 
-    # The credential selects authority; request data cannot choose identity.
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, payload)
+        _reject_internal_identity_selectors(payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
 
@@ -1282,69 +1277,36 @@ async def _handle_update_job(request: web.Request, principal: InternalAPIPrincip
     schedule_changed = new_schedule_type is not None or schedule_data is not None
     if schedule_changed:
         if existing_job is None:
-            existing_job = await sessions.get_job_by_id(job_id)
-        if existing_job is None or existing_job["chat_id"] != chat_id:
+            existing_job = await request.app[CORE_HOST_KEY].services.scheduler.get_job(
+                job_id,
+                _scheduled_job_authority(principal),
+            )
+        if existing_job is None:
             return web.json_response({"error": "Job not found or inactive"}, status=404)
 
-    updated = await sessions.update_job(
-        job_id,
-        chat_id=chat_id,
-        name=payload.get("name"),
-        prompt=payload.get("prompt"),
-        schedule_type=new_schedule_type,
-        schedule_data=schedule_data,
-        auto_remove=payload.get("auto_remove"),
-        notify_on_check=payload.get("notify_on_check"),
-    )
+    scheduler = request.app[CORE_HOST_KEY].services.scheduler
+    try:
+        updated = await scheduler.update_job(
+            job_id,
+            _scheduled_job_authority(principal),
+            WorkshopScheduledJobUpdate(
+                name=payload.get("name"),
+                prompt=payload.get("prompt"),
+                schedule_type=new_schedule_type,
+                schedule_data=schedule_data,
+                auto_remove=payload.get("auto_remove"),
+                notify_on_check=payload.get("notify_on_check"),
+            ),
+        )
+    except Exception:
+        log.exception("Failed to update and re-register job %d", job_id)
+        return web.json_response({"error": "Failed to register job"}, status=500)
 
     if not updated:
         return web.json_response({"error": "Job not found or inactive"}, status=404)
 
-    if schedule_changed:
-        assert existing_job is not None
-        scheduler = request.app[CORE_HOST_KEY].services.scheduler
-        try:
-            registered = await scheduler.register_job(job_id)
-        except Exception:
-            log.exception("Failed to re-register updated job %d with scheduler", job_id)
-            await _restore_job_after_failed_reschedule(scheduler, job_id, chat_id, existing_job)
-            return web.json_response({"error": "Failed to register job"}, status=500)
-        if not registered:
-            log.error("Failed to re-register updated job %d with scheduler", job_id)
-            await _restore_job_after_failed_reschedule(scheduler, job_id, chat_id, existing_job)
-            return web.json_response({"error": "Failed to register job"}, status=500)
-
     log.info("Updated job %d via API", job_id)
     return web.json_response({"updated": job_id})
-
-
-async def _restore_job_after_failed_reschedule(
-    scheduler: WorkshopCanonicalScheduler,
-    job_id: int,
-    chat_id: int,
-    previous_job: dict,
-) -> None:
-    """Best-effort rollback after PATCH committed but scheduler registration failed."""
-    restored = await sessions.update_job(
-        job_id,
-        chat_id=chat_id,
-        name=previous_job["name"],
-        prompt=previous_job["prompt"],
-        schedule_type=previous_job["schedule_type"],
-        schedule_data=previous_job["schedule_data"],
-        auto_remove=previous_job["auto_remove"],
-        notify_on_check=previous_job["notify_on_check"],
-    )
-    if not restored:
-        log.error("Failed to restore job %d after scheduler registration failure", job_id)
-        return
-    try:
-        restored_registered = await scheduler.register_job(job_id)
-    except Exception:
-        log.exception("Failed to restore scheduler entry for job %d after rollback", job_id)
-        return
-    if not restored_registered:
-        log.error("Failed to restore scheduler entry for job %d after rollback", job_id)
 
 
 # ── Service proxy ────────────────────────────────────────────────────

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -79,6 +79,8 @@ _OPERATIONAL_STATE_TABLES = {
     "workshop_execution_state_migrations",
     "workshop_job_owners",
     "workshop_operational_state_migrations",
+    "workshop_scheduled_job_migrations",
+    "workshop_scheduled_jobs",
 }
 _TELEGRAM_SUBJECT_PATTERN = re.compile(r"^-?[0-9]+$")
 _SYNTHETIC_ASSISTANT_PATTERN = re.compile(
@@ -566,19 +568,40 @@ def workshop_operational_state_status(db_path: Path) -> str:
                 "WHERE a.runtime_profile_id = m.runtime_profile_id "
                 "AND a.channel_id = m.channel_id AND a.agent_id = m.agent_id)",
             )
-            jobs = _scalar(connection, "SELECT COUNT(*) FROM workshop_job_owners")
-            unowned_jobs = _scalar(
+            jobs = _scalar(connection, "SELECT COUNT(*) FROM workshop_scheduled_jobs")
+            legacy_jobs = _scalar(connection, "SELECT COUNT(*) FROM jobs")
+            job_migrations = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM workshop_scheduled_job_migrations",
+            )
+            missing_job_migrations = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM channel_agent_runtime_assignments a WHERE NOT EXISTS ("
+                "SELECT 1 FROM workshop_scheduled_job_migrations m "
+                "WHERE m.runtime_profile_id = a.runtime_profile_id "
+                "AND m.channel_id = a.channel_id AND m.agent_id = a.agent_id)",
+            )
+            stale_job_migrations = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM workshop_scheduled_job_migrations m WHERE NOT EXISTS ("
+                "SELECT 1 FROM channel_agent_runtime_assignments a "
+                "WHERE a.runtime_profile_id = m.runtime_profile_id "
+                "AND a.channel_id = m.channel_id AND a.agent_id = m.agent_id)",
+            )
+            unmigrated_jobs = _scalar(
                 connection,
                 "SELECT COUNT(*) FROM jobs j JOIN workshop_execution_state_migrations e "
                 "ON e.runtime_config_id = j.chat_id LEFT JOIN workshop_job_owners o "
-                "ON o.job_id = j.id WHERE o.job_id IS NULL",
+                "ON o.job_id = j.id WHERE o.job_id IS NULL OR o.principal_id != e.principal_id "
+                "OR o.channel_id != e.channel_id OR o.agent_id != e.agent_id "
+                "OR o.runtime_profile_id != e.runtime_profile_id",
             )
             conflicting_jobs = _scalar(
                 connection,
-                "SELECT COUNT(*) FROM jobs j JOIN workshop_execution_state_migrations e "
-                "ON e.runtime_config_id = j.chat_id JOIN workshop_job_owners o ON o.job_id = j.id "
-                "WHERE o.principal_id != e.principal_id OR o.channel_id != e.channel_id "
-                "OR o.agent_id != e.agent_id OR o.runtime_profile_id != e.runtime_profile_id",
+                "SELECT COUNT(*) FROM workshop_scheduled_jobs c "
+                "JOIN workshop_job_owners o ON o.job_id = c.id "
+                "WHERE c.principal_id != o.principal_id OR c.channel_id != o.channel_id "
+                "OR c.agent_id != o.agent_id OR c.runtime_profile_id != o.runtime_profile_id",
             )
             github_subscriptions = _scalar(
                 connection,
@@ -601,17 +624,23 @@ def workshop_operational_state_status(db_path: Path) -> str:
         and migrated == profiles
         and missing == 0
         and stale == 0
-        and unowned_jobs == 0
+        and job_migrations == profiles
+        and missing_job_migrations == 0
+        and stale_job_migrations == 0
+        and unmigrated_jobs == 0
         and conflicting_jobs == 0
         and missing_subscriptions == 0
         else "INCOMPLETE"
     )
     return (
         f"{prefix} {state}; profiles={profiles}, migrated={migrated}, "
-        f"missing={missing}, stale={stale}, jobs={jobs}, unowned jobs={unowned_jobs}, "
-        f"conflicting jobs={conflicting_jobs}, GitHub principals={github_subscriptions}, "
+        f"missing={missing}, stale={stale}, jobs={jobs}, legacy archived={legacy_jobs}, "
+        f"job migrations={job_migrations}, missing job migrations={missing_job_migrations}, "
+        f"stale job migrations={stale_job_migrations}, "
+        f"unmigrated jobs={unmigrated_jobs}, conflicting jobs={conflicting_jobs}, "
+        f"GitHub principals={github_subscriptions}, "
         f"missing subscriptions={missing_subscriptions}; protected legacy ownership "
-        "reads=disabled, rollback dual writes=active"
+        "reads=disabled, compatibility job writes=disabled"
     )
 
 

--- a/src/kai/workshop/inbound.py
+++ b/src/kai/workshop/inbound.py
@@ -214,10 +214,10 @@ async def _resolve_scheduled_binding(
     message: ScheduledInboundMessage,
 ) -> _ResolvedInboundBinding:
     async with store.connection.execute(
-        "SELECT c.workshop_id FROM workshop_job_owners o "
-        "JOIN channels c ON c.id = o.channel_id "
-        "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.principal_id = o.principal_id "
-        "WHERE o.job_id = ? AND o.principal_id = ? AND o.channel_id = ?",
+        "SELECT c.workshop_id FROM workshop_scheduled_jobs j "
+        "JOIN channels c ON c.id = j.channel_id "
+        "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.principal_id = j.principal_id "
+        "WHERE j.id = ? AND j.principal_id = ? AND j.channel_id = ?",
         (message.job_id, message.principal_id, message.channel_id),
     ) as cursor:
         rows = list(await cursor.fetchall())

--- a/src/kai/workshop/operational_state.py
+++ b/src/kai/workshop/operational_state.py
@@ -120,9 +120,14 @@ async def reconcile_workshop_operational_state(
     try:
         await connection.execute("BEGIN IMMEDIATE")
         for namespace in registry.namespaces:
+            scheduled_jobs_migrated = await _scheduled_job_migration_owner(connection, namespace)
             migrated = await _migration_owner(connection, namespace)
             if migrated:
-                jobs += await _backfill_jobs(connection, namespace)
+                if not scheduled_jobs_migrated:
+                    job_count = await _backfill_jobs(connection, namespace)
+                    await _verify_legacy_jobs_for_cutover(connection, namespace)
+                    await _record_scheduled_job_migration(connection, namespace, job_count)
+                    jobs += job_count
                 await _sync_operator_github_policy(
                     connection,
                     namespace,
@@ -131,7 +136,11 @@ async def reconcile_workshop_operational_state(
                 await _verify_namespace(connection, namespace)
                 continue
 
-            job_count = await _backfill_jobs(connection, namespace)
+            job_count = 0
+            if not scheduled_jobs_migrated:
+                job_count = await _backfill_jobs(connection, namespace)
+                await _verify_legacy_jobs_for_cutover(connection, namespace)
+                await _record_scheduled_job_migration(connection, namespace, job_count)
             github_count = await _backfill_github_subscription(
                 connection,
                 namespace,
@@ -208,6 +217,54 @@ async def _migration_owner(
             "assignment or restore the database from backup"
         )
     return True
+
+
+async def _scheduled_job_migration_owner(
+    connection: aiosqlite.Connection,
+    namespace: WorkshopExecutionStateNamespace,
+) -> bool:
+    async with connection.execute(
+        "SELECT runtime_config_id, principal_id, channel_id, agent_id "
+        "FROM workshop_scheduled_job_migrations WHERE runtime_profile_id = ?",
+        (namespace.runtime_profile_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        return False
+    recorded = (int(row[0]), str(row[1]), str(row[2]), str(row[3]))
+    current = (
+        namespace.runtime_config_id,
+        str(namespace.principal_id),
+        str(namespace.channel_id),
+        str(namespace.agent_id),
+    )
+    if recorded != current:
+        raise WorkshopOperationalStateError(
+            "Canonical scheduled-job migration conflicts with current protected ownership "
+            f"for runtime profile {namespace.runtime_profile_id}; restore its recorded canonical "
+            "assignment or restore the database from backup"
+        )
+    return True
+
+
+async def _record_scheduled_job_migration(
+    connection: aiosqlite.Connection,
+    namespace: WorkshopExecutionStateNamespace,
+    legacy_jobs_count: int,
+) -> None:
+    await connection.execute(
+        "INSERT INTO workshop_scheduled_job_migrations ("
+        "runtime_profile_id, runtime_config_id, principal_id, channel_id, agent_id, "
+        "legacy_jobs_count) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            namespace.runtime_profile_id,
+            namespace.runtime_config_id,
+            namespace.principal_id,
+            namespace.channel_id,
+            namespace.agent_id,
+            legacy_jobs_count,
+        ),
+    )
 
 
 async def _legacy_setting(
@@ -307,7 +364,7 @@ async def _backfill_jobs(
     connection: aiosqlite.Connection,
     namespace: WorkshopExecutionStateNamespace,
 ) -> int:
-    cursor = await connection.execute(
+    await connection.execute(
         "INSERT OR IGNORE INTO workshop_job_owners ("
         "job_id, principal_id, channel_id, agent_id, runtime_profile_id"
         ") SELECT id, ?, ?, ?, ? FROM jobs WHERE chat_id = ?",
@@ -319,7 +376,26 @@ async def _backfill_jobs(
             namespace.runtime_config_id,
         ),
     )
-    return cursor.rowcount
+    job_cursor = await connection.execute(
+        "INSERT OR IGNORE INTO workshop_scheduled_jobs ("
+        "id, principal_id, channel_id, agent_id, runtime_profile_id, name, job_type, "
+        "prompt, schedule_type, schedule_data, created_at, active, auto_remove, notify_on_check"
+        ") SELECT j.id, o.principal_id, o.channel_id, o.agent_id, o.runtime_profile_id, "
+        "j.name, j.job_type, j.prompt, j.schedule_type, j.schedule_data, "
+        "strftime('%Y-%m-%dT%H:%M:%fZ', j.created_at || 'Z'), j.active, "
+        "j.auto_remove, j.notify_on_check FROM jobs j "
+        "JOIN workshop_job_owners o ON o.job_id = j.id "
+        "JOIN principals p ON p.id = o.principal_id AND p.kind = 'human' "
+        "JOIN channels c ON c.id = o.channel_id AND c.kind = 'direct' "
+        "JOIN channel_memberships cm ON cm.channel_id = c.id "
+        "AND cm.principal_id = p.id AND cm.role = 'owner' "
+        "JOIN agents a ON a.id = o.agent_id AND a.workshop_id = c.workshop_id "
+        "JOIN channel_agent_runtime_assignments ra ON ra.channel_id = c.id "
+        "AND ra.agent_id = a.id AND ra.runtime_profile_id = o.runtime_profile_id "
+        "WHERE j.chat_id = ?",
+        (namespace.runtime_config_id,),
+    )
+    return job_cursor.rowcount
 
 
 async def _backfill_github_subscription(
@@ -395,6 +471,21 @@ async def _verify_namespace(
     namespace: WorkshopExecutionStateNamespace,
 ) -> None:
     async with connection.execute(
+        "SELECT COUNT(*) FROM principal_github_subscriptions WHERE principal_id = ?",
+        (namespace.principal_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None or int(row[0]) != 1:
+        raise WorkshopOperationalStateError(
+            "Protected GitHub subscription policy has no unique canonical principal owner"
+        )
+
+
+async def _verify_legacy_jobs_for_cutover(
+    connection: aiosqlite.Connection,
+    namespace: WorkshopExecutionStateNamespace,
+) -> None:
+    async with connection.execute(
         "SELECT j.id FROM jobs j LEFT JOIN workshop_job_owners o ON o.job_id = j.id "
         "WHERE j.chat_id = ? AND (o.job_id IS NULL OR o.principal_id != ? OR o.channel_id != ? "
         "OR o.agent_id != ? OR o.runtime_profile_id != ?) ORDER BY j.id LIMIT 5",
@@ -415,11 +506,21 @@ async def _verify_namespace(
             "or remove and recreate the affected jobs"
         )
     async with connection.execute(
-        "SELECT COUNT(*) FROM principal_github_subscriptions WHERE principal_id = ?",
-        (namespace.principal_id,),
+        "SELECT j.id FROM jobs j JOIN workshop_job_owners o ON o.job_id = j.id "
+        "LEFT JOIN workshop_scheduled_jobs c ON c.id = j.id "
+        "WHERE j.chat_id = ? AND (c.id IS NULL OR c.principal_id != o.principal_id "
+        "OR c.channel_id != o.channel_id OR c.agent_id != o.agent_id "
+        "OR c.runtime_profile_id != o.runtime_profile_id OR c.name != j.name "
+        "OR c.job_type != j.job_type OR c.prompt != j.prompt "
+        "OR c.schedule_type != j.schedule_type OR c.schedule_data != j.schedule_data "
+        "OR c.active != j.active OR c.auto_remove != j.auto_remove "
+        "OR c.notify_on_check != j.notify_on_check) ORDER BY j.id LIMIT 5",
+        (namespace.runtime_config_id,),
     ) as cursor:
-        row = await cursor.fetchone()
-    if row is None or int(row[0]) != 1:
+        canonical_rows = await cursor.fetchall()
+    if canonical_rows:
+        job_ids = ", ".join(str(row[0]) for row in canonical_rows)
         raise WorkshopOperationalStateError(
-            "Protected GitHub subscription policy has no unique canonical principal owner"
+            "Protected scheduled jobs conflict with canonical definitions "
+            f"(job ids: {job_ids}); restore the database from the same pre-migration backup"
         )

--- a/src/kai/workshop/scheduled_jobs.py
+++ b/src/kai/workshop/scheduled_jobs.py
@@ -1,0 +1,307 @@
+"""Canonical scheduled-job persistence and ownership authorization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from kai.job_types import normalize_job_type
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
+from kai.workshop.store import WorkshopEventStore
+
+
+class WorkshopScheduledJobAuthorityError(RuntimeError):
+    """A scheduled-job owner does not resolve to one canonical execution lane."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopScheduledJobAuthority:
+    """Canonical authority allowed to own and manage scheduled work."""
+
+    principal_id: PrincipalId
+    channel_id: ChannelId
+    agent_id: AgentId
+    runtime_profile_id: RuntimeProfileId
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopScheduledJob:
+    """One canonical scheduled-job definition."""
+
+    job_id: int
+    authority: WorkshopScheduledJobAuthority
+    name: str
+    job_type: str
+    prompt: str
+    schedule_type: str
+    schedule_data: str
+    created_at: str
+    active: bool
+    auto_remove: bool
+    notify_on_check: bool
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the stable client-facing job representation."""
+        return {
+            "id": self.job_id,
+            "name": self.name,
+            "job_type": self.job_type,
+            "prompt": self.prompt,
+            "schedule_type": self.schedule_type,
+            "schedule_data": self.schedule_data,
+            "created_at": self.created_at,
+            "active": self.active,
+            "auto_remove": self.auto_remove,
+            "notify_on_check": self.notify_on_check,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopScheduledJobUpdate:
+    """Mutable fields accepted by canonical scheduled-job CRUD."""
+
+    name: str | None = None
+    prompt: str | None = None
+    schedule_type: str | None = None
+    schedule_data: str | None = None
+    auto_remove: bool | None = None
+    notify_on_check: bool | None = None
+
+
+_JOB_COLUMNS = (
+    "id, principal_id, channel_id, agent_id, runtime_profile_id, name, "
+    "job_type, prompt, schedule_type, schedule_data, created_at, active, "
+    "auto_remove, notify_on_check"
+)
+
+
+class WorkshopScheduledJobStore:
+    """Persist jobs using canonical ownership only."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def validate_authority(self, authority: WorkshopScheduledJobAuthority) -> None:
+        """Require one complete direct-channel execution assignment."""
+        async with self._store.connection.execute(
+            "SELECT COUNT(*) FROM channel_agent_runtime_assignments ra "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN agents a ON a.id = ra.agent_id AND a.workshop_id = c.workshop_id "
+            "JOIN channel_agents ca ON ca.channel_id = c.id AND ca.agent_id = a.id "
+            "JOIN channel_memberships cm ON cm.channel_id = c.id "
+            "AND cm.principal_id = ? AND cm.role = 'owner' "
+            "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+            "JOIN workshop_memberships wm ON wm.workshop_id = c.workshop_id "
+            "AND wm.principal_id = p.id "
+            "WHERE ra.channel_id = ? AND ra.agent_id = ? AND ra.runtime_profile_id = ?",
+            (
+                authority.principal_id,
+                authority.channel_id,
+                authority.agent_id,
+                authority.runtime_profile_id,
+            ),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None or int(row[0]) != 1:
+            raise WorkshopScheduledJobAuthorityError(
+                "Scheduled-job authority does not resolve to one canonical execution lane"
+            )
+
+    async def create(
+        self,
+        authority: WorkshopScheduledJobAuthority,
+        *,
+        name: str,
+        job_type: str,
+        prompt: str,
+        schedule_type: str,
+        schedule_data: str,
+        auto_remove: bool = False,
+        notify_on_check: bool = False,
+    ) -> WorkshopScheduledJob:
+        await self.validate_authority(authority)
+        canonical_job_type = normalize_job_type(job_type)
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            cursor = await connection.execute(
+                "INSERT INTO workshop_scheduled_jobs ("
+                "principal_id, channel_id, agent_id, runtime_profile_id, name, job_type, "
+                "prompt, schedule_type, schedule_data, auto_remove, notify_on_check"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    authority.principal_id,
+                    authority.channel_id,
+                    authority.agent_id,
+                    authority.runtime_profile_id,
+                    name,
+                    canonical_job_type,
+                    prompt,
+                    schedule_type,
+                    schedule_data,
+                    int(auto_remove),
+                    int(notify_on_check),
+                ),
+            )
+            if cursor.lastrowid is None:
+                raise RuntimeError("Canonical scheduled-job insert returned no ID")
+            job_id = int(cursor.lastrowid)
+            await connection.commit()
+        except Exception:
+            await connection.rollback()
+            raise
+        job = await self.get(job_id, authority, active_only=False)
+        if job is None:
+            raise RuntimeError("Canonical scheduled job disappeared after creation")
+        return job
+
+    async def list_active(
+        self,
+        authority: WorkshopScheduledJobAuthority,
+    ) -> tuple[WorkshopScheduledJob, ...]:
+        await self.validate_authority(authority)
+        async with self._store.connection.execute(
+            f"SELECT {_JOB_COLUMNS} FROM workshop_scheduled_jobs "
+            "WHERE principal_id = ? AND channel_id = ? AND agent_id = ? "
+            "AND runtime_profile_id = ? AND active = 1 ORDER BY id",
+            self._owner_values(authority),
+        ) as cursor:
+            return tuple(self._from_row(row) for row in await cursor.fetchall())
+
+    async def get(
+        self,
+        job_id: int,
+        authority: WorkshopScheduledJobAuthority,
+        *,
+        active_only: bool = True,
+    ) -> WorkshopScheduledJob | None:
+        await self.validate_authority(authority)
+        async with self._store.connection.execute(
+            f"SELECT {_JOB_COLUMNS} FROM workshop_scheduled_jobs WHERE id = ? "
+            "AND principal_id = ? AND channel_id = ? AND agent_id = ? "
+            f"AND runtime_profile_id = ?{' AND active = 1' if active_only else ''}",
+            (job_id, *self._owner_values(authority)),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return None if row is None else self._from_row(row)
+
+    async def get_for_scheduler(
+        self,
+        job_id: int,
+        *,
+        active_only: bool = True,
+    ) -> WorkshopScheduledJob | None:
+        async with self._store.connection.execute(
+            f"SELECT {_JOB_COLUMNS} FROM workshop_scheduled_jobs WHERE id = ?"
+            f"{' AND active = 1' if active_only else ''}",
+            (job_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        job = self._from_row(row)
+        await self.validate_authority(job.authority)
+        return job
+
+    async def active_ids(self) -> set[int]:
+        async with self._store.connection.execute(
+            "SELECT id FROM workshop_scheduled_jobs WHERE active = 1 ORDER BY id"
+        ) as cursor:
+            return {int(row[0]) for row in await cursor.fetchall()}
+
+    async def update(
+        self,
+        job_id: int,
+        authority: WorkshopScheduledJobAuthority,
+        update: WorkshopScheduledJobUpdate,
+    ) -> bool:
+        await self.validate_authority(authority)
+        fields: list[str] = []
+        values: list[object] = []
+        for column, value in (
+            ("name", update.name),
+            ("prompt", update.prompt),
+            ("schedule_type", update.schedule_type),
+            ("schedule_data", update.schedule_data),
+        ):
+            if value is not None:
+                fields.append(f"{column} = ?")
+                values.append(value)
+        for column, value in (
+            ("auto_remove", update.auto_remove),
+            ("notify_on_check", update.notify_on_check),
+        ):
+            if value is not None:
+                fields.append(f"{column} = ?")
+                values.append(int(value))
+        if not fields:
+            return False
+        cursor = await self._store.connection.execute(
+            f"UPDATE workshop_scheduled_jobs SET {', '.join(fields)} WHERE id = ? "
+            "AND principal_id = ? AND channel_id = ? AND agent_id = ? "
+            "AND runtime_profile_id = ? AND active = 1",
+            (*values, job_id, *self._owner_values(authority)),
+        )
+        await self._store.connection.commit()
+        return cursor.rowcount == 1
+
+    async def delete(self, job_id: int, authority: WorkshopScheduledJobAuthority) -> bool:
+        await self.validate_authority(authority)
+        cursor = await self._store.connection.execute(
+            "DELETE FROM workshop_scheduled_jobs WHERE id = ? AND principal_id = ? "
+            "AND channel_id = ? AND agent_id = ? AND runtime_profile_id = ?",
+            (job_id, *self._owner_values(authority)),
+        )
+        await self._store.connection.commit()
+        return cursor.rowcount == 1
+
+    async def deactivate(
+        self,
+        job_id: int,
+        authority: WorkshopScheduledJobAuthority | None = None,
+    ) -> bool:
+        if authority is None:
+            cursor = await self._store.connection.execute(
+                "UPDATE workshop_scheduled_jobs SET active = 0 WHERE id = ? AND active = 1",
+                (job_id,),
+            )
+        else:
+            await self.validate_authority(authority)
+            cursor = await self._store.connection.execute(
+                "UPDATE workshop_scheduled_jobs SET active = 0 WHERE id = ? "
+                "AND principal_id = ? AND channel_id = ? AND agent_id = ? "
+                "AND runtime_profile_id = ? AND active = 1",
+                (job_id, *self._owner_values(authority)),
+            )
+        await self._store.connection.commit()
+        return cursor.rowcount == 1
+
+    @staticmethod
+    def _owner_values(authority: WorkshopScheduledJobAuthority) -> tuple[str, str, str, str]:
+        return (
+            str(authority.principal_id),
+            str(authority.channel_id),
+            str(authority.agent_id),
+            str(authority.runtime_profile_id),
+        )
+
+    @staticmethod
+    def _from_row(row: Any) -> WorkshopScheduledJob:
+        return WorkshopScheduledJob(
+            job_id=int(row[0]),
+            authority=WorkshopScheduledJobAuthority(
+                PrincipalId(str(row[1])),
+                ChannelId(str(row[2])),
+                AgentId(str(row[3])),
+                RuntimeProfileId(str(row[4])),
+            ),
+            name=str(row[5]),
+            job_type=normalize_job_type(str(row[6])),
+            prompt=str(row[7]),
+            schedule_type=str(row[8]),
+            schedule_data=str(row[9]),
+            created_at=str(row[10]),
+            active=bool(row[11]),
+            auto_remove=bool(row[12]),
+            notify_on_check=bool(row[13]),
+        )

--- a/src/kai/workshop/scheduled_notifications.py
+++ b/src/kai/workshop/scheduled_notifications.py
@@ -54,10 +54,10 @@ class WorkshopScheduledReminderRecorder:
     async def _record_locked(self, reminder: ScheduledReminder) -> ScheduledReminderRecord:
         async with self._store.connection.execute(
             "SELECT c.workshop_id, c.id, a.principal_id "
-            "FROM workshop_job_owners o "
-            "JOIN channels c ON c.id = o.channel_id "
-            "JOIN agents a ON a.id = o.agent_id AND a.workshop_id = c.workshop_id "
-            "WHERE o.job_id = ?",
+            "FROM workshop_scheduled_jobs j "
+            "JOIN channels c ON c.id = j.channel_id "
+            "JOIN agents a ON a.id = j.agent_id AND a.workshop_id = c.workshop_id "
+            "WHERE j.id = ?",
             (reminder.job_id,),
         ) as cursor:
             rows = list(await cursor.fetchall())

--- a/src/kai/workshop/scheduler.py
+++ b/src/kai/workshop/scheduler.py
@@ -18,7 +18,7 @@ from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
 from kai.backend import AgentResponse
-from kai.job_types import JOB_TYPE_AGENT, JOB_TYPE_REMINDER, normalize_job_type
+from kai.job_types import JOB_TYPE_AGENT, JOB_TYPE_REMINDER
 from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.domain import (
@@ -35,6 +35,11 @@ from kai.workshop.execution_coordinator import (
 )
 from kai.workshop.inbound import ScheduledInboundMessage
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
+from kai.workshop.scheduled_jobs import (
+    WorkshopScheduledJobAuthority,
+    WorkshopScheduledJobStore,
+    WorkshopScheduledJobUpdate,
+)
 from kai.workshop.scheduled_notifications import (
     ScheduledReminder,
     WorkshopScheduledReminderRecorder,
@@ -55,6 +60,10 @@ class WorkshopSchedulerState(StrEnum):
     STOPPING = "stopping"
     STOPPED = "stopped"
     FAILED = "failed"
+
+
+class WorkshopScheduledJobRegistrationError(RuntimeError):
+    """A persisted job could not be made active in the timing engine."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,6 +114,7 @@ class WorkshopCanonicalScheduler:
         self._execution = execution
         self._compatibility_state = compatibility_state
         self._reminders = WorkshopScheduledReminderRecorder(store)
+        self._jobs = WorkshopScheduledJobStore(store)
         self._state = WorkshopSchedulerState.NEW
         self._stop_event = asyncio.Event()
         self._failure_event = asyncio.Event()
@@ -148,6 +158,110 @@ class WorkshopCanonicalScheduler:
             len(self._registered_jobs),
             len(self._firing_tasks),
         )
+
+    async def create_job(
+        self,
+        authority: WorkshopScheduledJobAuthority,
+        *,
+        name: str,
+        job_type: str,
+        prompt: str,
+        schedule_type: str,
+        schedule_data: str,
+        auto_remove: bool = False,
+        notify_on_check: bool = False,
+    ) -> int:
+        """Persist and register one canonically owned scheduled job."""
+        job = await self._jobs.create(
+            authority,
+            name=name,
+            job_type=job_type,
+            prompt=prompt,
+            schedule_type=schedule_type,
+            schedule_data=schedule_data,
+            auto_remove=auto_remove,
+            notify_on_check=notify_on_check,
+        )
+        try:
+            registered = await self.register_job(job.job_id)
+        except Exception as exc:
+            await self._jobs.deactivate(job.job_id, authority)
+            raise WorkshopScheduledJobRegistrationError(
+                "Canonical scheduler could not register the created job"
+            ) from exc
+        if not registered:
+            await self._jobs.deactivate(job.job_id, authority)
+            raise WorkshopScheduledJobRegistrationError("Canonical scheduler could not register the created job")
+        return job.job_id
+
+    async def list_jobs(
+        self,
+        authority: WorkshopScheduledJobAuthority,
+    ) -> list[dict[str, Any]]:
+        """List active jobs owned by one canonical execution lane."""
+        return [job.as_dict() for job in await self._jobs.list_active(authority)]
+
+    async def get_job(
+        self,
+        job_id: int,
+        authority: WorkshopScheduledJobAuthority,
+    ) -> dict[str, Any] | None:
+        """Return one active owned job without leaking cross-owner existence."""
+        job = await self._jobs.get(job_id, authority)
+        return None if job is None else job.as_dict()
+
+    async def delete_job(
+        self,
+        job_id: int,
+        authority: WorkshopScheduledJobAuthority,
+    ) -> bool:
+        """Delete one owned job and remove its registered timing callbacks."""
+        deleted = await self._jobs.delete(job_id, authority)
+        if deleted:
+            await self.remove_job(job_id)
+        return deleted
+
+    async def update_job(
+        self,
+        job_id: int,
+        authority: WorkshopScheduledJobAuthority,
+        update: WorkshopScheduledJobUpdate,
+    ) -> bool:
+        """Update one owned job, compensating if timing registration fails."""
+        previous = await self._jobs.get(job_id, authority)
+        if previous is None:
+            return False
+        changed_schedule = update.schedule_type is not None or update.schedule_data is not None
+        updated = await self._jobs.update(job_id, authority, update)
+        if not updated or not changed_schedule:
+            return updated
+        try:
+            registered = await self.register_job(job_id)
+            if not registered:
+                raise RuntimeError("Updated scheduled job could not be registered")
+        except Exception:
+            restored = await self._jobs.update(
+                job_id,
+                authority,
+                WorkshopScheduledJobUpdate(
+                    name=previous.name,
+                    prompt=previous.prompt,
+                    schedule_type=previous.schedule_type,
+                    schedule_data=previous.schedule_data,
+                    auto_remove=previous.auto_remove,
+                    notify_on_check=previous.notify_on_check,
+                ),
+            )
+            if not restored:
+                log.error("Failed to restore canonical job %d after scheduler registration failure", job_id)
+                raise
+            try:
+                if not await self.register_job(job_id):
+                    log.error("Restored canonical job %d could not be registered", job_id)
+            except Exception:
+                log.exception("Failed to restore scheduler entry for canonical job %d", job_id)
+            raise
+        return True
 
     async def register_job(self, job_id: int) -> bool:
         """Register or replace one active job after a committed mutation."""
@@ -223,10 +337,7 @@ class WorkshopCanonicalScheduler:
                 return
 
     async def _reconcile(self) -> None:
-        if not await self._jobs_table_exists():
-            return
-        async with self._store.connection.execute("SELECT id FROM jobs WHERE active = 1 ORDER BY id") as cursor:
-            active_ids = {int(row[0]) for row in await cursor.fetchall()}
+        active_ids = await self._jobs.active_ids()
         invalid_ids = [job_id for job_id in active_ids if await self._load_job(job_id) is None]
         if invalid_ids:
             rendered = ", ".join(str(job_id) for job_id in invalid_ids)
@@ -272,49 +383,26 @@ class WorkshopCanonicalScheduler:
                 _ensure_utc(datetime.fromisoformat(str(row[2]))),
             )
 
-    async def _jobs_table_exists(self) -> bool:
-        async with self._store.connection.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'jobs'"
-        ) as cursor:
-            return await cursor.fetchone() is not None
-
     async def _load_job(self, job_id: int, *, active_only: bool = True) -> _CanonicalJob | None:
-        if not await self._jobs_table_exists():
+        record = await self._jobs.get_for_scheduler(job_id, active_only=active_only)
+        if record is None:
             return None
-        async with self._store.connection.execute(
-            "SELECT j.id, j.name, j.job_type, j.prompt, j.schedule_type, j.schedule_data, "
-            "j.auto_remove, j.notify_on_check, j.created_at, "
-            "o.principal_id, o.channel_id, o.runtime_profile_id "
-            "FROM jobs j JOIN workshop_job_owners o ON o.job_id = j.id "
-            "JOIN principals p ON p.id = o.principal_id "
-            "JOIN channels c ON c.id = o.channel_id "
-            "JOIN channel_memberships cm ON cm.channel_id = c.id "
-            "AND cm.principal_id = p.id "
-            "JOIN agents a ON a.id = o.agent_id AND a.workshop_id = c.workshop_id "
-            "JOIN channel_agent_runtime_assignments ra ON ra.channel_id = c.id "
-            "AND ra.agent_id = a.id AND ra.runtime_profile_id = o.runtime_profile_id "
-            f"WHERE j.id = ?{' AND j.active = 1' if active_only else ''}",
-            (job_id,),
-        ) as cursor:
-            row = await cursor.fetchone()
-        if row is None:
-            return None
-        schedule_data = json.loads(str(row[5]))
+        schedule_data = json.loads(record.schedule_data)
         if not isinstance(schedule_data, dict):
             raise RuntimeError(f"Scheduled job {job_id} has invalid schedule data")
         return _CanonicalJob(
-            job_id=int(row[0]),
-            name=str(row[1]),
-            job_type=normalize_job_type(str(row[2])),
-            prompt=str(row[3]),
-            schedule_type=str(row[4]),
+            job_id=record.job_id,
+            name=record.name,
+            job_type=record.job_type,
+            prompt=record.prompt,
+            schedule_type=record.schedule_type,
             schedule_data=schedule_data,
-            created_at=_ensure_utc(datetime.fromisoformat(str(row[8]))),
-            auto_remove=bool(row[6]),
-            notify_on_check=bool(row[7]),
-            principal_id=PrincipalId(str(row[9])),
-            channel_id=ChannelId(str(row[10])),
-            runtime_profile_id=RuntimeProfileId(str(row[11])),
+            created_at=_ensure_utc(datetime.fromisoformat(record.created_at.replace("Z", "+00:00"))),
+            auto_remove=record.auto_remove,
+            notify_on_check=record.notify_on_check,
+            principal_id=record.authority.principal_id,
+            channel_id=record.authority.channel_id,
+            runtime_profile_id=record.authority.runtime_profile_id,
         )
 
     def _register_loaded_job(self, job: _CanonicalJob) -> None:
@@ -625,8 +713,7 @@ class WorkshopCanonicalScheduler:
         return row is not None and bool(row[0])
 
     async def _deactivate(self, job_id: int) -> None:
-        await self._store.connection.execute("UPDATE jobs SET active = 0 WHERE id = ?", (job_id,))
-        await self._store.connection.commit()
+        await self._jobs.deactivate(job_id)
         async with self._lock:
             self._remove_registered_job(job_id)
 

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 28
+WORKSHOP_SCHEMA_VERSION = 29
 
 
 @dataclass(frozen=True, slots=True)
@@ -1280,6 +1280,51 @@ _INTEGRATION_ROUTE_SCHEMA = SchemaMigration(
     ),
 )
 
+_CANONICAL_SCHEDULED_JOB_SCHEMA = SchemaMigration(
+    version=29,
+    name="canonical_scheduled_job_definitions",
+    statements=(
+        """
+        CREATE TABLE workshop_scheduled_jobs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            principal_id TEXT NOT NULL,
+            channel_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            runtime_profile_id TEXT NOT NULL CHECK (
+                length(runtime_profile_id) BETWEEN 1 AND 128
+            ),
+            name TEXT NOT NULL,
+            job_type TEXT NOT NULL CHECK (job_type IN ('reminder', 'agent')),
+            prompt TEXT NOT NULL,
+            schedule_type TEXT NOT NULL CHECK (
+                schedule_type IN ('once', 'daily', 'interval')
+            ),
+            schedule_data TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+            auto_remove INTEGER NOT NULL DEFAULT 0 CHECK (auto_remove IN (0, 1)),
+            notify_on_check INTEGER NOT NULL DEFAULT 0 CHECK (notify_on_check IN (0, 1))
+        )
+        """,
+        "CREATE INDEX workshop_scheduled_jobs_owner_idx ON workshop_scheduled_jobs "
+        "(principal_id, channel_id, agent_id, runtime_profile_id, active, id)",
+        "CREATE INDEX workshop_scheduled_jobs_active_idx ON workshop_scheduled_jobs (active, id)",
+        """
+        CREATE TABLE workshop_scheduled_job_migrations (
+            runtime_profile_id TEXT PRIMARY KEY CHECK (
+                length(runtime_profile_id) BETWEEN 1 AND 128
+            ),
+            runtime_config_id INTEGER NOT NULL,
+            principal_id TEXT NOT NULL,
+            channel_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            legacy_jobs_count INTEGER NOT NULL CHECK (legacy_jobs_count >= 0),
+            migrated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        )
+        """,
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1309,6 +1354,7 @@ _MIGRATIONS = (
     _CORE_SCHEDULER_SCHEMA,
     _GITHUB_AUTOMATION_SCHEMA,
     _INTEGRATION_ROUTE_SCHEMA,
+    _CANONICAL_SCHEDULED_JOB_SCHEMA,
 )
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -954,13 +954,25 @@ def _make_context(config=None, claude=None, pool=None, args=None, user_data=None
         "config": resolved_config,
     }
     application = MagicMock(spec=KaiTelegramApplication)
+    internal_api_contexts = MagicMock()
+    internal_api_contexts.for_runtime_config_id.side_effect = lambda runtime_config_id: SimpleNamespace(
+        principal_id=PrincipalId(f"prn_{runtime_config_id:032x}"),
+        channel_id=ChannelId(f"chn_{runtime_config_id:032x}"),
+        agent_id=AgentId("agt_" + "a" * 32),
+        runtime_profile_id=profile_id(runtime_config_id),
+    )
     application.core_services = SimpleNamespace(
         subprocess_pool=mock_pool,
         private_text_execution=None,
         conversation_runs=None,
         principal_storage=principal_storage,
         artifacts=_TestArtifactService(),
-        scheduler=SimpleNamespace(remove_job=AsyncMock()),
+        internal_api_contexts=internal_api_contexts,
+        scheduler=SimpleNamespace(
+            list_jobs=AsyncMock(return_value=[]),
+            get_job=AsyncMock(return_value=None),
+            delete_job=AsyncMock(return_value=False),
+        ),
     )
     ctx.application = application
     ctx.args = args or []
@@ -1382,8 +1394,7 @@ class TestHandleJob:
         """/job with no args lists all jobs."""
         update = _make_update()
         ctx = _make_context()
-        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=[]):
-            await handle_job(update, ctx)
+        await handle_job(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "No active" in reply
 
@@ -1392,10 +1403,18 @@ class TestHandleJob:
         """/job list is equivalent to /job with no args."""
         update = _make_update()
         ctx = _make_context(args=["list"])
-        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=[]):
-            await handle_job(update, ctx)
+        await handle_job(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "No active" in reply
+
+    @pytest.mark.asyncio
+    async def test_group_command_uses_authenticated_human_not_telegram_chat(self):
+        update = _make_update(chat_id=-100123, user_id=1)
+        ctx = _make_context()
+
+        await handle_job(update, ctx)
+
+        ctx.application.core_services.internal_api_contexts.for_runtime_config_id.assert_called_once_with(1)
 
     @pytest.mark.asyncio
     async def test_formats_interval_hours(self):
@@ -1411,8 +1430,8 @@ class TestHandleJob:
                 "schedule_data": json.dumps({"seconds": 7200}),
             }
         ]
-        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=jobs):
-            await handle_job(update, ctx)
+        ctx.application.core_services.scheduler.list_jobs.return_value = jobs
+        await handle_job(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "2h" in reply
         assert "\U0001f916" in reply  # robot emoji for claude type
@@ -1431,8 +1450,8 @@ class TestHandleJob:
                 "schedule_data": json.dumps({"seconds": 300}),
             }
         ]
-        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=jobs):
-            await handle_job(update, ctx)
+        ctx.application.core_services.scheduler.list_jobs.return_value = jobs
+        await handle_job(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "5m" in reply
         assert "\U0001f514" in reply  # bell emoji for reminder type
@@ -1450,8 +1469,8 @@ class TestHandleJob:
                 "schedule_data": json.dumps({"times": ["14:00"]}),
             }
         ]
-        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=jobs):
-            await handle_job(update, ctx)
+        ctx.application.core_services.scheduler.list_jobs.return_value = jobs
+        await handle_job(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "14:00" in reply
 
@@ -1464,7 +1483,6 @@ class TestHandleJob:
         ctx = _make_context(args=["info", "4"])
         job = {
             "id": 4,
-            "chat_id": 12345,
             "name": "Weather report",
             "job_type": "claude",
             "prompt": "What is the weather today?",
@@ -1473,8 +1491,8 @@ class TestHandleJob:
             "auto_remove": False,
             "notify_on_check": False,
         }
-        with patch("kai.bot.sessions.get_job_by_id", new_callable=AsyncMock, return_value=job):
-            await handle_job(update, ctx)
+        ctx.application.core_services.scheduler.get_job.return_value = job
+        await handle_job(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "Job #4" in reply
         assert "Weather report" in reply
@@ -1487,8 +1505,7 @@ class TestHandleJob:
         """/job info <id> returns not found for non-existent job."""
         update = _make_update()
         ctx = _make_context(args=["info", "999"])
-        with patch("kai.bot.sessions.get_job_by_id", new_callable=AsyncMock, return_value=None):
-            await handle_job(update, ctx)
+        await handle_job(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "not found" in reply.lower()
 
@@ -1497,19 +1514,7 @@ class TestHandleJob:
         """/job info <id> returns not found for a job owned by another chat."""
         update = _make_update(chat_id=12345)
         ctx = _make_context(args=["info", "4"])
-        job = {
-            "id": 4,
-            "chat_id": 99999,  # Different owner
-            "name": "Secret",
-            "job_type": "claude",
-            "prompt": "hidden",
-            "schedule_type": "daily",
-            "schedule_data": json.dumps({"times": ["08:00"]}),
-            "auto_remove": False,
-            "notify_on_check": False,
-        }
-        with patch("kai.bot.sessions.get_job_by_id", new_callable=AsyncMock, return_value=job):
-            await handle_job(update, ctx)
+        await handle_job(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "not found" in reply.lower()
 
@@ -1538,9 +1543,9 @@ class TestHandleJob:
         """Deletes from DB and removes the core scheduler task."""
         update = _make_update()
         ctx = _make_context(args=["cancel", "5"])
-        with patch("kai.bot.sessions.delete_job", new_callable=AsyncMock, return_value=True):
-            await handle_job(update, ctx)
-        ctx.application.core_services.scheduler.remove_job.assert_awaited_once_with(5)
+        ctx.application.core_services.scheduler.delete_job.return_value = True
+        await handle_job(update, ctx)
+        ctx.application.core_services.scheduler.delete_job.assert_awaited_once()
         reply = update.message.reply_text.call_args[0][0]
         assert "cancelled" in reply.lower()
 
@@ -1548,8 +1553,7 @@ class TestHandleJob:
     async def test_cancel_not_found(self):
         update = _make_update()
         ctx = _make_context(args=["cancel", "99"])
-        with patch("kai.bot.sessions.delete_job", new_callable=AsyncMock, return_value=False):
-            await handle_job(update, ctx)
+        await handle_job(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "not found" in reply.lower()
 
@@ -1588,8 +1592,7 @@ class TestHandleJob:
         """/jobs delegates to the list logic."""
         update = _make_update()
         ctx = _make_context()
-        with patch("kai.bot.sessions.get_jobs", new_callable=AsyncMock, return_value=[]):
-            await handle_jobs(update, ctx)
+        await handle_jobs(update, ctx)
         reply = update.message.reply_text.call_args[0][0]
         assert "No active" in reply
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4973,15 +4973,35 @@ class TestCmdStatus:
     def test_status_reports_core_owned_active_jobs(self, tmp_path):
         db_path = tmp_path / "kai.db"
         connection = sqlite3.connect(db_path)
-        connection.execute("CREATE TABLE jobs (id INTEGER PRIMARY KEY, active INTEGER NOT NULL)")
-        connection.execute("CREATE TABLE workshop_job_owners (job_id INTEGER PRIMARY KEY)")
+        connection.execute("CREATE TABLE channels (id TEXT PRIMARY KEY, kind TEXT NOT NULL)")
+        connection.execute("CREATE TABLE channel_memberships (channel_id TEXT, principal_id TEXT, role TEXT)")
+        connection.execute("CREATE TABLE agents (id TEXT PRIMARY KEY, workshop_id TEXT)")
+        connection.execute("ALTER TABLE channels ADD COLUMN workshop_id TEXT")
+        connection.execute(
+            "CREATE TABLE channel_agent_runtime_assignments (channel_id TEXT, agent_id TEXT, runtime_profile_id TEXT)"
+        )
+        connection.execute(
+            "CREATE TABLE workshop_scheduled_jobs ("
+            "id INTEGER PRIMARY KEY, principal_id TEXT, channel_id TEXT, agent_id TEXT, "
+            "runtime_profile_id TEXT, active INTEGER NOT NULL)"
+        )
         connection.execute("CREATE TABLE workshop_schedule_firings (status TEXT NOT NULL)")
         connection.executemany(
             "INSERT INTO workshop_schedule_firings(status) VALUES (?)",
             [("pending",), ("executing",), ("failed",)],
         )
-        connection.executemany("INSERT INTO jobs(active) VALUES (?)", [(1,), (1,), (0,)])
-        connection.execute("INSERT INTO workshop_job_owners(job_id) VALUES (1)")
+        connection.execute("INSERT INTO channels VALUES ('channel-1', 'direct', 'workshop-1')")
+        connection.execute("INSERT INTO channel_memberships VALUES ('channel-1', 'human-1', 'owner')")
+        connection.execute("INSERT INTO agents VALUES ('agent-1', 'workshop-1')")
+        connection.execute("INSERT INTO channel_agent_runtime_assignments VALUES ('channel-1', 'agent-1', 'profile-1')")
+        connection.executemany(
+            "INSERT INTO workshop_scheduled_jobs VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (1, "human-1", "channel-1", "agent-1", "profile-1", 1),
+                (2, "human-2", "channel-2", "agent-2", "profile-2", 1),
+                (3, "human-1", "channel-1", "agent-1", "profile-1", 0),
+            ],
+        )
         connection.commit()
         connection.close()
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -49,6 +49,7 @@ from kai.webhook import (
 )
 from kai.workshop.domain import AgentId, ChannelId, PrincipalId
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
+from kai.workshop.scheduler import WorkshopScheduledJobRegistrationError
 from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageNamespace,
     WorkshopPrincipalStorageRegistry,
@@ -93,6 +94,83 @@ def _principal_storage_registry() -> WorkshopPrincipalStorageRegistry:
     )
 
 
+def _runtime_config_id_for_authority(authority) -> int:
+    return int(str(authority.principal_id).removeprefix("prn_"), 16)
+
+
+class _CanonicalSchedulerDouble:
+    """Exercise handler contracts while legacy session tests remain isolated."""
+
+    def __init__(self) -> None:
+        self.register_job = AsyncMock(return_value=True)
+        self.remove_job = AsyncMock()
+
+    async def create_job(self, authority, **fields) -> int:
+        runtime_config_id = _runtime_config_id_for_authority(authority)
+        job_id = await sessions.create_job(chat_id=runtime_config_id, **fields)
+        try:
+            if not await self.register_job(job_id):
+                raise RuntimeError("registration failed")
+        except Exception as exc:
+            await sessions.deactivate_job(job_id, chat_id=runtime_config_id)
+            raise WorkshopScheduledJobRegistrationError("registration failed") from exc
+        return job_id
+
+    async def list_jobs(self, authority) -> list[dict]:
+        jobs = await sessions.get_jobs(_runtime_config_id_for_authority(authority))
+        return [{key: value for key, value in job.items() if key != "chat_id"} for job in jobs]
+
+    async def get_job(self, job_id: int, authority) -> dict | None:
+        job = await sessions.get_job_by_id(job_id)
+        if job is None or job["chat_id"] != _runtime_config_id_for_authority(authority):
+            return None
+        return {key: value for key, value in job.items() if key != "chat_id"}
+
+    async def delete_job(self, job_id: int, authority) -> bool:
+        deleted = await sessions.delete_job(
+            job_id,
+            chat_id=_runtime_config_id_for_authority(authority),
+        )
+        if deleted:
+            await self.remove_job(job_id)
+        return deleted
+
+    async def update_job(self, job_id: int, authority, update) -> bool:
+        runtime_config_id = _runtime_config_id_for_authority(authority)
+        previous = await sessions.get_job_by_id(job_id)
+        if previous is None or previous["chat_id"] != runtime_config_id:
+            return False
+        updated = await sessions.update_job(
+            job_id,
+            chat_id=runtime_config_id,
+            name=update.name,
+            prompt=update.prompt,
+            schedule_type=update.schedule_type,
+            schedule_data=update.schedule_data,
+            auto_remove=update.auto_remove,
+            notify_on_check=update.notify_on_check,
+        )
+        if not updated or (update.schedule_type is None and update.schedule_data is None):
+            return updated
+        try:
+            if not await self.register_job(job_id):
+                raise RuntimeError("registration failed")
+        except Exception:
+            await sessions.update_job(
+                job_id,
+                chat_id=runtime_config_id,
+                name=previous["name"],
+                prompt=previous["prompt"],
+                schedule_type=previous["schedule_type"],
+                schedule_data=previous["schedule_data"],
+                auto_remove=previous["auto_remove"],
+                notify_on_check=previous["notify_on_check"],
+            )
+            await self.register_job(job_id)
+            raise
+        return True
+
+
 async def _call_memory_delete_all_as_authorized(request, *, chat_id: int = 123):
     """Exercise delete-all handler behavior with an explicitly privileged principal."""
     context = _internal_api_context(chat_id)
@@ -135,10 +213,7 @@ def mock_request():
         ALLOWED_USER_IDS_KEY: {123, 456},
         CORE_HOST_KEY: SimpleNamespace(
             services=SimpleNamespace(
-                scheduler=SimpleNamespace(
-                    register_job=AsyncMock(return_value=True),
-                    remove_job=AsyncMock(),
-                )
+                scheduler=_CanonicalSchedulerDouble(),
             )
         ),
     }

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -57,7 +57,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -188,6 +188,8 @@ class TestWorkshopSchema:
             "workshop_schedule_firings",
             "workshop_github_automation_work",
             "workshop_integration_routes",
+            "workshop_scheduled_jobs",
+            "workshop_scheduled_job_migrations",
             "messages",
             "artifacts",
             "deliveries",
@@ -202,7 +204,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 28
+        assert await workshop_store.schema_version() == 29
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -215,7 +217,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 28
+        assert await second.schema_version() == 29
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -236,7 +238,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -282,6 +284,7 @@ class TestWorkshopSchema:
                     26,
                     27,
                     28,
+                    29,
                 ]
         finally:
             await upgraded.close()
@@ -304,7 +307,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -345,7 +348,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -398,7 +401,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -442,7 +445,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -486,7 +489,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -530,7 +533,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -634,7 +637,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -761,7 +764,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -455,7 +455,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_operational_state.py
+++ b/tests/test_workshop_operational_state.py
@@ -95,6 +95,21 @@ class TestCanonicalOperationalStateMigration:
         assert first.github_subscriptions == 1
         assert second.newly_migrated == 0
         assert [job["id"] for job in await sessions.get_jobs(101)] == [job_id]
+        async with sessions._get_db().execute(
+            "SELECT id, name, job_type, prompt, schedule_type, schedule_data FROM workshop_scheduled_jobs"
+        ) as cursor:
+            assert tuple(await cursor.fetchone()) == (
+                job_id,
+                "daily",
+                "agent",
+                "Check status",
+                "daily",
+                '{"times":["09:00"]}',
+            )
+        async with sessions._get_db().execute(
+            "SELECT legacy_jobs_count FROM workshop_scheduled_job_migrations"
+        ) as cursor:
+            assert (await cursor.fetchone())[0] == 1
         assert await sessions.get_effective_repos(101, ["ignored/after-cutover"]) == ["owner/added"]
         settings = await sessions.resolve_github_settings(101, _config(101))
         assert settings["pr_review"] is False
@@ -116,7 +131,36 @@ class TestCanonicalOperationalStateMigration:
         assert migration.newly_migrated == 0
         assert await sessions.get_effective_repos(101, []) == ["owner/repo-101"]
 
-    async def test_restart_self_heals_job_created_during_rollback_window(self, database: Path):
+    async def test_existing_operational_receipt_gets_one_time_job_cutover(self, database: Path):
+        legacy_job_id = await sessions.create_job(
+            101,
+            "existing",
+            "reminder",
+            "Preserve me",
+            "once",
+            "{}",
+        )
+        registry = await _bootstrap(101)
+        await sessions.initialize_workshop_operational_state(registry, _config(101))
+        await sessions._get_db().execute("DELETE FROM workshop_scheduled_job_migrations")
+        await sessions._get_db().execute("DELETE FROM workshop_scheduled_jobs")
+        await sessions._get_db().commit()
+
+        migration = await sessions.initialize_workshop_operational_state(registry, _config(101))
+
+        assert migration.newly_migrated == 0
+        assert migration.jobs == 1
+        async with sessions._get_db().execute(
+            "SELECT name FROM workshop_scheduled_jobs WHERE id = ?",
+            (legacy_job_id,),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] == "existing"
+        async with sessions._get_db().execute(
+            "SELECT legacy_jobs_count FROM workshop_scheduled_job_migrations"
+        ) as cursor:
+            assert (await cursor.fetchone())[0] == 1
+
+    async def test_restart_does_not_import_post_cutover_legacy_job(self, database: Path):
         registry = await _bootstrap(101)
         await sessions.initialize_workshop_operational_state(registry, _config(101))
         cursor = await sessions._get_db().execute(
@@ -124,7 +168,7 @@ class TestCanonicalOperationalStateMigration:
             "VALUES (101, 'rollback', 'reminder', 'Check safely', 'once', '{}')"
         )
         await sessions._get_db().commit()
-        job_id = int(cursor.lastrowid)
+        legacy_job_id = int(cursor.lastrowid)
 
         await sessions.close_db()
         await sessions.init_db(database)
@@ -132,37 +176,46 @@ class TestCanonicalOperationalStateMigration:
         migration = await sessions.initialize_workshop_operational_state(registry, _config(101))
 
         assert migration.newly_migrated == 0
-        assert migration.jobs == 1
-        assert [job["id"] for job in await sessions.get_jobs(101)] == [job_id]
+        assert migration.jobs == 0
+        async with sessions._get_db().execute(
+            "SELECT 1 FROM workshop_scheduled_jobs WHERE id = ?",
+            (legacy_job_id,),
+        ) as canonical:
+            assert await canonical.fetchone() is None
+        assert "unmigrated jobs=1" in workshop_operational_state_status(database)
 
-    async def test_restart_rejects_conflicting_job_owner_with_remediation(self, database: Path):
+    async def test_restart_does_not_overwrite_post_cutover_canonical_update(
+        self,
+        database: Path,
+    ):
+        legacy_job_id = await sessions.create_job(
+            101,
+            "original",
+            "reminder",
+            "Remember",
+            "once",
+            "{}",
+        )
         registry = await _bootstrap(101)
         await sessions.initialize_workshop_operational_state(registry, _config(101))
-        cursor = await sessions._get_db().execute(
-            "INSERT INTO jobs (chat_id, name, job_type, prompt, schedule_type, schedule_data) "
-            "VALUES (101, 'conflict', 'reminder', 'Do not expose', 'once', '{}')"
-        )
-        job_id = int(cursor.lastrowid)
-        namespace = registry.namespaces[0]
         await sessions._get_db().execute(
-            "INSERT INTO workshop_job_owners "
-            "(job_id, principal_id, channel_id, agent_id, runtime_profile_id) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (
-                job_id,
-                "prn_00000000000000000000000000000001",
-                namespace.channel_id,
-                namespace.agent_id,
-                namespace.runtime_profile_id,
-            ),
+            "UPDATE workshop_scheduled_jobs SET name = ? WHERE id = ?",
+            ("canonical update", legacy_job_id),
         )
         await sessions._get_db().commit()
 
-        with pytest.raises(
-            WorkshopOperationalStateError,
-            match=rf"job ids: {job_id}.*restore workshop_job_owners",
-        ):
-            await sessions.initialize_workshop_operational_state(registry, _config(101))
+        await sessions.close_db()
+        await sessions.init_db(database)
+        registry = await _bootstrap(101)
+
+        migration = await sessions.initialize_workshop_operational_state(registry, _config(101))
+
+        assert migration.jobs == 0
+        async with sessions._get_db().execute(
+            "SELECT name FROM workshop_scheduled_jobs WHERE id = ?",
+            (legacy_job_id,),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] == "canonical update"
 
     async def test_conflicting_receipt_owner_fails_closed(self, database: Path):
         registry = await _bootstrap(101)
@@ -310,5 +363,5 @@ class TestCanonicalOperationalStateDiagnostic:
 
         drifted = workshop_operational_state_status(database)
         assert drifted.startswith("Workshop operational state: INCOMPLETE;")
-        assert "unowned jobs=1" in drifted
+        assert "unmigrated jobs=1" in drifted
         assert "secret" not in drifted

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -404,7 +404,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_scheduled_jobs.py
+++ b/tests/test_workshop_scheduled_jobs.py
@@ -1,0 +1,140 @@
+"""Canonical scheduled-job persistence and authorization contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kai import sessions
+from kai.workshop.bootstrap import BootstrapHuman
+from kai.workshop.domain import AgentId
+from kai.workshop.scheduled_jobs import (
+    WorkshopScheduledJobAuthority,
+    WorkshopScheduledJobAuthorityError,
+    WorkshopScheduledJobStore,
+    WorkshopScheduledJobUpdate,
+)
+from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
+
+
+@pytest.fixture
+async def scheduled_jobs(tmp_path: Path):
+    database = tmp_path / "kai.db"
+    await sessions.init_db(database)
+    await sessions.bootstrap_workshop_foundation(
+        (
+            BootstrapHuman(
+                display_name="Daniel",
+                role="admin",
+                transport="telegram",
+                external_subject="101",
+                external_channel_id="101",
+                runtime_profile_id=profile_id(101),
+            ),
+            BootstrapHuman(
+                display_name="Scott",
+                role="member",
+                transport="telegram",
+                external_subject="202",
+                external_channel_id="202",
+                runtime_profile_id=profile_id(202),
+            ),
+        )
+    )
+    registry, _ = await sessions.initialize_workshop_execution_state(profile_registry(101, 202))
+    store = WorkshopEventStore.from_initialized_connection(sessions._get_db())
+    authorities = {
+        namespace.runtime_config_id: WorkshopScheduledJobAuthority(
+            namespace.principal_id,
+            namespace.channel_id,
+            namespace.agent_id,
+            namespace.runtime_profile_id,
+        )
+        for namespace in registry.namespaces
+    }
+    yield WorkshopScheduledJobStore(store), authorities
+    await sessions.close_db()
+
+
+class TestWorkshopScheduledJobStore:
+    async def test_crud_is_scoped_to_one_canonical_execution_lane(self, scheduled_jobs):
+        store, authorities = scheduled_jobs
+        daniel = authorities[101]
+        scott = authorities[202]
+
+        created = await store.create(
+            daniel,
+            name="Daily status",
+            job_type="claude",
+            prompt="Report status",
+            schedule_type="daily",
+            schedule_data='{"times":["09:00"]}',
+            auto_remove=True,
+        )
+
+        assert created.job_type == "agent"
+        assert created.as_dict()["id"] == created.job_id
+        assert "principal_id" not in created.as_dict()
+        assert [job.job_id for job in await store.list_active(daniel)] == [created.job_id]
+        assert await store.get(created.job_id, scott) is None
+
+        assert await store.update(
+            created.job_id,
+            daniel,
+            WorkshopScheduledJobUpdate(
+                name="Updated status",
+                schedule_data='{"times":["10:00"]}',
+                notify_on_check=True,
+            ),
+        )
+        updated = await store.get(created.job_id, daniel)
+        assert updated is not None
+        assert updated.name == "Updated status"
+        assert updated.schedule_data == '{"times":["10:00"]}'
+        assert updated.notify_on_check is True
+
+        assert not await store.delete(created.job_id, scott)
+        assert await store.delete(created.job_id, daniel)
+        assert await store.get(created.job_id, daniel, active_only=False) is None
+
+    async def test_invalid_authority_fails_closed_without_mutation(self, scheduled_jobs):
+        store, authorities = scheduled_jobs
+        valid = authorities[101]
+        invalid = WorkshopScheduledJobAuthority(
+            valid.principal_id,
+            valid.channel_id,
+            AgentId("agt_" + "f" * 32),
+            valid.runtime_profile_id,
+        )
+
+        with pytest.raises(WorkshopScheduledJobAuthorityError, match="canonical execution lane"):
+            await store.create(
+                invalid,
+                name="Forbidden",
+                job_type="reminder",
+                prompt="Do not create",
+                schedule_type="once",
+                schedule_data='{"run_at":"2036-01-01T00:00:00Z"}',
+            )
+
+        assert await store.active_ids() == set()
+
+    async def test_deactivation_retains_definition_but_hides_active_job(self, scheduled_jobs):
+        store, authorities = scheduled_jobs
+        authority = authorities[101]
+        created = await store.create(
+            authority,
+            name="One shot",
+            job_type="reminder",
+            prompt="Remember",
+            schedule_type="once",
+            schedule_data='{"run_at":"2036-01-01T00:00:00Z"}',
+        )
+
+        assert await store.deactivate(created.job_id, authority)
+        assert await store.get(created.job_id, authority) is None
+        retained = await store.get(created.job_id, authority, active_only=False)
+        assert retained is not None
+        assert retained.active is False

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -17,10 +17,14 @@ from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.client_events import ClientTimelineMessageEvent, read_client_channel_events
 from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
-from kai.workshop.domain import ChannelId, PrincipalId, RuntimeProfileId
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
 from kai.workshop.execution_coordinator import CanonicalExecutionDisposition
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.scheduled_jobs import (
+    WorkshopScheduledJobAuthority,
+    WorkshopScheduledJobStore,
+)
 from kai.workshop.scheduler import (
     WorkshopCanonicalScheduler,
     _CanonicalJob,
@@ -193,27 +197,25 @@ async def _install_owned_job(
         principal_id, channel_id = await cursor.fetchone()
     async with store.connection.execute("SELECT id FROM agents") as cursor:
         agent_id = (await cursor.fetchone())[0]
-    job_id = await sessions.create_job(
-        chat_id=101,
+    job = await WorkshopScheduledJobStore(store).create(
+        WorkshopScheduledJobAuthority(
+            PrincipalId(str(principal_id)),
+            ChannelId(str(channel_id)),
+            AgentId(str(agent_id)),
+            profile_id(101),
+        ),
         name="Canonical reminder",
         job_type=job_type,
         prompt=prompt,
         schedule_type="once",
         schedule_data=json.dumps({"run_at": run_at.isoformat()}),
     )
-    await sessions._get_db().execute(
-        "INSERT INTO workshop_job_owners "
-        "(job_id, principal_id, channel_id, agent_id, runtime_profile_id) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (job_id, principal_id, channel_id, agent_id, profile_id(101)),
-    )
-    await sessions._get_db().commit()
-    return store, job_id
+    return store, job.job_id
 
 
 async def _job_owner(store: WorkshopEventStore, job_id: int) -> tuple[PrincipalId, ChannelId]:
     async with store.connection.execute(
-        "SELECT principal_id, channel_id FROM workshop_job_owners WHERE job_id = ?",
+        "SELECT principal_id, channel_id FROM workshop_scheduled_jobs WHERE id = ?",
         (job_id,),
     ) as cursor:
         row = await cursor.fetchone()
@@ -292,7 +294,7 @@ async def test_workshop_only_reminder_fires_canonically_without_delivery(tmp_pat
         async with source_store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
             assert (await cursor.fetchone())[0] == 0
         async with source_store.connection.execute(
-            "SELECT active FROM jobs WHERE id = ?",
+            "SELECT active FROM workshop_scheduled_jobs WHERE id = ?",
             (job_id,),
         ) as cursor:
             assert (await cursor.fetchone())[0] == 0
@@ -361,21 +363,24 @@ async def test_scheduler_fails_closed_for_active_job_without_canonical_owner(
     tmp_path: Path,
 ) -> None:
     database = tmp_path / "kai.db"
-    await sessions.init_db(database)
-    await sessions._get_db().execute(
-        "INSERT INTO jobs "
-        "(chat_id, name, job_type, prompt, schedule_type, schedule_data) "
-        "VALUES (101, 'Unowned', 'reminder', 'No fallback', 'interval', ?)",
-        (json.dumps({"seconds": 60}),),
+    store, job_id = await _install_owned_job(
+        database,
+        transport="workshop",
+        run_at=datetime.now(UTC) + timedelta(hours=1),
     )
-    await sessions._get_db().commit()
+    await store.connection.execute(
+        "UPDATE workshop_scheduled_jobs SET runtime_profile_id = ? WHERE id = ?",
+        (RuntimeProfileId("rtp_" + "9" * 32), job_id),
+    )
+    await store.connection.commit()
 
-    with pytest.raises(RuntimeError, match="complete canonical owner"):
+    with pytest.raises(RuntimeError, match="canonical execution lane"):
         await WorkshopCanonicalScheduler.open_and_start(
             database,
             _UnusedExecution(),  # type: ignore[arg-type]
             _UnusedCompatibilityState(),  # type: ignore[arg-type]
         )
+    await store.close()
     await sessions.close_db()
 
 
@@ -389,33 +394,35 @@ async def test_once_daily_and_interval_jobs_reconcile_into_core_scheduler(
         run_at=datetime.now(UTC) + timedelta(hours=1),
     )
     async with source_store.connection.execute(
-        "SELECT principal_id, channel_id, agent_id, runtime_profile_id FROM workshop_job_owners WHERE job_id = ?",
+        "SELECT principal_id, channel_id, agent_id, runtime_profile_id FROM workshop_scheduled_jobs WHERE id = ?",
         (once_id,),
     ) as cursor:
         owner = tuple(await cursor.fetchone())
-    interval_id = await sessions.create_job(
-        chat_id=102,
+    authority = WorkshopScheduledJobAuthority(
+        PrincipalId(str(owner[0])),
+        ChannelId(str(owner[1])),
+        AgentId(str(owner[2])),
+        RuntimeProfileId(str(owner[3])),
+    )
+    job_store = WorkshopScheduledJobStore(source_store)
+    interval = await job_store.create(
+        authority,
         name="Interval",
         job_type="reminder",
         prompt="Interval reminder",
         schedule_type="interval",
         schedule_data=json.dumps({"seconds": 60}),
     )
-    daily_id = await sessions.create_job(
-        chat_id=103,
+    daily = await job_store.create(
+        authority,
         name="Daily",
         job_type="reminder",
         prompt="Daily reminder",
         schedule_type="daily",
         schedule_data=json.dumps({"times": ["09:00", "17:00"]}),
     )
-    await sessions._get_db().executemany(
-        "INSERT INTO workshop_job_owners "
-        "(job_id, principal_id, channel_id, agent_id, runtime_profile_id) "
-        "VALUES (?, ?, ?, ?, ?)",
-        ((interval_id, *owner), (daily_id, *owner)),
-    )
-    await sessions._get_db().commit()
+    interval_id = interval.job_id
+    daily_id = daily.job_id
 
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -466,7 +466,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 28
+            assert await upgraded.schema_version() == 29
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"


### PR DESCRIPTION
## Summary

- add canonical scheduled-job definitions owned by principal, channel, agent, and runtime profile
- migrate existing compatibility jobs once while preserving IDs, schedules, and firing behavior
- route both Telegram commands and the internal API through one core scheduler CRUD service
- make scheduler firing, inbound recording, and reminder delivery read only canonical job authority
- report cutover receipts, legacy archive counts, ownership drift, and post-cutover compatibility writes

## Migration and rollback safety

- schema migration 29 is additive; the legacy `jobs` table remains as a non-authoritative archive
- each protected runtime receives a durable one-time cutover receipt, including runtimes that had already completed the earlier operational-state migration
- restarts do not re-import canonical updates or deletions from the legacy archive
- an unexpected post-cutover legacy job is reported as incomplete instead of silently becoming active
- registration failures deactivate new jobs, while failed schedule updates restore the prior canonical definition and registration

## Verification

- `make check`
- `.venv/bin/python -m pytest tests/ -q` (6,100 passed)
- focused adapter, scheduler, migration, authorization, schema, and installer-status coverage (340 passed)

Closes #1097
