### PR TITLE
Make protected internal publication canonical

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -25,6 +25,10 @@ from kai.workshop.integration_notifications import WorkshopIntegrationNotificati
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
+from kai.workshop.proactive_publication import (
+    ProactivePublicationAuthority,
+    WorkshopProactivePublicationService,
+)
 from kai.workshop.run_previews import WorkshopRunPreviewRegistry
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
@@ -123,6 +127,7 @@ class KaiCoreServices:
     artifacts: WorkshopArtifactService
     settings_workspaces: WorkshopSettingsWorkspaceService
     memory_queries: WorkshopMemoryQueryService
+    proactive_publication: WorkshopProactivePublicationService
     integration_notifications: WorkshopIntegrationNotificationService
     github_automation: WorkshopGitHubAutomationService
 
@@ -248,6 +253,21 @@ class KaiApplicationHost:
                 runtime_pool,
                 self._execution_state,
             )
+            proactive_publication = WorkshopProactivePublicationService(
+                client_store,
+                artifacts,
+                artifact_storage_root=Path(self._config.session_db_path).parent / "files",
+                delivery_transports=frozenset({"telegram"}) if self._config.telegram_enabled else frozenset(),
+            )
+            for context in self._internal_api_contexts.contexts:
+                await proactive_publication.validate_authority(
+                    ProactivePublicationAuthority(
+                        principal_id=context.principal_id,
+                        channel_id=context.channel_id,
+                        agent_id=context.agent_id,
+                        runtime_profile_id=context.runtime_profile_id,
+                    )
+                )
             integration_notifications = await WorkshopIntegrationNotificationService.open(
                 Path(self._config.session_db_path)
             )
@@ -277,6 +297,7 @@ class KaiApplicationHost:
                 artifacts=artifacts,
                 settings_workspaces=settings_workspaces,
                 memory_queries=memory_queries,
+                proactive_publication=proactive_publication,
                 integration_notifications=integration_notifications,
                 github_automation=github_automation,
             )

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -836,8 +836,8 @@ def build_session_context(
             f"(e.g., background task results), use curl (NEVER WebFetch) to POST JSON to "
             f"http://localhost:{api.webhook_port}/api/send-message "
             f"with header 'X-Webhook-Secret: $KAI_WEBHOOK_SECRET' (environment variable). "
-            f'Required: "text" (the message content). '
-            f"Long messages are automatically split at Telegram's 4096-char limit.]"
+            f'Required: "text" (the message content). Optional: "idempotency_key" for safe retries. '
+            f"Success records the message canonically before optional client delivery.]"
         )
         parts.append(
             f"[File API: To send a file to the user, use curl (NEVER WebFetch) to POST JSON to "
@@ -845,8 +845,8 @@ def build_session_context(
             f"with header 'X-Webhook-Secret: $KAI_WEBHOOK_SECRET' (environment variable). "
             f'Required: "path" (absolute file path within the current workspace {workspace} '
             f"or an exact incoming-file path previously supplied by Kai). "
-            f'Optional: "caption". Images are sent as photos, '
-            f"everything else as documents.\n"
+            f'Optional: "caption" and "idempotency_key" for safe retries. '
+            f"Success records a canonical artifact before optional client delivery.\n"
             f"Incoming files from the user are auto-saved and their exact paths "
             f"are included in the message.]"
         )

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -9010,14 +9010,29 @@ def _internal_api_authority_status(db_path: Path) -> str:
                     ")"
                 ).fetchone()[0]
             )
+            publication_tables = {
+                str(row[0])
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' "
+                    "AND name IN ('event_log', 'messages', 'artifacts', 'delivery_outbox')"
+                ).fetchall()
+            }
         finally:
             connection.close()
     except sqlite3.Error as exc:
         return f"{prefix} NOT VERIFIED ({exc})"
-    status = "active" if profiles > 0 and profiles == contexts else "INCOMPLETE"
+    publication_ready = publication_tables == {
+        "event_log",
+        "messages",
+        "artifacts",
+        "delivery_outbox",
+    }
+    status = "active" if profiles > 0 and profiles == contexts and publication_ready else "INCOMPLETE"
     return (
         f"{prefix} {status}; profiles={profiles}, canonical contexts={contexts}, "
-        f"missing={profiles - contexts}; caller identity selectors=disabled"
+        f"missing={profiles - contexts}; caller identity selectors=disabled, "
+        f"compatibility adapter=retired, proactive publication="
+        f"{'canonical/outbox' if publication_ready else 'unavailable'}"
     )
 
 

--- a/src/kai/internal_api_auth.py
+++ b/src/kai/internal_api_auth.py
@@ -56,7 +56,6 @@ class InternalAPIPrincipal:
     channel_id: ChannelId
     agent_id: AgentId
     runtime_profile_id: RuntimeProfileId
-    _runtime_config_id: int
     scopes: frozenset[InternalAPIScope]
     allowed_services: frozenset[str] = frozenset()
 
@@ -67,10 +66,6 @@ class InternalAPIPrincipal:
     def allows_service(self, service_name: str) -> bool:
         """Return whether this principal may call one named service."""
         return self.allows(InternalAPIScope.SERVICES_CALL) and service_name in self.allowed_services
-
-    def compatibility_runtime_config_id(self) -> int:
-        """Return the server-private key for compatibility persistence adapters."""
-        return self._runtime_config_id
 
 
 class InternalAPIAuth:
@@ -171,7 +166,6 @@ class InternalAPIAuth:
             channel_id=context.channel_id,
             agent_id=context.agent_id,
             runtime_profile_id=context.runtime_profile_id,
-            _runtime_config_id=context.compatibility_runtime_config_id(),
             scopes=scopes,
             allowed_services=allowed_services,
         )

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -211,8 +211,8 @@ class SubprocessPool:
             from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
             from kai.workshop.runtime_profiles import runtime_profile_id_for_config_id
 
-            contexts = tuple(
-                WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
+            contexts_by_runtime_config_id = {
+                runtime_config_id: WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
                     runtime_config_id,
                     (
                         protected_profiles_by_config_id[runtime_config_id].profile_id
@@ -221,14 +221,17 @@ class SubprocessPool:
                     ),
                 )
                 for runtime_config_id in runtime_config_ids
-            )
+            }
+            contexts = tuple(contexts_by_runtime_config_id.values())
         else:
             contexts = internal_api_contexts.contexts
+            contexts_by_runtime_config_id = {
+                runtime_config_id: internal_api_contexts.for_runtime_config_id(runtime_config_id)
+                for runtime_config_id in runtime_config_ids
+            }
         self._internal_api_contexts = internal_api_contexts
         self._protected_internal_api_contexts = config.protected_install
