### PR TITLE
fix: gate delivery by enabled adapters

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -19,6 +19,7 @@ from kai.workshop.delivery_authority import (
     DeliveryAuthorityEpoch,
     WorkshopConversationDeliveryAuthority,
 )
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.github_automation import WorkshopGitHubAutomationService
 from kai.workshop.integration_notifications import WorkshopIntegrationNotificationService
@@ -130,6 +131,7 @@ class KaiCoreServices:
     proactive_publication: WorkshopProactivePublicationService
     integration_notifications: WorkshopIntegrationNotificationService
     github_automation: WorkshopGitHubAutomationService
+    delivery_policy: WorkshopDeliveryBindingPolicy
 
 
 class KaiApplicationHost:
@@ -200,6 +202,9 @@ class KaiApplicationHost:
         integration_notifications: WorkshopIntegrationNotificationService | None = None
         github_automation: WorkshopGitHubAutomationService | None = None
         try:
+            delivery_policy = WorkshopDeliveryBindingPolicy(
+                frozenset({"telegram"}) if self._config.telegram_enabled else frozenset()
+            )
             subprocess_pool = SubprocessPool(
                 config=self._config,
                 services_info=self._services_info,
@@ -222,6 +227,7 @@ class KaiApplicationHost:
                 Path(self._config.session_db_path),
                 runtime_pool,
                 registered_backend_ids=self._registered_backend_ids,
+                delivery_policy=delivery_policy,
             )
             run_previews = WorkshopRunPreviewRegistry()
             client_commands = WorkshopClientCommandExecutor(
@@ -235,6 +241,7 @@ class KaiApplicationHost:
                 Path(self._config.session_db_path),
                 private_execution,
                 compatibility_state,
+                delivery_policy,
             )
             artifacts = WorkshopArtifactService(
                 client_store,
@@ -257,7 +264,7 @@ class KaiApplicationHost:
                 client_store,
                 artifacts,
                 artifact_storage_root=Path(self._config.session_db_path).parent / "files",
-                delivery_transports=frozenset({"telegram"}) if self._config.telegram_enabled else frozenset(),
+                delivery_policy=delivery_policy,
             )
             for context in self._internal_api_contexts.contexts:
                 await proactive_publication.validate_authority(
@@ -269,7 +276,8 @@ class KaiApplicationHost:
                     )
                 )
             integration_notifications = await WorkshopIntegrationNotificationService.open(
-                Path(self._config.session_db_path)
+                Path(self._config.session_db_path),
+                delivery_policy,
             )
             github_automation = await WorkshopGitHubAutomationService.open_and_start(
                 Path(self._config.session_db_path),
@@ -300,6 +308,7 @@ class KaiApplicationHost:
                 proactive_publication=proactive_publication,
                 integration_notifications=integration_notifications,
                 github_automation=github_automation,
+                delivery_policy=delivery_policy,
             )
             self._state = KaiApplicationState.READY
             return self._services

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -54,6 +54,7 @@ from kai.workshop.conversation_runs import (
     CanonicalConversationRunResolution,
     resolve_canonical_conversation_run,
 )
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import MessageId
 from kai.workshop.execution_state import (
     WorkshopExecutionStateMigration,
@@ -515,6 +516,8 @@ async def record_workshop_streaming_preview(
 
 async def record_workshop_streaming_finalization(
     message: OutboundMessage,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy,
 ) -> OutboundStreamingFinalizationResult:
     """Atomically record one authoritative reply and its delivery plan.
 
@@ -530,10 +533,18 @@ async def record_workshop_streaming_finalization(
     async with _workshop_event_lock:
         store = WorkshopEventStore.from_initialized_connection(_get_db())
         try:
-            return await record_outbound_message_with_streaming_finalization(store, message)
+            return await record_outbound_message_with_streaming_finalization(
+                store,
+                message,
+                delivery_policy=delivery_policy,
+            )
         except aiosqlite.Error:
             try:
-                return await record_outbound_message_with_streaming_finalization(store, message)
+                return await record_outbound_message_with_streaming_finalization(
+                    store,
+                    message,
+                    delivery_policy=delivery_policy,
+                )
             except Exception as resolution_error:
                 raise WorkshopFinalizationCommitUncertainError(
                     "Could not determine whether the Workshop reply transaction committed"

--- a/src/kai/workshop/conversation_commands.py
+++ b/src/kai/workshop/conversation_commands.py
@@ -13,6 +13,7 @@ from kai.workshop.delivery_outbox import (
     DeliveryRequestResult,
     WorkshopDeliveryOutbox,
 )
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import ChannelBindingId, ChannelId, MessageId, PrincipalId, RuntimeProfileId
 from kai.workshop.inbound import (
     ClientInboundMessage,
@@ -79,9 +80,16 @@ class WorkshopConversationCommandService:
     the execution coordinator owned by the production private-text runtime.
     """
 
-    def __init__(self, store: WorkshopEventStore, *, artifact_storage_root: Path | None = None) -> None:
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        *,
+        artifact_storage_root: Path | None = None,
+        delivery_policy: WorkshopDeliveryBindingPolicy | None = None,
+    ) -> None:
         self._store = store
         self._artifact_storage_root = artifact_storage_root
+        self._delivery_policy = delivery_policy or WorkshopDeliveryBindingPolicy.disabled()
 
     async def accept(
         self,
@@ -262,6 +270,8 @@ class WorkshopConversationCommandService:
         principal_id: PrincipalId,
         channel_id: ChannelId,
     ) -> ChannelBindingId | None:
+        if not self._delivery_policy.is_enabled("telegram"):
+            return None
         async with self._store.connection.execute(
             "SELECT cb.id, EXISTS (SELECT 1 FROM external_identities ei "
             "WHERE ei.principal_id = ? AND ei.provider = 'telegram' "

--- a/src/kai/workshop/delivery_policy.py
+++ b/src/kai/workshop/delivery_policy.py
@@ -1,0 +1,62 @@
+"""Core-owned eligibility policy for optional delivery adapters."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from kai.workshop.domain import ChannelBindingId, ChannelId
+from kai.workshop.store import WorkshopEventStore
+
+_TRANSPORT_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopDeliveryBindingPolicy:
+    """Resolve persisted bindings only for currently enabled transports.
+
+    A binding records a possible external destination. It does not by itself
+    authorize delivery while its adapter is disabled.
+    """
+
+    enabled_transports: frozenset[str]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.enabled_transports, frozenset):
+            raise TypeError("enabled_transports must be a frozenset")
+        if any(
+            not isinstance(transport, str) or not _TRANSPORT_PATTERN.fullmatch(transport)
+            for transport in self.enabled_transports
+        ):
+            raise ValueError("enabled_transports must contain lowercase transport identifiers")
+
+    @classmethod
+    def disabled(cls) -> WorkshopDeliveryBindingPolicy:
+        return cls(frozenset())
+
+    def is_enabled(self, transport: str) -> bool:
+        if not isinstance(transport, str) or not _TRANSPORT_PATTERN.fullmatch(transport):
+            raise ValueError("transport must be a lowercase transport identifier")
+        return transport in self.enabled_transports
+
+    async def binding_ids(
+        self,
+        store: WorkshopEventStore,
+        channel_id: ChannelId,
+        *,
+        transport: str | None = None,
+    ) -> tuple[ChannelBindingId, ...]:
+        """Return stable bindings eligible under the current adapter policy."""
+        if not isinstance(channel_id, ChannelId):
+            raise ValueError("channel_id must be a ChannelId")
+        transports = self.enabled_transports
+        if transport is not None:
+            transports = frozenset({transport}) if self.is_enabled(transport) else frozenset()
+        if not transports:
+            return ()
+        placeholders = ", ".join("?" for _ in transports)
+        async with store.connection.execute(
+            f"SELECT id FROM channel_bindings WHERE channel_id = ? AND transport IN ({placeholders}) ORDER BY id",
+            (channel_id, *sorted(transports)),
+        ) as cursor:
+            return tuple(ChannelBindingId(str(row[0])) for row in await cursor.fetchall())

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -15,6 +15,7 @@ from kai.agent_failure import AgentFailureKind
 from kai.backend import AgentResponse, StreamEvent
 from kai.workshop.artifacts import ArtifactMessageNotFoundError, build_agent_prompt_for_message
 from kai.workshop.conversation_context import assemble_canonical_conversation_context
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import AgentId, ChannelId, RunExecutionOwnerId, RunId
 from kai.workshop.protected_execution import PreparedWorkshopExecution
 from kai.workshop.run_execution_authority import (
@@ -144,6 +145,7 @@ class WorkshopCanonicalExecutionCoordinator:
         database_lock: asyncio.Lock | None = None,
         transcript_projection: CanonicalTranscriptProjection | None = None,
         artifact_storage_root: Path | None = None,
+        delivery_policy: WorkshopDeliveryBindingPolicy,
     ) -> None:
         if not registered_backend_ids:
             raise ValueError("registered_backend_ids must not be empty")
@@ -161,6 +163,7 @@ class WorkshopCanonicalExecutionCoordinator:
         self._transcript_projection = transcript_projection
         self._artifact_storage_root = artifact_storage_root
         self._trace_store = WorkshopRunTraceStore(store)
+        self._delivery_policy = delivery_policy
 
     async def execute(
         self,
@@ -272,7 +275,10 @@ class WorkshopCanonicalExecutionCoordinator:
                     await authority.expire_grant(claim, occurred_at=now)
                     expired += 1
                 else:
-                    await WorkshopRunTerminalTransactionCoordinator(authority).interrupt_expired(
+                    await WorkshopRunTerminalTransactionCoordinator(
+                        authority,
+                        delivery_policy=self._delivery_policy,
+                    ).interrupt_expired(
                         claim,
                         occurred_at=now,
                     )
@@ -323,7 +329,10 @@ class WorkshopCanonicalExecutionCoordinator:
                     if success_transformer is not None
                     else CanonicalSuccessOutcome(response.text)
                 )
-            terminal = WorkshopRunTerminalTransactionCoordinator(authority)
+            terminal = WorkshopRunTerminalTransactionCoordinator(
+                authority,
+                delivery_policy=self._delivery_policy,
+            )
             async with self._database_lock:
                 active.settling = True
                 if response is None or (response.success and not response.text.strip()):
@@ -382,7 +391,10 @@ class WorkshopCanonicalExecutionCoordinator:
                         pass
                 async with self._database_lock:
                     active.settling = True
-                    settled = await WorkshopRunTerminalTransactionCoordinator(active.authority).fail(
+                    settled = await WorkshopRunTerminalTransactionCoordinator(
+                        active.authority,
+                        delivery_policy=self._delivery_policy,
+                    ).fail(
                         active.claim,
                         failure_code=TerminalFailureCode.EXECUTION_INTERRUPTED,
                         occurred_at=self._now(),
@@ -405,7 +417,10 @@ class WorkshopCanonicalExecutionCoordinator:
             if active.started:
                 async with self._database_lock:
                     active.settling = True
-                    result = await WorkshopRunTerminalTransactionCoordinator(active.authority).fail(
+                    result = await WorkshopRunTerminalTransactionCoordinator(
+                        active.authority,
+                        delivery_policy=self._delivery_policy,
+                    ).fail(
                         active.claim,
                         failure_code=TerminalFailureCode.EXECUTION_INTERRUPTED,
                         occurred_at=self._now(),
@@ -423,7 +438,10 @@ class WorkshopCanonicalExecutionCoordinator:
             )
         async with self._database_lock:
             active.settling = True
-            result = await WorkshopRunTerminalTransactionCoordinator(active.authority).confirm_cancellation(
+            result = await WorkshopRunTerminalTransactionCoordinator(
+                active.authority,
+                delivery_policy=self._delivery_policy,
+            ).confirm_cancellation(
                 active.claim,
                 occurred_at=self._now(),
             )

--- a/src/kai/workshop/integration_notifications.py
+++ b/src/kai/workshop/integration_notifications.py
@@ -14,6 +14,7 @@ from kai.workshop.delivery_outbox import (
     DeliveryRequestResult,
     WorkshopDeliveryOutbox,
 )
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     ChannelBindingId,
     ChannelId,
@@ -93,15 +94,20 @@ class IntegrationRouteStatus:
 class WorkshopIntegrationNotificationService:
     """Own canonical integration recording independently of client adapters."""
 
-    def __init__(self, store: WorkshopEventStore) -> None:
+    def __init__(self, store: WorkshopEventStore, delivery_policy: WorkshopDeliveryBindingPolicy) -> None:
         self._store = store
+        self._delivery_policy = delivery_policy
         self._outbox = WorkshopDeliveryOutbox(store)
         self._lock = asyncio.Lock()
         self._closed = False
 
     @classmethod
-    async def open(cls, database_path: Path) -> WorkshopIntegrationNotificationService:
-        service = cls(await WorkshopEventStore.open(database_path))
+    async def open(
+        cls,
+        database_path: Path,
+        delivery_policy: WorkshopDeliveryBindingPolicy,
+    ) -> WorkshopIntegrationNotificationService:
+        service = cls(await WorkshopEventStore.open(database_path), delivery_policy)
         try:
             await service.reconcile_default_generic_route()
         except BaseException:
@@ -447,24 +453,20 @@ class WorkshopIntegrationNotificationService:
 
             projection = CanonicalConversationProjection()
             await self._store.project_pending_in_transaction(projection)
-            async with connection.execute(
-                "SELECT id FROM channel_bindings WHERE channel_id = ? ORDER BY id",
-                (channel_id,),
-            ) as cursor:
-                binding_rows = tuple(await cursor.fetchall())
+            binding_ids = await self._delivery_policy.binding_ids(self._store, channel_id)
             deliveries = tuple(
                 [
                     await self._outbox.request_delivery_in_transaction(
                         DeliveryRequest(
                             message_id=message_id,
-                            channel_binding_id=ChannelBindingId(str(row[0])),
+                            channel_binding_id=binding_id,
                             mode="text",
                             purpose=NOTIFICATION_PURPOSE,
                             occurred_at=occurred_at,
                             max_attempts=5,
                         )
                     )
-                    for row in binding_rows
+                    for binding_id in binding_ids
                 ]
             )
             if inserted and any(not delivery.inserted for delivery in deliveries):

--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -22,6 +22,7 @@ from kai.workshop.delivery_outbox import (
     DeliveryRequestResult,
     WorkshopDeliveryOutbox,
 )
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     ChannelBindingId,
     ChannelId,
@@ -185,15 +186,12 @@ async def _existing_outbound(
 async def _resolve_telegram_binding(
     store: WorkshopEventStore,
     channel_id: ChannelId,
+    delivery_policy: WorkshopDeliveryBindingPolicy,
 ) -> ChannelBindingId:
-    async with store.connection.execute(
-        "SELECT id FROM channel_bindings WHERE channel_id = ? AND transport = 'telegram' ORDER BY id",
-        (channel_id,),
-    ) as cursor:
-        rows = list(await cursor.fetchall())
-    if len(rows) != 1:
+    binding_ids = await delivery_policy.binding_ids(store, channel_id, transport="telegram")
+    if len(binding_ids) != 1:
         raise OutboundDeliveryBindingError("Canonical reply channel must have exactly one Telegram binding")
-    return ChannelBindingId(str(rows[0][0]))
+    return binding_ids[0]
 
 
 async def _confirmed_preview_message_id(
@@ -261,6 +259,8 @@ async def record_outbound_message(store: WorkshopEventStore, message: OutboundMe
 async def record_outbound_message_with_delivery(
     store: WorkshopEventStore,
     message: OutboundMessage,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy,
 ) -> OutboundDeliveryResult:
     """Atomically create one canonical reply and its pending Telegram text delivery.
 
@@ -271,7 +271,7 @@ async def record_outbound_message_with_delivery(
     try:
         await connection.execute("BEGIN IMMEDIATE")
         binding = await _resolve_outbound(store, message.in_reply_to_message_id)
-        channel_binding_id = await _resolve_telegram_binding(store, binding.channel_id)
+        channel_binding_id = await _resolve_telegram_binding(store, binding.channel_id, delivery_policy)
         message_result = await _existing_outbound(store, binding, message)
         if message_result is None:
             message_result = await store.append_in_transaction(_outbound_envelope(binding, message))
@@ -306,6 +306,8 @@ async def record_outbound_message_with_delivery(
 async def record_outbound_message_with_streaming_finalization(
     store: WorkshopEventStore,
     message: OutboundMessage,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy,
 ) -> OutboundStreamingFinalizationResult:
     """Atomically persist a reply, delivery request, and immutable operation plan.
 
@@ -317,7 +319,11 @@ async def record_outbound_message_with_streaming_finalization(
     connection = store.connection
     try:
         await connection.execute("BEGIN IMMEDIATE")
-        result = await record_outbound_message_with_streaming_finalization_in_transaction(store, message)
+        result = await record_outbound_message_with_streaming_finalization_in_transaction(
+            store,
+            message,
+            delivery_policy=delivery_policy,
+        )
         await connection.commit()
         return result
     except Exception:
@@ -329,6 +335,7 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
     store: WorkshopEventStore,
     message: OutboundMessage,
     *,
+    delivery_policy: WorkshopDeliveryBindingPolicy,
     request_delivery: bool = True,
 ) -> OutboundStreamingFinalizationResult:
     """Persist a reply and immutable delivery plan in a caller-owned transaction."""
@@ -342,7 +349,7 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
             store,
             message.in_reply_to_message_id,
         )
-        if request_delivery
+        if request_delivery and delivery_policy.is_enabled("telegram")
         else None
     )
     if streaming_target is not None and (

--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -13,6 +13,7 @@ from kai.workshop.conversation_commands import (
     WorkshopConversationCommandService,
 )
 from kai.workshop.conversation_context import assemble_canonical_prior_pairs
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import MessageId, RunId, RuntimeProfileId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
@@ -68,6 +69,7 @@ class WorkshopPrivateTextExecutionService:
         runtime_pool: WorkshopRuntimePool,
         *,
         registered_backend_ids: frozenset[str],
+        delivery_policy: WorkshopDeliveryBindingPolicy,
     ) -> WorkshopPrivateTextExecutionService:
         store = await WorkshopEventStore.open(database_path)
         database_lock = asyncio.Lock()
@@ -82,6 +84,7 @@ class WorkshopPrivateTextExecutionService:
             database_lock=database_lock,
             transcript_projection=CanonicalTranscriptProjection(database_path.parent / "history"),
             artifact_storage_root=database_path.parent / "files",
+            delivery_policy=delivery_policy,
         )
         service = cls(
             store,
@@ -89,6 +92,7 @@ class WorkshopPrivateTextExecutionService:
             WorkshopConversationCommandService(
                 store,
                 artifact_storage_root=database_path.parent / "files",
+                delivery_policy=delivery_policy,
             ),
             database_lock,
             runtime_pool,

--- a/src/kai/workshop/proactive_publication.py
+++ b/src/kai/workshop/proactive_publication.py
@@ -20,9 +20,9 @@ from kai.workshop.delivery_outbox import (
     DeliveryRequestResult,
     WorkshopDeliveryOutbox,
 )
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     AgentId,
-    ChannelBindingId,
     ChannelId,
     EventEnvelope,
     EventId,
@@ -84,14 +84,12 @@ class WorkshopProactivePublicationService:
         artifacts: WorkshopArtifactService,
         *,
         artifact_storage_root: Path,
-        delivery_transports: frozenset[str],
+        delivery_policy: WorkshopDeliveryBindingPolicy,
     ) -> None:
-        if any(not isinstance(transport, str) or not transport for transport in delivery_transports):
-            raise ValueError("delivery_transports must contain non-empty identifiers")
         self._store = store
         self._artifacts = artifacts
         self._artifact_storage_root = artifact_storage_root.resolve()
-        self._delivery_transports = delivery_transports
+        self._delivery_policy = delivery_policy
         self._lock = asyncio.Lock()
 
     async def validate_authority(self, authority: ProactivePublicationAuthority) -> None:
@@ -224,16 +222,7 @@ class WorkshopProactivePublicationService:
                     artifact.for_message(message_id),
                     storage_root=self._artifact_storage_root,
                 )
-            binding_ids: tuple[ChannelBindingId, ...] = ()
-            if self._delivery_transports:
-                placeholders = ", ".join("?" for _ in self._delivery_transports)
-                parameters = (authority.channel_id, *sorted(self._delivery_transports))
-                async with connection.execute(
-                    "SELECT id FROM channel_bindings WHERE channel_id = ? "
-                    f"AND transport IN ({placeholders}) ORDER BY id",
-                    parameters,
-                ) as cursor:
-                    binding_ids = tuple(ChannelBindingId(str(row[0])) for row in await cursor.fetchall())
+            binding_ids = await self._delivery_policy.binding_ids(self._store, authority.channel_id)
             deliveries = tuple(
                 [
                     await WorkshopDeliveryOutbox(self._store).request_delivery_in_transaction(

--- a/src/kai/workshop/run_execution_authority.py
+++ b/src/kai/workshop/run_execution_authority.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     EventEnvelope,
     EventId,
@@ -817,7 +818,12 @@ class WorkshopRunExecutionAuthority:
             changed=True,
         )
 
-    async def recover_expired(self, *, occurred_at: datetime) -> RunRecoveryResult:
+    async def recover_expired(
+        self,
+        *,
+        occurred_at: datetime,
+        delivery_policy: WorkshopDeliveryBindingPolicy,
+    ) -> RunRecoveryResult:
         """Recover expired authority through the canonical terminal contract."""
         occurred_at = _timestamp(occurred_at, field_name="occurred_at")
         expired = interrupted = 0
@@ -831,7 +837,10 @@ class WorkshopRunExecutionAuthority:
                 # part of the authority module's construction dependency.
                 from kai.workshop.terminal_transactions import WorkshopRunTerminalTransactionCoordinator
 
-                await WorkshopRunTerminalTransactionCoordinator(self).interrupt_expired(
+                await WorkshopRunTerminalTransactionCoordinator(
+                    self,
+                    delivery_policy=delivery_policy,
+                ).interrupt_expired(
                     claim,
                     occurred_at=occurred_at,
                 )

--- a/src/kai/workshop/scheduled_notifications.py
+++ b/src/kai/workshop/scheduled_notifications.py
@@ -12,8 +12,8 @@ from kai.workshop.delivery_outbox import (
     DeliveryRequestResult,
     WorkshopDeliveryOutbox,
 )
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
-    ChannelBindingId,
     ChannelId,
     EventEnvelope,
     EventId,
@@ -43,8 +43,9 @@ class ScheduledReminderRecord:
 class WorkshopScheduledReminderRecorder:
     """Append one reminder to its canonical channel and optional adapter outbox."""
 
-    def __init__(self, store: WorkshopEventStore) -> None:
+    def __init__(self, store: WorkshopEventStore, delivery_policy: WorkshopDeliveryBindingPolicy) -> None:
         self._store = store
+        self._delivery_policy = delivery_policy
         self._lock = asyncio.Lock()
 
     async def record(self, reminder: ScheduledReminder) -> ScheduledReminderRecord:
@@ -106,11 +107,11 @@ class WorkshopScheduledReminderRecorder:
                 raise IdempotencyConflictError(f"Event identity {idempotency_key!r} was reused with different content")
             projection = CanonicalConversationProjection()
             await self._store.project_pending_in_transaction(projection)
-            async with connection.execute(
-                "SELECT id FROM channel_bindings WHERE channel_id = ? AND transport = 'telegram' ORDER BY id",
-                (channel_id,),
-            ) as cursor:
-                bindings = list(await cursor.fetchall())
+            bindings = await self._delivery_policy.binding_ids(
+                self._store,
+                channel_id,
+                transport="telegram",
+            )
             if len(bindings) > 1:
                 raise RuntimeError("Scheduled reminder channel has ambiguous Telegram bindings")
             delivery = None
@@ -118,7 +119,7 @@ class WorkshopScheduledReminderRecorder:
                 delivery = await WorkshopDeliveryOutbox(self._store).request_delivery_in_transaction(
                     DeliveryRequest(
                         message_id=message_id,
-                        channel_binding_id=ChannelBindingId(str(bindings[0][0])),
+                        channel_binding_id=bindings[0],
                         mode="text",
                         purpose=NOTIFICATION_PURPOSE,
                         occurred_at=occurred_at,

--- a/src/kai/workshop/scheduler.py
+++ b/src/kai/workshop/scheduler.py
@@ -21,6 +21,7 @@ from kai.backend import AgentResponse
 from kai.job_types import JOB_TYPE_AGENT, JOB_TYPE_REMINDER
 from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.conversation_commands import ConversationCommandDisposition
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     CanonicalMemoryProvenance,
     ChannelId,
@@ -109,11 +110,12 @@ class WorkshopCanonicalScheduler:
         store: WorkshopEventStore,
         execution: WorkshopPrivateTextExecutionService,
         compatibility_state: WorkshopCompatibilityStateWriter,
+        delivery_policy: WorkshopDeliveryBindingPolicy,
     ) -> None:
         self._store = store
         self._execution = execution
         self._compatibility_state = compatibility_state
-        self._reminders = WorkshopScheduledReminderRecorder(store)
+        self._reminders = WorkshopScheduledReminderRecorder(store, delivery_policy)
         self._jobs = WorkshopScheduledJobStore(store)
         self._state = WorkshopSchedulerState.NEW
         self._stop_event = asyncio.Event()
@@ -131,9 +133,10 @@ class WorkshopCanonicalScheduler:
         database_path: Path,
         execution: WorkshopPrivateTextExecutionService,
         compatibility_state: WorkshopCompatibilityStateWriter,
+        delivery_policy: WorkshopDeliveryBindingPolicy,
     ) -> WorkshopCanonicalScheduler:
         store = await WorkshopEventStore.open(database_path)
-        service = cls(store, execution, compatibility_state)
+        service = cls(store, execution, compatibility_state, delivery_policy)
         try:
             await service._recover_interrupted_firings()
             service._scheduler.start(paused=True)

--- a/src/kai/workshop/terminal_transactions.py
+++ b/src/kai/workshop/terminal_transactions.py
@@ -9,6 +9,7 @@ from enum import StrEnum
 
 import aiosqlite
 
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import MessageId
 from kai.workshop.outbound import (
     OutboundMessage,
@@ -115,11 +116,17 @@ class WorkshopRunTerminalTransactionCoordinator:
     This service is not constructed by production code.
     """
 
-    def __init__(self, authority: WorkshopRunExecutionAuthority) -> None:
+    def __init__(
+        self,
+        authority: WorkshopRunExecutionAuthority,
+        *,
+        delivery_policy: WorkshopDeliveryBindingPolicy,
+    ) -> None:
         if not isinstance(authority, WorkshopRunExecutionAuthority):
             raise TypeError("authority must be a WorkshopRunExecutionAuthority")
         self._authority = authority
         self._store = authority.event_store
+        self._delivery_policy = delivery_policy
 
     async def complete(
         self,
@@ -232,6 +239,7 @@ class WorkshopRunTerminalTransactionCoordinator:
                     body=body,
                     occurred_at=occurred_at,
                 ),
+                delivery_policy=self._delivery_policy,
                 request_delivery=request_delivery,
             )
             message_id = finalization.message.event.envelope.aggregate_id

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from kai.config import DATA_DIR, load_config
 from kai.workshop.client_access import WorkshopClientAccess, WorkshopClientAccessError
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     ChannelId,
     DeviceId,
@@ -187,7 +188,10 @@ async def _run(args: argparse.Namespace) -> int:
     store = await WorkshopEventStore.open(_deployed_database(DATA_DIR))
     try:
         if args.command == "integration-route":
-            service = WorkshopIntegrationNotificationService(store)
+            service = WorkshopIntegrationNotificationService(
+                store,
+                WorkshopDeliveryBindingPolicy.disabled(),
+            )
             if args.action == "set":
                 try:
                     channel_id = ChannelId(args.channel_id)

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -139,7 +139,7 @@ class _FakeIntegrationNotifications:
         self.events = events
 
     @classmethod
-    async def open(cls, _path: Path):
+    async def open(cls, _path: Path, _delivery_policy):
         events = _FakeExecutionFactory.events
         events.append("integrations:open")
         return cls(events)
@@ -300,6 +300,7 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
         },
     }
     assert services.subprocess_pool is not None
+    assert services.delivery_policy.enabled_transports == frozenset()
     assert host_dependencies == [
         "pool:start",
         "store:open",

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -12,6 +12,7 @@ import pytest
 from kai import sessions
 from kai.workshop.domain import MessageId
 from kai.workshop.outbound import OutboundMessage
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 
 
 @pytest.fixture
@@ -69,7 +70,10 @@ class TestWorkshopFinalizationAdapter:
         recorder = AsyncMock(side_effect=[aiosqlite.OperationalError("commit result lost"), expected])
 
         with patch("kai.sessions.record_outbound_message_with_streaming_finalization", recorder):
-            result = await sessions.record_workshop_streaming_finalization(message)
+            result = await sessions.record_workshop_streaming_finalization(
+                message,
+                delivery_policy=TELEGRAM_DELIVERY_POLICY,
+            )
 
         assert result is expected
         assert recorder.await_count == 2
@@ -91,7 +95,10 @@ class TestWorkshopFinalizationAdapter:
             patch("kai.sessions.record_outbound_message_with_streaming_finalization", recorder),
             pytest.raises(sessions.WorkshopFinalizationCommitUncertainError),
         ):
-            await sessions.record_workshop_streaming_finalization(message)
+            await sessions.record_workshop_streaming_finalization(
+                message,
+                delivery_policy=TELEGRAM_DELIVERY_POLICY,
+            )
 
         assert recorder.await_count == 2
 

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -25,6 +25,7 @@ from kai.workshop.run_execution_authority import (
 )
 from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
 from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+from tests.workshop_delivery import DISABLED_DELIVERY_POLICY, TELEGRAM_DELIVERY_POLICY
 from tests.workshop_profiles import profile_id
 
 _NOW = datetime(2026, 8, 12, 20, 0, tzinfo=UTC)
@@ -159,6 +160,7 @@ class TestAtomicConversationCommandAcceptance:
         service = WorkshopConversationCommandService(
             store,
             artifact_storage_root=storage_root,
+            delivery_policy=TELEGRAM_DELIVERY_POLICY,
         )
         try:
             accepted = await service.accept(_message(), artifact=artifact)
@@ -429,6 +431,7 @@ class TestAtomicClientConversationCommandAcceptance:
         service = WorkshopConversationCommandService(
             store,
             artifact_storage_root=storage_root,
+            delivery_policy=TELEGRAM_DELIVERY_POLICY,
         )
         try:
             accepted = await service.accept_client(message, artifact=artifact)
@@ -504,9 +507,10 @@ class TestAtomicClientConversationCommandAcceptance:
     ):
         store, principal_id, channel_id = await _open_client_store(tmp_path / "kai.db")
         try:
