### PR TITLE
Retire compatibility execution state

### DIFF
--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -551,6 +551,14 @@ async def record_workshop_delivery_observation(observation: DeliveryObservation)
 
 async def get_session(chat_id: int) -> str | None:
     """Get the current agent session ID for a chat, or None if no session exists."""
+    namespace = _execution_state_namespace(chat_id)
+    if namespace is not None:
+        async with _get_db().execute(
+            "SELECT provider_session_id FROM channel_agent_runtime_sessions WHERE channel_id = ? AND agent_id = ?",
+            (namespace.channel_id, namespace.agent_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return str(row[0]) if row is not None and row[0] is not None else None
     async with _get_db().execute("SELECT session_id FROM sessions WHERE chat_id = ?", (chat_id,)) as cursor:
         row = await cursor.fetchone()
         return row["session_id"] if row else None
@@ -568,6 +576,11 @@ async def save_session(chat_id: int, session_id: str, model: str) -> None:
         session_id: Agent session identifier reported by the backend.
         model: Model name used for this session (e.g., "sonnet").
     """
+    # Protected runtimes settle provider continuity atomically with their
+    # canonical terminal run.  A later compatibility write must not recreate
+    # the retired integer-keyed session row.
+    if _execution_state_namespace(chat_id) is not None:
+        return
     await _get_db().execute(
         """
         INSERT INTO sessions (chat_id, session_id, model)
@@ -584,12 +597,29 @@ async def save_session(chat_id: int, session_id: str, model: str) -> None:
 
 async def clear_session(chat_id: int) -> None:
     """Delete the session record for a chat. Used by /new and workspace switching."""
+    namespace = _execution_state_namespace(chat_id)
+    if namespace is not None:
+        await _get_db().execute(
+            "DELETE FROM channel_agent_runtime_sessions WHERE channel_id = ? AND agent_id = ?",
+            (namespace.channel_id, namespace.agent_id),
+        )
+        await _get_db().commit()
+        return
     await _get_db().execute("DELETE FROM sessions WHERE chat_id = ?", (chat_id,))
     await _get_db().commit()
 
 
 async def get_stats(chat_id: int) -> dict | None:
     """Get session statistics for the /stats command. Returns None if no session exists."""
+    namespace = _execution_state_namespace(chat_id)
+    if namespace is not None:
+        async with _get_db().execute(
+            "SELECT provider_session_id AS session_id, model, created_at, updated_at AS last_used_at "
+            "FROM channel_agent_runtime_sessions WHERE channel_id = ? AND agent_id = ?",
+            (namespace.channel_id, namespace.agent_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return dict(row) if row is not None else None
     async with _get_db().execute(
         "SELECT session_id, model, created_at, last_used_at FROM sessions WHERE chat_id = ?",
         (chat_id,),
@@ -1173,6 +1203,69 @@ async def delete_settings_by_prefix(prefix: str) -> None:
 # while User B uses sonnet on the same repo.
 
 
+async def get_canonical_workspace_config_settings(
+    namespace: WorkshopExecutionStateNamespace,
+    workspace_path: str,
+) -> dict[str, str]:
+    async with _get_db().execute(
+        "SELECT field, value FROM channel_agent_workspace_settings "
+        "WHERE channel_id = ? AND agent_id = ? AND workspace_path = ? ORDER BY field",
+        (namespace.channel_id, namespace.agent_id, workspace_path),
+    ) as cursor:
+        rows = await cursor.fetchall()
+    return {str(row["field"]): str(row["value"]) for row in rows}
+
+
+async def set_canonical_workspace_config_setting(
+    namespace: WorkshopExecutionStateNamespace,
+    workspace_path: str,
+    field: str,
+    value: str,
+) -> None:
+    if field not in {"model", "timeout", "env", "prompt"}:
+        raise ValueError(f"Unsupported workspace setting field: {field}")
+    await _get_db().execute(
+        "INSERT INTO channel_agent_workspace_settings "
+        "(channel_id, agent_id, runtime_profile_id, workspace_path, field, value) "
+        "VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(channel_id, agent_id, workspace_path, field) "
+        "DO UPDATE SET runtime_profile_id = excluded.runtime_profile_id, "
+        "value = excluded.value, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+        (
+            namespace.channel_id,
+            namespace.agent_id,
+            namespace.runtime_profile_id,
+            workspace_path,
+            field,
+            value,
+        ),
+    )
+    await _get_db().commit()
+
+
+async def delete_canonical_workspace_config_setting(
+    namespace: WorkshopExecutionStateNamespace,
+    workspace_path: str,
+    field: str,
+) -> None:
+    await _get_db().execute(
+        "DELETE FROM channel_agent_workspace_settings "
+        "WHERE channel_id = ? AND agent_id = ? AND workspace_path = ? AND field = ?",
+        (namespace.channel_id, namespace.agent_id, workspace_path, field),
+    )
+    await _get_db().commit()
+
+
+async def delete_all_canonical_workspace_config(
+    namespace: WorkshopExecutionStateNamespace,
+    workspace_path: str,
+) -> None:
+    await _get_db().execute(
+        "DELETE FROM channel_agent_workspace_settings WHERE channel_id = ? AND agent_id = ? AND workspace_path = ?",
+        (namespace.channel_id, namespace.agent_id, workspace_path),
+    )
+    await _get_db().commit()
+
+
 async def get_workspace_config_settings(chat_id: int, workspace_path: str) -> dict[str, str]:
     """
     Get all config overrides for a user's workspace.
@@ -1183,13 +1276,7 @@ async def get_workspace_config_settings(chat_id: int, workspace_path: str) -> di
     """
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        async with _get_db().execute(
-            "SELECT field, value FROM channel_agent_workspace_settings "
-            "WHERE channel_id = ? AND agent_id = ? AND workspace_path = ? ORDER BY field",
-            (namespace.channel_id, namespace.agent_id, workspace_path),
-        ) as cursor:
-            rows = await cursor.fetchall()
-            return {str(row["field"]): str(row["value"]) for row in rows}
+        return await get_canonical_workspace_config_settings(namespace, workspace_path)
 
     # Use SUBSTR for exact prefix matching instead of LIKE, which
     # treats underscores in filesystem paths as single-char wildcards.
@@ -1210,21 +1297,8 @@ async def set_workspace_config_setting(chat_id: int, workspace_path: str, field:
     key = f"ws_config:{chat_id}:{workspace_path}:{field}"
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        await _get_db().execute(
-            "INSERT INTO channel_agent_workspace_settings "
-            "(channel_id, agent_id, runtime_profile_id, workspace_path, field, value) "
-            "VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(channel_id, agent_id, workspace_path, field) "
-            "DO UPDATE SET runtime_profile_id = excluded.runtime_profile_id, "
-            "value = excluded.value, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
-            (
-                namespace.channel_id,
-                namespace.agent_id,
-                namespace.runtime_profile_id,
-                workspace_path,
-                field,
-                value,
-            ),
-        )
+        await set_canonical_workspace_config_setting(namespace, workspace_path, field, value)
+        return
     await _get_db().execute(
         "INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
         (key, value),
@@ -1237,11 +1311,8 @@ async def delete_workspace_config_setting(chat_id: int, workspace_path: str, fie
     key = f"ws_config:{chat_id}:{workspace_path}:{field}"
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        await _get_db().execute(
-            "DELETE FROM channel_agent_workspace_settings "
-            "WHERE channel_id = ? AND agent_id = ? AND workspace_path = ? AND field = ?",
-            (namespace.channel_id, namespace.agent_id, workspace_path, field),
-        )
+        await delete_canonical_workspace_config_setting(namespace, workspace_path, field)
+        return
     await _get_db().execute("DELETE FROM settings WHERE key = ?", (key,))
     await _get_db().commit()
 
@@ -1250,10 +1321,8 @@ async def delete_all_workspace_config(chat_id: int, workspace_path: str) -> None
     """Remove all config overrides for this user's workspace."""
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        await _get_db().execute(
-            "DELETE FROM channel_agent_workspace_settings WHERE channel_id = ? AND agent_id = ? AND workspace_path = ?",
-            (namespace.channel_id, namespace.agent_id, workspace_path),
-        )
+        await delete_all_canonical_workspace_config(namespace, workspace_path)
+        return
     keys = tuple(f"ws_config:{chat_id}:{workspace_path}:{field}" for field in ("model", "timeout", "env", "prompt"))
     await _get_db().execute(
         "DELETE FROM settings WHERE key IN (?, ?, ?, ?)",
@@ -1285,9 +1354,41 @@ async def build_workspace_config(
     The WorkspaceConfig import is deferred to avoid a circular dependency
     (config.py does not import sessions.py; this direction is safe).
     """
-    from kai.config import WorkspaceConfig
-
     db_settings = await get_workspace_config_settings(chat_id, str(workspace_path))
+    return _build_workspace_config_from_settings(
+        yaml_config,
+        workspace_path,
+        db_settings,
+        owner_label=f"compatibility owner {chat_id}",
+    )
+
+
+async def build_canonical_workspace_config(
+    yaml_config: WorkspaceConfig | None,
+    workspace_path: Path,
+    namespace: WorkshopExecutionStateNamespace,
+) -> WorkspaceConfig | None:
+    """Layer canonical workspace overrides on top of operator policy."""
+    db_settings = await get_canonical_workspace_config_settings(
+        namespace,
+        str(workspace_path),
+    )
+    return _build_workspace_config_from_settings(
+        yaml_config,
+        workspace_path,
+        db_settings,
+        owner_label=f"runtime profile {namespace.runtime_profile_id}",
+    )
+
+
+def _build_workspace_config_from_settings(
+    yaml_config: WorkspaceConfig | None,
+    workspace_path: Path,
+    db_settings: dict[str, str],
+    *,
+    owner_label: str,
+) -> WorkspaceConfig | None:
+    from kai.config import WorkspaceConfig
 
     if not db_settings and yaml_config is None:
         return None
@@ -1308,7 +1409,7 @@ async def build_workspace_config(
         try:
             timeout = int(db_settings["timeout"])
         except (ValueError, TypeError):
-            log.warning("Corrupt timeout in DB for chat %d workspace %s", chat_id, workspace_path)
+            log.warning("Corrupt timeout in DB for %s workspace %s", owner_label, workspace_path)
     if "env" in db_settings:
         # DB env vars merge on top of YAML env vars (not replace).
         # This lets admins set baseline env vars in YAML and users
@@ -1316,7 +1417,7 @@ async def build_workspace_config(
         try:
             db_env = json.loads(db_settings["env"])
         except json.JSONDecodeError:
-            log.warning("Corrupt env JSON in DB for chat %d workspace %s", chat_id, workspace_path)
+            log.warning("Corrupt env JSON in DB for %s workspace %s", owner_label, workspace_path)
             db_env = {}
         if env is None:
             env = db_env
@@ -1351,6 +1452,75 @@ async def build_workspace_config(
 _USER_SETTING_FIELDS = {"model", "timeout"}
 
 
+async def get_canonical_execution_settings(
+    namespace: WorkshopExecutionStateNamespace,
+) -> dict[str, str]:
+    """Read mutable settings by their canonical channel-agent owner."""
+    async with _get_db().execute(
+        "SELECT field, value FROM channel_agent_execution_settings "
+        "WHERE channel_id = ? AND agent_id = ? ORDER BY field",
+        (namespace.channel_id, namespace.agent_id),
+    ) as cursor:
+        rows = await cursor.fetchall()
+    return {str(row["field"]): str(row["value"]) for row in rows}
+
+
+async def set_canonical_execution_setting(
+    namespace: WorkshopExecutionStateNamespace,
+    field: str,
+    value: str,
+) -> None:
+    if field not in {"model", "timeout", "workspace"}:
+        raise ValueError(f"Unsupported execution setting field: {field}")
+    await _get_db().execute(
+        "INSERT INTO channel_agent_execution_settings "
+        "(channel_id, agent_id, runtime_profile_id, field, value) VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT(channel_id, agent_id, field) DO UPDATE SET "
+        "runtime_profile_id = excluded.runtime_profile_id, value = excluded.value, "
+        "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+        (
+            namespace.channel_id,
+            namespace.agent_id,
+            namespace.runtime_profile_id,
+            field,
+            value,
+        ),
+    )
+    await _get_db().commit()
+
+
+async def delete_canonical_execution_setting(
+    namespace: WorkshopExecutionStateNamespace,
+    field: str,
+) -> None:
+    await _get_db().execute(
+        "DELETE FROM channel_agent_execution_settings WHERE channel_id = ? AND agent_id = ? AND field = ?",
+        (namespace.channel_id, namespace.agent_id, field),
+    )
+    await _get_db().commit()
+
+
+async def delete_all_canonical_user_settings(
+    namespace: WorkshopExecutionStateNamespace,
+) -> None:
+    await _get_db().execute(
+        "DELETE FROM channel_agent_execution_settings "
+        "WHERE channel_id = ? AND agent_id = ? AND field IN ('model', 'timeout')",
+        (namespace.channel_id, namespace.agent_id),
+    )
+    await _get_db().commit()
+
+
+async def clear_canonical_runtime_session(
+    namespace: WorkshopExecutionStateNamespace,
+) -> None:
+    await _get_db().execute(
+        "DELETE FROM channel_agent_runtime_sessions WHERE channel_id = ? AND agent_id = ?",
+        (namespace.channel_id, namespace.agent_id),
+    )
+    await _get_db().commit()
+
+
 async def get_user_settings(chat_id: int) -> dict[str, str]:
     """
     Get all per-user settings from the database.
@@ -1362,14 +1532,8 @@ async def get_user_settings(chat_id: int) -> dict[str, str]:
     """
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        async with _get_db().execute(
-            "SELECT field, value FROM channel_agent_execution_settings "
-            "WHERE channel_id = ? AND agent_id = ? AND field IN ('model', 'timeout') "
-            "ORDER BY field",
-            (namespace.channel_id, namespace.agent_id),
-        ) as cursor:
-            rows = await cursor.fetchall()
-            return {str(row["field"]): str(row["value"]) for row in rows}
+        settings = await get_canonical_execution_settings(namespace)
+        return {field: value for field, value in settings.items() if field in _USER_SETTING_FIELDS}
 
     result = {}
     for field in _USER_SETTING_FIELDS:
@@ -1404,11 +1568,8 @@ async def delete_all_user_settings(chat_id: int) -> None:
     """
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        await _get_db().execute(
-            "DELETE FROM channel_agent_execution_settings "
-            "WHERE channel_id = ? AND agent_id = ? AND field IN ('model', 'timeout')",
-            (namespace.channel_id, namespace.agent_id),
-        )
+        await delete_all_canonical_user_settings(namespace)
+        return
     for field in _USER_SETTING_FIELDS:
         await _get_db().execute("DELETE FROM settings WHERE key = ?", (f"{field}:{chat_id}",))
     await _get_db().commit()
@@ -1434,27 +1595,15 @@ async def set_active_workspace(chat_id: int, workspace_path: str) -> None:
 
 
 async def delete_active_workspace(chat_id: int) -> None:
-    """Clear the active workspace from canonical and rollback storage."""
+    """Clear the active workspace from its authoritative storage."""
     await _delete_execution_setting(chat_id, "workspace")
 
 
 async def _set_execution_setting(chat_id: int, field: str, value: str) -> None:
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        await _get_db().execute(
-            "INSERT INTO channel_agent_execution_settings "
-            "(channel_id, agent_id, runtime_profile_id, field, value) VALUES (?, ?, ?, ?, ?) "
-            "ON CONFLICT(channel_id, agent_id, field) DO UPDATE SET "
-            "runtime_profile_id = excluded.runtime_profile_id, value = excluded.value, "
-            "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
-            (
-                namespace.channel_id,
-                namespace.agent_id,
-                namespace.runtime_profile_id,
-                field,
-                value,
-            ),
-        )
+        await set_canonical_execution_setting(namespace, field, value)
+        return
     await _get_db().execute(
         "INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
         (f"{field}:{chat_id}", value),
@@ -1465,10 +1614,8 @@ async def _set_execution_setting(chat_id: int, field: str, value: str) -> None:
 async def _delete_execution_setting(chat_id: int, field: str) -> None:
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        await _get_db().execute(
-            "DELETE FROM channel_agent_execution_settings WHERE channel_id = ? AND agent_id = ? AND field = ?",
-            (namespace.channel_id, namespace.agent_id, field),
-        )
+        await delete_canonical_execution_setting(namespace, field)
+        return
     await _get_db().execute("DELETE FROM settings WHERE key = ?", (f"{field}:{chat_id}",))
     await _get_db().commit()
 
@@ -1549,15 +1696,47 @@ async def upsert_workspace_history(path: str, chat_id: int) -> None:
     """Record or refresh a workspace path in the user's history."""
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        await _get_db().execute(
-            "INSERT INTO principal_workspace_history (principal_id, path, last_used_at) "
-            "VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT(principal_id, path) "
-            "DO UPDATE SET last_used_at = excluded.last_used_at",
-            (namespace.principal_id, path),
-        )
+        await upsert_canonical_workspace_history(namespace, path)
+        return
     await _get_db().execute(
         "INSERT OR REPLACE INTO workspace_history (path, chat_id, last_used_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
         (path, chat_id),
+    )
+    await _get_db().commit()
+
+
+async def get_canonical_workspace_history(
+    namespace: WorkshopExecutionStateNamespace,
+    limit: int = 10,
+) -> list[dict]:
+    async with _get_db().execute(
+        "SELECT path, last_used_at FROM principal_workspace_history "
+        "WHERE principal_id = ? ORDER BY last_used_at DESC LIMIT ?",
+        (namespace.principal_id, limit),
+    ) as cursor:
+        return [dict(row) for row in await cursor.fetchall()]
+
+
+async def upsert_canonical_workspace_history(
+    namespace: WorkshopExecutionStateNamespace,
+    path: str,
+) -> None:
+    await _get_db().execute(
+        "INSERT INTO principal_workspace_history (principal_id, path, last_used_at) "
+        "VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT(principal_id, path) "
+        "DO UPDATE SET last_used_at = excluded.last_used_at",
+        (namespace.principal_id, path),
+    )
+    await _get_db().commit()
+
+
+async def delete_canonical_workspace_history(
+    namespace: WorkshopExecutionStateNamespace,
+    path: str,
+) -> None:
+    await _get_db().execute(
+        "DELETE FROM principal_workspace_history WHERE principal_id = ? AND path = ?",
+        (namespace.principal_id, path),
     )
     await _get_db().commit()
 
@@ -1674,13 +1853,7 @@ async def get_workspace_history(chat_id: int, limit: int = 10) -> list[dict]:
     """
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        async with _get_db().execute(
-            "SELECT path, last_used_at FROM principal_workspace_history "
-            "WHERE principal_id = ? ORDER BY last_used_at DESC LIMIT ?",
-            (namespace.principal_id, limit),
-        ) as cursor:
-            rows = await cursor.fetchall()
-            return [dict(r) for r in rows]
+        return await get_canonical_workspace_history(namespace, limit)
 
     async with _get_db().execute(
         "SELECT path, last_used_at FROM workspace_history WHERE chat_id = ? ORDER BY last_used_at DESC LIMIT ?",
@@ -1694,10 +1867,8 @@ async def delete_workspace_history(path: str, chat_id: int) -> None:
     """Remove a workspace path from a user's history."""
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        await _get_db().execute(
-            "DELETE FROM principal_workspace_history WHERE principal_id = ? AND path = ?",
-            (namespace.principal_id, path),
-        )
+        await delete_canonical_workspace_history(namespace, path)
+        return
     await _get_db().execute(
         "DELETE FROM workspace_history WHERE path = ? AND chat_id = ?",
         (path, chat_id),
@@ -1740,10 +1911,8 @@ async def add_allowed_workspace(chat_id: int, path: str) -> None:
     db = _get_db()
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        await db.execute(
-            "INSERT OR IGNORE INTO principal_workspace_grants (principal_id, path) VALUES (?, ?)",
-            (namespace.principal_id, path),
-        )
+        await add_canonical_workspace_grant(namespace, path)
+        return
     await db.execute(
         "INSERT OR IGNORE INTO allowed_workspaces (chat_id, path) VALUES (?, ?)",
         (chat_id, path),
@@ -1760,20 +1929,15 @@ async def remove_allowed_workspace(chat_id: int, path: str) -> bool:
     so the caller can give appropriate feedback).
     """
     db = _get_db()
-    canonical_removed = 0
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        canonical_cursor = await db.execute(
-            "DELETE FROM principal_workspace_grants WHERE principal_id = ? AND path = ?",
-            (namespace.principal_id, path),
-        )
-        canonical_removed = canonical_cursor.rowcount
+        return await remove_canonical_workspace_grant(namespace, path)
     cursor = await db.execute(
         "DELETE FROM allowed_workspaces WHERE chat_id = ? AND path = ?",
         (chat_id, path),
     )
     await db.commit()
-    return canonical_removed > 0 if namespace is not None else cursor.rowcount > 0
+    return cursor.rowcount > 0
 
 
 async def get_allowed_workspaces(chat_id: int) -> list[Path]:
@@ -1787,18 +1951,46 @@ async def get_allowed_workspaces(chat_id: int) -> list[Path]:
     db = _get_db()
     namespace = _execution_state_namespace(chat_id)
     if namespace is not None:
-        cursor = await db.execute(
-            "SELECT path FROM principal_workspace_grants WHERE principal_id = ? ORDER BY created_at, rowid",
-            (namespace.principal_id,),
-        )
-        rows = await cursor.fetchall()
-        return [Path(row[0]) for row in rows]
+        return await get_canonical_workspace_grants(namespace)
     cursor = await db.execute(
         "SELECT path FROM allowed_workspaces WHERE chat_id = ? ORDER BY rowid",
         (chat_id,),
     )
     rows = await cursor.fetchall()
     return [Path(row[0]) for row in rows]
+
+
+async def add_canonical_workspace_grant(
+    namespace: WorkshopExecutionStateNamespace,
+    path: str,
+) -> None:
+    await _get_db().execute(
+        "INSERT OR IGNORE INTO principal_workspace_grants (principal_id, path) VALUES (?, ?)",
+        (namespace.principal_id, path),
+    )
+    await _get_db().commit()
+
+
+async def remove_canonical_workspace_grant(
+    namespace: WorkshopExecutionStateNamespace,
+    path: str,
+) -> bool:
+    cursor = await _get_db().execute(
+        "DELETE FROM principal_workspace_grants WHERE principal_id = ? AND path = ?",
+        (namespace.principal_id, path),
+    )
+    await _get_db().commit()
+    return cursor.rowcount > 0
+
+
+async def get_canonical_workspace_grants(
+    namespace: WorkshopExecutionStateNamespace,
+) -> list[Path]:
+    cursor = await _get_db().execute(
+        "SELECT path FROM principal_workspace_grants WHERE principal_id = ? ORDER BY created_at, rowid",
+        (namespace.principal_id,),
+    )
+    return [Path(row[0]) for row in await cursor.fetchall()]
 
 
 async def resolve_workspace_access(

--- a/src/kai/workshop/client_commands.py
+++ b/src/kai/workshop/client_commands.py
@@ -159,11 +159,6 @@ class WorkshopClientCommandExecutor:
             if result.terminal is None:
                 return
             compatibility_state = self._compatibility_state.for_profile(context.runtime_profile_id)
-            if result.session_id and result.selection is not None:
-                await compatibility_state.save_session(
-                    result.session_id,
-                    result.selection.model,
-                )
             if result.disposition == CanonicalExecutionDisposition.COMPLETED and result.workspace is not None:
                 result_message_id = result.terminal.finalization.message.event.envelope.aggregate_id
                 if not isinstance(result_message_id, MessageId):

--- a/src/kai/workshop/compatibility_state.py
+++ b/src/kai/workshop/compatibility_state.py
@@ -30,9 +30,6 @@ class WorkshopProfileCompatibilityState:
         """Return the configured canonical episode-context window."""
         return self._config.episode_classifier_context_turns
 
-    async def save_session(self, session_id: str, model: str) -> None:
-        await sessions.save_session(self._runtime_config_id, session_id, model)
-
     async def github_token(self) -> str | None:
         """Read the transitional protected token without exposing its integer key."""
         return await sessions.get_setting(f"github_token:{self._runtime_config_id}")

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -458,7 +458,7 @@ def workshop_execution_state_status(db_path: Path) -> str:
         f"{prefix} {state}; profiles={profiles}, migrated={migrated}, "
         f"missing={missing}, stale={stale}, orphaned={orphaned}, unclassified={unclassified}, settings={settings}, "
         f"workspace settings={workspace_settings}, history={history}, grants={grants}; "
-        "protected legacy reads=disabled, rollback dual writes=active"
+        "protected legacy reads=disabled, rollback dual writes=disabled"
     )
 
 

--- a/src/kai/workshop/scheduler.py
+++ b/src/kai/workshop/scheduler.py
@@ -663,8 +663,6 @@ class WorkshopCanonicalScheduler:
             success_transformer=transform,
         )
         compatibility = self._compatibility_state.for_profile(accepted.runtime_profile_id)
-        if result.session_id and result.selection is not None:
-            await compatibility.save_session(result.session_id, result.selection.model)
         if result.disposition == CanonicalExecutionDisposition.COMPLETED and result.terminal is not None:
             result_message_id = result.terminal.finalization.message.event.envelope.aggregate_id
             inbound_message_id = accepted.command.message.event.envelope.aggregate_id

--- a/src/kai/workshop/settings_workspaces.py
+++ b/src/kai/workshop/settings_workspaces.py
@@ -95,9 +95,8 @@ class SettingsWorkspaceAuthority:
 class WorkshopSettingsWorkspaceService:
     """Own settings/workspace mutations above all client adapters.
 
-    Public methods accept canonical authority only. The service contains the
-    temporary conversion to the compatibility persistence/runtime key so neither
-    Telegram nor Workshop HTTP can make independent mutation decisions.
+    Public methods and persistence are addressed only by canonical authority;
+    transport identities never enter this service.
     """
 
     def __init__(
@@ -138,11 +137,20 @@ class WorkshopSettingsWorkspaceService:
             raise WorkshopSettingsWorkspaceAccessDenied("The principal does not own this runtime profile")
         return self._canonical_authority(namespace)
 
-    def _runtime_config_id(self, authority: SettingsWorkspaceAuthority) -> int:
+    def _namespace(
+        self,
+        authority: SettingsWorkspaceAuthority,
+    ) -> WorkshopExecutionStateNamespace:
         namespace = self._execution_state.maybe_for_runtime_profile_id(authority.runtime_profile_id)
         if namespace is None:
             raise WorkshopSettingsWorkspaceAccessDenied("Runtime profile has no canonical execution state")
-        return namespace.runtime_config_id
+        if (
+            namespace.principal_id != authority.principal_id
+            or namespace.channel_id != authority.channel_id
+            or namespace.agent_id != authority.agent_id
+        ):
+            raise WorkshopSettingsWorkspaceAccessDenied("Runtime profile authority changed")
+        return namespace
 
     def _lock(self, authority: SettingsWorkspaceAuthority) -> asyncio.Lock:
         return self._locks.setdefault(authority.runtime_profile_id, asyncio.Lock())
@@ -152,7 +160,7 @@ class WorkshopSettingsWorkspaceService:
         authority: SettingsWorkspaceAuthority,
     ) -> SettingsWorkspaceSnapshot:
         profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
-        runtime_config_id = self._runtime_config_id(authority)
+        namespace = self._namespace(authority)
         workspace = await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)
         model, timeout_value = await self._effective_values(
             authority,
@@ -161,7 +169,7 @@ class WorkshopSettingsWorkspaceService:
         home = self._runtime_pool.get_home_workspace(authority.runtime_profile_id)
         home_resolved = home.resolve()
         base, allowed = await self._runtime_pool.resolve_workspace_access(authority.runtime_profile_id)
-        history = await sessions.get_workspace_history(runtime_config_id)
+        history = await sessions.get_canonical_workspace_history(namespace)
         candidates: list[Path] = [home, workspace, *allowed]
         candidates.extend(Path(str(item["path"])) for item in history)
         seen: set[Path] = set()
@@ -219,26 +227,26 @@ class WorkshopSettingsWorkspaceService:
         ):
             raise WorkshopSettingsWorkspaceValidationError("The model is not allowed by this runtime profile")
         async with self._lock(authority):
-            runtime_config_id = self._runtime_config_id(authority)
+            namespace = self._namespace(authority)
             workspace = str(await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id))
-            prior_user = await sessions.get_user_settings(runtime_config_id)
-            await sessions.set_user_setting(runtime_config_id, "model", normalized)
+            prior_user = await sessions.get_canonical_execution_settings(namespace)
+            await sessions.set_canonical_execution_setting(namespace, "model", normalized)
             try:
-                await sessions.delete_workspace_config_setting(
-                    runtime_config_id,
+                await sessions.delete_canonical_workspace_config_setting(
+                    namespace,
                     workspace,
                     "model",
                 )
             except BaseException:
                 if "model" in prior_user:
-                    await sessions.set_user_setting(
-                        runtime_config_id,
+                    await sessions.set_canonical_execution_setting(
+                        namespace,
                         "model",
                         prior_user["model"],
                     )
                 else:
-                    await sessions.delete_user_setting(
-                        runtime_config_id,
+                    await sessions.delete_canonical_execution_setting(
+                        namespace,
                         "model",
                     )
                 raise
@@ -247,7 +255,7 @@ class WorkshopSettingsWorkspaceService:
                 normalized,
             )
             await self._runtime_pool.restart(authority.runtime_profile_id)
-            await sessions.clear_session(runtime_config_id)
+            await sessions.clear_canonical_runtime_session(namespace)
         return await self.inspect(authority)
 
     async def set_timeout(
@@ -260,9 +268,9 @@ class WorkshopSettingsWorkspaceService:
         if timeout_seconds <= 0 or timeout_seconds > 600:
             raise WorkshopSettingsWorkspaceValidationError("Timeout must be between 1 and 600 seconds")
         async with self._lock(authority):
-            runtime_config_id = self._runtime_config_id(authority)
-            await sessions.set_user_setting(
-                runtime_config_id,
+            namespace = self._namespace(authority)
+            await sessions.set_canonical_execution_setting(
+                namespace,
                 "timeout",
                 str(timeout_seconds),
             )
@@ -280,11 +288,11 @@ class WorkshopSettingsWorkspaceService:
         if field not in {None, "model", "timeout"}:
             raise WorkshopSettingsWorkspaceValidationError("Only model and timeout settings can be reset")
         async with self._lock(authority):
-            runtime_config_id = self._runtime_config_id(authority)
+            namespace = self._namespace(authority)
             if field is None:
-                await sessions.delete_all_user_settings(runtime_config_id)
+                await sessions.delete_all_canonical_user_settings(namespace)
             else:
-                await sessions.delete_user_setting(runtime_config_id, field)
+                await sessions.delete_canonical_execution_setting(namespace, field)
             workspace = await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)
             model, timeout = await self._effective_values(authority, workspace)
             self._runtime_pool.set_model_if_running(
@@ -296,7 +304,7 @@ class WorkshopSettingsWorkspaceService:
                 int(timeout.value),
             )
             await self._runtime_pool.restart(authority.runtime_profile_id)
-            await sessions.clear_session(runtime_config_id)
+            await sessions.clear_canonical_runtime_session(namespace)
         return await self.inspect(authority)
 
     async def switch_workspace(
@@ -318,19 +326,21 @@ class WorkshopSettingsWorkspaceService:
                 allowed,
             ):
                 raise WorkshopSettingsWorkspaceAccessDenied("Workspace is outside this runtime profile's grants")
-            runtime_config_id = self._runtime_config_id(authority)
+            namespace = self._namespace(authority)
             yaml_config = self._config.get_workspace_config(requested)
-            workspace_config = await sessions.build_workspace_config(
+            workspace_config = await sessions.build_canonical_workspace_config(
                 yaml_config,
                 requested,
-                runtime_config_id,
+                namespace,
             )
-            prior_workspace = await sessions.get_active_workspace(runtime_config_id)
+            prior_settings = await sessions.get_canonical_execution_settings(namespace)
+            prior_workspace = prior_settings.get("workspace")
             if requested == home:
-                await sessions.delete_active_workspace(runtime_config_id)
+                await sessions.delete_canonical_execution_setting(namespace, "workspace")
             else:
-                await sessions.set_active_workspace(
-                    runtime_config_id,
+                await sessions.set_canonical_execution_setting(
+                    namespace,
+                    "workspace",
                     str(requested),
                 )
             try:
@@ -341,18 +351,19 @@ class WorkshopSettingsWorkspaceService:
                 )
             except BaseException:
                 if prior_workspace is None:
-                    await sessions.delete_active_workspace(runtime_config_id)
+                    await sessions.delete_canonical_execution_setting(namespace, "workspace")
                 else:
-                    await sessions.set_active_workspace(
-                        runtime_config_id,
+                    await sessions.set_canonical_execution_setting(
+                        namespace,
+                        "workspace",
                         prior_workspace,
                     )
                 raise
-            await sessions.clear_session(runtime_config_id)
+            await sessions.clear_canonical_runtime_session(namespace)
             if requested != home:
-                await sessions.upsert_workspace_history(
+                await sessions.upsert_canonical_workspace_history(
+                    namespace,
                     str(requested),
-                    runtime_config_id,
                 )
         return await self.inspect(authority)
 
@@ -361,11 +372,11 @@ class WorkshopSettingsWorkspaceService:
         authority: SettingsWorkspaceAuthority,
         workspace_path: str | None = None,
     ) -> WorkspaceConfigSnapshot:
-        runtime_config_id = self._runtime_config_id(authority)
+        namespace = self._namespace(authority)
         workspace = await self._authorized_workspace(authority, workspace_path)
         yaml_config = self._config.get_workspace_config(workspace)
-        overrides = await sessions.get_workspace_config_settings(
-            runtime_config_id,
+        overrides = await sessions.get_canonical_workspace_config_settings(
+            namespace,
             str(workspace),
         )
         model, timeout = await self._effective_values(authority, workspace)
@@ -487,8 +498,8 @@ class WorkshopSettingsWorkspaceService:
                 authority,
                 workspace_path,
             )
-            settings = await sessions.get_workspace_config_settings(
-                self._runtime_config_id(authority),
+            settings = await sessions.get_canonical_workspace_config_settings(
+                self._namespace(authority),
                 str(workspace),
             )
             environment = self._decode_environment(settings.get("env"))
@@ -513,8 +524,8 @@ class WorkshopSettingsWorkspaceService:
                 authority,
                 workspace_path,
             )
-            settings = await sessions.get_workspace_config_settings(
-                self._runtime_config_id(authority),
+            settings = await sessions.get_canonical_workspace_config_settings(
+                self._namespace(authority),
                 str(workspace),
             )
             environment = self._decode_environment(settings.get("env"))
@@ -546,13 +557,13 @@ class WorkshopSettingsWorkspaceService:
         field: str,
         value: str,
     ) -> None:
-        runtime_config_id = self._runtime_config_id(authority)
-        prior = await sessions.get_workspace_config_settings(
-            runtime_config_id,
+        namespace = self._namespace(authority)
+        prior = await sessions.get_canonical_workspace_config_settings(
+            namespace,
             str(workspace),
         )
-        await sessions.set_workspace_config_setting(
-            runtime_config_id,
+        await sessions.set_canonical_workspace_config_setting(
+            namespace,
             str(workspace),
             field,
             value,
@@ -561,15 +572,15 @@ class WorkshopSettingsWorkspaceService:
             await self._apply_workspace_config(authority, workspace)
         except BaseException:
             if field in prior:
-                await sessions.set_workspace_config_setting(
-                    runtime_config_id,
+                await sessions.set_canonical_workspace_config_setting(
+                    namespace,
                     str(workspace),
                     field,
                     prior[field],
                 )
             else:
-                await sessions.delete_workspace_config_setting(
-                    runtime_config_id,
+                await sessions.delete_canonical_workspace_config_setting(
+                    namespace,
                     str(workspace),
                     field,
                 )
@@ -582,32 +593,32 @@ class WorkshopSettingsWorkspaceService:
         *,
         field: str | None,
     ) -> None:
-        runtime_config_id = self._runtime_config_id(authority)
-        prior = await sessions.get_workspace_config_settings(
-            runtime_config_id,
+        namespace = self._namespace(authority)
+        prior = await sessions.get_canonical_workspace_config_settings(
+            namespace,
             str(workspace),
         )
         if field is None:
-            await sessions.delete_all_workspace_config(
-                runtime_config_id,
+            await sessions.delete_all_canonical_workspace_config(
+                namespace,
                 str(workspace),
             )
         else:
-            await sessions.delete_workspace_config_setting(
-                runtime_config_id,
+            await sessions.delete_canonical_workspace_config_setting(
+                namespace,
                 str(workspace),
                 field,
             )
         try:
             await self._apply_workspace_config(authority, workspace)
         except BaseException:
-            await sessions.delete_all_workspace_config(
-                runtime_config_id,
+            await sessions.delete_all_canonical_workspace_config(
+                namespace,
                 str(workspace),
             )
             for prior_field, prior_value in prior.items():
-                await sessions.set_workspace_config_setting(
-                    runtime_config_id,
+                await sessions.set_canonical_workspace_config_setting(
+                    namespace,
                     str(workspace),
                     prior_field,
                     prior_value,
@@ -637,12 +648,12 @@ class WorkshopSettingsWorkspaceService:
         authority: SettingsWorkspaceAuthority,
         workspace: Path,
     ) -> None:
-        runtime_config_id = self._runtime_config_id(authority)
+        namespace = self._namespace(authority)
         yaml_config: WorkspaceConfig | None = self._config.get_workspace_config(workspace)
-        config = await sessions.build_workspace_config(
+        config = await sessions.build_canonical_workspace_config(
             yaml_config,
             workspace,
-            runtime_config_id,
+            namespace,
         )
         model, timeout = await self._effective_values(authority, workspace)
         await self._runtime_pool.apply_workspace_config_if_running(
@@ -652,7 +663,7 @@ class WorkshopSettingsWorkspaceService:
             model=str(model.value),
             timeout_seconds=int(timeout.value),
         )
-        await sessions.clear_session(runtime_config_id)
+        await sessions.clear_canonical_runtime_session(namespace)
 
     async def _effective_values(
         self,
@@ -660,10 +671,10 @@ class WorkshopSettingsWorkspaceService:
         workspace: Path,
     ) -> tuple[EffectiveValue, EffectiveValue]:
         profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
-        runtime_config_id = self._runtime_config_id(authority)
-        user = await sessions.get_user_settings(runtime_config_id)
-        workspace_overrides = await sessions.get_workspace_config_settings(
-            runtime_config_id,
+        namespace = self._namespace(authority)
+        user = await sessions.get_canonical_execution_settings(namespace)
+        workspace_overrides = await sessions.get_canonical_workspace_config_settings(
+            namespace,
             str(workspace),
         )
         yaml_config = self._config.get_workspace_config(workspace)

--- a/tests/test_workshop_client_commands.py
+++ b/tests/test_workshop_client_commands.py
@@ -74,7 +74,6 @@ async def test_submission_returns_before_execution_and_preserves_compatibility_s
     )
     profile_state = SimpleNamespace(
         memory_context_turns=4,
-        save_session=AsyncMock(),
         schedule_memory_ingestion=Mock(),
     )
     compatibility_state = SimpleNamespace(for_profile=Mock(return_value=profile_state))
@@ -93,7 +92,6 @@ async def test_submission_returns_before_execution_and_preserves_compatibility_s
         release.set()
         await executor.stop()
 
-    profile_state.save_session.assert_awaited_once_with("session-1", "gpt-5.6-sol")
     profile_state.schedule_memory_ingestion.assert_called_once_with(
         prompt="Hello from Workshop",
         assistant_text="Completed through the protected lane",
@@ -124,11 +122,7 @@ async def test_terminal_replay_does_not_schedule_or_duplicate_compatibility_writ
         recoverable_client_runs=AsyncMock(return_value=()),
         request_run_cancellation=AsyncMock(),
     )
-    profile_state = SimpleNamespace(
-        append_history=Mock(),
-        save_session=AsyncMock(),
-        schedule_memory_ingestion=Mock(),
-    )
+    profile_state = SimpleNamespace(schedule_memory_ingestion=Mock())
     compatibility_state = SimpleNamespace(for_profile=Mock(return_value=profile_state))
     executor = WorkshopClientCommandExecutor(execution, compatibility_state)
     await executor.start()

--- a/tests/test_workshop_compatibility_state.py
+++ b/tests/test_workshop_compatibility_state.py
@@ -1,14 +1,14 @@
 """Tests for profile-addressed compatibility-state writes."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
 from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, RunId
 from tests.workshop_profiles import profile_id
 
 
-async def test_profile_state_preserves_existing_storage_keys(monkeypatch):
+async def test_profile_state_retains_only_non_session_compatibility_boundaries(monkeypatch):
     config = SimpleNamespace(
         get_user_config=lambda runtime_config_id: (
             SimpleNamespace(os_user="daniel") if runtime_config_id == 101 else None
@@ -23,12 +23,7 @@ async def test_profile_state_preserves_existing_storage_keys(monkeypatch):
             )
         )
     )
-    save_session = AsyncMock()
     schedule = Mock()
-    monkeypatch.setattr(
-        "kai.workshop.compatibility_state.sessions.save_session",
-        save_session,
-    )
     monkeypatch.setattr(
         "kai.workshop.compatibility_state.schedule_memory_ingestion",
         schedule,
@@ -36,7 +31,7 @@ async def test_profile_state_preserves_existing_storage_keys(monkeypatch):
 
     state = WorkshopCompatibilityStateWriter(config, runtime_pool).for_profile(profile_id(101))
     provenance = CanonicalMemoryProvenance(RunId.new(), MessageId.new(), MessageId.new())
-    await state.save_session("session-1", "gpt-5.6-sol")
+    assert not hasattr(state, "save_session")
     state.schedule_memory_ingestion(
         prompt="Hello",
         assistant_text="Hi",
@@ -47,7 +42,6 @@ async def test_profile_state_preserves_existing_storage_keys(monkeypatch):
     )
 
     runtime_pool.runtime_profile.assert_called_once_with(profile_id(101))
-    save_session.assert_awaited_once_with(101, "session-1", "gpt-5.6-sol")
     schedule.assert_called_once_with(
         prompt="Hello",
         assistant_text="Hi",

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -156,7 +156,30 @@ class TestCanonicalExecutionStateMigration:
 
 
 class TestCanonicalExecutionStateWrites:
-    async def test_protected_mutations_dual_write_for_rollback_and_isolate_humans(self, database: Path):
+    async def test_protected_session_calls_cannot_read_or_mutate_legacy_archive(
+        self,
+        database: Path,
+    ):
+        await _initialize(database, 101)
+        await sessions._get_db().execute(
+            "INSERT INTO sessions (chat_id, session_id, model) VALUES (?, ?, ?)",
+            (101, "archived-session", "archived-model"),
+        )
+        await sessions._get_db().commit()
+
+        assert await sessions.get_session(101) is None
+        await sessions.save_session(101, "new-session", "gpt-5.6-sol")
+        await sessions.clear_session(101)
+
+        async with sessions._get_db().execute(
+            "SELECT session_id, model FROM sessions WHERE chat_id = ?",
+            (101,),
+        ) as cursor:
+            archived = await cursor.fetchone()
+        assert archived is not None
+        assert tuple(archived) == ("archived-session", "archived-model")
+
+    async def test_protected_mutations_freeze_legacy_archive_and_isolate_humans(self, database: Path):
         await _initialize(database, 101, 202)
 
         await sessions.set_user_setting(101, "model", "gpt-5.5")
@@ -169,12 +192,12 @@ class TestCanonicalExecutionStateWrites:
         assert await sessions.get_user_settings(202) == {}
         assert await sessions.get_workspace_history(202) == []
         assert await sessions.get_allowed_workspaces(202) == []
-        for key, expected in (
-            ("model:101", "gpt-5.5"),
-            ("workspace:101", "/projects/alice"),
-            ("ws_config:101:/projects/alice:timeout", "300"),
+        for key in (
+            "model:101",
+            "workspace:101",
+            "ws_config:101:/projects/alice:timeout",
         ):
-            assert await sessions.get_setting(key) == expected
+            assert await sessions.get_setting(key) is None
 
         await sessions.delete_user_setting(101, "model")
         await sessions.delete_active_workspace(101)
@@ -188,7 +211,7 @@ class TestCanonicalExecutionStateWrites:
         assert await sessions.get_workspace_history(101) == []
         assert await sessions.get_allowed_workspaces(101) == []
 
-    async def test_workspace_config_delete_preserves_colon_prefixed_workspace_in_both_stores(
+    async def test_workspace_config_delete_preserves_colon_prefixed_canonical_workspace(
         self,
         database: Path,
     ):
@@ -203,7 +226,7 @@ class TestCanonicalExecutionStateWrites:
         assert await sessions.get_workspace_config_settings(101, shorter) == {}
         assert await sessions.get_workspace_config_settings(101, colon_prefixed) == {"model": "gpt-5.6-sol"}
         assert await sessions.get_setting("ws_config:101:/projects/alice:model") is None
-        assert await sessions.get_setting("ws_config:101:/projects/alice:archive:model") == "gpt-5.6-sol"
+        assert await sessions.get_setting("ws_config:101:/projects/alice:archive:model") is None
 
     async def test_unmapped_development_callers_retain_legacy_behavior(self, database: Path):
         await _initialize(database, 101)
@@ -227,6 +250,7 @@ class TestCanonicalExecutionStateDiagnostic:
         assert status.startswith("Workshop execution state: active;")
         assert "profiles=1, migrated=1, missing=0, stale=0" in status
         assert "protected legacy reads=disabled" in status
+        assert "rollback dual writes=disabled" in status
         assert "secret-model-name" not in status
         assert "101" not in status
 

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -131,9 +131,6 @@ class _CanonicalRuntime:
 class _CanonicalCompatibility:
     memory_context_turns = 10
 
-    async def save_session(self, _session_id: str, _model: str) -> None:
-        pass
-
     def schedule_memory_ingestion(self, **_kwargs) -> None:
         pass
 

--- a/tests/test_workshop_settings_workspaces.py
+++ b/tests/test_workshop_settings_workspaces.py
@@ -38,9 +38,6 @@ class _RuntimePool:
             timeout_seconds=120,
         )
 
-    def compatibility_runtime_config_id(self, _profile_id) -> int:
-        return 101
-
     def runtime_profile(self, _profile_id):
         return self.profile
 
@@ -143,38 +140,38 @@ async def test_model_change_uses_one_ordered_core_transaction(
     service, pool, authority, _, _ = _service(tmp_path)
     calls: list[tuple[object, ...]] = []
 
-    async def get_settings(_runtime_config_id: int):
+    async def get_settings(_namespace):
         return {"model": "gpt-5.6-sol", "timeout": "120"}
 
-    async def history(_runtime_config_id: int):
+    async def history(_namespace):
         return []
 
-    async def workspace_settings(_runtime_config_id: int, _workspace: str):
+    async def workspace_settings(_namespace, _workspace: str):
         return {}
 
     async def record(name: str, *args):
         calls.append((name, *args))
 
-    monkeypatch.setattr(sessions, "get_user_settings", get_settings)
-    monkeypatch.setattr(sessions, "get_workspace_history", history)
+    monkeypatch.setattr(sessions, "get_canonical_execution_settings", get_settings)
+    monkeypatch.setattr(sessions, "get_canonical_workspace_history", history)
     monkeypatch.setattr(
         sessions,
-        "get_workspace_config_settings",
+        "get_canonical_workspace_config_settings",
         workspace_settings,
     )
     monkeypatch.setattr(
         sessions,
-        "set_user_setting",
+        "set_canonical_execution_setting",
         lambda *args: record("set", *args),
     )
     monkeypatch.setattr(
         sessions,
-        "delete_workspace_config_setting",
+        "delete_canonical_workspace_config_setting",
         lambda *args: record("clear-workspace-model", *args),
     )
     monkeypatch.setattr(
         sessions,
-        "clear_session",
+        "clear_canonical_runtime_session",
         lambda *args: record("clear-session", *args),
     )
 
@@ -182,9 +179,9 @@ async def test_model_change_uses_one_ordered_core_transaction(
 
     assert pool.events[:2] == ["running-model:gpt-5.6-terra", "restart"]
     assert calls == [
-        ("set", 101, "model", "gpt-5.6-terra"),
-        ("clear-workspace-model", 101, str(pool.home), "model"),
-        ("clear-session", 101),
+        ("set", calls[0][1], "model", "gpt-5.6-terra"),
+        ("clear-workspace-model", calls[0][1], str(pool.home), "model"),
+        ("clear-session", calls[0][1]),
     ]
     assert snapshot.backend == "codex"
 
@@ -195,22 +192,22 @@ async def test_inspection_reports_workspace_precedence(
 ) -> None:
     service, pool, authority, _, _ = _service(tmp_path)
 
-    async def get_settings(_runtime_config_id: int):
+    async def get_settings(_namespace):
         return {"model": "gpt-5.6-sol", "timeout": "120"}
 
-    async def workspace_settings(_runtime_config_id: int, _workspace: str):
+    async def workspace_settings(_namespace, _workspace: str):
         return {"model": "gpt-5.6-terra", "timeout": "240"}
 
-    async def history(_runtime_config_id: int):
+    async def history(_namespace):
         return []
 
-    monkeypatch.setattr(sessions, "get_user_settings", get_settings)
+    monkeypatch.setattr(sessions, "get_canonical_execution_settings", get_settings)
     monkeypatch.setattr(
         sessions,
-        "get_workspace_config_settings",
+        "get_canonical_workspace_config_settings",
         workspace_settings,
     )
-    monkeypatch.setattr(sessions, "get_workspace_history", history)
+    monkeypatch.setattr(sessions, "get_canonical_workspace_history", history)
 
     snapshot = await service.inspect(authority)
 
@@ -233,11 +230,11 @@ async def test_model_persistence_failure_does_not_mutate_live_runtime(
     async def fail_persistence(*_args):
         raise OSError("database unavailable")
 
-    async def get_settings(_runtime_config_id: int):
+    async def get_settings(_namespace):
         return {}
 
-    monkeypatch.setattr(sessions, "set_user_setting", fail_persistence)
-    monkeypatch.setattr(sessions, "get_user_settings", get_settings)
+    monkeypatch.setattr(sessions, "set_canonical_execution_setting", fail_persistence)
+    monkeypatch.setattr(sessions, "get_canonical_execution_settings", get_settings)
 
     with pytest.raises(OSError, match="database unavailable"):
         await service.set_model(authority, "gpt-5.6-terra")
@@ -275,17 +272,17 @@ async def test_workspace_config_mutation_applies_core_precedence_without_exposin
     service, pool, authority, _, _ = _service(tmp_path)
     stored: dict[str, str] = {}
 
-    async def get_settings(_runtime_config_id: int):
+    async def get_settings(_namespace):
         return {}
 
     async def get_workspace_settings(
-        _runtime_config_id: int,
+        _namespace,
         _workspace: str,
     ):
         return dict(stored)
 
     async def set_workspace_setting(
-        _runtime_config_id: int,
+        _namespace,
         _workspace: str,
         field: str,
         value: str,
@@ -295,22 +292,22 @@ async def test_workspace_config_mutation_applies_core_precedence_without_exposin
     async def build_config(*_args):
         return None
 
-    async def clear_session(_runtime_config_id: int) -> None:
+    async def clear_session(_namespace) -> None:
         return None
 
-    monkeypatch.setattr(sessions, "get_user_settings", get_settings)
+    monkeypatch.setattr(sessions, "get_canonical_execution_settings", get_settings)
     monkeypatch.setattr(
         sessions,
-        "get_workspace_config_settings",
+        "get_canonical_workspace_config_settings",
         get_workspace_settings,
     )
     monkeypatch.setattr(
         sessions,
-        "set_workspace_config_setting",
+        "set_canonical_workspace_config_setting",
         set_workspace_setting,
     )
-    monkeypatch.setattr(sessions, "build_workspace_config", build_config)
-    monkeypatch.setattr(sessions, "clear_session", clear_session)
+    monkeypatch.setattr(sessions, "build_canonical_workspace_config", build_config)
+    monkeypatch.setattr(sessions, "clear_canonical_runtime_session", clear_session)
 
     model_snapshot = await service.set_workspace_config(
         authority,


### PR DESCRIPTION
## Summary

- address Workshop settings, workspace state, history, grants, and runtime-session resets by canonical execution authority
- stop protected compatibility helpers from reading or mutating archived integer-keyed state
- retire redundant provider-session writes after canonical terminal settlement and report rollback dual writes disabled
- preserve unmapped development callers and all migration/archive evidence

## Validation

- `make check`
- `make typecheck`
- `make client-check` (54 tests)
- `.venv/bin/python -m pytest tests/ -q` (6109 tests)

Part of #917.