-        self._contexts_by_runtime_config_id = {
-            context.compatibility_runtime_config_id(): context for context in contexts
-        }
+        self._contexts_by_runtime_config_id = contexts_by_runtime_config_id
         self._internal_api_auth = InternalAPIAuth.for_execution_contexts(
             contexts,
             allowed_services_by_profile=allowed_services_by_profile,

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -9,7 +9,7 @@ Provides functionality to:
 4. Expose a scheduling API for creating cron-style jobs via HTTP
 5. Expose a jobs query API for listing and fetching scheduled jobs
 6. Proxy authenticated requests to external services (service layer)
-7. Send text messages and files to the Telegram chat (messaging APIs)
+7. Publish proactive text messages and files to canonical Workshop channels
 8. Monitor webhook health and auto-recover from Telegram delivery failures
 9. Redeem Workshop client enrollment grants and synchronize authorized timelines
 
@@ -26,8 +26,8 @@ Routes are organized into these groups:
     - /api/jobs             - Job listing and detail API
     - /api/jobs/{id}        - Job detail (GET), deletion (DELETE), and update (PATCH)
     - /api/services/{name}  - External service proxy (injects auth from .env)
-    - /api/send-message     - Send a text message to the Telegram chat
-    - /api/send-file        - Send a file from the filesystem to the Telegram chat
+    - /api/send-message     - Publish a proactive canonical text message
+    - /api/send-file        - Publish a proactive canonical artifact
     - /api/memory/add       - Store a structured memory (POST)
     - /api/memory/search    - Search memories by query (POST)
     - /api/memory/stats     - Memory statistics for a user (GET)
@@ -71,12 +71,10 @@ from kai import memory, services, sessions
 from kai.application_host import KaiApplicationHost, KaiCoreServices
 from kai.config import (
     DATA_DIR,
-    IMAGE_EXTENSIONS,
     Config,
 )
 from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, InternalAPIScope
 from kai.job_types import CANONICAL_JOB_TYPES, normalize_job_type
-from kai.telegram_utils import chunk_text
 from kai.workshop.artifacts import MAX_ARTIFACT_BYTES, WorkshopArtifactService
 from kai.workshop.client_api import (
     WorkshopClientCommandSubmitter,
@@ -102,6 +100,10 @@ from kai.workshop.integration_notifications import (
     WorkshopIntegrationNotificationService,
 )
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
+from kai.workshop.proactive_publication import (
+    ProactivePublicationAuthority,
+    ProactivePublicationResult,
+)
 from kai.workshop.run_previews import WorkshopRunPreviewRegistry
 from kai.workshop.scheduled_jobs import (
     WorkshopScheduledJobAuthority,
@@ -143,7 +145,6 @@ GENERIC_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("generic_webhook_secret
 GITHUB_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("github_webhook_secret", str)
 INTERNAL_API_AUTH_KEY: web.AppKey[InternalAPIAuth] = web.AppKey("internal_api_auth", InternalAPIAuth)
 NOTIFICATION_CHAT_IDS_KEY: web.AppKey[set[int]] = web.AppKey("notification_chat_ids", set)
-POOL_KEY: web.AppKey[object] = web.AppKey("pool", object)
 TELEGRAM_APP_KEY: web.AppKey[Application] = web.AppKey("telegram_app", Application)
 TELEGRAM_BOT_KEY: web.AppKey[Bot] = web.AppKey("telegram_bot", Bot)
 TELEGRAM_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("telegram_webhook_secret", str)
@@ -477,15 +478,6 @@ def _reject_internal_identity_selectors(payload: dict) -> None:
             f"Identity selector {supplied[0]} is not accepted; the internal API credential already binds "
             "the canonical execution context"
         )
-
-
-def _resolve_internal_runtime_config_id(
-    principal: InternalAPIPrincipal,
-    payload: dict,
-) -> int:
-    """Resolve the remaining private key for handlers not yet cut over."""
-    _reject_internal_identity_selectors(payload)
-    return principal.compatibility_runtime_config_id()
 
 
 def _scheduled_job_authority(principal: InternalAPIPrincipal) -> WorkshopScheduledJobAuthority:
@@ -1380,20 +1372,41 @@ async def _handle_service_call(request: web.Request, principal: InternalAPIPrinc
 # ── Messaging ────────────────────────────────────────────────────────
 
 
+def _proactive_authority(principal: InternalAPIPrincipal) -> ProactivePublicationAuthority:
+    return ProactivePublicationAuthority(
+        principal_id=principal.principal_id,
+        channel_id=principal.channel_id,
+        agent_id=principal.agent_id,
+        runtime_profile_id=principal.runtime_profile_id,
+    )
+
+
+def _proactive_response(result: ProactivePublicationResult, **extra: object) -> web.Response:
+    return web.json_response(
+        {
+            "status": "recorded",
+            "delivery": result.delivery_status,
+            "deliveries": len(result.deliveries),
+            **extra,
+        }
+    )
+
+
 @_require_internal_api(InternalAPIScope.MESSAGES_SEND)
 async def _handle_send_message(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
-    Send a text message to the Telegram chat.
+    Publish a proactive agent message to the credential's canonical channel.
 
     Called by the inner Claude process to proactively notify the user - e.g.,
     when a background task completes, or a scheduled job wants to report
     results without going through the full Claude prompt cycle.
 
-    Accepts a JSON body with a required "text" field. Messages longer than
-    Telegram's 4096-character limit are split into chunks.
+    Optional adapter delivery is requested durably after canonical recording.
+    An optional idempotency_key makes an uncertain caller retry resolve to the
+    same message and delivery work.
 
     Returns:
-        JSON {"status": "sent"} on success, or an appropriate HTTP error.
+        Recorded status plus queued/delivered/not-configured adapter state.
     """
     try:
         payload = await request.json()
@@ -1408,25 +1421,36 @@ async def _handle_send_message(request: web.Request, principal: InternalAPIPrinc
     if not isinstance(payload, dict):
         return web.json_response({"error": "Request body must be a JSON object"}, status=400)
 
-    text = payload.get("text", "").strip()
+    raw_text = payload.get("text", "")
+    if not isinstance(raw_text, str):
+        return web.json_response({"error": "text must be a string"}, status=400)
+    text = raw_text.strip()
     if not text:
         return web.json_response({"error": "Missing required field: text"}, status=400)
 
-    bot = request.app[TELEGRAM_BOT_KEY]
     try:
-        chat_id = _resolve_internal_runtime_config_id(principal, payload)
+        _reject_internal_identity_selectors(payload)
     except ValueError as e:
         return web.json_response({"error": str(e)}, status=400)
 
     try:
-        for part in chunk_text(text):
-            await bot.send_message(chat_id, part)
+        request_id = payload.get("idempotency_key")
+        if request_id is None:
+            request_id = uuid.uuid4().hex
+        result = await request.app[CORE_HOST_KEY].services.proactive_publication.publish_text(
+            _proactive_authority(principal),
+            request_id=request_id,
+            body=text,
+            occurred_at=datetime.now(UTC),
+        )
+    except ValueError as exc:
+        return web.json_response({"error": str(exc)}, status=400)
     except Exception:
-        log.exception("Failed to send message to chat %d via API", chat_id)
-        return web.json_response({"error": "Failed to send message"}, status=500)
+        log.exception("Canonical proactive message publication failed")
+        return web.json_response({"error": "Message publication failed"}, status=500)
 
-    log.info("Sent message to chat %d via API (%d chars)", chat_id, len(text))
-    return web.json_response({"status": "sent"})
+    log.info("Recorded proactive canonical message (%d chars)", len(text))
+    return _proactive_response(result)
 
 
 # ── File exchange ────────────────────────────────────────────────────
@@ -1435,12 +1459,12 @@ async def _handle_send_message(request: web.Request, principal: InternalAPIPrinc
 @_require_internal_api(InternalAPIScope.FILES_SEND)
 async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipal) -> web.Response:
     """
-    Send a file from the filesystem to the Telegram chat.
+    Publish a file from the filesystem as a canonical channel artifact.
 
     Called by the inner Claude process to deliver files back to the user.
     Accepts a JSON body with a required "path" field (absolute path) and
-    an optional "caption". Images are sent as photos (rendered inline),
-    everything else as document attachments.
+    optional "caption" and "idempotency_key". Optional adapters deliver the
+    artifact later through durable channel-binding workers.
 
     Path confinement: the resolved path must be inside the authenticated
     principal's current workspace or its scoped upload directory. This
@@ -1448,8 +1472,7 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     principal from sending files from another principal's upload directory.
 
     Returns:
-        JSON {"status": "sent", "file": "<filename>"} on success, or an
-        appropriate HTTP error (400/401/403/404).
+        Recorded status, adapter state, and canonical filename on success.
     """
     try:
         payload = await request.json()
@@ -1467,6 +1490,8 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     file_path = payload.get("path")
     if not file_path:
         return web.json_response({"error": "Missing required field: path"}, status=400)
+    if not isinstance(file_path, str):
+        return web.json_response({"error": "path must be a string"}, status=400)
 
     # Identity and authority are bound to the credential. Caller-supplied
     # selectors are rejected before any filesystem lookup.
@@ -1514,29 +1539,28 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     if not path.is_file():
         return web.json_response({"error": f"File not found: {file_path}"}, status=404)
 
-    # Direct Telegram publication is the remaining bounded compatibility seam
-    # and is retired in the next internal-API slice. It is not consulted for
-    # workspace or storage authorization above.
-    chat_id = principal.compatibility_runtime_config_id()
-    bot = request.app[TELEGRAM_BOT_KEY]
     caption = payload.get("caption", "")
-
-    # Send images as photos (Telegram renders them inline) and everything
-    # else as document attachments (preserves filename, allows any type).
+    if not isinstance(caption, str):
+        return web.json_response({"error": "caption must be a string"}, status=400)
     try:
-        suffix = path.suffix.lower()
-        if suffix in IMAGE_EXTENSIONS:
-            with open(path, "rb") as f:
-                await bot.send_photo(chat_id, f, caption=caption or None)
-        else:
-            with open(path, "rb") as f:
-                await bot.send_document(chat_id, f, caption=caption or None, filename=path.name)
+        request_id = payload.get("idempotency_key")
+        if request_id is None:
+            request_id = uuid.uuid4().hex
+        result = await request.app[CORE_HOST_KEY].services.proactive_publication.publish_file(
+            _proactive_authority(principal),
+            request_id=request_id,
+            path=path,
+            caption=caption,
+            occurred_at=datetime.now(UTC),
+        )
+    except ValueError as exc:
+        return web.json_response({"error": str(exc)}, status=400)
     except Exception:
-        log.exception("Failed to send file %s to chat %d", path, chat_id)
-        return web.json_response({"error": "Failed to send file"}, status=500)
+        log.exception("Canonical proactive artifact publication failed")
+        return web.json_response({"error": "File publication failed"}, status=500)
 
-    log.info("Sent file %s to chat %d via API", path.name, chat_id)
-    return web.json_response({"status": "sent", "file": path.name})
+    log.info("Recorded proactive canonical artifact %s", path.name)
+    return _proactive_response(result, file=path.name)
 
 
 # ── Memory API ───────────────────────────────────────────────────────
@@ -2151,10 +2175,8 @@ def _register_routes(
     app.router.add_post("/api/schedule", _handle_schedule)
     app.router.add_delete("/api/jobs/{id}", _handle_delete_job)
     app.router.add_patch("/api/jobs/{id}", _handle_update_job)
-    if telegram_enabled:
-        # These compatibility operations still use Telegram delivery.
-        app.router.add_post("/api/send-message", _handle_send_message)
-        app.router.add_post("/api/send-file", _handle_send_file)
+    app.router.add_post("/api/send-message", _handle_send_message)
+    app.router.add_post("/api/send-file", _handle_send_file)
 
 
 async def _register_workshop_client_api(
@@ -2286,10 +2308,6 @@ async def start(
 
     # Retain the loaded application configuration for compatibility APIs.
     _app[CONFIG_KEY] = config
-
-    # Store the subprocess pool for per-user workspace lookup in send-file.
-    # Set by main.py after pool creation; may be None during init.
-    _app[POOL_KEY] = pool
 
     # Workspace policy lets canonical review work resolve a local checkout for
     # _resolve_local_repo() match incoming PR webhook repos against

--- a/src/kai/workshop/artifacts.py
+++ b/src/kai/workshop/artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 import os
 import re
 import secrets
@@ -234,17 +235,21 @@ class _ResolvedArtifactMessage:
     created_by_principal_id: PrincipalId
 
 
-async def _resolve_inbound_message(
+async def _resolve_artifact_message(
     store: WorkshopEventStore,
     message_id: MessageId,
+    *,
+    author_kind: str,
 ) -> _ResolvedArtifactMessage:
+    if author_kind not in {"human", "agent"}:
+        raise ValueError("author_kind must be human or agent")
     async with store.connection.execute(
         "SELECT c.workshop_id, m.channel_id, m.author_principal_id "
         "FROM messages m "
         "JOIN channels c ON c.id = m.channel_id "
-        "JOIN principals p ON p.id = m.author_principal_id AND p.kind = 'human' "
+        "JOIN principals p ON p.id = m.author_principal_id AND p.kind = ? "
         "WHERE m.id = ?",
-        (message_id,),
+        (author_kind, message_id),
     ) as cursor:
         rows = list(await cursor.fetchall())
     if len(rows) != 1:
@@ -443,7 +448,51 @@ async def record_inbound_artifact_in_transaction(
         raise RuntimeError("record_inbound_artifact_in_transaction requires an active transaction")
     if not isinstance(storage_root, Path):
         raise ValueError("storage_root must be a Path")
-    resolved_message = await _resolve_inbound_message(store, artifact.message_id)
+    return await _record_artifact_in_transaction(
+        store,
+        artifact,
+        storage_root=storage_root,
+        author_kind="human",
+        event_version=1,
+        metadata_source="artifact_shadow",
+    )
+
+
+async def record_published_artifact_in_transaction(
+    store: WorkshopEventStore,
+    artifact: InboundArtifact,
+    *,
+    storage_root: Path,
+) -> AppendResult:
+    """Append agent-authored artifact metadata inside a publication transaction."""
+    return await _record_artifact_in_transaction(
+        store,
+        artifact,
+        storage_root=storage_root,
+        author_kind="agent",
+        event_version=2,
+        metadata_source="internal_api",
+    )
+
+
+async def _record_artifact_in_transaction(
+    store: WorkshopEventStore,
+    artifact: InboundArtifact,
+    *,
+    storage_root: Path,
+    author_kind: str,
+    event_version: int,
+    metadata_source: str,
+) -> AppendResult:
+    if not store.connection.in_transaction:
+        raise RuntimeError("artifact recording requires an active transaction")
+    if not isinstance(storage_root, Path):
+        raise ValueError("storage_root must be a Path")
+    resolved_message = await _resolve_artifact_message(
+        store,
+        artifact.message_id,
+        author_kind=author_kind,
+    )
     resolved_path = _resolve_storage_path(artifact.storage_path, storage_root)
     byte_size, content_sha256 = _file_identity(resolved_path)
     token = _stable_source_token(artifact)
@@ -453,7 +502,7 @@ async def record_inbound_artifact_in_transaction(
         return EventEnvelope.create(
             event_id=EventId.derived(resolved_message.workshop_id, f"artifact-event:{token}"),
             event_type=WorkshopEventType.ARTIFACT_CREATED,
-            event_version=1,
+            event_version=event_version,
             workshop_id=resolved_message.workshop_id,
             aggregate_type="artifact",
             aggregate_id=ArtifactId.derived(resolved_message.workshop_id, f"artifact:{token}"),
@@ -473,7 +522,7 @@ async def record_inbound_artifact_in_transaction(
                 "source_transport": artifact.source_transport,
                 "source_unique_id": artifact.source_unique_id,
             },
-            metadata={"source": "artifact_shadow"},
+            metadata={"source": metadata_source},
         )
 
     envelope = create_envelope(str(resolved_path))
@@ -494,6 +543,55 @@ async def record_inbound_artifact_in_transaction(
         result = await store.append_in_transaction(envelope)
     await store.project_pending_in_transaction(CanonicalConversationProjection())
     return result
+
+
+async def artifact_for_delivery(
+    store: WorkshopEventStore,
+    message_id: MessageId,
+    *,
+    storage_root: Path,
+) -> tuple[StoredArtifact, str]:
+    """Resolve one agent-published artifact and its transport caption."""
+    async with store.connection.execute(
+        "SELECT a.id, a.message_id, a.channel_id, a.kind, a.media_type, "
+        "a.byte_size, a.content_sha256, a.original_filename, a.created_at, "
+        "a.storage_path, e.metadata_json "
+        "FROM artifacts a JOIN messages m ON m.id = a.message_id "
+        "JOIN principals p ON p.id = m.author_principal_id AND p.kind = 'agent' "
+        "JOIN event_log e ON e.position = m.created_event_position "
+        "WHERE a.message_id = ? ORDER BY a.created_event_position, a.id",
+        (message_id,),
+    ) as cursor:
+        rows = list(await cursor.fetchall())
+    if len(rows) != 1:
+        raise ArtifactMessageNotFoundError("Published artifact message does not resolve uniquely")
+    row = rows[0]
+    path = _resolve_storage_path(Path(str(row[9])), storage_root)
+    summary = ArtifactSummary(
+        artifact_id=ArtifactId(str(row[0])),
+        message_id=MessageId(str(row[1])),
+        channel_id=ChannelId(str(row[2])),
+        kind=str(row[3]),
+        media_type=str(row[4]),
+        byte_size=int(row[5]),
+        content_sha256=str(row[6]),
+        original_filename=str(row[7]) if row[7] is not None else None,
+        created_at=datetime.fromisoformat(str(row[8]).replace("Z", "+00:00")),
+    )
+    actual_size, actual_hash = _file_identity(path)
+    if actual_size != summary.byte_size or actual_hash != summary.content_sha256:
+        raise ArtifactStorageBoundaryError("Artifact content no longer matches canonical provenance")
+    metadata = json.loads(str(row[10]))
+    if (
+        not isinstance(metadata, dict)
+        or metadata.get("source") != "internal_api"
+        or metadata.get("publication_kind") != "file"
+    ):
+        raise ArtifactStorageBoundaryError("Published artifact provenance is invalid")
+    caption = metadata.get("caption", "")
+    if not isinstance(caption, str):
+        raise ArtifactStorageBoundaryError("Published artifact caption is invalid")
+    return StoredArtifact(summary=summary, storage_path=path), caption
 
 
 async def artifacts_for_messages(

--- a/src/kai/workshop/internal_api_contexts.py
+++ b/src/kai/workshop/internal_api_contexts.py
@@ -24,10 +24,6 @@ class WorkshopInternalAPIExecutionContext:
     runtime_profile_id: RuntimeProfileId
     _runtime_config_id: int = field(repr=False)
 
-    def compatibility_runtime_config_id(self) -> int:
-        """Return the private compatibility key used behind server adapters."""
-        return self._runtime_config_id
-
     @classmethod
     def for_unprotected_runtime(
         cls,

--- a/src/kai/workshop/proactive_publication.py
+++ b/src/kai/workshop/proactive_publication.py
@@ -1,0 +1,303 @@
+"""Canonical proactive messages and artifacts from protected agent runtimes."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from kai.workshop.artifacts import (
+    StagedArtifact,
+    WorkshopArtifactService,
+    record_published_artifact_in_transaction,
+)
+from kai.workshop.delivery_outbox import (
+    NOTIFICATION_PURPOSE,
+    DeliveryRequest,
+    DeliveryRequestResult,
+    WorkshopDeliveryOutbox,
+)
+from kai.workshop.domain import (
+    AgentId,
+    ChannelBindingId,
+    ChannelId,
+    EventEnvelope,
+    EventId,
+    MessageId,
+    PrincipalId,
+    RuntimeProfileId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+
+PROACTIVE_ARTIFACT_MODE = "artifact"
+_REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+class ProactivePublicationError(RuntimeError):
+    """A proactive effect could not be recorded under canonical authority."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProactivePublicationAuthority:
+    principal_id: PrincipalId
+    channel_id: ChannelId
+    agent_id: AgentId
+    runtime_profile_id: RuntimeProfileId
+
+
+@dataclass(frozen=True, slots=True)
+class ProactivePublicationResult:
+    message_id: MessageId
+    inserted: bool
+    deliveries: tuple[DeliveryRequestResult, ...]
+
+    @property
+    def delivery_status(self) -> str:
+        if not self.deliveries:
+            return "not_configured"
+        states = {result.delivery.status for result in self.deliveries}
+        if states == {"succeeded"}:
+            return "delivered"
+        if "failed" in states:
+            return "failed"
+        return "queued"
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedAuthority:
+    workshop_id: WorkshopId
+    agent_principal_id: PrincipalId
+
+
+class WorkshopProactivePublicationService:
+    """Record proactive effects before requesting optional adapter delivery."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        artifacts: WorkshopArtifactService,
+        *,
+        artifact_storage_root: Path,
+        delivery_transports: frozenset[str],
+    ) -> None:
+        if any(not isinstance(transport, str) or not transport for transport in delivery_transports):
+            raise ValueError("delivery_transports must contain non-empty identifiers")
+        self._store = store
+        self._artifacts = artifacts
+        self._artifact_storage_root = artifact_storage_root.resolve()
+        self._delivery_transports = delivery_transports
+        self._lock = asyncio.Lock()
+
+    async def validate_authority(self, authority: ProactivePublicationAuthority) -> None:
+        await self._resolve_authority(authority)
+
+    async def publish_text(
+        self,
+        authority: ProactivePublicationAuthority,
+        *,
+        request_id: str,
+        body: str,
+        occurred_at: datetime,
+    ) -> ProactivePublicationResult:
+        if not body:
+            raise ValueError("body must be non-empty")
+        async with self._lock:
+            return await self._record(
+                authority,
+                request_id=request_id,
+                body=body,
+                occurred_at=occurred_at,
+                kind="text",
+                mode="text",
+                caption=None,
+                artifact=None,
+            )
+
+    async def publish_file(
+        self,
+        authority: ProactivePublicationAuthority,
+        *,
+        request_id: str,
+        path: Path,
+        caption: str,
+        occurred_at: datetime,
+    ) -> ProactivePublicationResult:
+        self._validate_request(request_id, occurred_at)
+        if not isinstance(path, Path) or not path.is_absolute():
+            raise ValueError("path must be absolute")
+
+        async def chunks() -> AsyncIterator[bytes]:
+            with path.open("rb") as source:
+                while chunk := source.read(1024 * 1024):
+                    yield chunk
+
+        async with self._lock:
+            staged = await self._artifacts.stage_upload(
+                principal_id=authority.principal_id,
+                runtime_profile_id=authority.runtime_profile_id,
+                filename=path.name,
+                claimed_media_type=None,
+                chunks=chunks(),
+                source_transport="internal_api",
+                source_unique_id=request_id,
+                occurred_at=occurred_at,
+                original_filename=path.name,
+            )
+            try:
+                return await self._record(
+                    authority,
+                    request_id=request_id,
+                    body=caption or f"File: {path.name}",
+                    occurred_at=occurred_at,
+                    kind="file",
+                    mode=PROACTIVE_ARTIFACT_MODE,
+                    caption=caption,
+                    artifact=staged,
+                )
+            except Exception:
+                staged.discard()
+                raise
+
+    async def _record(
+        self,
+        authority: ProactivePublicationAuthority,
+        *,
+        request_id: str,
+        body: str,
+        occurred_at: datetime,
+        kind: str,
+        mode: str,
+        caption: str | None,
+        artifact: StagedArtifact | None,
+    ) -> ProactivePublicationResult:
+        self._validate_request(request_id, occurred_at)
+        resolved = await self._resolve_authority(authority)
+        stable_name = f"internal-api-publication:v1:{authority.runtime_profile_id}:{kind}:{request_id}"
+        message_id = MessageId.derived(resolved.workshop_id, stable_name)
+        payload = {
+            "channel_id": authority.channel_id,
+            "author_principal_id": resolved.agent_principal_id,
+            "body": body,
+        }
+        metadata: dict[str, object] = {
+            "source": "internal_api",
+            "publication_kind": kind,
+            "request_id": request_id,
+            "runtime_profile_id": authority.runtime_profile_id,
+        }
+        if caption is not None:
+            metadata["caption"] = caption
+        envelope = EventEnvelope.create(
+            event_id=EventId.derived(resolved.workshop_id, f"{stable_name}:event"),
+            event_type=WorkshopEventType.MESSAGE_CREATED,
+            event_version=1,
+            workshop_id=resolved.workshop_id,
+            aggregate_type="message",
+            aggregate_id=message_id,
+            actor_principal_id=resolved.agent_principal_id,
+            occurred_at=occurred_at.astimezone(UTC),
+            idempotency_key=stable_name,
+            payload=payload,
+            metadata=metadata,
+        )
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            existing = await self._store.event_by_idempotency_key(stable_name)
+            inserted = existing is None
+            if existing is None:
+                await self._store.append_in_transaction(envelope)
+            elif existing.envelope.content_hash != envelope.content_hash:
+                raise IdempotencyConflictError(f"Event identity {stable_name!r} was reused with different content")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            artifact_result = None
+            if artifact is not None:
+                artifact_result = await record_published_artifact_in_transaction(
+                    self._store,
+                    artifact.for_message(message_id),
+                    storage_root=self._artifact_storage_root,
+                )
+            binding_ids: tuple[ChannelBindingId, ...] = ()
+            if self._delivery_transports:
+                placeholders = ", ".join("?" for _ in self._delivery_transports)
+                parameters = (authority.channel_id, *sorted(self._delivery_transports))
+                async with connection.execute(
+                    "SELECT id FROM channel_bindings WHERE channel_id = ? "
+                    f"AND transport IN ({placeholders}) ORDER BY id",
+                    parameters,
+                ) as cursor:
+                    binding_ids = tuple(ChannelBindingId(str(row[0])) for row in await cursor.fetchall())
+            deliveries = tuple(
+                [
+                    await WorkshopDeliveryOutbox(self._store).request_delivery_in_transaction(
+                        DeliveryRequest(
+                            message_id=message_id,
+                            channel_binding_id=binding_id,
+                            mode=mode,
+                            purpose=NOTIFICATION_PURPOSE,
+                            occurred_at=occurred_at,
+                            max_attempts=5,
+                        )
+                    )
+                    for binding_id in binding_ids
+                ]
+            )
+            prior_states = {inserted, *(delivery.inserted for delivery in deliveries)}
+            if artifact_result is not None:
+                prior_states.add(artifact_result.inserted)
+            if len(prior_states) != 1:
+                raise ProactivePublicationError(
+                    "Canonical publication, artifact, and delivery requests do not share one prior state"
+                )
+            await self._store.project_pending_in_transaction(projection)
+            await connection.commit()
+            return ProactivePublicationResult(message_id, inserted, deliveries)
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def _resolve_authority(
+        self,
+        authority: ProactivePublicationAuthority,
+    ) -> _ResolvedAuthority:
+        if not isinstance(authority, ProactivePublicationAuthority):
+            raise ValueError("authority must be canonical")
+        async with self._store.connection.execute(
+            "SELECT c.workshop_id, a.principal_id FROM channels c "
+            "JOIN channel_memberships cm ON cm.channel_id = c.id "
+            "AND cm.principal_id = ? AND cm.role = 'owner' "
+            "JOIN principals human ON human.id = cm.principal_id AND human.kind = 'human' "
+            "JOIN channel_agents ca ON ca.channel_id = c.id AND ca.agent_id = ? "
+            "JOIN agents a ON a.id = ca.agent_id AND a.workshop_id = c.workshop_id "
+            "JOIN principals agent ON agent.id = a.principal_id AND agent.kind = 'agent' "
+            "JOIN channel_agent_runtime_assignments ra ON ra.channel_id = c.id "
+            "AND ra.agent_id = a.id AND ra.runtime_profile_id = ? "
+            "WHERE c.id = ? AND c.kind = 'direct'",
+            (
+                authority.principal_id,
+                authority.agent_id,
+                authority.runtime_profile_id,
+                authority.channel_id,
+            ),
+        ) as cursor:
+            rows = tuple(await cursor.fetchall())
+        if len(rows) != 1:
+            raise ProactivePublicationError("Canonical proactive publication authority is missing or ambiguous")
+        return _ResolvedAuthority(
+            workshop_id=WorkshopId(str(rows[0][0])),
+            agent_principal_id=PrincipalId(str(rows[0][1])),
+        )
+
+    @staticmethod
+    def _validate_request(request_id: str, occurred_at: datetime) -> None:
+        if not isinstance(request_id, str) or not _REQUEST_ID_PATTERN.fullmatch(request_id):
+            raise ValueError("request_id must be a bounded delivery identifier")
+        if occurred_at.tzinfo is None or occurred_at.utcoffset() is None:
+            raise ValueError("occurred_at must be timezone-aware")

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -705,6 +705,8 @@ class CanonicalConversationProjection:
                 ),
             )
         elif envelope.event_type == WorkshopEventType.ARTIFACT_CREATED:
+            if envelope.event_version not in {1, 2}:
+                raise ValueError("Unsupported Workshop artifact event version")
             created_by = _required_text(payload, "created_by_principal_id")
             if envelope.actor_principal_id != created_by:
                 raise ValueError("Workshop artifact actor must match created_by_principal_id")
@@ -717,13 +719,14 @@ class CanonicalConversationProjection:
                 (message_id,),
             ) as cursor:
                 message_row = await cursor.fetchone()
+            expected_author_kind = "human" if envelope.event_version == 1 else "agent"
             if message_row is None or tuple(message_row) != (
                 envelope.workshop_id,
                 channel_id,
                 created_by,
-                "human",
+                expected_author_kind,
             ):
-                raise ValueError("Workshop artifact must belong to its human-authored message")
+                raise ValueError("Workshop artifact must belong to a message with the event-version author kind")
             kind = _required_text(payload, "kind")
             if kind not in {"photo", "document", "voice"}:
                 raise ValueError("Workshop artifact kind is unsupported")

--- a/src/kai/workshop/telegram_delivery.py
+++ b/src/kai/workshop/telegram_delivery.py
@@ -8,6 +8,7 @@ import warnings
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import StrEnum
+from pathlib import Path
 from typing import Protocol
 
 from telegram.constants import ParseMode
@@ -25,6 +26,11 @@ from telegram.error import (
 from telegram.warnings import PTBDeprecationWarning
 
 from kai.telegram_utils import chunk_text
+from kai.workshop.artifacts import (
+    ArtifactMessageNotFoundError,
+    ArtifactStorageBoundaryError,
+    artifact_for_delivery,
+)
 from kai.workshop.delivery_fragments import (
     EDIT_OPERATION,
     SEND_OPERATION,
@@ -33,6 +39,7 @@ from kai.workshop.delivery_fragments import (
 )
 from kai.workshop.delivery_outbox import (
     CONVERSATION_REPLY_PURPOSE,
+    NOTIFICATION_PURPOSE,
     SEND_FRAGMENTS_CONTRACT,
     STREAMING_FINALIZATION_CONTRACT,
     DeliveryClaim,
@@ -42,6 +49,8 @@ from kai.workshop.delivery_outbox import (
     WorkshopDeliveryOutbox,
 )
 from kai.workshop.domain import DeliveryAuthorityEpochId, DeliveryId
+from kai.workshop.proactive_publication import PROACTIVE_ARTIFACT_MODE
+from kai.workshop.store import WorkshopEventStore
 
 _NUMERIC_CHAT_ID_PATTERN = re.compile(r"^-?[1-9][0-9]{0,19}$")
 _USERNAME_CHAT_ID_PATTERN = re.compile(r"^@[A-Za-z][A-Za-z0-9_]{4,31}$")
@@ -75,6 +84,27 @@ class TelegramTextBot(Protocol):
         message_id: int,
         text: str,
         parse_mode: str | None = None,
+    ) -> TelegramSentMessage: ...
+
+
+class TelegramArtifactBot(Protocol):
+    """The Bot API surface needed by durable artifact delivery."""
+
+    async def send_photo(
+        self,
+        *,
+        chat_id: int | str,
+        photo: object,
+        caption: str | None = None,
+    ) -> TelegramSentMessage: ...
+
+    async def send_document(
+        self,
+        *,
+        chat_id: int | str,
+        document: object,
+        caption: str | None = None,
+        filename: str | None = None,
     ) -> TelegramSentMessage: ...
 
 
@@ -267,6 +297,159 @@ class WorkshopTelegramDeliveryAdapter:
                 ambiguous=True,
             )
         return message_id
+
+
+class WorkshopTelegramArtifactDeliveryAdapter:
+    """Deliver one canonically recorded agent artifact through Telegram."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        bot: TelegramArtifactBot,
+        *,
+        storage_root: Path,
+    ) -> None:
+        self._store = store
+        self._bot = bot
+        self._storage_root = storage_root.resolve()
+
+    async def deliver(self, claim: DeliveryClaim) -> int:
+        if not isinstance(claim, DeliveryClaim):
+            raise ValueError("claim must be a DeliveryClaim")
+        if claim.transport != "telegram":
+            raise TelegramDeliveryContractError("telegram_transport_mismatch")
+        if claim.mode != PROACTIVE_ARTIFACT_MODE:
+            raise TelegramDeliveryContractError("telegram_mode_unsupported")
+        try:
+            artifact, caption = await artifact_for_delivery(
+                self._store,
+                claim.message_id,
+                storage_root=self._storage_root,
+            )
+        except (ArtifactMessageNotFoundError, ArtifactStorageBoundaryError) as exc:
+            raise TelegramDeliveryContractError("telegram_artifact_unavailable") from exc
+
+        target = _telegram_target(claim.external_channel_id)
+        try:
+            with artifact.storage_path.open("rb") as source:
+                if artifact.summary.kind == "photo":
+                    sent = await self._bot.send_photo(
+                        chat_id=target,
+                        photo=source,
+                        caption=caption or None,
+                    )
+                else:
+                    sent = await self._bot.send_document(
+                        chat_id=target,
+                        document=source,
+                        caption=caption or None,
+                        filename=artifact.summary.original_filename,
+                    )
+        except TelegramError as error:
+            raise _classify_telegram_error(error) from error
+        except OSError as exc:
+            raise TelegramDeliveryContractError("telegram_artifact_unavailable") from exc
+        message_id = getattr(sent, "message_id", None)
+        if not isinstance(message_id, int) or isinstance(message_id, bool) or message_id <= 0:
+            raise TelegramDeliveryFailure(
+                retryable=False,
+                error_code="telegram_response_invalid",
+                ambiguous=True,
+            )
+        return message_id
+
+
+class WorkshopTelegramArtifactDeliveryWorker:
+    """Claim and settle the durable proactive-artifact Telegram lane."""
+
+    def __init__(
+        self,
+        outbox: WorkshopDeliveryOutbox,
+        adapter: WorkshopTelegramArtifactDeliveryAdapter,
+        *,
+        worker_id: str,
+        lease_duration: timedelta = timedelta(seconds=30),
+        poll_interval: float = 1.0,
+    ) -> None:
+        if poll_interval <= 0 or poll_interval > 60:
+            raise ValueError("poll_interval must be positive and at most 60 seconds")
+        self._outbox = outbox
+        self._adapter = adapter
+        self._worker_id = worker_id
+        self._lease_duration = lease_duration
+        self._poll_interval = poll_interval
+
+    async def run_once(self) -> TelegramWorkResult:
+        claim = await self._outbox.claim_next(
+            self._worker_id,
+            purposes=(NOTIFICATION_PURPOSE,),
+            execution_contracts=(SEND_FRAGMENTS_CONTRACT,),
+            lease_duration=self._lease_duration,
+            transport="telegram",
+            modes=(PROACTIVE_ARTIFACT_MODE,),
+        )
+        return await self._run_claim(claim)
+
+    async def run_delivery(self, delivery_id: DeliveryId) -> TelegramWorkResult:
+        if not isinstance(delivery_id, DeliveryId):
+            raise ValueError("delivery_id must be a DeliveryId")
+        claim = await self._outbox.claim_next(
+            self._worker_id,
+            purposes=(NOTIFICATION_PURPOSE,),
+            execution_contracts=(SEND_FRAGMENTS_CONTRACT,),
+            lease_duration=self._lease_duration,
+            transport="telegram",
+            modes=(PROACTIVE_ARTIFACT_MODE,),
+            delivery_id=delivery_id,
+        )
+        return await self._run_claim(claim)
+
+    async def recover_expired_leases(self) -> DeliveryRecoveryResult:
+        return await self._outbox.recover_expired_leases(
+            purposes=(NOTIFICATION_PURPOSE,),
+            execution_contracts=(SEND_FRAGMENTS_CONTRACT,),
+        )
+
+    async def _run_claim(self, claim: DeliveryClaim | None) -> TelegramWorkResult:
+        if claim is None:
+            return TelegramWorkResult(outcome=TelegramWorkOutcome.IDLE)
+        try:
+            await self._adapter.deliver(claim)
+        except TelegramDeliveryFailure as failure:
+            state = await self._outbox.mark_failed(
+                claim,
+                retryable=failure.retryable and not failure.ambiguous,
+                error_code=failure.error_code,
+                minimum_retry_delay=failure.minimum_retry_delay,
+            )
+            return TelegramWorkResult(
+                outcome=(
+                    TelegramWorkOutcome.RETRY_SCHEDULED if state.status == "retry_wait" else TelegramWorkOutcome.FAILED
+                ),
+                delivery_id=claim.delivery_id,
+                attempt_number=claim.attempt_number,
+                error_code=failure.error_code,
+            )
+        state = await self._outbox.mark_succeeded(claim)
+        if state.status != "succeeded":
+            raise RuntimeError("Successful Telegram artifact delivery did not reach succeeded state")
+        return TelegramWorkResult(
+            outcome=TelegramWorkOutcome.SUCCEEDED,
+            delivery_id=claim.delivery_id,
+            attempt_number=claim.attempt_number,
+        )
+
+    async def run(self, stop_event: asyncio.Event) -> None:
+        if not isinstance(stop_event, asyncio.Event):
+            raise ValueError("stop_event must be an asyncio.Event")
+        while not stop_event.is_set():
+            result = await self.run_once()
+            if result.outcome != TelegramWorkOutcome.IDLE:
+                continue
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=self._poll_interval)
+            except TimeoutError:
+                pass
 
 
 class WorkshopTelegramStreamingFinalizationAdapter:

--- a/src/kai/workshop/telegram_delivery_runtime.py
+++ b/src/kai/workshop/telegram_delivery_runtime.py
@@ -21,7 +21,10 @@ from kai.workshop.domain import DeliveryAuthorityEpochId
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery import (
     WORKSHOP_CLIENT_TEXT_MODE,
+    TelegramArtifactBot,
     TelegramTextBot,
+    WorkshopTelegramArtifactDeliveryAdapter,
+    WorkshopTelegramArtifactDeliveryWorker,
     WorkshopTelegramDeliveryAdapter,
     WorkshopTelegramDeliveryWorker,
     WorkshopTelegramStreamingFinalizationAdapter,
@@ -330,9 +333,13 @@ class WorkshopTelegramNotificationService:
         self,
         worker_store: WorkshopEventStore,
         runtime: WorkshopTelegramDeliveryRuntime,
+        artifact_store: WorkshopEventStore,
+        artifact_runtime: WorkshopTelegramDeliveryRuntime,
     ) -> None:
         self._worker_store = worker_store
         self._runtime = runtime
+        self._artifact_store = artifact_store
+        self._artifact_runtime = artifact_runtime
         self._closed = False
 
     @classmethod
@@ -345,6 +352,8 @@ class WorkshopTelegramNotificationService:
     ) -> WorkshopTelegramNotificationService:
         worker_store: WorkshopEventStore | None = None
         runtime: WorkshopTelegramDeliveryRuntime | None = None
+        artifact_store: WorkshopEventStore | None = None
+        artifact_runtime: WorkshopTelegramDeliveryRuntime | None = None
         try:
             worker_store = await WorkshopEventStore.open(database_path)
             worker = WorkshopTelegramDeliveryWorker(
@@ -357,7 +366,26 @@ class WorkshopTelegramNotificationService:
             )
             runtime = WorkshopTelegramDeliveryRuntime(worker, worker)
             await runtime.start()
+            artifact_store = await WorkshopEventStore.open(database_path)
+            artifact_worker = WorkshopTelegramArtifactDeliveryWorker(
+                WorkshopDeliveryOutbox(artifact_store),
+                WorkshopTelegramArtifactDeliveryAdapter(
+                    artifact_store,
+                    cast(TelegramArtifactBot, bot),
+                    storage_root=database_path.parent / "files",
+                ),
+                worker_id=f"{worker_id}-artifact",
+            )
+            artifact_runtime = WorkshopTelegramDeliveryRuntime(artifact_worker, artifact_worker)
+            await artifact_runtime.start()
         except BaseException:
+            if artifact_runtime is not None:
+                try:
+                    await artifact_runtime.stop()
+                except Exception:
+                    pass
+            if artifact_store is not None:
+                await artifact_store.close()
             if runtime is not None:
                 try:
                     await runtime.stop()
@@ -368,20 +396,39 @@ class WorkshopTelegramNotificationService:
             raise
         assert worker_store is not None
         assert runtime is not None
-        return cls(worker_store, runtime)
+        assert artifact_store is not None
+        assert artifact_runtime is not None
+        return cls(worker_store, runtime, artifact_store, artifact_runtime)
 
     @property
     def ready(self) -> bool:
-        return not self._closed and self._runtime.ready
+        return not self._closed and self._runtime.ready and self._artifact_runtime.ready
 
     async def wait(self) -> None:
-        await self._runtime.wait()
+        waits = {
+            asyncio.create_task(self._runtime.wait()),
+            asyncio.create_task(self._artifact_runtime.wait()),
+        }
+        done, pending = await asyncio.wait(waits, return_when=asyncio.FIRST_COMPLETED)
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        for task in done:
+            await task
 
     async def stop(self) -> None:
         if self._closed:
             return
         try:
-            await self._runtime.stop()
+            results = await asyncio.gather(
+                self._runtime.stop(),
+                self._artifact_runtime.stop(),
+                return_exceptions=True,
+            )
         finally:
             self._closed = True
+            await self._artifact_store.close()
             await self._worker_store.close()
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -162,7 +162,10 @@ curl -s -X POST http://localhost:8080/api/send-message \
   -d '{"text": "Your build finished successfully."}'
 ```
 
-Fields: `text` (string, required).
+Fields: `text` (string, required), `idempotency_key` (string, optional but
+recommended for retries). A successful response means the message was recorded
+canonically; `delivery` reports `queued`, `delivered`, or `not_configured` for
+optional client adapters.
 
 ## Sending Files
 
@@ -177,7 +180,10 @@ curl -s -X POST http://localhost:8080/api/send-file \
 
 - `path` - required; absolute path within the current workspace
 - `caption` - string; optional
-- Images (png, jpg, webp) are sent as photos (rendered inline). Everything else is sent as a document attachment.
+- `idempotency_key` - string; optional but recommended for retries
+- The artifact appears in Workshop first. Configured adapters deliver it from
+  the durable outbox; Telegram renders images as photos and other files as
+  document attachments.
 
 ## Memory System
 

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -243,6 +243,7 @@ def _host() -> KaiApplicationHost:
             session_db_path=Path("/tmp/kai-test.db"),
             spec_dir="specs",
             pr_review_timeout_s=900,
+            telegram_enabled=False,
         ),  # type: ignore[arg-type]
         runtime_profiles=SimpleNamespace(),  # type: ignore[arg-type]
         execution_state=SimpleNamespace(),  # type: ignore[arg-type]
@@ -415,6 +416,8 @@ async def test_real_core_lifecycle_uses_workshop_identity_without_telegram_appli
             "workshop",
             "browser-human",
         )
+        internal_contexts = await WorkshopInternalAPIContextRegistry.from_store(store, profiles)
+        context = internal_contexts.for_runtime_profile(profile_id(101))
     finally:
         await store.close()
 
@@ -438,9 +441,19 @@ async def test_real_core_lifecycle_uses_workshop_identity_without_telegram_appli
     host = KaiApplicationHost(
         config=config,
         runtime_profiles=profiles,
-        execution_state=_execution_state(PrincipalId(str(principal_id)), 101),
+        execution_state=WorkshopExecutionStateRegistry(
+            (
+                WorkshopExecutionStateNamespace(
+                    principal_id=context.principal_id,
+                    channel_id=context.channel_id,
+                    agent_id=context.agent_id,
+                    runtime_profile_id=context.runtime_profile_id,
+                    runtime_config_id=101,
+                ),
+            )
+        ),
         principal_storage=principal_storage,
-        internal_api_contexts=_internal_contexts(PrincipalId(str(principal_id)), 101),
+        internal_api_contexts=internal_contexts,
         services_info=[],
         registered_backend_ids=frozenset({"codex"}),
     )
@@ -481,6 +494,8 @@ async def test_core_activates_delivery_authority_before_recovering_expired_start
             "telegram",
             "101",
         )
+        internal_contexts = await WorkshopInternalAPIContextRegistry.from_store(store, profiles)
+        context = internal_contexts.for_runtime_profile(profile_id(101))
         accepted = await WorkshopConversationCommandService(store).accept(
             InboundMessage(
                 transport="telegram",
@@ -525,7 +540,17 @@ async def test_core_activates_delivery_authority_before_recovering_expired_start
             default_model="gpt-5.6-sol",
         ),
         runtime_profiles=profiles,
-        execution_state=_execution_state(PrincipalId(str(principal_id)), 101),
+        execution_state=WorkshopExecutionStateRegistry(
+            (
+                WorkshopExecutionStateNamespace(
+                    principal_id=context.principal_id,
+                    channel_id=context.channel_id,
+                    agent_id=context.agent_id,
+                    runtime_profile_id=context.runtime_profile_id,
+                    runtime_config_id=101,
+                ),
+            )
+        ),
         principal_storage=WorkshopPrincipalStorageRegistry(
             (
                 WorkshopPrincipalStorageNamespace(
@@ -535,7 +560,7 @@ async def test_core_activates_delivery_authority_before_recovering_expired_start
                 ),
             )
         ),
-        internal_api_contexts=_internal_contexts(PrincipalId(str(principal_id)), 101),
+        internal_api_contexts=internal_contexts,
         services_info=[],
         registered_backend_ids=frozenset({"codex"}),
     )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5109,6 +5109,10 @@ class TestCmdStatus:
             "CREATE TABLE channel_memberships (channel_id TEXT, principal_id TEXT, role TEXT);"
             "CREATE TABLE principals (id TEXT, kind TEXT);"
             "CREATE TABLE workshop_memberships (principal_id TEXT, workshop_id TEXT);"
+            "CREATE TABLE event_log (position INTEGER);"
+            "CREATE TABLE messages (id TEXT);"
+            "CREATE TABLE artifacts (id TEXT);"
+            "CREATE TABLE delivery_outbox (id TEXT);"
             "INSERT INTO channel_agent_runtime_assignments VALUES ('rtp_one','chn_one','agt_one');"
             "INSERT INTO channels VALUES ('chn_one','direct','wsp_one');"
             "INSERT INTO agents VALUES ('agt_one','wsp_one');"
@@ -5122,7 +5126,8 @@ class TestCmdStatus:
 
         assert _internal_api_authority_status(db_path) == (
             "Workshop internal API authority: active; profiles=1, "
-            "canonical contexts=1, missing=0; caller identity selectors=disabled"
+            "canonical contexts=1, missing=0; caller identity selectors=disabled, "
+            "compatibility adapter=retired, proactive publication=canonical/outbox"
         )
 
     def test_deployed_status_reports_named_secrets_without_values(self, tmp_path, monkeypatch):

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -36,6 +36,8 @@ def test_agent_credentials_are_unique_and_resolve_server_side() -> None:
     assert principal_123.channel_id == context_123.channel_id
     assert principal_123.agent_id == context_123.agent_id
     assert principal_123.runtime_profile_id == context_123.runtime_profile_id
+    assert not hasattr(principal_123, "_runtime_config_id")
+    assert not hasattr(principal_123, "compatibility_runtime_config_id")
     assert principal_456.principal_id == context_456.principal_id
     assert auth.authenticate("not-a-token") is None
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -117,7 +117,7 @@ class TestInstanceCreation:
         assert credential
         principal = pool.internal_api_auth.authenticate(credential)
         assert principal is not None
-        assert principal.compatibility_runtime_config_id() == 111
+        assert not hasattr(principal, "compatibility_runtime_config_id")
         assert principal.runtime_profile_id == profile_id(111)
 
     def test_services_are_filtered_per_user_and_bound_to_principal(self):
@@ -527,7 +527,11 @@ class TestPerUserBackendRouting:
         }
         for chat_id in users:
             (tmp_path / "home" / str(chat_id)).mkdir(parents=True)
-        config = _make_config(protected_install=True, user_configs=users)
+        config = _make_config(
+            protected_install=True,
+            allowed_user_ids=set(users),
+            user_configs=users,
+        )
         pool = SubprocessPool(
             config=config,
             services_info=[],

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -20,7 +20,6 @@ from kai.webhook import (
     GITHUB_WEBHOOK_SECRET_KEY,
     INTERNAL_API_AUTH_KEY,
     NOTIFICATION_CHAT_IDS_KEY,
-    POOL_KEY,
     TELEGRAM_APP_KEY,
     TELEGRAM_BOT_KEY,
     WORKSPACE_BASE_KEY,
@@ -339,7 +338,6 @@ def _default_github_token_lookup():
 def _build_test_app(
     cooldown: int = 300,
     config: object | None = None,
-    pool: object | None = None,
 ) -> web.Application:
     """Build a minimal aiohttp app with _handle_github wired up.
 
@@ -403,8 +401,6 @@ def _build_test_app(
         app[CONFIG_KEY] = mock_config
     else:
         app[CONFIG_KEY] = config
-    if pool is not None:
-        app[POOL_KEY] = pool
     app.router.add_post("/webhook/github", _handle_github)
     return app
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import hmac as hmac_mod
+import inspect
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -43,11 +44,11 @@ from kai.webhook import (
     _handle_service_call,
     _handle_telegram_update,
     _handle_update_job,
-    _resolve_internal_runtime_config_id,
     stop,
 )
-from kai.workshop.domain import AgentId, ChannelId, PrincipalId
+from kai.workshop.domain import AgentId, ChannelId, MessageId, PrincipalId
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
+from kai.workshop.proactive_publication import ProactivePublicationResult
 from kai.workshop.scheduler import WorkshopScheduledJobRegistrationError
 from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageNamespace,
@@ -178,7 +179,6 @@ async def _call_memory_delete_all_as_authorized(request, *, chat_id: int = 123):
         channel_id=context.channel_id,
         agent_id=context.agent_id,
         runtime_profile_id=context.runtime_profile_id,
-        _runtime_config_id=context.compatibility_runtime_config_id(),
         scopes=frozenset({InternalAPIScope.MEMORY_DELETE_ALL}),
     )
     return await _handle_memory_delete_all.__wrapped__(request, principal)
@@ -216,6 +216,10 @@ def mock_request(tmp_path):
                 scheduler=_CanonicalSchedulerDouble(),
                 runtime_pool=SimpleNamespace(
                     get_effective_workspace=AsyncMock(return_value=tmp_path),
+                ),
+                proactive_publication=SimpleNamespace(
+                    publish_text=AsyncMock(return_value=ProactivePublicationResult(MessageId.new(), True, ())),
+                    publish_file=AsyncMock(return_value=ProactivePublicationResult(MessageId.new(), True, ())),
                 ),
             )
         ),