-            accepted = await WorkshopConversationCommandService(store).accept_client(
-                _client_message(principal_id, channel_id)
-            )
+            accepted = await WorkshopConversationCommandService(
+                store,
+                delivery_policy=TELEGRAM_DELIVERY_POLICY,
+            ).accept_client(_client_message(principal_id, channel_id))
 
             assert accepted.command.disposition == ConversationCommandDisposition.NEWLY_ACCEPTED
             assert accepted.command.message.inserted is True
@@ -540,7 +544,10 @@ class TestAtomicClientConversationCommandAcceptance:
         tmp_path: Path,
     ):
         store, principal_id, channel_id = await _open_client_store(tmp_path / "kai.db")
-        service = WorkshopConversationCommandService(store)
+        service = WorkshopConversationCommandService(
+            store,
+            delivery_policy=TELEGRAM_DELIVERY_POLICY,
+        )
         message = _client_message(principal_id, channel_id)
         try:
             first = await service.accept_client(message)
@@ -613,5 +620,27 @@ class TestAtomicClientConversationCommandAcceptance:
                     "message.created",
                     "run.accepted",
                 ]
+        finally:
+            await store.close()
+
+    async def test_disabled_telegram_adapter_does_not_enqueue_for_retained_binding(
+        self,
+        tmp_path: Path,
+    ):
+        store, principal_id, channel_id = await _open_client_store(tmp_path / "kai.db")
+        try:
+            accepted = await WorkshopConversationCommandService(
+                store,
+                delivery_policy=DISABLED_DELIVERY_POLICY,
+            ).accept_client(_client_message(principal_id, channel_id))
+
+            assert accepted.delivery is None
+            async with store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_bindings WHERE channel_id = ? AND transport = 'telegram'",
+                (channel_id,),
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 1
         finally:
             await store.close()

