### PR TITLE
Canonicalize internal memory and storage authority

### DIFF
--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -892,6 +892,8 @@ class CanonicalMemoryNamespaceResolver(Protocol):
 
     def maybe_for_principal_id(self, principal_id: str) -> _CanonicalMemoryNamespace | None: ...
 
+    def maybe_for_runtime_profile_id(self, runtime_profile_id: str) -> _CanonicalMemoryNamespace | None: ...
+
 
 class CanonicalMemoryAuthorityError(RuntimeError):
     """Semantic memory cannot be attributed to one canonical owner."""
@@ -919,8 +921,19 @@ def configure_memory_authority(
 
 def _canonical_memory_owner(
     user_id: str,
+    *,
+    runtime_profile_id: str | None = None,
 ) -> tuple[str, _CanonicalMemoryNamespace | None]:
     registry = _MEMORY_AUTHORITY_REGISTRY
+    if runtime_profile_id is not None:
+        if registry is None:
+            raise CanonicalMemoryAuthorityError("Canonical semantic-memory authority is not configured")
+        namespace = registry.maybe_for_runtime_profile_id(runtime_profile_id)
+        if namespace is None or str(namespace.principal_id) != user_id:
+            raise CanonicalMemoryAuthorityError(
+                "Runtime profile does not belong to the canonical semantic-memory principal"
+            )
+        return user_id, namespace
     if registry is None:
         return user_id, None
     canonical = registry.maybe_for_principal_id(user_id)
@@ -1995,7 +2008,13 @@ def embed_texts(texts: list[str]) -> list[list[float]]:
     return _embed_via_configured_embedder(texts)
 
 
-def search(query: str, *, user_id: str, limit: int | None = None) -> list[MemoryResult]:
+def search(
+    query: str,
+    *,
+    user_id: str,
+    limit: int | None = None,
+    runtime_profile_id: str | None = None,
+) -> list[MemoryResult]:
     """
     Search for memories semantically similar to the query.
 
@@ -2004,6 +2023,9 @@ def search(query: str, *, user_id: str, limit: int | None = None) -> list[Memory
         user_id: Semantic-memory owner key. Protected runtime IDs resolve to
             their canonical Workshop principal.
         limit: Max results. Defaults to config.memory_search_limit.
+        runtime_profile_id: Optional exact protected runtime authority. When
+            supplied, it must belong to ``user_id`` and canonical memory
+            authority must be configured.
 
     Returns:
         List of MemoryResult sorted by descending similarity score.
@@ -2013,7 +2035,10 @@ def search(query: str, *, user_id: str, limit: int | None = None) -> list[Memory
         return []
 
     effective_limit = limit if limit is not None else _config.memory_search_limit
-    storage_user_id, namespace = _canonical_memory_owner(user_id)
+    storage_user_id, namespace = _canonical_memory_owner(
+        user_id,
+        runtime_profile_id=runtime_profile_id,
+    )
 
     try:
         result = _memory.search(
@@ -3239,6 +3264,7 @@ def add_structured(
     memory_type: str = "fact",
     tags: list[str] | None = None,
     metadata: dict | None = None,
+    runtime_profile_id: str | None = None,
 ) -> str | None:
     """
     Store a single structured memory with explicit type and metadata.
@@ -3259,6 +3285,9 @@ def add_structured(
         metadata: Optional additional key/value pairs. Merged into the final
             metadata dict; the keys "type" and "tags" are reserved and will
             be overwritten by memory_type and tags arguments.
+        runtime_profile_id: Optional exact protected runtime authority. When
+            supplied, it must belong to ``user_id`` and is stamped into
+            canonical provenance.
 
     Returns:
         The Mem0 memory ID as a string on success. None if memory is
@@ -3284,7 +3313,10 @@ def add_structured(
         # never-raise contract; a conflicting caller must get the
         # same None-plus-warning failure surface as a store error,
         # not an exception the caller was told cannot happen.
-        storage_user_id, namespace = _canonical_memory_owner(user_id)
+        storage_user_id, namespace = _canonical_memory_owner(
+            user_id,
+            runtime_profile_id=runtime_profile_id,
+        )
 
         # Build the metadata dict. Caller-provided metadata comes
         # first so the reserved keys (type, tags) can override
@@ -3319,7 +3351,12 @@ def add_structured(
     return None
 
 
-def get_all(*, user_id: str, limit: int | None = 1000) -> list[MemoryResult]:
+def get_all(
+    *,
+    user_id: str,
+    limit: int | None = 1000,
+    runtime_profile_id: str | None = None,
+) -> list[MemoryResult]:
     """
     Get all memories for a user.
 
@@ -3340,6 +3377,8 @@ def get_all(*, user_id: str, limit: int | None = 1000) -> list[MemoryResult]:
             see spec 310 §7.2.1 for the cap-vs-pagination tradeoff and
             the long-term plan to switch to true cursor pagination once
             single users approach the new ceiling.
+        runtime_profile_id: Optional exact protected runtime authority used to
+            enforce the complete provenance tuple.
     """
     if _memory is None:
         return []
@@ -3351,7 +3390,10 @@ def get_all(*, user_id: str, limit: int | None = 1000) -> list[MemoryResult]:
     # 1000. Aligned with the spec §7.2.1 guidance ("100000").
     effective_top_k = 100_000 if limit is None else limit
 
-    storage_user_id, namespace = _canonical_memory_owner(user_id)
+    storage_user_id, namespace = _canonical_memory_owner(
+        user_id,
+        runtime_profile_id=runtime_profile_id,
+    )
     try:
         result = _memory.get_all(filters={"user_id": storage_user_id}, top_k=effective_top_k)
         raw_results = result.get("results", []) if isinstance(result, dict) else result
@@ -3914,7 +3956,7 @@ def update_metadata(*, user_id: str, memory_id: str, data: str, metadata: dict[s
     return True
 
 
-def delete_all(*, user_id: str) -> None:
+def delete_all(*, user_id: str, runtime_profile_id: str | None = None) -> None:
     """
     Delete every memory the caller can see.
 
@@ -3937,7 +3979,10 @@ def delete_all(*, user_id: str) -> None:
     if _memory is None:
         return
 
-    storage_user_id, namespace = _canonical_memory_owner(user_id)
+    storage_user_id, namespace = _canonical_memory_owner(
+        user_id,
+        runtime_profile_id=runtime_profile_id,
+    )
     try:
         while True:
             result = _memory.get_all(
@@ -3960,7 +4005,7 @@ def delete_all(*, user_id: str) -> None:
         log.warning("Memory delete_all failed", exc_info=True)
 
 
-def get_stats(*, user_id: str) -> MemoryStats:
+def get_stats(*, user_id: str, runtime_profile_id: str | None = None) -> MemoryStats:
     """
     Get memory statistics for a user.
 
@@ -3986,7 +4031,11 @@ def get_stats(*, user_id: str) -> MemoryStats:
 
     Returns zeroed stats if disabled (memories will be []).
     """
-    memories = get_all(user_id=user_id, limit=None)
+    memories = get_all(
+        user_id=user_id,
+        limit=None,
+        runtime_profile_id=runtime_profile_id,
+    )
 
     # All-rows aggregates (legacy). Computed across every source.
     by_type: dict[str, int] = {}

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -1468,9 +1468,10 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     if not file_path:
         return web.json_response({"error": "Missing required field: path"}, status=400)
 
-    # Resolve chat_id first - needed for per-user workspace confinement
+    # Identity and authority are bound to the credential. Caller-supplied
+    # selectors are rejected before any filesystem lookup.
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, payload)
+        _reject_internal_identity_selectors(payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
 
@@ -1481,27 +1482,31 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     # has their own per-user home workspace resolved from the pool (#353).
     # When the pool is unavailable (transient startup state) we refuse the
     # request rather than opening a global fallback path.
-    pool = request.app.get(POOL_KEY)
-    if pool is None:
+    core_host = request.app.get(CORE_HOST_KEY)
+    if core_host is None:
         return web.json_response({"error": "No workspace configured"}, status=403)
-    workspace = str(await pool.get_effective_workspace(chat_id))
-    # Allow files from either the workspace or this authenticated principal's
-    # canonical upload directory. The prior configured-user directory remains
-    # readable during migration, but the legacy shared root and sibling
-    # principals' directories are excluded. Both scopes are resolved from the
-    # authenticated credential, never from caller-selected request fields.
+    try:
+        workspace = str(await core_host.services.runtime_pool.get_effective_workspace(principal.runtime_profile_id))
+    except Exception:
+        log.exception("Internal file workspace resolution failed")
+        return web.json_response({"error": "No workspace configured"}, status=403)
+
+    # Allow files from the effective workspace or this authenticated
+    # principal's canonical upload directory. Numeric compatibility
+    # directories are archives and are never protected runtime read roots.
     workspace_resolved = Path(workspace).resolve()
     storage_registry = request.app.get(WORKSHOP_PRINCIPAL_STORAGE_KEY)
     if storage_registry is None:
         return web.json_response({"error": "Principal storage unavailable"}, status=403)
     try:
-        storage_namespace = storage_registry.for_runtime_config_id(principal.compatibility_runtime_config_id())
+        storage_namespace = storage_registry.for_runtime_profile(principal.runtime_profile_id)
     except WorkshopStorageNamespaceError:
+        return web.json_response({"error": "Principal storage unavailable"}, status=403)
+    if storage_namespace.principal_id != principal.principal_id:
         return web.json_response({"error": "Principal storage unavailable"}, status=403)
     allowed_roots = (
         workspace_resolved,
         storage_namespace.files_directory(DATA_DIR).resolve(),
-        storage_namespace.legacy_files_directory(DATA_DIR).resolve(),
     )
     if not any(path.is_relative_to(root) for root in allowed_roots):
         return web.json_response({"error": "Path outside allowed directories"}, status=403)
@@ -1509,6 +1514,10 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     if not path.is_file():
         return web.json_response({"error": f"File not found: {file_path}"}, status=404)
 
+    # Direct Telegram publication is the remaining bounded compatibility seam
+    # and is retired in the next internal-API slice. It is not consulted for
+    # workspace or storage authorization above.
+    chat_id = principal.compatibility_runtime_config_id()
     bot = request.app[TELEGRAM_BOT_KEY]
     caption = payload.get("caption", "")
 
@@ -1541,11 +1550,10 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
 #     "no data" and inner Claude could not pick a retry policy from the
 #     status code alone.
 #
-#   - Memory primitives take user_id as a string; _resolve_internal_runtime_config_id returns
-#     int. Stringify at the boundary in every handler. Removing the cast
-#     is a load-bearing bug: Mem0 keys are stored under the string form,
-#     so a missed cast would silently isolate the caller's memories from
-#     their existing facts.
+#   - Memory primitives take user_id as a string. Every handler passes the
+#     credential-bound canonical principal ID; memory.py's configured
+#     authority resolver adds and verifies the complete canonical provenance
+#     tuple without creating a second namespace.
 #
 #   - Handlers import memory as a module (`from kai import memory`) so
 #     tests can patch `kai.memory.<func>` uniformly. Function-level
@@ -1676,7 +1684,7 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
             return web.json_response({"error": "metadata.confidence must be a number in [0.0, 1.0]"}, status=400)
 
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, payload)
+        _reject_internal_identity_selectors(payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
 
@@ -1686,8 +1694,7 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
     if not memory.is_enabled():
         return _memory_disabled_response()
 
-    # int -> str at the memory boundary; do NOT remove the cast.
-    user_id = str(chat_id)
+    user_id = str(principal.principal_id)
 
     # Server-side provenance stamp. Lazy imports keep
     # memory_extraction (and its one-shot reasoner stack) out of this
@@ -1712,14 +1719,16 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
     # must surface as the handler's clean JSON 500, not mis-scope the
     # write to global silently or escape as a framework HTML 500.
     try:
-        pool = request.app.get(POOL_KEY)
-        active_project = None
-        if pool is not None:
-            api_config: Config = request.app[CONFIG_KEY]
-            workspace = await pool.get_effective_workspace(chat_id)
-            active_project = detect_active_memory_project(workspace, merged_registry(api_config.memory_projects))
+        api_config: Config = request.app[CONFIG_KEY]
+        workspace = await request.app[CORE_HOST_KEY].services.runtime_pool.get_effective_workspace(
+            principal.runtime_profile_id
+        )
+        active_project = detect_active_memory_project(
+            workspace,
+            merged_registry(api_config.memory_projects),
+        )
     except Exception:
-        log.exception("memory add: workspace scope resolution failed for chat %d", chat_id)
+        log.exception("Memory add workspace scope resolution failed")
         return web.json_response({"error": "Memory storage failed"}, status=500)
     final_metadata.update(_route_write_scope(None, active_project))
 
@@ -1738,9 +1747,10 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
             memory_type=memory_type,
             tags=tags,
             metadata=final_metadata,
+            runtime_profile_id=str(principal.runtime_profile_id),
         )
     except Exception:
-        log.exception("memory.add_structured failed for chat %d", chat_id)
+        log.exception("memory.add_structured failed for canonical principal")
         return web.json_response({"error": "Memory storage failed"}, status=500)
 
     if memory_id is None:
@@ -1755,7 +1765,7 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
         # transient store failures.
         return web.json_response({"error": "Memory storage failed"}, status=500)
 
-    log.info("Stored memory %s for chat %d via API", memory_id, chat_id)
+    log.info("Stored memory %s through canonical internal API authority", memory_id)
     return web.json_response({"id": memory_id})
 
 
@@ -1810,7 +1820,7 @@ async def _handle_memory_search(request: web.Request, principal: InternalAPIPrin
         return web.json_response({"error": "limit must be a positive integer"}, status=400)
 
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, payload)
+        _reject_internal_identity_selectors(payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
 
@@ -1822,7 +1832,7 @@ async def _handle_memory_search(request: web.Request, principal: InternalAPIPrin
     if not memory.is_enabled():
         return _memory_disabled_response()
 
-    user_id = str(chat_id)
+    user_id = str(principal.principal_id)
 
     # Defense-in-depth around the full risky path: primitive call AND
     # serialization. search() catches its own exceptions and returns []
@@ -1834,14 +1844,19 @@ async def _handle_memory_search(request: web.Request, principal: InternalAPIPrin
     # Without the wider guard, asdict raising TypeError or json_response
     # raising ValueError would escape to aiohttp as an unstyled HTML 500.
     try:
-        results = memory.search(query, user_id=user_id, limit=limit)
+        results = memory.search(
+            query,
+            user_id=user_id,
+            limit=limit,
+            runtime_profile_id=str(principal.runtime_profile_id),
+        )
         # asdict() flattens each frozen dataclass to a plain dict. Every
         # value inside MemoryResult.metadata is JSON-native because Mem0
         # stores metadata in Qdrant as JSON, so json_response can
         # serialize the whole structure without a custom encoder.
         return web.json_response({"results": [asdict(r) for r in results]})
     except Exception:
-        log.exception("memory.search failed for chat %d", chat_id)
+        log.exception("memory.search failed for canonical principal")
         return web.json_response({"error": "Memory search failed"}, status=500)
 
 
@@ -1870,7 +1885,7 @@ async def _handle_memory_stats(request: web.Request, principal: InternalAPIPrinc
     """
     # Query parameters cannot select identity; the credential owns routing.
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, dict(request.query))
+        _reject_internal_identity_selectors(dict(request.query))
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
 
@@ -1881,7 +1896,7 @@ async def _handle_memory_stats(request: web.Request, principal: InternalAPIPrinc
     if not memory.is_enabled():
         return _memory_disabled_response()
 
-    user_id = str(chat_id)
+    user_id = str(principal.principal_id)
 
     # Wider guard around primitive call AND serialization, matching the
     # search handler. get_stats() doesn't have its own try/except today
@@ -1890,14 +1905,17 @@ async def _handle_memory_stats(request: web.Request, principal: InternalAPIPrinc
     # remaining route by which an exception could escape to aiohttp as
     # an HTML 500.
     try:
-        stats = memory.get_stats(user_id=user_id)
+        stats = memory.get_stats(
+            user_id=user_id,
+            runtime_profile_id=str(principal.runtime_profile_id),
+        )
         # asdict() preserves None for the optional confidence_* fields,
         # which become JSON null on the wire. The CLAUDE.md
         # "Memory System" section documents this so inner Claude does
         # not misread null as a store failure.
         return web.json_response(asdict(stats))
     except Exception:
-        log.exception("memory.get_stats failed for chat %d", chat_id)
+        log.exception("memory.get_stats failed for canonical principal")
         return web.json_response({"error": "Memory stats failed"}, status=500)
 
 
@@ -1937,10 +1955,10 @@ async def _handle_memory_delete_all(request: web.Request, principal: InternalAPI
     if not isinstance(payload, dict):
         return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 
-    # Confirm-token check before compatibility storage resolution: a request with the
+    # Confirm-token check before canonical authority validation: a request with the
     # wrong token is structurally bad input regardless of which user it
     # was aimed at, and rejecting it first means we don't waste a
-    # _resolve_internal_runtime_config_id call on requests we will reject anyway.
+    # selector check on requests we will reject anyway.
     if payload.get("confirm") != _DELETE_ALL_CONFIRM_TOKEN:
         return web.json_response(
             {"error": f'Missing or incorrect confirm field; expected "{_DELETE_ALL_CONFIRM_TOKEN}"'},
@@ -1948,7 +1966,7 @@ async def _handle_memory_delete_all(request: web.Request, principal: InternalAPI
         )
 
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, payload)
+        _reject_internal_identity_selectors(payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
 
@@ -1958,7 +1976,7 @@ async def _handle_memory_delete_all(request: web.Request, principal: InternalAPI
     if not memory.is_enabled():
         return _memory_disabled_response()
 
-    user_id = str(chat_id)
+    user_id = str(principal.principal_id)
     # Defense-in-depth guard, matching the pattern used in
     # _handle_memory_search and _handle_memory_stats. delete_all()
     # catches its own internal errors today (memory.py:1066-1069), so
@@ -1968,12 +1986,15 @@ async def _handle_memory_delete_all(request: web.Request, principal: InternalAPI
     # shape), the handler still returns a clean 500 JSON body instead
     # of an aiohttp HTML 500 page.
     try:
-        memory.delete_all(user_id=user_id)
+        memory.delete_all(
+            user_id=user_id,
+            runtime_profile_id=str(principal.runtime_profile_id),
+        )
     except Exception:
-        log.exception("memory.delete_all failed for chat %d", chat_id)
+        log.exception("memory.delete_all failed for canonical principal")
         return web.json_response({"error": "Memory delete failed"}, status=500)
 
-    log.info("Deleted all memories for chat %d via API", chat_id)
+    log.info("Deleted memories through canonical internal API authority")
     return web.json_response({"status": "deleted"})
 
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -22,7 +22,6 @@ from kai.webhook import (
     GENERIC_WEBHOOK_SECRET_KEY,
     GITHUB_WEBHOOK_SECRET_KEY,
     INTERNAL_API_AUTH_KEY,
-    POOL_KEY,
     TELEGRAM_APP_KEY,
     TELEGRAM_BOT_KEY,
     TELEGRAM_WEBHOOK_SECRET_KEY,
@@ -81,12 +80,12 @@ def _principal_storage_registry() -> WorkshopPrincipalStorageRegistry:
     return WorkshopPrincipalStorageRegistry(
         (
             WorkshopPrincipalStorageNamespace(
-                PrincipalId("prn_" + "1" * 32),
+                _internal_api_context(123).principal_id,
                 profile_id(123),
                 123,
             ),
             WorkshopPrincipalStorageNamespace(
-                PrincipalId("prn_" + "2" * 32),
+                _internal_api_context(456).principal_id,
                 profile_id(456),
                 456,
             ),
@@ -201,7 +200,7 @@ def _default_github_token_lookup():
 
 
 @pytest.fixture
-def mock_request():
+def mock_request(tmp_path):
     """Create a minimal mock request with app dict and helpers."""
     request = MagicMock(spec=web.Request)
     request.app = {
@@ -211,9 +210,13 @@ def mock_request():
         TELEGRAM_BOT_KEY: AsyncMock(),
         CHAT_ID_KEY: 123,
         ALLOWED_USER_IDS_KEY: {123, 456},
+        CONFIG_KEY: SimpleNamespace(memory_projects={}),
         CORE_HOST_KEY: SimpleNamespace(
             services=SimpleNamespace(
                 scheduler=_CanonicalSchedulerDouble(),
+                runtime_pool=SimpleNamespace(
+                    get_effective_workspace=AsyncMock(return_value=tmp_path),
+                ),
             )
         ),
     }
@@ -581,19 +584,20 @@ class TestUpdateJob:
 @pytest.fixture
 def send_file_request(tmp_path):
     """Create a mock request for the send-file endpoint with workspace confinement."""
-    # Send-file resolves the workspace via pool.get_effective_workspace(chat_id)
-    # rather than a global app["workspace"] slot. The fixture supplies a mock
-    # pool whose get_effective_workspace() returns tmp_path so path confinement
-    # passes.
-    mock_pool = MagicMock()
-    mock_pool.get_effective_workspace = AsyncMock(return_value=tmp_path)
+    # Send-file resolves workspace through the credential's protected runtime
+    # profile. The fixture supplies that canonical facade directly.
+    runtime_pool = SimpleNamespace(
+        get_effective_workspace=AsyncMock(return_value=tmp_path),
+    )
     request = MagicMock(spec=web.Request)
     request.app = {
         INTERNAL_API_AUTH_KEY: _make_internal_api_auth(),
         GENERIC_WEBHOOK_SECRET_KEY: "signing-secret",
         TELEGRAM_BOT_KEY: AsyncMock(),
         CHAT_ID_KEY: 123,
-        POOL_KEY: mock_pool,
+        CORE_HOST_KEY: SimpleNamespace(
+            services=SimpleNamespace(runtime_pool=runtime_pool),
+        ),
         WORKSHOP_PRINCIPAL_STORAGE_KEY: _principal_storage_registry(),
     }
     request.headers = {"X-Webhook-Secret": "test-secret"}
@@ -607,7 +611,7 @@ def isolated_send_file_roots(tmp_path, send_file_request, monkeypatch):
     workspace.mkdir()
     data_dir = tmp_path / "data"
     monkeypatch.setattr("kai.webhook.DATA_DIR", data_dir)
-    send_file_request.app[POOL_KEY].get_effective_workspace.return_value = workspace
+    send_file_request.app[CORE_HOST_KEY].services.runtime_pool.get_effective_workspace.return_value = workspace
     return send_file_request, workspace, data_dir
 
 
@@ -638,6 +642,9 @@ class TestSendFile:
         body = json.loads(resp.body)
         assert body["status"] == "sent"
         send_file_request.app[TELEGRAM_BOT_KEY].send_document.assert_called_once()
+        send_file_request.app[CORE_HOST_KEY].services.runtime_pool.get_effective_workspace.assert_awaited_once_with(
+            profile_id(123)
+        )
 
     async def test_caption_forwarded_to_telegram(self, tmp_path, send_file_request):
         """Optional caption is passed through to the Telegram send call."""
@@ -672,7 +679,7 @@ class TestSendFile:
     async def test_authenticated_principal_can_send_own_uploaded_file(self, isolated_send_file_roots):
         """The principal's canonical opaque upload directory is allowed."""
         request, _workspace, data_dir = isolated_send_file_roots
-        namespace = request.app[WORKSHOP_PRINCIPAL_STORAGE_KEY].for_runtime_config_id(123)
+        namespace = request.app[WORKSHOP_PRINCIPAL_STORAGE_KEY].for_runtime_profile(profile_id(123))
         uploaded = namespace.files_directory(data_dir) / "report.txt"
         uploaded.parent.mkdir(parents=True)
         uploaded.write_text("principal-owned")
@@ -686,7 +693,7 @@ class TestSendFile:
     async def test_file_scope_follows_authenticated_credential(self, isolated_send_file_roots):
         """A second credential receives its own scope, independent of app defaults."""
         request, _workspace, data_dir = isolated_send_file_roots
-        namespace = request.app[WORKSHOP_PRINCIPAL_STORAGE_KEY].for_runtime_config_id(456)
+        namespace = request.app[WORKSHOP_PRINCIPAL_STORAGE_KEY].for_runtime_profile(profile_id(456))
         uploaded = namespace.files_directory(data_dir) / "report.txt"
         uploaded.parent.mkdir(parents=True)
         uploaded.write_text("second principal")
@@ -702,11 +709,37 @@ class TestSendFile:
     async def test_authenticated_principal_cannot_send_sibling_uploaded_file(self, isolated_send_file_roots):
         """A FILES_SEND credential cannot select another principal's upload."""
         request, _workspace, data_dir = isolated_send_file_roots
-        namespace = request.app[WORKSHOP_PRINCIPAL_STORAGE_KEY].for_runtime_config_id(456)
+        namespace = request.app[WORKSHOP_PRINCIPAL_STORAGE_KEY].for_runtime_profile(profile_id(456))
         sibling_file = namespace.files_directory(data_dir) / "secret.txt"
         sibling_file.parent.mkdir(parents=True)
         sibling_file.write_text("other principal")
         request.json = AsyncMock(return_value={"path": str(sibling_file)})
+
+        resp = await _handle_send_file(request)
+
+        assert resp.status == 403
+        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
+
+    async def test_runtime_profile_storage_must_belong_to_authenticated_principal(
+        self,
+        isolated_send_file_roots,
+    ):
+        """A mismatched protected profile/storage mapping fails closed."""
+        request, _workspace, data_dir = isolated_send_file_roots
+        wrong_owner = _internal_api_context(456)
+        request.app[WORKSHOP_PRINCIPAL_STORAGE_KEY] = WorkshopPrincipalStorageRegistry(
+            (
+                WorkshopPrincipalStorageNamespace(
+                    wrong_owner.principal_id,
+                    profile_id(123),
+                    123,
+                ),
+            )
+        )
+        uploaded = data_dir / "files" / str(wrong_owner.principal_id) / "secret.txt"
+        uploaded.parent.mkdir(parents=True)
+        uploaded.write_text("wrong owner")
+        request.json = AsyncMock(return_value={"path": str(uploaded)})
 
         resp = await _handle_send_file(request)
 
@@ -730,10 +763,10 @@ class TestSendFile:
         """Resolving a symlink into a sibling principal's directory is denied."""
         request, _workspace, data_dir = isolated_send_file_roots
         registry = request.app[WORKSHOP_PRINCIPAL_STORAGE_KEY]
-        sibling_file = registry.for_runtime_config_id(456).files_directory(data_dir) / "secret.txt"
+        sibling_file = registry.for_runtime_profile(profile_id(456)).files_directory(data_dir) / "secret.txt"
         sibling_file.parent.mkdir(parents=True)
         sibling_file.write_text("other principal")
-        link = registry.for_runtime_config_id(123).files_directory(data_dir) / "link.txt"
+        link = registry.for_runtime_profile(profile_id(123)).files_directory(data_dir) / "link.txt"
         link.parent.mkdir(parents=True)
         link.symlink_to(sibling_file)
         request.json = AsyncMock(return_value={"path": str(link)})
@@ -743,11 +776,11 @@ class TestSendFile:
         assert resp.status == 403
         request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
 
-    async def test_authenticated_principal_can_send_pre_migration_uploaded_file(
+    async def test_authenticated_principal_cannot_send_from_numeric_archive(
         self,
         isolated_send_file_roots,
     ):
-        """Existing numeric upload directories remain readable during migration."""
+        """Numeric upload archives are not protected runtime read roots."""
         request, _workspace, data_dir = isolated_send_file_roots
         legacy = data_dir / "files" / "123" / "legacy.txt"
         legacy.parent.mkdir(parents=True)
@@ -756,8 +789,8 @@ class TestSendFile:
 
         resp = await _handle_send_file(request)
 
-        assert resp.status == 200
-        request.app[TELEGRAM_BOT_KEY].send_document.assert_awaited_once()
+        assert resp.status == 403
+        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
 
     async def test_invalid_json_returns_400(self, send_file_request):
         """Returns 400 for malformed JSON body."""
@@ -2643,6 +2676,9 @@ class TestMemoryAdd:
         assert resp.status == 200
         body = json.loads(resp.body.decode())
         assert body == {"id": "mem-uuid-123"}
+        mock_request.app[CORE_HOST_KEY].services.runtime_pool.get_effective_workspace.assert_awaited_once_with(
+            profile_id(123)
+        )
 
     async def test_returns_503_when_memory_disabled(self, mock_request):
         """Precheck path: is_enabled() False -> 503; primitive NOT called."""
@@ -2799,17 +2835,15 @@ class TestMemoryAdd:
         mock_add.assert_not_called()
 
     async def test_returns_500_when_workspace_resolution_fails(self, mock_request):
-        """Scope routing hits the settings DB via the pool; a transient
+        """Scope routing hits the settings DB via the runtime facade; a transient
         failure there must produce the handler's clean JSON 500, not
         mis-scope the write to global silently or escape as a framework
         HTML 500."""
-        from kai.webhook import POOL_KEY
-
         mock_request.headers = {"X-Webhook-Secret": "test-secret"}
         mock_request.json = AsyncMock(return_value={"content": "x"})
-        pool = MagicMock()
-        pool.get_effective_workspace = AsyncMock(side_effect=RuntimeError("settings DB down"))
-        mock_request.app[POOL_KEY] = pool
+        mock_request.app[CORE_HOST_KEY].services.runtime_pool.get_effective_workspace.side_effect = RuntimeError(
+            "settings DB down"
+        )
 
         with (
             patch("kai.memory.is_enabled", return_value=True),
@@ -2845,7 +2879,7 @@ class TestMemoryAdd:
             "id": "mem-1",
             "memory": "User prefers Earl Grey",
             "metadata": stamped,
-            "user_id": "123",
+            "user_id": str(_internal_api_context(123).principal_id),
             "created_at": "2026-08-19T00:00:00+00:00",
             "updated_at": "2026-08-19T00:00:00+00:00",
         }
@@ -2854,19 +2888,14 @@ class TestMemoryAdd:
             get=lambda memory_id: row,
         )
         with patch("kai.memory._memory", fake_mem0):
-            facts = memory.get_all_facts(user_id="123")
+            canonical_user_id = str(_internal_api_context(123).principal_id)
+            facts = memory.get_all_facts(user_id=canonical_user_id)
             assert [f.id for f in facts] == ["mem-1"]
-            detail = memory.get_by_id(user_id="123", memory_id="mem-1")
+            detail = memory.get_by_id(user_id=canonical_user_id, memory_id="mem-1")
             assert detail is not None and detail.metadata["source"] == "explicit"
 
-    async def test_stringifies_chat_id_for_user_id(self, mock_request):
-        """Handler converts int chat_id -> str user_id at the memory boundary.
-
-        This is load-bearing: Mem0 keys memories by the string form of
-        user_id. A missed cast would isolate API-stored memories from the
-        existing facts under the same chat_id (silently, since both writes
-        succeed).
-        """
+    async def test_uses_credential_bound_principal_for_user_id(self, mock_request):
+        """Memory ownership comes directly from the credential's principal."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.json = AsyncMock(return_value={"content": "x"})
 
@@ -2877,7 +2906,8 @@ class TestMemoryAdd:
             await _handle_memory_add(mock_request)
 
         kwargs = mock_add.call_args.kwargs
-        assert kwargs["user_id"] == "456"
+        assert kwargs["user_id"] == str(_internal_api_context(456).principal_id)
+        assert kwargs["runtime_profile_id"] == str(profile_id(456))
         assert isinstance(kwargs["user_id"], str)
 
     async def test_returns_400_on_identity_selector(self, mock_request):
@@ -3095,6 +3125,22 @@ class TestMemorySearch:
             await _handle_memory_search(mock_request)
 
         assert mock_search.call_args.kwargs["limit"] == 5
+        assert mock_search.call_args.kwargs["user_id"] == str(_internal_api_context(123).principal_id)
+        assert mock_search.call_args.kwargs["runtime_profile_id"] == str(profile_id(123))
+
+    async def test_search_credentials_keep_principals_isolated(self, mock_request):
+        """A second credential searches its own canonical namespace."""
+        mock_request.headers = {"X-Webhook-Secret": "other-secret"}
+        mock_request.json = AsyncMock(return_value={"query": "x"})
+
+        with (
+            patch("kai.memory.is_enabled", return_value=True),
+            patch("kai.memory.search", return_value=[]) as mock_search,
+        ):
+            await _handle_memory_search(mock_request)
+
+        assert mock_search.call_args.kwargs["user_id"] == str(_internal_api_context(456).principal_id)
+        assert mock_search.call_args.kwargs["runtime_profile_id"] == str(profile_id(456))
 
     async def test_passes_none_limit_when_omitted(self, mock_request):
         """When `limit` is omitted, the handler passes None so search()
@@ -3294,8 +3340,8 @@ class TestMemoryStats:
         assert resp.status == 503
         mock_get_stats.assert_not_called()
 
-    async def test_reads_chat_id_from_query_string(self, mock_request):
-        """GET endpoint: chat_id comes from query params, mirroring _handle_get_jobs."""
+    async def test_uses_credential_bound_principal_for_stats(self, mock_request):
+        """GET stats derives canonical ownership from the credential."""
         from kai.memory import MemoryStats
 
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
@@ -3308,8 +3354,8 @@ class TestMemoryStats:
             resp = await _handle_memory_stats(mock_request)
 
         assert resp.status == 200
-        # Verify the int->str cast happened at the memory boundary.
-        assert mock_get_stats.call_args.kwargs["user_id"] == "456"
+        assert mock_get_stats.call_args.kwargs["user_id"] == str(_internal_api_context(456).principal_id)
+        assert mock_get_stats.call_args.kwargs["runtime_profile_id"] == str(profile_id(456))
 
     async def test_returns_401_on_bad_secret(self, mock_request):
         mock_request.headers = {"X-Webhook-Secret": "nope"}
@@ -3430,15 +3476,16 @@ class TestMemoryDeleteAll:
         # acking a no-op.
         mock_del.assert_not_called()
 
-    async def test_calls_delete_all_with_stringified_user_id(self, mock_request):
-        """int -> str cast at the memory boundary, same as add."""
+    async def test_delete_all_uses_credential_bound_principal(self, mock_request):
+        """Delete-all receives the canonical principal string."""
         mock_request.headers = {"X-Webhook-Secret": "other-secret"}
         mock_request.json = AsyncMock(return_value={"confirm": self._CONFIRM})
 
         with patch("kai.memory.is_enabled", return_value=True), patch("kai.memory.delete_all") as mock_del:
             await _call_memory_delete_all_as_authorized(mock_request, chat_id=456)
 
-        assert mock_del.call_args.kwargs["user_id"] == "456"
+        assert mock_del.call_args.kwargs["user_id"] == str(_internal_api_context(456).principal_id)
+        assert mock_del.call_args.kwargs["runtime_profile_id"] == str(profile_id(456))
         assert isinstance(mock_del.call_args.kwargs["user_id"], str)
 
     async def test_returns_401_on_bad_secret(self, mock_request):

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -314,6 +314,72 @@ class TestCanonicalMemoryNamespace:
         with pytest.raises(memory.CanonicalMemoryAuthorityError, match="restore the memory and database backups"):
             memory.migrate_memory_namespace(first, sibling_namespaces=(second,))
 
+    def test_exact_runtime_authority_stamps_shared_principal_provenance(self):
+        principal_id = PrincipalId.new()
+        first = WorkshopExecutionStateNamespace(
+            principal_id=principal_id,
+            channel_id=ChannelId.new(),
+            agent_id=AgentId.new(),
+            runtime_profile_id=profile_id(101),
+            runtime_config_id=101,
+        )
+        second = WorkshopExecutionStateNamespace(
+            principal_id=principal_id,
+            channel_id=ChannelId.new(),
+            agent_id=AgentId.new(),
+            runtime_profile_id=profile_id(202),
+            runtime_config_id=202,
+        )
+        fake = _FakeMem0(
+            [
+                {"id": "first", "memory": "First", "user_id": "101", "metadata": {}},
+                {"id": "second", "memory": "Second", "user_id": "202", "metadata": {}},
+            ]
+        )
+        memory._memory = fake
+        memory._config = SimpleNamespace(memory_search_limit=10)
+        registry = WorkshopExecutionStateRegistry((first, second))
+        memory.configure_memory_authority(registry)
+        memory.migrate_memory_namespace(first, sibling_namespaces=(second,))
+        memory.migrate_memory_namespace(second, sibling_namespaces=(first,))
+
+        first_hits = memory.search(
+            "fact",
+            user_id=str(principal_id),
+            runtime_profile_id=str(first.runtime_profile_id),
+        )
+        second_hits = memory.search(
+            "fact",
+            user_id=str(principal_id),
+            runtime_profile_id=str(second.runtime_profile_id),
+        )
+        added = memory.add_structured(
+            "First runtime only",
+            user_id=str(principal_id),
+            runtime_profile_id=str(first.runtime_profile_id),
+        )
+
+        # Memory ownership is intentionally per-principal: both runtime
+        # profiles recall the human's full corpus. Exact runtime authority is
+        # still required to stamp and validate the provenance of new writes.
+        assert [row.id for row in first_hits] == ["first", "second"]
+        assert [row.id for row in second_hits] == ["first", "second"]
+        assert added is not None
+        assert fake.rows[added]["metadata"][memory.WORKSHOP_RUNTIME_PROFILE_ID_KEY] == str(first.runtime_profile_id)
+
+    def test_exact_runtime_authority_rejects_wrong_principal(self):
+        namespace = _namespace(101)
+        memory._memory = _FakeMem0()
+        memory._config = SimpleNamespace(memory_search_limit=10)
+        memory.configure_memory_authority(WorkshopExecutionStateRegistry((namespace,)))
+
+        with pytest.raises(memory.CanonicalMemoryAuthorityError, match="does not belong"):
+            memory.search(
+                "fact",
+                user_id=str(PrincipalId.new()),
+                runtime_profile_id=str(namespace.runtime_profile_id),
+            )
+
     def test_two_protected_humans_have_disjoint_memory_namespaces(self):
         first = _namespace(101)
         second = _namespace(202)


### PR DESCRIPTION
## Summary

- bind internal memory reads, writes, statistics, and deletion to the credential's canonical principal and exact runtime profile
- resolve memory workspace scope and file authorization through the canonical runtime and principal-storage registries
- stop treating numeric compatibility upload archives as protected internal-API file roots
- preserve per-principal semantic recall while validating and stamping exact runtime provenance

## Validation

- `make check`
- `.venv/bin/python -m pytest tests/test_webhook_api.py tests/test_memory.py tests/test_workshop_memory_authority.py -q` (532 passed)
- `.venv/bin/python -m pytest` (6105 passed)

Part of #1097.