@@ -593,10 +597,14 @@ def send_file_request(tmp_path):
     request.app = {
         INTERNAL_API_AUTH_KEY: _make_internal_api_auth(),
         GENERIC_WEBHOOK_SECRET_KEY: "signing-secret",
-        TELEGRAM_BOT_KEY: AsyncMock(),
         CHAT_ID_KEY: 123,
         CORE_HOST_KEY: SimpleNamespace(
-            services=SimpleNamespace(runtime_pool=runtime_pool),
+            services=SimpleNamespace(
+                runtime_pool=runtime_pool,
+                proactive_publication=SimpleNamespace(
+                    publish_file=AsyncMock(return_value=ProactivePublicationResult(MessageId.new(), True, ()))
+                ),
+            ),
         ),
         WORKSHOP_PRINCIPAL_STORAGE_KEY: _principal_storage_registry(),
     }
@@ -616,8 +624,8 @@ def isolated_send_file_roots(tmp_path, send_file_request, monkeypatch):
 
 
 class TestSendFile:
-    async def test_send_image_as_photo(self, tmp_path, send_file_request):
-        """Image files are sent via send_photo (rendered inline in Telegram)."""
+    async def test_records_image_as_canonical_artifact(self, tmp_path, send_file_request):
+        """Image files enter canonical publication before adapter delivery."""
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg")
 