--- a/tests/test_workshop_delivery_authority.py
+++ b/tests/test_workshop_delivery_authority.py
@@ -35,6 +35,7 @@ from kai.workshop.telegram_delivery import (
     WorkshopTelegramStreamingFinalizationAdapter,
     WorkshopTelegramStreamingFinalizationWorker,
 )
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 
 _NOW = datetime(2026, 8, 12, 15, 0, tzinfo=UTC)
 
@@ -84,6 +85,7 @@ async def _finalize(store: WorkshopEventStore, inbound_id: MessageId, *, sequenc
             body=f"Final answer {sequence}",
             occurred_at=_NOW + timedelta(minutes=sequence, seconds=1),
         ),
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
     )
 
 

--- a/tests/test_workshop_delivery_policy.py
+++ b/tests/test_workshop_delivery_policy.py
@@ -1,0 +1,78 @@
+"""Core delivery eligibility is adapter enablement plus persisted bindings."""
+
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
+from kai.workshop.domain import ChannelId
+from kai.workshop.store import WorkshopEventStore
+
+
+async def _store_with_bindings(path: Path) -> tuple[WorkshopEventStore, ChannelId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Daniel",
+                role="admin",
+                transport="telegram",
+                external_subject="101",
+                external_channel_id="101",
+            ),
+        ),
+    )
+    async with store.connection.execute(
+        "SELECT channel_id FROM channel_bindings WHERE transport = 'telegram'"
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    channel_id = ChannelId(str(row[0]))
+    await store.connection.execute(
+        "INSERT INTO channel_bindings (id, channel_id, transport, external_channel_id, created_at) "
+        "VALUES (?, ?, 'desktop', 'desktop-101', '2026-08-25T00:00:00Z')",
+        ("cbd_00000000000000000000000000000001", channel_id),
+    )
+    await store.connection.commit()
+    return store, channel_id
+
+
+def test_policy_rejects_invalid_transport_identifiers():
+    with pytest.raises(ValueError, match="lowercase"):
+        WorkshopDeliveryBindingPolicy(frozenset({"Telegram"}))
+    with pytest.raises(ValueError, match="lowercase"):
+        WorkshopDeliveryBindingPolicy(frozenset({1}))  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="frozenset"):
+        WorkshopDeliveryBindingPolicy({"telegram"})  # type: ignore[arg-type]
+
+
+async def test_disabled_policy_retains_bindings_without_making_them_eligible(tmp_path: Path):
+    store, channel_id = await _store_with_bindings(tmp_path / "kai.db")
+    try:
+        policy = WorkshopDeliveryBindingPolicy.disabled()
+
+        assert await policy.binding_ids(store, channel_id) == ()
+        assert await policy.binding_ids(store, channel_id, transport="telegram") == ()
+        async with store.connection.execute(
+            "SELECT transport FROM channel_bindings WHERE channel_id = ? ORDER BY transport",
+            (channel_id,),
+        ) as cursor:
+            assert [str(row[0]) for row in await cursor.fetchall()] == ["desktop", "telegram"]
+    finally:
+        await store.close()
+
+
+async def test_policy_selects_only_bindings_for_enabled_transports(tmp_path: Path):
+    store, channel_id = await _store_with_bindings(tmp_path / "kai.db")
+    try:
+        telegram_only = WorkshopDeliveryBindingPolicy(frozenset({"telegram"}))
+        mixed = WorkshopDeliveryBindingPolicy(frozenset({"desktop", "telegram"}))
+
+        telegram_bindings = await telegram_only.binding_ids(store, channel_id)
+        assert len(telegram_bindings) == 1
+        assert await telegram_only.binding_ids(store, channel_id, transport="desktop") == ()
+        assert len(await mixed.binding_ids(store, channel_id)) == 2
+    finally:
+        await store.close()