@@ -626,12 +634,15 @@ class TestSendFile:
 
         assert resp.status == 200
         body = json.loads(resp.body)
-        assert body["status"] == "sent"
+        assert body["status"] == "recorded"
+        assert body["delivery"] == "not_configured"
         assert body["file"] == "photo.jpg"
-        send_file_request.app[TELEGRAM_BOT_KEY].send_photo.assert_called_once()
+        publish = send_file_request.app[CORE_HOST_KEY].services.proactive_publication.publish_file
+        publish.assert_awaited_once()
+        assert publish.await_args.kwargs["path"] == img
 
-    async def test_send_document(self, tmp_path, send_file_request):
-        """Non-image files are sent via send_document (as attachments)."""
+    async def test_records_document_as_canonical_artifact(self, tmp_path, send_file_request):
+        """Documents use the same canonical publication service."""
         doc = tmp_path / "report.pdf"
         doc.write_bytes(b"%PDF-1.4 fake")
 
@@ -640,14 +651,14 @@ class TestSendFile:
 
         assert resp.status == 200
         body = json.loads(resp.body)
-        assert body["status"] == "sent"
-        send_file_request.app[TELEGRAM_BOT_KEY].send_document.assert_called_once()
+        assert body["status"] == "recorded"
+        send_file_request.app[CORE_HOST_KEY].services.proactive_publication.publish_file.assert_awaited_once()
         send_file_request.app[CORE_HOST_KEY].services.runtime_pool.get_effective_workspace.assert_awaited_once_with(
             profile_id(123)
         )
 