--- a/tests/test_workshop_direct_text_cutover.py
+++ b/tests/test_workshop_direct_text_cutover.py
@@ -17,6 +17,7 @@ from kai.workshop.outbound import OutboundMessage
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.streaming_preview import ConfirmedTelegramStreamingPreview
 from kai.workshop.telegram_delivery_runtime import WorkshopTelegramConversationDeliveryService
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 
 _NOW = datetime(2026, 1, 1, 18, 0, tzinfo=UTC)
 
@@ -65,7 +66,8 @@ async def test_shared_finalizer_and_dedicated_worker_finalize_one_preview_withou
                 in_reply_to_message_id=inbound_id,
                 body="Durable final answer",
                 occurred_at=_NOW + timedelta(seconds=2),
-            )
+            ),
+            delivery_policy=TELEGRAM_DELIVERY_POLICY,
         )
 
         for _ in range(200):

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -29,6 +29,7 @@ from kai.workshop.run_execution_authority import (
 from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
 from kai.workshop.runtime_sessions import load_runtime_session
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 
 _NOW = datetime(2026, 8, 12, 22, 0, tzinfo=UTC)
 _RUNTIME_PROFILE_ID = RuntimeProfileId.new()
@@ -128,6 +129,7 @@ def _coordinator(store, preparation, *, lease_seconds: int = 60):
         registered_backend_ids=frozenset({"codex"}),
         clock=lambda: _NOW + timedelta(seconds=10),
         lease_duration=timedelta(seconds=lease_seconds),
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
     )
 
 

--- a/tests/test_workshop_github_notifications.py
+++ b/tests/test_workshop_github_notifications.py
@@ -16,6 +16,7 @@ from kai.workshop.bootstrap import (
     bootstrap_default_workshop,
 )
 from kai.workshop.delivery_outbox import NOTIFICATION_PURPOSE
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import ChannelId
 from kai.workshop.integration_notifications import (
     IntegrationNotification,
@@ -23,6 +24,7 @@ from kai.workshop.integration_notifications import (
     WorkshopIntegrationNotificationService,
 )
 from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+from tests.workshop_delivery import DISABLED_DELIVERY_POLICY, TELEGRAM_DELIVERY_POLICY
 
 _NOW = datetime(2026, 8, 13, 12, 0, tzinfo=UTC)
 
@@ -49,6 +51,13 @@ async def _open_notification_store(path: Path) -> WorkshopEventStore:
         ),
     )
     return store
+
+
+async def _notification_channel(store: WorkshopEventStore) -> ChannelId:
+    async with store.connection.execute("SELECT id FROM channels WHERE kind = 'notification'") as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return ChannelId(str(row[0]))
 
 
 def _notification(*, body: str = "**Push** to [kai](https://github.com/example/kai)") -> IntegrationNotification:
@@ -95,7 +104,7 @@ class TestWorkshopIntegrationNotificationService:
         store = await _open_notification_store(path)
         await store.close()
 