-    async def test_caption_forwarded_to_telegram(self, tmp_path, send_file_request):
-        """Optional caption is passed through to the Telegram send call."""
+    async def test_caption_forwarded_to_canonical_publication(self, tmp_path, send_file_request):
+        """Optional caption is passed to canonical publication."""
         f = tmp_path / "pic.png"
         f.write_bytes(b"fake-png")
 
@@ -655,14 +666,32 @@ class TestSendFile:
         resp = await _handle_send_file(send_file_request)
 
         assert resp.status == 200
-        call_kwargs = send_file_request.app[TELEGRAM_BOT_KEY].send_photo.call_args
-        assert call_kwargs[1].get("caption") == "Here you go"
+        publish = send_file_request.app[CORE_HOST_KEY].services.proactive_publication.publish_file
+        assert publish.await_args.kwargs["caption"] == "Here you go"
+
+    async def test_idempotency_key_is_forwarded_to_file_publication(self, tmp_path, send_file_request):
+        f = tmp_path / "report.txt"
+        f.write_text("report")
+        send_file_request.json = AsyncMock(return_value={"path": str(f), "idempotency_key": "caller-file-1"})
+
+        assert (await _handle_send_file(send_file_request)).status == 200
+
+        publish = send_file_request.app[CORE_HOST_KEY].services.proactive_publication.publish_file
+        assert publish.await_args.kwargs["request_id"] == "caller-file-1"
 
     async def test_missing_path_returns_400(self, send_file_request):
         """Returns 400 when the required path field is absent."""
         send_file_request.json = AsyncMock(return_value={})
         resp = await _handle_send_file(send_file_request)
         assert resp.status == 400