-        service = await WorkshopIntegrationNotificationService.open(path)
+        service = await WorkshopIntegrationNotificationService.open(path, TELEGRAM_DELIVERY_POLICY)
         try:
             status = await service.route_status(source="generic", route_name="default")
 
@@ -109,7 +118,7 @@ class TestWorkshopIntegrationNotificationService:
         path = tmp_path / "kai.db"
         store = await _open_notification_store(path)
         await store.close()
-        service = await WorkshopIntegrationNotificationService.open(path)
+        service = await WorkshopIntegrationNotificationService.open(path, TELEGRAM_DELIVERY_POLICY)
         try:
             notification = IntegrationNotification(
                 delivery_id="generic-route-1",
@@ -125,6 +134,61 @@ class TestWorkshopIntegrationNotificationService:
             assert len(result.deliveries) == 1
         finally:
             await service.close()
+
+    async def test_disabled_adapter_retains_binding_without_enqueuing_notification(self, tmp_path: Path):
+        store = await _open_notification_store(tmp_path / "kai.db")
+        try:
+            result = await WorkshopIntegrationNotificationService(
+                store,
+                DISABLED_DELIVERY_POLICY,
+            ).record_for_channel(_notification(), await _notification_channel(store))
+
+            assert result.inserted is True
+            assert result.deliveries == ()
+            async with store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_bindings WHERE transport = 'telegram'"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 2
+
+            # Enabling an adapter later does not discover or enqueue historical
+            # canonical messages. Only new publication work can request delivery.
+            enabled_service = WorkshopIntegrationNotificationService(
+                store,
+                TELEGRAM_DELIVERY_POLICY,
+            )
+            await enabled_service.route_status(source="generic", route_name="default")
+            async with store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+        finally:
+            await store.close()
+
+    async def test_mixed_bindings_enqueue_only_for_enabled_transport(self, tmp_path: Path):
+        store = await _open_notification_store(tmp_path / "kai.db")
+        channel_id = await _notification_channel(store)
+        await store.connection.execute(
+            "INSERT INTO channel_bindings (id, channel_id, transport, external_channel_id, created_at) "
+            "VALUES (?, ?, 'desktop', 'desktop-notifications', '2026-08-25T00:00:00Z')",
+            ("cbd_00000000000000000000000000000002", channel_id),
+        )
+        await store.connection.commit()
+        try:
+            desktop_policy = WorkshopDeliveryBindingPolicy(frozenset({"desktop"}))
+            result = await WorkshopIntegrationNotificationService(store, desktop_policy).record_for_channel(
+                _notification(),
+                channel_id,
+            )
+
+            assert len(result.deliveries) == 1
+            assert result.deliveries[0].delivery.transport == "desktop"
+            async with store.connection.execute(
+                "SELECT transport FROM delivery_outbox WHERE message_id = ?",
+                (result.message_id,),
+            ) as cursor:
+                assert [str(row[0]) for row in await cursor.fetchall()] == ["desktop"]
+        finally:
+            await store.close()
 
     async def test_ambiguous_admin_policy_does_not_seed_or_deliver(self, tmp_path: Path):
         store = await WorkshopEventStore.open(tmp_path / "kai.db")
@@ -148,7 +212,7 @@ class TestWorkshopIntegrationNotificationService:
             ),
         )
         try:
-            service = WorkshopIntegrationNotificationService(store)
+            service = WorkshopIntegrationNotificationService(store, TELEGRAM_DELIVERY_POLICY)
             status = await service.reconcile_default_generic_route()
 
             assert status.state == "ambiguous"
@@ -202,7 +266,7 @@ class TestWorkshopIntegrationNotificationService:
         try:
             async with store.connection.execute("SELECT id FROM channels WHERE kind = 'notification'") as cursor:
                 channel_id = ChannelId(str((await cursor.fetchone())[0]))