+
+    async def test_non_string_path_returns_400(self, send_file_request):
+        send_file_request.json = AsyncMock(return_value={"path": 42})
+
+        resp = await _handle_send_file(send_file_request)
+
+        assert resp.status == 400
+        assert "path must be a string" in resp.text
 
     async def test_file_not_found_returns_404(self, tmp_path, send_file_request):
         """Returns 404 when the file doesn't exist on disk."""
@@ -688,7 +717,7 @@ class TestSendFile:
         resp = await _handle_send_file(request)
 
         assert resp.status == 200
-        request.app[TELEGRAM_BOT_KEY].send_document.assert_awaited_once()
+        request.app[CORE_HOST_KEY].services.proactive_publication.publish_file.assert_awaited_once()
 
     async def test_file_scope_follows_authenticated_credential(self, isolated_send_file_roots):
         """A second credential receives its own scope, independent of app defaults."""
@@ -703,8 +732,8 @@ class TestSendFile:
         resp = await _handle_send_file(request)
 
         assert resp.status == 200
-        request.app[TELEGRAM_BOT_KEY].send_document.assert_awaited_once()
-        assert request.app[TELEGRAM_BOT_KEY].send_document.await_args.args[0] == 456
+        publish = request.app[CORE_HOST_KEY].services.proactive_publication.publish_file
+        assert publish.await_args.args[0].principal_id == _internal_api_context(456).principal_id
 
     async def test_authenticated_principal_cannot_send_sibling_uploaded_file(self, isolated_send_file_roots):
         """A FILES_SEND credential cannot select another principal's upload."""
@@ -718,7 +747,7 @@ class TestSendFile:
         resp = await _handle_send_file(request)
 
         assert resp.status == 403
-        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
+        request.app[CORE_HOST_KEY].services.proactive_publication.publish_file.assert_not_awaited()
 
     async def test_runtime_profile_storage_must_belong_to_authenticated_principal(
         self,
@@ -744,7 +773,7 @@ class TestSendFile:
         resp = await _handle_send_file(request)
 
         assert resp.status == 403
-        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
+        request.app[CORE_HOST_KEY].services.proactive_publication.publish_file.assert_not_awaited()
 
     async def test_authenticated_principal_cannot_send_legacy_shared_file(self, isolated_send_file_roots):
         """Ambiguous files in the legacy shared root are not exposed by the API."""
@@ -757,7 +786,7 @@ class TestSendFile:
         resp = await _handle_send_file(request)
 
         assert resp.status == 403
-        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
+        request.app[CORE_HOST_KEY].services.proactive_publication.publish_file.assert_not_awaited()
 
     async def test_symlink_cannot_escape_principal_upload_directory(self, isolated_send_file_roots):
         """Resolving a symlink into a sibling principal's directory is denied."""
@@ -774,7 +803,7 @@ class TestSendFile:
         resp = await _handle_send_file(request)
 
         assert resp.status == 403
-        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
+        request.app[CORE_HOST_KEY].services.proactive_publication.publish_file.assert_not_awaited()
 
     async def test_authenticated_principal_cannot_send_from_numeric_archive(
         self,
@@ -790,7 +819,7 @@ class TestSendFile:
         resp = await _handle_send_file(request)
 
         assert resp.status == 403
-        request.app[TELEGRAM_BOT_KEY].send_document.assert_not_awaited()
+        request.app[CORE_HOST_KEY].services.proactive_publication.publish_file.assert_not_awaited()
 
     async def test_invalid_json_returns_400(self, send_file_request):
         """Returns 400 for malformed JSON body."""
@@ -816,34 +845,50 @@ def send_message_request():
     request.app = {
         INTERNAL_API_AUTH_KEY: _make_internal_api_auth(),
         GENERIC_WEBHOOK_SECRET_KEY: "signing-secret",
-        TELEGRAM_BOT_KEY: AsyncMock(),
         CHAT_ID_KEY: 123,
+        CORE_HOST_KEY: SimpleNamespace(
+            services=SimpleNamespace(
+                proactive_publication=SimpleNamespace(
+                    publish_text=AsyncMock(return_value=ProactivePublicationResult(MessageId.new(), True, ()))
+                )
+            )
+        ),
     }
     request.headers = {"X-Webhook-Secret": "test-secret"}
     return request
 
 
 class TestSendMessage:
-    async def test_sends_short_message(self, send_message_request):
-        """Short messages are sent as a single Telegram message."""
+    async def test_records_short_message(self, send_message_request):
+        """Short messages are recorded through canonical publication."""
         send_message_request.json = AsyncMock(return_value={"text": "Hello!"})
         resp = await _handle_send_message(send_message_request)
 
         assert resp.status == 200
         body = json.loads(resp.body)
-        assert body["status"] == "sent"
-        send_message_request.app[TELEGRAM_BOT_KEY].send_message.assert_called_once_with(123, "Hello!")
+        assert body == {"status": "recorded", "delivery": "not_configured", "deliveries": 0}
+        publish = send_message_request.app[CORE_HOST_KEY].services.proactive_publication.publish_text
+        publish.assert_awaited_once()
+        assert publish.await_args.kwargs["body"] == "Hello!"
 
-    async def test_splits_long_message(self, send_message_request):
-        """Messages exceeding 4096 chars are split into multiple sends."""
-        # Create a message with two paragraphs, each over 2048 chars
+    async def test_records_long_message_once(self, send_message_request):
+        """Transport chunking occurs in adapters, after one canonical record."""
         long_text = ("A" * 2100) + "\n\n" + ("B" * 2100)
         send_message_request.json = AsyncMock(return_value={"text": long_text})
         resp = await _handle_send_message(send_message_request)
 
         assert resp.status == 200
-        bot = send_message_request.app[TELEGRAM_BOT_KEY]
-        assert bot.send_message.call_count == 2
+        publish = send_message_request.app[CORE_HOST_KEY].services.proactive_publication.publish_text
+        publish.assert_awaited_once()
+        assert publish.await_args.kwargs["body"] == long_text
+
+    async def test_idempotency_key_is_forwarded_to_text_publication(self, send_message_request):
+        send_message_request.json = AsyncMock(return_value={"text": "Hello", "idempotency_key": "caller-text-1"})
+
+        assert (await _handle_send_message(send_message_request)).status == 200
+
+        publish = send_message_request.app[CORE_HOST_KEY].services.proactive_publication.publish_text
+        assert publish.await_args.kwargs["request_id"] == "caller-text-1"
 
     async def test_missing_text_returns_400(self, send_message_request):
         """Returns 400 when the required text field is absent."""
@@ -856,6 +901,14 @@ class TestSendMessage:
         send_message_request.json = AsyncMock(return_value={"text": "   "})
         resp = await _handle_send_message(send_message_request)
         assert resp.status == 400
+
+    async def test_non_string_text_returns_400(self, send_message_request):
+        send_message_request.json = AsyncMock(return_value={"text": ["not", "text"]})
+
+        resp = await _handle_send_message(send_message_request)
+
+        assert resp.status == 400
+        assert "text must be a string" in resp.text
 
     async def test_invalid_json_returns_400(self, send_message_request):
         """Returns 400 for malformed JSON body."""
@@ -870,10 +923,12 @@ class TestSendMessage:
         resp = await _handle_send_message(send_message_request)
         assert resp.status == 401
 
-    async def test_telegram_error_returns_500(self, send_message_request):
-        """Returns 500 when the Telegram send fails."""
+    async def test_publication_error_returns_500(self, send_message_request):
+        """Returns 500 when canonical publication fails."""
         send_message_request.json = AsyncMock(return_value={"text": "Hello"})
-        send_message_request.app[TELEGRAM_BOT_KEY].send_message = AsyncMock(side_effect=RuntimeError("Boom"))
+        send_message_request.app[CORE_HOST_KEY].services.proactive_publication.publish_text.side_effect = RuntimeError(
+            "Boom"
+        )
         resp = await _handle_send_message(send_message_request)
         assert resp.status == 500
 
@@ -2023,40 +2078,20 @@ class TestServiceCall:
         mock_call.assert_not_called()
 
 
-# ── _resolve_internal_runtime_config_id ────────────────────────────────────────────────
-
-
-class TestResolveInternalRuntimeConfigId:
-    def _principal(self, chat_id: int = 123) -> InternalAPIPrincipal:
-        """Resolve a deterministic test principal from its credential."""
-        auth = _make_internal_api_auth()
-        credential = "test-secret" if chat_id == 123 else "other-secret"
-        principal = auth.authenticate(credential)
-        assert principal is not None
-        return principal
-
-    @pytest.mark.parametrize(
-        "selector",
-        [
-            "chat_id",
-            "user_id",
-            "principal_id",
-            "channel_id",
-            "agent_id",
-            "runtime_profile_id",
-            "runtime_config_id",
-        ],
-    )
-    def test_any_explicit_identity_selector_is_rejected(self, selector):
-        """Request data can never repeat or select execution identity."""
-        principal = self._principal()
-        with pytest.raises(ValueError, match=f"Identity selector {selector} is not accepted"):
-            _resolve_internal_runtime_config_id(principal, {selector: "anything"})
-
-    def test_omitted_chat_id_uses_principal(self):
-        """Omitted chat_id resolves to the authenticated principal."""
-        principal = self._principal()
-        assert _resolve_internal_runtime_config_id(principal, {}) == 123
+class TestInternalPublicationRetirementGuard:
+    def test_handlers_have_no_compatibility_identity_or_direct_telegram_send(self):
+        """Protected publication cannot regress to direct transport effects."""
+        source = "\n".join(
+            (
+                inspect.getsource(webhook_mod._handle_send_message),
+                inspect.getsource(webhook_mod._handle_send_file),
+            )
+        )
+        assert "compatibility_runtime_config_id" not in source
+        assert "TELEGRAM_BOT_KEY" not in source
+        assert ".send_message(" not in source
+        assert ".send_photo(" not in source
+        assert ".send_document(" not in source
 
 
 class TestGetJobsCredentialRouting:
@@ -2129,7 +2164,7 @@ class TestChatIdAuthorization:
         resp = await _handle_send_message(mock_request)
 
         assert resp.status == 401
-        mock_request.app[TELEGRAM_BOT_KEY].send_message.assert_not_called()
+        mock_request.app[CORE_HOST_KEY].services.proactive_publication.publish_text.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_notification_credential_cannot_manage_jobs(self, mock_request):
@@ -2203,21 +2238,6 @@ class TestChatIdAuthorization:
 
         resp = await _handle_send_file(mock_request)
         assert resp.status == 400
-
-    def test_resolve_internal_runtime_config_id_rejects_selector(self):
-        """The server-private resolver rejects request identity fields."""
-        principal = _make_internal_api_auth().authenticate("test-secret")
-        assert principal is not None
-
-        with pytest.raises(ValueError, match="Identity selector chat_id is not accepted"):
-            _resolve_internal_runtime_config_id(principal, {"chat_id": 999999})
-
-    def test_resolve_internal_runtime_config_id_rejects_matching_selector(self):
-        """Even a matching repeated identity is rejected."""
-        principal = _make_internal_api_auth().authenticate("test-secret")
-        assert principal is not None
-        with pytest.raises(ValueError, match="Identity selector chat_id is not accepted"):
-            _resolve_internal_runtime_config_id(principal, {"chat_id": 123})
 
 
 # ── Job ownership ──────────────────────────────────────────────────

--- a/tests/test_webhook_routes.py
+++ b/tests/test_webhook_routes.py
@@ -92,8 +92,8 @@ def test_workshop_only_keeps_integrations_but_omits_telegram_routes() -> None:
     assert ("POST", "/api/schedule") in routes
     assert ("DELETE", "/api/jobs/{id}") in routes
     assert ("PATCH", "/api/jobs/{id}") in routes
-    assert ("POST", "/api/send-message") not in routes
-    assert ("POST", "/api/send-file") not in routes
+    assert ("POST", "/api/send-message") in routes
+    assert ("POST", "/api/send-file") in routes
 
 
 async def test_health_reports_non_sensitive_memory_mode(monkeypatch) -> None:

--- a/tests/test_workshop_internal_api_contexts.py
+++ b/tests/test_workshop_internal_api_contexts.py
@@ -39,7 +39,7 @@ async def test_resolves_complete_canonical_context_for_every_profile(tmp_path: P
         assert context.channel_id.startswith("chn_")
         assert context.agent_id.startswith("agt_")
         assert context.runtime_profile_id == profile_id(101)
-        assert context.compatibility_runtime_config_id() == 101
+        assert not hasattr(context, "compatibility_runtime_config_id")
         assert registry.for_runtime_profile(profile_id(101)) is context
     finally:
         await store.close()

--- a/tests/test_workshop_proactive_publication.py
+++ b/tests/test_workshop_proactive_publication.py
@@ -1,0 +1,212 @@
+"""Canonical authority and idempotency for protected proactive publication."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.artifacts import WorkshopArtifactService, artifact_for_delivery
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.domain import AgentId
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
+from kai.workshop.proactive_publication import (
+    PROACTIVE_ARTIFACT_MODE,
+    ProactivePublicationAuthority,
+    ProactivePublicationError,
+    WorkshopProactivePublicationService,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
+from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
+
+_NOW = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
+
+
+async def _publication_service(
+    tmp_path: Path,
+    *,
+    delivery_transports: frozenset[str] = frozenset({"telegram"}),
+):
+    store = await WorkshopEventStore.open(tmp_path / "kai.db")
+    profiles = profile_registry(101)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                "Daniel",
+                "admin",
+                "telegram",
+                "101",
+                "101",
+                profile_id(101),
+            ),
+        ),
+    )
+    contexts = await WorkshopInternalAPIContextRegistry.from_store(store, profiles)
+    context = contexts.for_runtime_profile(profile_id(101))
+    storage = await WorkshopPrincipalStorageRegistry.from_store(store, profiles)
+    artifacts = WorkshopArtifactService(
+        store,
+        data_dir=tmp_path,
+        principal_storage=storage,
+        runtime_profiles=profiles,
+    )
+    service = WorkshopProactivePublicationService(
+        store,
+        artifacts,
+        artifact_storage_root=tmp_path / "files",
+        delivery_transports=delivery_transports,
+    )
+    authority = ProactivePublicationAuthority(
+        context.principal_id,
+        context.channel_id,
+        context.agent_id,
+        context.runtime_profile_id,
+    )
+    return store, service, authority
+
+
+async def test_workshop_only_text_is_canonical_without_adapter_delivery(tmp_path: Path):
+    store, service, authority = await _publication_service(
+        tmp_path,
+        delivery_transports=frozenset(),
+    )
+    try:
+        result = await service.publish_text(
+            authority,
+            request_id="workshop-only-text",
+            body="Canonical without Telegram",
+            occurred_at=_NOW,
+        )
+
+        assert result.inserted is True
+        assert result.deliveries == ()
+        assert result.delivery_status == "not_configured"
+        async with store.connection.execute(
+            "SELECT m.body, p.kind, e.metadata_json FROM messages m "
+            "JOIN principals p ON p.id = m.author_principal_id "
+            "JOIN event_log e ON e.position = m.created_event_position WHERE m.id = ?",
+            (result.message_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        assert row[0:2] == ("Canonical without Telegram", "agent")
+        assert json.loads(str(row[2])) == {
+            "publication_kind": "text",
+            "request_id": "workshop-only-text",
+            "runtime_profile_id": authority.runtime_profile_id,
+            "source": "internal_api",
+        }
+    finally:
+        await store.close()
+
+
+async def test_hybrid_text_records_once_and_requests_bound_delivery(tmp_path: Path):
+    store, service, authority = await _publication_service(tmp_path)
+    try:
+        first = await service.publish_text(
+            authority,
+            request_id="hybrid-text",
+            body="Canonical then adapter",
+            occurred_at=_NOW,
+        )
+        replay = await service.publish_text(
+            authority,
+            request_id="hybrid-text",
+            body="Canonical then adapter",
+            occurred_at=_NOW,
+        )
+
+        assert first.inserted is True
+        assert replay.inserted is False
+        assert replay.message_id == first.message_id
+        assert len(first.deliveries) == len(replay.deliveries) == 1
+        assert first.deliveries[0].inserted is True
+        assert replay.deliveries[0].inserted is False
+        assert first.delivery_status == "queued"
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM messages WHERE id = ?",
+            (first.message_id,),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] == 1
+        async with store.connection.execute("SELECT transport, mode, purpose, status FROM delivery_outbox") as cursor:
+            assert tuple(await cursor.fetchone()) == ("telegram", "text", "notification", "pending")
+
+        with pytest.raises(IdempotencyConflictError):
+            await service.publish_text(
+                authority,
+                request_id="hybrid-text",
+                body="Conflicting retry",
+                occurred_at=_NOW,
+            )
+    finally:
+        await store.close()
+
+
+async def test_file_is_one_agent_artifact_and_one_durable_adapter_request(tmp_path: Path):
+    store, service, authority = await _publication_service(tmp_path)
+    source = tmp_path / "report.txt"
+    source.write_text("publication artifact", encoding="utf-8")
+    try:
+        first = await service.publish_file(
+            authority,
+            request_id="hybrid-file",
+            path=source.resolve(),
+            caption="Qualification report",
+            occurred_at=_NOW,
+        )
+        replay = await service.publish_file(
+            authority,
+            request_id="hybrid-file",
+            path=source.resolve(),
+            caption="Qualification report",
+            occurred_at=_NOW,
+        )
+
+        assert first.inserted is True
+        assert replay.inserted is False
+        assert first.message_id == replay.message_id
+        assert len(first.deliveries) == 1
+        assert first.deliveries[0].delivery.mode == PROACTIVE_ARTIFACT_MODE
+        await store.rebuild_projection(CanonicalConversationProjection())
+        async with store.connection.execute(
+            "SELECT m.body, p.kind, COUNT(a.id) FROM messages m "
+            "JOIN principals p ON p.id = m.author_principal_id "
+            "LEFT JOIN artifacts a ON a.message_id = m.id WHERE m.id = ? GROUP BY m.id",
+            (first.message_id,),
+        ) as cursor:
+            assert tuple(await cursor.fetchone()) == ("Qualification report", "agent", 1)
+        artifact, caption = await artifact_for_delivery(
+            store,
+            first.message_id,
+            storage_root=tmp_path / "files",
+        )
+        assert artifact.storage_path.read_text(encoding="utf-8") == "publication artifact"
+        assert artifact.summary.original_filename == "report.txt"
+        assert caption == "Qualification report"
+    finally:
+        await store.close()
+
+
+async def test_invalid_canonical_lane_fails_before_any_publication(tmp_path: Path):
+    store, service, authority = await _publication_service(tmp_path)
+    invalid = replace(authority, agent_id=AgentId("agt_" + "f" * 32))
+    try:
+        with pytest.raises(ProactivePublicationError, match="missing or ambiguous"):
+            await service.publish_text(
+                invalid,
+                request_id="forbidden",
+                body="Do not record",
+                occurred_at=_NOW,
+            )
+        async with store.connection.execute("SELECT COUNT(*) FROM messages") as cursor:
+            assert (await cursor.fetchone())[0] == 0
+        async with store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
+            assert (await cursor.fetchone())[0] == 0
+    finally:
+        await store.close()

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -227,7 +227,7 @@ def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, mon
 
     assert instance.backend_name == "codex"
     assert principal is not None
-    assert principal.compatibility_runtime_config_id() == runtime_config_id
+    assert not hasattr(principal, "compatibility_runtime_config_id")
     assert principal.allowed_services == frozenset({"perplexity"})
     assert instance._api_context.services_info == services_info
     assert instance.workspace == tmp_path / "home" / str(runtime_config_id)
@@ -474,7 +474,7 @@ def test_negative_group_key_retains_legacy_compatibility_runtime(tmp_path, monke
     assert instance.backend_name == "codex"
     principal = pool.internal_api_auth.authenticate(instance._api_context.webhook_secret)
     assert principal is not None
-    assert principal.compatibility_runtime_config_id() == -100999
+    assert not hasattr(principal, "compatibility_runtime_config_id")
     assert principal.allowed_services == frozenset()
 
 

--- a/tests/test_workshop_telegram_delivery.py
+++ b/tests/test_workshop_telegram_delivery.py
@@ -12,6 +12,7 @@ import pytest
 from telegram.constants import ParseMode
 from telegram.error import BadRequest, Forbidden, InvalidToken, NetworkError, RetryAfter, TelegramError, TimedOut
 
+from kai.workshop.artifacts import WorkshopArtifactService
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.delivery_fragments import (
     DeliveryFragment,
@@ -37,17 +38,26 @@ from kai.workshop.domain import (
     WorkshopId,
 )
 from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.outbound import OutboundMessage, record_outbound_message
+from kai.workshop.proactive_publication import (
+    ProactivePublicationAuthority,
+    WorkshopProactivePublicationService,
+)
 from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery import (
     WORKSHOP_CLIENT_TEXT_MODE,
     TelegramDeliveryContractError,
     TelegramDeliveryFailure,
     TelegramWorkOutcome,
+    WorkshopTelegramArtifactDeliveryAdapter,
+    WorkshopTelegramArtifactDeliveryWorker,
     WorkshopTelegramDeliveryAdapter,
     WorkshopTelegramDeliveryWorker,
 )
+from tests.workshop_profiles import profile_id, profile_registry
 
 _NOW = datetime(2026, 8, 12, 9, 32, tzinfo=UTC)
 
@@ -229,6 +239,61 @@ async def _add_group_binding(
     return binding_id
 
 
+async def _open_with_proactive_artifact(
+    tmp_path: Path,
+    *,
+    filename: str,
+    content: bytes,
+    caption: str,
+):
+    store = await WorkshopEventStore.open(tmp_path / "kai.db")
+    profiles = profile_registry(101)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                "Authorized Human",
+                "admin",
+                "telegram",
+                "101",
+                "101",
+                profile_id(101),
+            ),
+        ),
+    )
+    context = (await WorkshopInternalAPIContextRegistry.from_store(store, profiles)).for_runtime_profile(
+        profile_id(101)
+    )
+    storage = await WorkshopPrincipalStorageRegistry.from_store(store, profiles)
+    service = WorkshopProactivePublicationService(
+        store,
+        WorkshopArtifactService(
+            store,
+            data_dir=tmp_path,
+            principal_storage=storage,
+            runtime_profiles=profiles,
+        ),
+        artifact_storage_root=tmp_path / "files",
+        delivery_transports=frozenset({"telegram"}),
+    )
+    source = tmp_path / filename
+    source.write_bytes(content)
+    publication = await service.publish_file(
+        ProactivePublicationAuthority(
+            context.principal_id,
+            context.channel_id,
+            context.agent_id,
+            context.runtime_profile_id,
+        ),
+        request_id=f"artifact-{filename}",
+        path=source.resolve(),
+        caption=caption,
+        occurred_at=_NOW,
+    )
+    assert len(publication.deliveries) == 1
+    return store, publication.deliveries[0].delivery.delivery_id
+
+
 class TestWorkshopTelegramDeliveryAdapter:
     @pytest.mark.parametrize(
         ("external_channel_id", "expected_target"),
@@ -280,6 +345,107 @@ class TestWorkshopTelegramDeliveryAdapter:
 
         bot.send_message.assert_not_awaited()
 
+
+class TestWorkshopTelegramArtifactDelivery:
+    async def test_document_worker_delivers_canonical_artifact_and_settles_outbox(
+        self,
+        tmp_path: Path,
+    ):
+        store, delivery_id = await _open_with_proactive_artifact(
+            tmp_path,
+            filename="report.txt",
+            content=b"canonical report",
+            caption="Read this report",
+        )
+        bot = AsyncMock()
+        bot.send_document.return_value = SimpleNamespace(message_id=7001)
+        worker = WorkshopTelegramArtifactDeliveryWorker(
+            WorkshopDeliveryOutbox(store),
+            WorkshopTelegramArtifactDeliveryAdapter(
+                store,
+                bot,
+                storage_root=tmp_path / "files",
+            ),
+            worker_id="telegram-artifact-worker",
+        )
+        try:
+            result = await worker.run_once()
+
+            assert result.outcome == TelegramWorkOutcome.SUCCEEDED
+            assert result.delivery_id == delivery_id
+            assert (await WorkshopDeliveryOutbox(store).state(delivery_id)).status == "succeeded"
+            assert bot.send_document.await_args.kwargs["chat_id"] == 101
+            assert bot.send_document.await_args.kwargs["caption"] == "Read this report"
+            assert bot.send_document.await_args.kwargs["filename"] == "report.txt"
+            bot.send_photo.assert_not_awaited()
+        finally:
+            await store.close()
+
+    async def test_photo_adapter_uses_photo_delivery(self, tmp_path: Path):
+        store, _ = await _open_with_proactive_artifact(
+            tmp_path,
+            filename="image.png",
+            content=b"not decoded by the transport",
+            caption="Image caption",
+        )
+        outbox = WorkshopDeliveryOutbox(store)
+        claim = await outbox.claim_next(
+            "photo-worker",
+            purposes=("notification",),
+            execution_contracts=(SEND_FRAGMENTS_CONTRACT,),
+            transport="telegram",
+            modes=("artifact",),
+        )
+        assert claim is not None
+        bot = AsyncMock()
+        bot.send_photo.return_value = SimpleNamespace(message_id=7002)
+        try:
+            assert (
+                await WorkshopTelegramArtifactDeliveryAdapter(
+                    store,
+                    bot,
+                    storage_root=tmp_path / "files",
+                ).deliver(claim)
+                == 7002
+            )
+            assert bot.send_photo.await_args.kwargs["chat_id"] == 101
+            assert bot.send_photo.await_args.kwargs["caption"] == "Image caption"
+            bot.send_document.assert_not_awaited()
+        finally:
+            await store.close()
+
+    async def test_ambiguous_artifact_timeout_is_not_automatically_resent(self, tmp_path: Path):
+        store, delivery_id = await _open_with_proactive_artifact(
+            tmp_path,
+            filename="report.txt",
+            content=b"canonical report",
+            caption="Read this report",
+        )
+        bot = AsyncMock()
+        bot.send_document.side_effect = TimedOut()
+        worker = WorkshopTelegramArtifactDeliveryWorker(
+            WorkshopDeliveryOutbox(store),
+            WorkshopTelegramArtifactDeliveryAdapter(
+                store,
+                bot,
+                storage_root=tmp_path / "files",
+            ),
+            worker_id="telegram-artifact-worker",
+        )
+        try:
+            result = await worker.run_once()
+
+            assert result.outcome == TelegramWorkOutcome.FAILED
+            assert result.error_code == "telegram_timeout_uncertain"
+            state = await WorkshopDeliveryOutbox(store).state(delivery_id)
+            assert state.status == "failed"
+            assert await worker.run_once() == type(result)(outcome=TelegramWorkOutcome.IDLE)
+            assert bot.send_document.await_count == 1
+        finally:
+            await store.close()
+
+
+class TestWorkshopTelegramDeliveryAdapterContinued:
     async def test_markdown_rejection_retries_once_as_plain_text(self):
         bot = AsyncMock()
         bot.send_message.side_effect = [BadRequest("can't parse entities"), SimpleNamespace(message_id=1002)]


### PR DESCRIPTION
## Summary

- record protected proactive text and file publication in the canonical Workshop timeline before any client delivery
- deliver configured Telegram text and artifacts from the durable outbox, while leaving Workshop-only installations free of undeliverable adapter work
- retire the protected API's compatibility runtime identity accessor and report canonical publication authority in installation status
- preserve safe retries with bounded idempotency keys and atomic canonical message, artifact, and delivery creation

## Validation

- `make check`
- `make test` — 6,107 passed
- focused publication, delivery, webhook, host, and installer tests — 947 passed

Part of #1097.