-            service = WorkshopIntegrationNotificationService(store)
+            service = WorkshopIntegrationNotificationService(store, TELEGRAM_DELIVERY_POLICY)
 
             status = await service.set_route(
                 source="generic",
@@ -221,7 +285,7 @@ class TestWorkshopIntegrationNotificationService:
             async with store.connection.execute("SELECT id FROM channels WHERE kind = 'notification'") as cursor:
                 channel_id = ChannelId(str((await cursor.fetchone())[0]))
 
-            result = await WorkshopIntegrationNotificationService(store).record_for_channel(
+            result = await WorkshopIntegrationNotificationService(store, TELEGRAM_DELIVERY_POLICY).record_for_channel(
                 _notification(),
                 channel_id,
             )
@@ -241,7 +305,7 @@ class TestWorkshopIntegrationNotificationService:
     ):
         store = await _open_notification_store(tmp_path / "kai.db")
         try:
-            result = await WorkshopIntegrationNotificationService(store).record_for_binding(
+            result = await WorkshopIntegrationNotificationService(store, TELEGRAM_DELIVERY_POLICY).record_for_binding(
                 _notification(),
                 transport="telegram",
                 external_channel_id="-100123",
@@ -287,7 +351,7 @@ class TestWorkshopIntegrationNotificationService:
     ):
         path = tmp_path / "kai.db"
         store = await _open_notification_store(path)
-        first = await WorkshopIntegrationNotificationService(store).record_for_binding(
+        first = await WorkshopIntegrationNotificationService(store, TELEGRAM_DELIVERY_POLICY).record_for_binding(
             _notification(),
             transport="telegram",
             external_channel_id="-100123",
@@ -296,7 +360,7 @@ class TestWorkshopIntegrationNotificationService:
 
         reopened = await WorkshopEventStore.open(path)
         try:
-            retry = await WorkshopIntegrationNotificationService(reopened).record_for_binding(
+            retry = await WorkshopIntegrationNotificationService(reopened, TELEGRAM_DELIVERY_POLICY).record_for_binding(
                 IntegrationNotification(
                     **{
                         **{
@@ -329,7 +393,7 @@ class TestWorkshopIntegrationNotificationService:
     ):
         store = await _open_notification_store(tmp_path / "kai.db")
         try:
-            recorder = WorkshopIntegrationNotificationService(store)
+            recorder = WorkshopIntegrationNotificationService(store, TELEGRAM_DELIVERY_POLICY)
             await recorder.record_for_binding(_notification(), transport="telegram", external_channel_id="-100123")
             with pytest.raises(IdempotencyConflictError):
                 await recorder.record_for_binding(
@@ -355,7 +419,7 @@ class TestWorkshopIntegrationNotificationService:
                 occurred_at=_NOW,
             )
             assert (
-                await WorkshopIntegrationNotificationService(store).record_for_binding(
+                await WorkshopIntegrationNotificationService(store, TELEGRAM_DELIVERY_POLICY).record_for_binding(
                     notification,
                     transport="telegram",
                     external_channel_id="-100999",
@@ -377,7 +441,9 @@ class TestWorkshopIntegrationNotificationService:
                 body="Build complete",
                 occurred_at=_NOW,
             )
-            result = await WorkshopIntegrationNotificationService(store).record_for_default_admin(notification)
+            result = await WorkshopIntegrationNotificationService(
+                store, TELEGRAM_DELIVERY_POLICY
+            ).record_for_default_admin(notification)
 
             assert result.inserted is True
             assert len(result.deliveries) == 1
@@ -392,7 +458,7 @@ class TestWorkshopIntegrationNotificationService:
     async def test_generic_delivery_identity_is_idempotent(self, tmp_path: Path):
         store = await _open_notification_store(tmp_path / "kai.db")
         try:
-            service = WorkshopIntegrationNotificationService(store)
+            service = WorkshopIntegrationNotificationService(store, TELEGRAM_DELIVERY_POLICY)
             notification = IntegrationNotification(
                 delivery_id="generic-retry-1",
                 source="generic",

--- a/tests/test_workshop_outbound.py
+++ b/tests/test_workshop_outbound.py
@@ -28,12 +28,23 @@ from kai.workshop.outbound import (
     OutboundMessageNotFoundError,
     record_delivery_observation,
     record_outbound_message,
-    record_outbound_message_with_delivery,
+)
+from kai.workshop.outbound import (
+    record_outbound_message_with_delivery as _record_outbound_message_with_delivery,
 )
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 
 _NOW = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+
+
+async def record_outbound_message_with_delivery(store, message):
+    return await _record_outbound_message_with_delivery(
+        store,
+        message,
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
+    )
 
 
 async def _open_with_inbound(path: Path) -> tuple[WorkshopEventStore, MessageId]:

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -24,6 +24,7 @@ from kai.workshop.private_text_execution import (
 from kai.workshop.run_lifecycle import RunStatus
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 from tests.workshop_profiles import profile_id, profile_registry
 
 _NOW = datetime(2026, 1, 1, 23, 0, tzinfo=UTC)
@@ -104,6 +105,7 @@ async def test_owner_accepts_executes_and_atomically_enqueues_terminal_reply(tmp
         database,
         WorkshopRuntimePool(pool, profile_registry(101)),  # type: ignore[arg-type]
         registered_backend_ids=frozenset({"codex"}),
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
     )
     observed: list[str] = []
     try:
@@ -149,6 +151,7 @@ async def test_owner_routes_stop_to_exact_active_runtime_and_terminal_cancellati
         database,
         WorkshopRuntimePool(pool, profile_registry(101)),  # type: ignore[arg-type]
         registered_backend_ids=frozenset({"codex"}),
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
     )
     try:
         accepted = await service.accept(_message())
@@ -191,6 +194,7 @@ async def test_owner_discovers_only_durably_accepted_workshop_client_runs(tmp_pa
         database,
         WorkshopRuntimePool(pool, profile_registry(101)),  # type: ignore[arg-type]
         registered_backend_ids=frozenset({"codex"}),
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
     )
     try:
         accepted = await service.accept_client(

--- a/tests/test_workshop_proactive_publication.py
+++ b/tests/test_workshop_proactive_publication.py
@@ -11,6 +11,7 @@ import pytest
 
 from kai.workshop.artifacts import WorkshopArtifactService, artifact_for_delivery
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import AgentId
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.proactive_publication import (
@@ -60,7 +61,7 @@ async def _publication_service(
         store,
         artifacts,
         artifact_storage_root=tmp_path / "files",
-        delivery_transports=delivery_transports,
+        delivery_policy=WorkshopDeliveryBindingPolicy(delivery_transports),
     )
     authority = ProactivePublicationAuthority(
         context.principal_id,

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -24,6 +24,7 @@ from kai.workshop.run_execution_authority import (
 )
 from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 
 _NOW = datetime(2026, 8, 12, 18, 0, tzinfo=UTC)
 
@@ -340,7 +341,10 @@ class TestRunExecutionRecovery:
         try:
             accepted = await _accepted(store, inbound_id)
             first = await _grant(authority, accepted.run.run_id)
-            recovery = await authority.recover_expired(occurred_at=_NOW + timedelta(seconds=63))
+            recovery = await authority.recover_expired(
+                occurred_at=_NOW + timedelta(seconds=63),
+                delivery_policy=TELEGRAM_DELIVERY_POLICY,
+            )
             second = await _grant(authority, accepted.run.run_id, offset=64)
 
             assert recovery.expired_before_dispatch == 1
@@ -362,7 +366,10 @@ class TestRunExecutionRecovery:
             accepted = await _accepted(store, inbound_id)
             granted = await _grant(authority, accepted.run.run_id)
             await authority.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
-            recovery = await authority.recover_expired(occurred_at=_NOW + timedelta(seconds=63))
+            recovery = await authority.recover_expired(
+                occurred_at=_NOW + timedelta(seconds=63),
+                delivery_policy=TELEGRAM_DELIVERY_POLICY,
+            )
 
             assert recovery.expired_before_dispatch == 0
             assert recovery.interrupted_after_dispatch == 1

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -37,6 +37,7 @@ from kai.workshop.scheduler import (
 )
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.timeline import read_channel_timeline
+from tests.workshop_delivery import DISABLED_DELIVERY_POLICY, TELEGRAM_DELIVERY_POLICY
 from tests.workshop_profiles import profile_id, profile_registry
 
 
@@ -280,6 +281,7 @@ async def test_workshop_only_reminder_fires_canonically_without_delivery(tmp_pat
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
         _UnusedCompatibilityState(),  # type: ignore[arg-type]
+        DISABLED_DELIVERY_POLICY,
     )
     try:
         await asyncio.sleep(0.25)
@@ -328,11 +330,39 @@ async def test_telegram_bound_reminder_uses_notification_outbox(tmp_path: Path) 
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
         _UnusedCompatibilityState(),  # type: ignore[arg-type]
+        TELEGRAM_DELIVERY_POLICY,
     )
     try:
         await asyncio.sleep(0.25)
         async with source_store.connection.execute("SELECT purpose, status FROM delivery_outbox") as cursor:
             assert tuple(await cursor.fetchone()) == ("notification", "pending")
+    finally:
+        await scheduler.stop()
+        await source_store.close()
+        await sessions.close_db()
+
+
+async def test_disabled_telegram_adapter_does_not_enqueue_retained_reminder_binding(tmp_path: Path) -> None:
+    database = tmp_path / "kai.db"
+    source_store, _ = await _install_owned_job(
+        database,
+        transport="telegram",
+        run_at=datetime.now(UTC) + timedelta(milliseconds=100),
+    )
+    scheduler = await WorkshopCanonicalScheduler.open_and_start(
+        database,
+        _UnusedExecution(),  # type: ignore[arg-type]
+        _UnusedCompatibilityState(),  # type: ignore[arg-type]
+        DISABLED_DELIVERY_POLICY,
+    )
+    try:
+        await asyncio.sleep(0.25)
+        async with source_store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
+            assert int((await cursor.fetchone())[0]) == 0
+        async with source_store.connection.execute(
+            "SELECT COUNT(*) FROM channel_bindings WHERE transport = 'telegram'"
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 1
     finally:
         await scheduler.stop()
         await source_store.close()
@@ -348,6 +378,7 @@ async def test_scheduler_starts_without_legacy_jobs_table(tmp_path: Path) -> Non
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
         _UnusedCompatibilityState(),  # type: ignore[arg-type]
+        DISABLED_DELIVERY_POLICY,
     )
     try:
         assert scheduler.readiness.ready is True
@@ -376,6 +407,7 @@ async def test_scheduler_fails_closed_for_active_job_without_canonical_owner(
             database,
             _UnusedExecution(),  # type: ignore[arg-type]
             _UnusedCompatibilityState(),  # type: ignore[arg-type]
+            DISABLED_DELIVERY_POLICY,
         )
     await store.close()
     await sessions.close_db()
@@ -425,6 +457,7 @@ async def test_once_daily_and_interval_jobs_reconcile_into_core_scheduler(
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
         _UnusedCompatibilityState(),  # type: ignore[arg-type]
+        DISABLED_DELIVERY_POLICY,
     )
     try:
         assert scheduler.readiness.active_jobs == 3
@@ -458,6 +491,7 @@ async def test_interrupted_reminder_firing_recovers_once(tmp_path: Path) -> None
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
         _UnusedCompatibilityState(),  # type: ignore[arg-type]
+        DISABLED_DELIVERY_POLICY,
     )
     try:
         await asyncio.sleep(0.2)
@@ -493,6 +527,7 @@ async def test_workshop_only_agent_job_uses_canonical_execution(tmp_path: Path) 
         database,
         execution,  # type: ignore[arg-type]
         _CompatibilityState(),  # type: ignore[arg-type]
+        DISABLED_DELIVERY_POLICY,
     )
     try:
         await asyncio.sleep(0.25)
@@ -534,11 +569,13 @@ async def test_agent_firing_completes_through_real_canonical_coordinator(
         database,
         WorkshopRuntimePool(pool, profile_registry(101)),  # type: ignore[arg-type]
         registered_backend_ids=frozenset({"codex"}),
+        delivery_policy=DISABLED_DELIVERY_POLICY,
     )
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,
         execution,
         _CanonicalCompatibilityState(),  # type: ignore[arg-type]
+        DISABLED_DELIVERY_POLICY,
     )
     try:
         await asyncio.sleep(0.35)

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -36,7 +36,9 @@ from kai.workshop.outbound import (
     OutboundMessage,
     OutboundStreamingPreviewConflictError,
     record_outbound_message,
-    record_outbound_message_with_streaming_finalization,
+)
+from kai.workshop.outbound import (
+    record_outbound_message_with_streaming_finalization as _record_outbound_message_with_streaming_finalization,
 )
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.streaming_preview import (
@@ -48,8 +50,17 @@ from kai.workshop.telegram_delivery import (
     WorkshopTelegramDeliveryAdapter,
     WorkshopTelegramDeliveryWorker,
 )
+from tests.workshop_delivery import DISABLED_DELIVERY_POLICY, TELEGRAM_DELIVERY_POLICY
 
 _NOW = datetime(2026, 8, 12, 12, 0, tzinfo=UTC)
+
+
+async def record_outbound_message_with_streaming_finalization(store, message):
+    return await _record_outbound_message_with_streaming_finalization(
+        store,
+        message,
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
+    )
 
 
 @dataclass
@@ -122,6 +133,30 @@ async def _assert_no_finalization_state(store: WorkshopEventStore, inbound_id: M
 
 
 class TestAtomicStreamingFinalization:
+    async def test_disabled_telegram_adapter_records_reply_without_delivery_for_retained_binding(
+        self,
+        tmp_path: Path,
+    ):
+        store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
+        try:
+            result = await _record_outbound_message_with_streaming_finalization(
+                store,
+                _outbound(inbound_id),
+                delivery_policy=DISABLED_DELIVERY_POLICY,
+            )
+
+            assert result.message.inserted is True
+            assert result.delivery is None
+            assert result.plan is None
+            async with store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_bindings WHERE transport = 'telegram'"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 1
+        finally:
+            await store.close()
+
     async def test_short_reply_with_preview_is_one_explicit_edit_operation(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:

--- a/tests/test_workshop_telegram_delivery.py
+++ b/tests/test_workshop_telegram_delivery.py
@@ -57,6 +57,7 @@ from kai.workshop.telegram_delivery import (
     WorkshopTelegramDeliveryAdapter,
     WorkshopTelegramDeliveryWorker,
 )
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 from tests.workshop_profiles import profile_id, profile_registry
 
 _NOW = datetime(2026, 8, 12, 9, 32, tzinfo=UTC)
@@ -274,7 +275,7 @@ async def _open_with_proactive_artifact(
             runtime_profiles=profiles,
         ),
         artifact_storage_root=tmp_path / "files",
-        delivery_transports=frozenset({"telegram"}),
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
     )
     source = tmp_path / filename
     source.write_bytes(content)

--- a/tests/test_workshop_telegram_streaming_finalization.py
+++ b/tests/test_workshop_telegram_streaming_finalization.py
@@ -56,6 +56,7 @@ from kai.workshop.telegram_delivery import (
     WorkshopTelegramStreamingFinalizationAdapter,
     WorkshopTelegramStreamingFinalizationWorker,
 )
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 
 _NOW = datetime(2026, 8, 12, 13, 30, tzinfo=UTC)
 
@@ -158,6 +159,7 @@ async def _prepare_finalization(
             body=body,
             occurred_at=_NOW + timedelta(seconds=2),
         ),
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
     )
     return store, result.delivery.delivery.delivery_id
 

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -34,11 +34,21 @@ from kai.workshop.terminal_transactions import (
     TerminalOutcome,
     TerminalTransactionCommitUncertainError,
     TerminalTransactionStateConflictError,
-    WorkshopRunTerminalTransactionCoordinator,
 )
+from kai.workshop.terminal_transactions import (
+    WorkshopRunTerminalTransactionCoordinator as _WorkshopRunTerminalTransactionCoordinator,
+)
+from tests.workshop_delivery import DISABLED_DELIVERY_POLICY, TELEGRAM_DELIVERY_POLICY
 from tests.workshop_profiles import profile_id
 
 _NOW = datetime(2026, 8, 12, 21, 0, tzinfo=UTC)
+
+
+def WorkshopRunTerminalTransactionCoordinator(authority):
+    return _WorkshopRunTerminalTransactionCoordinator(
+        authority,
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
+    )
 
 
 async def _started_run(
@@ -116,7 +126,10 @@ async def _started_client_run(
     ) as cursor:
         row = await cursor.fetchone()
     assert row is not None
-    accepted = await WorkshopConversationCommandService(store).accept_client(
+    accepted = await WorkshopConversationCommandService(
+        store,
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
+    ).accept_client(
         ClientInboundMessage(
             principal_id=PrincipalId(str(row[0])),
             channel_id=ChannelId(str(row[1])),
@@ -165,7 +178,10 @@ async def _started_workshop_only_client_run(
     ) as cursor:
         row = await cursor.fetchone()
     assert row is not None
-    accepted = await WorkshopConversationCommandService(store).accept_client(
+    accepted = await WorkshopConversationCommandService(
+        store,
+        delivery_policy=DISABLED_DELIVERY_POLICY,
+    ).accept_client(
         ClientInboundMessage(
             principal_id=PrincipalId(str(row[0])),
             channel_id=ChannelId(str(row[1])),
@@ -470,6 +486,7 @@ class TestAtomicTerminalTransactions:
                     body="Half state",
                     occurred_at=_NOW + timedelta(seconds=4),
                 ),
+                delivery_policy=TELEGRAM_DELIVERY_POLICY,
             )
 
             with pytest.raises(TerminalTransactionStateConflictError, match="share one prior state"):

--- a/tests/test_workshop_transcript_export.py
+++ b/tests/test_workshop_transcript_export.py
@@ -32,6 +32,7 @@ from kai.workshop.transcript_export import (
     inspect_canonical_transcript_snapshot,
 )
 from kai.workshop_cli import _parser
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 from tests.workshop_profiles import profile_id
 
 _NOW = datetime(2026, 8, 15, 9, 0, tzinfo=UTC)
@@ -87,7 +88,10 @@ async def _complete(store: WorkshopEventStore, acceptance, suffix: str):
         lease_expires_at=_NOW + timedelta(minutes=int(suffix) + 2),
     )
     started = await authority.start(granted.claim, occurred_at=_NOW + timedelta(minutes=int(suffix), seconds=2))
-    return await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+    return await WorkshopRunTerminalTransactionCoordinator(
+        authority,
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
+    ).complete(
         started.claim,
         body=f"Canonical answer {suffix}",
         occurred_at=_NOW + timedelta(minutes=int(suffix), seconds=3),

--- a/tests/workshop_delivery.py
+++ b/tests/workshop_delivery.py
@@ -1,0 +1,6 @@
+"""Shared delivery-policy fixtures for Workshop contract tests."""
+
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
+
+TELEGRAM_DELIVERY_POLICY = WorkshopDeliveryBindingPolicy(frozenset({"telegram"}))
+DISABLED_DELIVERY_POLICY = WorkshopDeliveryBindingPolicy.disabled()


### PR DESCRIPTION
Closes #1107.

## Summary

- add one core-owned delivery eligibility policy that combines current adapter enablement with retained channel bindings
- inject that immutable policy into browser echo, assistant finalization, scheduling, proactive publication, and integration delivery producers
- preserve retained bindings while preventing disabled adapters from creating outbox work or immutable delivery plans
- preserve enabled Telegram delivery and support mixed binding sets without treating every persisted binding as currently eligible

## Qualification

- disabled Telegram with retained bindings creates canonical messages but no delivery rows
- scheduled reminders and proactive publications remain canonical-only while Telegram is disabled
- integration notifications select only enabled transports from mixed bindings
- enabling a policy later does not enqueue historical messages
- existing enabled Telegram delivery contracts remain intact

## Validation

- `ruff check .`
- `ruff format --check .`
- `pyright`
- `pytest -q` — 6001 passed
