### PR TITLE
Make core delivery planning adapter-pluggable

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -152,6 +152,7 @@ class KaiApplicationHost:
         internal_api_contexts: WorkshopInternalAPIContextRegistry,
         services_info: list[dict],
         registered_backend_ids: frozenset[str],
+        delivery_policy: WorkshopDeliveryBindingPolicy,
     ) -> None:
         self._config = config
         self._runtime_profiles = runtime_profiles
@@ -160,6 +161,7 @@ class KaiApplicationHost:
         self._internal_api_contexts = internal_api_contexts
         self._services_info = services_info
         self._registered_backend_ids = registered_backend_ids
+        self._delivery_policy = delivery_policy
         self._state = KaiApplicationState.NEW
         self._services: KaiCoreServices | None = None
         self._adapters: dict[str, KaiApplicationAdapter] = {}
@@ -202,9 +204,7 @@ class KaiApplicationHost:
         integration_notifications: WorkshopIntegrationNotificationService | None = None
         github_automation: WorkshopGitHubAutomationService | None = None
         try:
-            delivery_policy = WorkshopDeliveryBindingPolicy(
-                frozenset({"telegram"}) if self._config.telegram_enabled else frozenset()
-            )
+            delivery_policy = self._delivery_policy
             subprocess_pool = SubprocessPool(
                 config=self._config,
                 services_info=self._services_info,

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -49,8 +49,9 @@ from kai.backend_registry import load_backend_registry
 from kai.config import DATA_DIR, PROJECT_ROOT, _read_protected_file, load_config
 from kai.http_adapter import HttpAdapter
 from kai.memory_backup import run_memory_backup
-from kai.telegram_adapter import TelegramAdapter
+from kai.telegram_adapter import TELEGRAM_DELIVERY_CAPABILITIES, TelegramAdapter
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 
 
@@ -134,6 +135,15 @@ def _workshop_registered_backend_ids(config) -> frozenset[str]:
     configured = {config.default_backend}
     configured.update(user.backend for user in config.user_configs.values() if user.backend)
     return frozenset(configured)
+
+
+def _delivery_policy(config) -> WorkshopDeliveryBindingPolicy:
+    """Compose adapter declarations outside the transport-neutral host."""
+    capabilities = (TELEGRAM_DELIVERY_CAPABILITIES,) if config.telegram_enabled else ()
+    return WorkshopDeliveryBindingPolicy(
+        frozenset(item.transport for item in capabilities),
+        capabilities,
+    )
 
 
 def setup_logging() -> None:
@@ -637,6 +647,7 @@ def _start() -> None:
                 internal_api_contexts=internal_api_contexts,
                 services_info=services.get_available_services(),
                 registered_backend_ids=_workshop_registered_backend_ids(config),
+                delivery_policy=_delivery_policy(config),
             )
             core_services = await core_host.start()
             logging.info("Kai core application host is ready")

--- a/src/kai/telegram_adapter.py
+++ b/src/kai/telegram_adapter.py
@@ -14,12 +14,23 @@ from kai.application_host import KaiCoreServices
 from kai.bot import create_bot
 from kai.config import Config
 from kai.telegram_context import KaiTelegramApplication
+from kai.workshop.delivery_policy import DeliveryAdapterCapabilities
 from kai.workshop.telegram_delivery_runtime import (
     WorkshopTelegramConversationDeliveryService,
     WorkshopTelegramNotificationService,
 )
 
 log = logging.getLogger(__name__)
+
+TELEGRAM_DELIVERY_CAPABILITIES = DeliveryAdapterCapabilities(
+    transport="telegram",
+    final_text=True,
+    preview_streaming=True,
+    message_editing=True,
+    replies=True,
+    threads=True,
+    attachments=True,
+)
 
 
 class TelegramAdapterState(StrEnum):

--- a/src/kai/workshop/__init__.py
+++ b/src/kai/workshop/__init__.py
@@ -1,10 +1,4 @@
-"""Transport-independent Kai Workshop domain and persistence foundations.
-
-The current production service seeds this state and shadow-records accepted
-inbound text, successful assistant results, and delivery observations. Existing
-Telegram routing, histories, and responses remain authoritative until replay
-and parity evidence supports an explicit cutover.
-"""
+"""Transport-independent Kai Workshop domain and persistence services."""
 
 from kai.workshop.artifacts import (
     ArtifactMessageNotFoundError,

--- a/src/kai/workshop/conversation_commands.py
+++ b/src/kai/workshop/conversation_commands.py
@@ -7,14 +7,10 @@ from enum import StrEnum
 from pathlib import Path
 
 from kai.workshop.artifacts import StagedArtifact, record_inbound_artifact_in_transaction
-from kai.workshop.delivery_outbox import (
-    CONVERSATION_REPLY_PURPOSE,
-    DeliveryRequest,
-    DeliveryRequestResult,
-    WorkshopDeliveryOutbox,
-)
+from kai.workshop.delivery_outbox import CONVERSATION_REPLY_PURPOSE, DeliveryRequestResult
+from kai.workshop.delivery_planning import CanonicalDeliveryIntent, WorkshopDeliveryPlanner
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
-from kai.workshop.domain import ChannelBindingId, ChannelId, MessageId, PrincipalId, RuntimeProfileId
+from kai.workshop.domain import MessageId, RuntimeProfileId
 from kai.workshop.inbound import (
     ClientInboundMessage,
     InboundMessage,
@@ -62,11 +58,16 @@ class ConversationCommandAcceptance:
 
 @dataclass(frozen=True, slots=True)
 class ClientConversationCommandAcceptance:
-    """Atomic client acceptance plus optional transport compatibility work."""
+    """Atomic client acceptance plus independently durable adapter work."""
 
     command: ConversationCommandAcceptance
-    delivery: DeliveryRequestResult | None
+    deliveries: tuple[DeliveryRequestResult, ...]
     runtime_profile_id: RuntimeProfileId
+
+    @property
+    def delivery(self) -> DeliveryRequestResult | None:
+        """Compatibility view for callers that expect at most one adapter."""
+        return self.deliveries[0] if len(self.deliveries) == 1 else None
 
     @property
     def run(self) -> DurableRun:
@@ -89,7 +90,8 @@ class WorkshopConversationCommandService:
     ) -> None:
         self._store = store
         self._artifact_storage_root = artifact_storage_root
-        self._delivery_policy = delivery_policy or WorkshopDeliveryBindingPolicy.disabled()
+        effective_policy = delivery_policy or WorkshopDeliveryBindingPolicy.disabled()
+        self._delivery_planner = WorkshopDeliveryPlanner(self._store, effective_policy)
 
     async def accept(
         self,
@@ -147,7 +149,7 @@ class WorkshopConversationCommandService:
         *,
         artifact: StagedArtifact | None = None,
     ) -> ClientConversationCommandAcceptance:
-        """Accept one canonical browser command and optional Telegram echo."""
+        """Accept one canonical browser command and optional adapter echoes."""
         if not isinstance(message, ClientInboundMessage):
             raise ValueError("message must be a ClientInboundMessage")
         connection = self._store.connection
@@ -179,29 +181,20 @@ class WorkshopConversationCommandService:
                 )
             except WorkshopRuntimeAssignmentError as exc:
                 raise ConversationCommandStateConflictError(str(exc)) from exc
-            binding_id = await self._optional_telegram_binding(
-                message.principal_id,
-                message.channel_id,
-            )
-            delivery = (
-                await WorkshopDeliveryOutbox(self._store).request_delivery_in_transaction(
-                    DeliveryRequest(
-                        message_id=inbound_message_id,
-                        channel_binding_id=binding_id,
-                        mode="workshop_client_text",
-                        purpose=CONVERSATION_REPLY_PURPOSE,
-                        occurred_at=inbound.event.envelope.occurred_at,
-                        max_attempts=5,
-                    )
+            planning = await self._delivery_planner.plan_in_transaction(
+                CanonicalDeliveryIntent(
+                    message_id=inbound_message_id,
+                    channel_id=message.channel_id,
+                    mode="workshop_client_text",
+                    purpose=CONVERSATION_REPLY_PURPOSE,
+                    occurred_at=inbound.event.envelope.occurred_at,
+                    recipient_principal_id=message.principal_id,
                 )
-                if binding_id is not None
-                else None
             )
             prior_states = {inbound.inserted, lifecycle.changed}
             if artifact_result is not None:
                 prior_states.add(artifact_result.inserted)
-            if delivery is not None:
-                prior_states.add(delivery.inserted)
+            prior_states.update(delivery.inserted for delivery in planning.deliveries)
             if len(prior_states) != 1:
                 raise ConversationCommandStateConflictError(
                     "Canonical inbound, run acceptance, and delivery request did not share one prior state"
@@ -214,7 +207,7 @@ class WorkshopConversationCommandService:
             await connection.commit()
             return ClientConversationCommandAcceptance(
                 command=ConversationCommandAcceptance(inbound, lifecycle, disposition),
-                delivery=delivery,
+                deliveries=planning.deliveries,
                 runtime_profile_id=runtime_profile_id,
             )
         except Exception:
@@ -258,36 +251,12 @@ class WorkshopConversationCommandService:
             await connection.commit()
             return ClientConversationCommandAcceptance(
                 command=ConversationCommandAcceptance(inbound, lifecycle, disposition),
-                delivery=None,
+                deliveries=(),
                 runtime_profile_id=runtime_profile_id,
             )
         except Exception:
             await connection.rollback()
             raise
-
-    async def _optional_telegram_binding(
-        self,
-        principal_id: PrincipalId,
-        channel_id: ChannelId,
-    ) -> ChannelBindingId | None:
-        if not self._delivery_policy.is_enabled("telegram"):
-            return None
-        async with self._store.connection.execute(
-            "SELECT cb.id, EXISTS (SELECT 1 FROM external_identities ei "
-            "WHERE ei.principal_id = ? AND ei.provider = 'telegram' "
-            "AND ei.external_subject = cb.external_channel_id) "
-            "FROM channel_bindings cb "
-            "WHERE cb.channel_id = ? AND cb.transport = 'telegram'",
-            (principal_id, channel_id),
-        ) as cursor:
-            rows = list(await cursor.fetchall())
-        if not rows:
-            return None
-        if len(rows) != 1 or int(rows[0][1]) != 1:
-            raise ConversationCommandStateConflictError(
-                "Client command has an ambiguous or mismatched Telegram binding"
-            )
-        return ChannelBindingId(str(rows[0][0]))
 
     async def _replay_disposition(self, run: DurableRun) -> ConversationCommandDisposition:
         if run.status in {RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.CANCELLED}:

--- a/src/kai/workshop/delivery_authority.py
+++ b/src/kai/workshop/delivery_authority.py
@@ -7,13 +7,12 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from kai.workshop.delivery_outbox import (
+    CONVERSATION_FINALIZATION_LANE,
     CONVERSATION_REPLY_PURPOSE,
     STREAMING_FINALIZATION_CONTRACT,
 )
 from kai.workshop.domain import DeliveryAuthorityEpochId
 from kai.workshop.store import WorkshopEventStore
-
-TELEGRAM_CONVERSATION_FINALIZATION_LANE = "telegram_conversation_streaming_finalization"
 
 
 class DeliveryAuthorityError(RuntimeError):
@@ -60,11 +59,11 @@ def _parse_timestamp(value: str) -> datetime:
 
 
 class WorkshopConversationDeliveryAuthority:
-    """Own the durable activation boundary for one future Telegram route.
+    """Own the durable activation boundary for conversation finalization.
 
-    Production startup activates or resumes one epoch before Telegram ingress.
+    Production startup activates or resumes one epoch before adapters start.
     The separate service remains usable by operator tooling and tests without
-    implicitly constructing a delivery worker.
+    implicitly constructing a transport worker.
     """
 
     def __init__(
@@ -108,7 +107,7 @@ class WorkshopConversationDeliveryAuthority:
             )
             await connection.execute(
                 "INSERT INTO delivery_authority_epochs (id, lane, status, activated_at) VALUES (?, ?, 'active', ?)",
-                (epoch.epoch_id, TELEGRAM_CONVERSATION_FINALIZATION_LANE, _format_timestamp(now)),
+                (epoch.epoch_id, CONVERSATION_FINALIZATION_LANE, _format_timestamp(now)),
             )
             await connection.commit()
             return DeliveryAuthorityActivationResult(epoch=epoch, inserted=True)
@@ -188,7 +187,7 @@ class WorkshopConversationDeliveryAuthority:
             "SELECT id, status, activated_at, deactivated_at, terminal_failures_acknowledged_at "
             "FROM delivery_authority_epochs "
             "WHERE lane = ? AND status = 'active' ORDER BY activated_at",
-            (TELEGRAM_CONVERSATION_FINALIZATION_LANE,),
+            (CONVERSATION_FINALIZATION_LANE,),
         ) as cursor:
             rows = list(await cursor.fetchall())
         if len(rows) > 1:

--- a/src/kai/workshop/delivery_fragments.py
+++ b/src/kai/workshop/delivery_fragments.py
@@ -17,7 +17,8 @@ from kai.workshop.delivery_outbox import (
 from kai.workshop.domain import DeliveryAttemptId, DeliveryId
 from kai.workshop.store import WorkshopEventStore
 
-_MAX_FRAGMENTS = 1000
+_MAX_FRAGMENTS = 10_000
+_MAX_FRAGMENT_BODY_SIZE = 1_000_000
 
 DeliveryFragmentOperationKind = Literal["send", "edit"]
 SEND_OPERATION: DeliveryFragmentOperationKind = "send"
@@ -52,29 +53,28 @@ class DeliveryFragment:
     external_message_id: str | None
     sent_at: datetime | None
     operation: DeliveryFragmentOperationKind = SEND_OPERATION
-    target_external_message_id: int | None = None
+    target_external_message_id: int | str | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class DeliveryFragmentOperation:
     operation: DeliveryFragmentOperationKind
     body: str
-    target_external_message_id: int | None = None
+    target_external_message_id: int | str | None = None
 
     def __post_init__(self) -> None:
         if self.operation not in _OPERATION_KINDS:
             raise ValueError("operation must be send or edit")
-        if not isinstance(self.body, str) or not self.body or len(self.body) > 4096:
-            raise ValueError("body must contain between 1 and 4096 characters")
+        if not isinstance(self.body, str) or not 1 <= len(self.body) <= _MAX_FRAGMENT_BODY_SIZE:
+            raise ValueError(f"body must contain between 1 and {_MAX_FRAGMENT_BODY_SIZE} characters")
         if self.operation == SEND_OPERATION:
             if self.target_external_message_id is not None:
-                raise ValueError("send operations cannot identify an existing Telegram message")
-        elif (
-            not isinstance(self.target_external_message_id, int)
-            or isinstance(self.target_external_message_id, bool)
-            or self.target_external_message_id <= 0
+                raise ValueError("send operations cannot identify an existing external message")
+        elif isinstance(self.target_external_message_id, bool) or not (
+            (isinstance(self.target_external_message_id, int) and self.target_external_message_id > 0)
+            or (isinstance(self.target_external_message_id, str) and 1 <= len(self.target_external_message_id) <= 255)
         ):
-            raise ValueError("edit operations require a positive target_external_message_id")
+            raise ValueError("edit operations require a bounded target_external_message_id")
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,6 +91,15 @@ def _parse_timestamp(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
 
 
+def _external_identifier(value: object) -> int | str | None:
+    if value is None:
+        return None
+    text = str(value)
+    if text.isdecimal() and int(text) > 0:
+        return int(text)
+    return text
+
+
 class WorkshopDeliveryFragments:
     """Persist an immutable plan and monotonic progress for one delivery.
 
@@ -98,7 +107,7 @@ class WorkshopDeliveryFragments:
     written before the external API call. If the call cannot be proven to have
     failed or succeeded, it moves to ``uncertain`` and must never be retried
     automatically. This deliberately prefers operator reconciliation over a
-    duplicate Telegram message.
+    duplicate external message.
     """
 
     def __init__(
@@ -120,6 +129,30 @@ class WorkshopDeliveryFragments:
             await connection.execute("BEGIN IMMEDIATE")
             await self._require_lease_owner(connection, claim, now=now, require_unexpired=True)
             result = await self._prepare_in_transaction(claim.delivery_id, operations, occurred_at=now)
+            await connection.commit()
+            return result.fragments
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def prepare_operations(
+        self,
+        claim: DeliveryClaim,
+        operations: tuple[DeliveryFragmentOperation, ...],
+    ) -> tuple[DeliveryFragment, ...]:
+        """Let the claiming adapter persist its immutable provider operation plan."""
+        self._validate_claim(claim)
+        self._validate_operations(operations)
+        connection = self._store.connection
+        now = self._now()
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            await self._require_lease_owner(connection, claim, now=now, require_unexpired=True)
+            result = await self._prepare_in_transaction(
+                claim.delivery_id,
+                operations,
+                occurred_at=now,
+            )
             await connection.commit()
             return result.fragments
         except Exception:
@@ -148,8 +181,14 @@ class WorkshopDeliveryFragments:
             row = await cursor.fetchone()
         if row is None or str(row["execution_contract"]) != STREAMING_FINALIZATION_CONTRACT:
             raise DeliveryFragmentStateError("Delivery does not own the streaming-finalization contract")
-        if str(row["status"]) != "pending" or int(row["attempt_count"]) != 0:
-            raise DeliveryFragmentStateError("Streaming-finalization plan must be created before its first claim")
+        status = str(row["status"])
+        attempt_count = int(row["attempt_count"])
+        if (status == "pending" and attempt_count == 0) or (status == "leased" and attempt_count > 0):
+            pass
+        else:
+            raise DeliveryFragmentStateError(
+                "Streaming-finalization plan must be created before or during its active claim"
+            )
         return await self._prepare_in_transaction(delivery_id, operations, occurred_at=occurred_at)
 
     async def _prepare_in_transaction(
@@ -166,11 +205,7 @@ class WorkshopDeliveryFragments:
                 DeliveryFragmentOperation(
                     operation=self._operation_kind(row["operation"]),
                     body=str(row["body"]),
-                    target_external_message_id=(
-                        int(row["target_external_message_id"])
-                        if row["target_external_message_id"] is not None
-                        else None
-                    ),
+                    target_external_message_id=_external_identifier(row["target_external_message_id"]),
                 )
                 for row in existing
             )
@@ -250,14 +285,13 @@ class WorkshopDeliveryFragments:
         claim: DeliveryClaim,
         fragment: DeliveryFragment,
         *,
-        external_message_id: int,
+        external_message_id: int | str,
     ) -> DeliveryFragment:
-        if (
-            not isinstance(external_message_id, int)
-            or isinstance(external_message_id, bool)
-            or external_message_id <= 0
+        if isinstance(external_message_id, bool) or not (
+            (isinstance(external_message_id, int) and external_message_id > 0)
+            or (isinstance(external_message_id, str) and 1 <= len(external_message_id) <= 255)
         ):
-            raise ValueError("external_message_id must be a positive integer")
+            raise ValueError("external_message_id must be a bounded provider identifier")
         self._validate_fragment_for_claim(claim, fragment)
         connection = self._store.connection
         now = self._now()
@@ -398,8 +432,8 @@ class WorkshopDeliveryFragments:
     def _validate_bodies(bodies: tuple[str, ...]) -> None:
         if not isinstance(bodies, tuple) or not bodies or len(bodies) > _MAX_FRAGMENTS:
             raise ValueError(f"bodies must contain between 1 and {_MAX_FRAGMENTS} fragments")
-        if any(not isinstance(body, str) or not body or len(body) > 4096 for body in bodies):
-            raise ValueError("each fragment body must contain between 1 and 4096 characters")
+        if any(not isinstance(body, str) or not 1 <= len(body) <= _MAX_FRAGMENT_BODY_SIZE for body in bodies):
+            raise ValueError(f"each fragment body must contain between 1 and {_MAX_FRAGMENT_BODY_SIZE} characters")
 
     @staticmethod
     def _validate_operations(operations: tuple[DeliveryFragmentOperation, ...]) -> None:
@@ -450,9 +484,7 @@ class WorkshopDeliveryFragments:
             external_message_id=(str(row["external_message_id"]) if row["external_message_id"] is not None else None),
             sent_at=(_parse_timestamp(str(row["sent_at"])) if row["sent_at"] is not None else None),
             operation=WorkshopDeliveryFragments._operation_kind(row["operation"]),
-            target_external_message_id=(
-                int(row["target_external_message_id"]) if row["target_external_message_id"] is not None else None
-            ),
+            target_external_message_id=_external_identifier(row["target_external_message_id"]),
         )
 
     def _now(self) -> datetime:

--- a/src/kai/workshop/delivery_outbox.py
+++ b/src/kai/workshop/delivery_outbox.py
@@ -32,6 +32,7 @@ _MAX_ATTEMPTS = 20
 _MAX_MINIMUM_RETRY_DELAY = timedelta(days=1)
 _RETRY_BASE_SECONDS = 5
 _RETRY_MAX_SECONDS = 300
+CONVERSATION_FINALIZATION_LANE = "conversation_streaming_finalization"
 
 DeliveryPurpose = Literal["conversation_reply", "notification", "qualification"]
 CONVERSATION_REPLY_PURPOSE: DeliveryPurpose = "conversation_reply"
@@ -236,9 +237,9 @@ def _retry_delay(attempt_number: int) -> timedelta:
 class WorkshopDeliveryOutbox:
     """Durable delivery state with lease-based, at-least-once work claims.
 
-    Production private-text finalization and explicit qualification use this
-    class. Other Telegram paths retain their existing delivery behavior until
-    separately bounded cutovers move them.
+    Core application services publish transport-neutral work here. Each
+    enabled adapter claims and settles only the transport and execution
+    contracts it implements.
     """
 
     def __init__(
@@ -272,7 +273,7 @@ class WorkshopDeliveryOutbox:
         if request.authority_epoch_id is not None:
             async with connection.execute(
                 "SELECT COUNT(*) FROM delivery_authority_epochs "
-                "WHERE id = ? AND lane = 'telegram_conversation_streaming_finalization' "
+                "WHERE id = ? AND lane = 'conversation_streaming_finalization' "
                 "AND status = 'active'",
                 (request.authority_epoch_id,),
             ) as cursor:
@@ -442,7 +443,7 @@ class WorkshopDeliveryOutbox:
                 filters.append(
                     "EXISTS (SELECT 1 FROM delivery_authority_epochs ae "
                     "WHERE ae.id = o.authority_epoch_id "
-                    "AND ae.lane = 'telegram_conversation_streaming_finalization' "
+                    "AND ae.lane = 'conversation_streaming_finalization' "
                     "AND ae.status = 'active')"
                 )
             if delivery_id is not None:
@@ -614,7 +615,7 @@ class WorkshopDeliveryOutbox:
             if persisted_epoch is not None:
                 async with connection.execute(
                     "SELECT COUNT(*) FROM delivery_authority_epochs "
-                    "WHERE id = ? AND lane = 'telegram_conversation_streaming_finalization' "
+                    "WHERE id = ? AND lane = 'conversation_streaming_finalization' "
                     "AND status = 'active'",
                     (persisted_epoch,),
                 ) as cursor:
@@ -756,7 +757,7 @@ class WorkshopDeliveryOutbox:
         active_authority_filter = (
             " AND EXISTS (SELECT 1 FROM delivery_authority_epochs ae "
             "WHERE ae.id = delivery_outbox.authority_epoch_id "
-            "AND ae.lane = 'telegram_conversation_streaming_finalization' "
+            "AND ae.lane = 'conversation_streaming_finalization' "
             "AND ae.status = 'active')"
             if authority_epoch_id is not None
             else ""

--- a/src/kai/workshop/delivery_planning.py
+++ b/src/kai/workshop/delivery_planning.py
@@ -1,0 +1,127 @@
+"""Transport-neutral planning of durable delivery intents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
+    SEND_FRAGMENTS_CONTRACT,
+    STREAMING_FINALIZATION_CONTRACT,
+    DeliveryPurpose,
+    DeliveryRequest,
+    DeliveryRequestResult,
+    WorkshopDeliveryOutbox,
+)
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
+from kai.workshop.domain import ChannelId, MessageId, PrincipalId
+from kai.workshop.store import WorkshopEventStore
+
+DeliveryContentKind = Literal["text", "attachment"]
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalDeliveryIntent:
+    """Canonical publication facts from which adapter work may be planned."""
+
+    message_id: MessageId
+    channel_id: ChannelId
+    mode: str
+    purpose: DeliveryPurpose
+    occurred_at: datetime
+    content_kind: DeliveryContentKind = "text"
+    recipient_principal_id: PrincipalId | None = None
+    preview_eligible: bool = False
+    max_attempts: int = 5
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.message_id, MessageId):
+            raise ValueError("message_id must be a MessageId")
+        if not isinstance(self.channel_id, ChannelId):
+            raise ValueError("channel_id must be a ChannelId")
+        if self.content_kind not in {"text", "attachment"}:
+            raise ValueError("content_kind must be text or attachment")
+        if self.recipient_principal_id is not None and not isinstance(
+            self.recipient_principal_id,
+            PrincipalId,
+        ):
+            raise ValueError("recipient_principal_id must be a PrincipalId when supplied")
+        if not isinstance(self.preview_eligible, bool):
+            raise ValueError("preview_eligible must be a boolean")
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryPlanningResult:
+    """All independently durable adapter requests for one publication."""
+
+    deliveries: tuple[DeliveryRequestResult, ...]
+
+
+class WorkshopDeliveryPlanner:
+    """Fan out one canonical intent according to enabled adapter capabilities."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        policy: WorkshopDeliveryBindingPolicy,
+    ) -> None:
+        self._store = store
+        self._policy = policy
+        self._outbox = WorkshopDeliveryOutbox(store)
+
+    async def plan_in_transaction(
+        self,
+        intent: CanonicalDeliveryIntent,
+    ) -> DeliveryPlanningResult:
+        if not self._store.connection.in_transaction:
+            raise RuntimeError("plan_in_transaction requires an active transaction")
+        bindings = await self._policy.bindings(
+            self._store,
+            intent.channel_id,
+            principal_id=intent.recipient_principal_id,
+        )
+        selected = tuple(
+            binding
+            for binding in bindings
+            if (
+                (intent.content_kind == "text" and binding.capabilities.final_text)
+                or (intent.content_kind == "attachment" and binding.capabilities.attachments)
+            )
+        )
+        needs_streaming_authority = any(
+            intent.purpose == CONVERSATION_REPLY_PURPOSE
+            and intent.preview_eligible
+            and binding.capabilities.preview_streaming
+            for binding in selected
+        )
+        authority_epoch_id = None
+        if needs_streaming_authority:
+            authority_epoch = await WorkshopConversationDeliveryAuthority(self._store).active_epoch_in_transaction()
+            assert authority_epoch is not None
+            authority_epoch_id = authority_epoch.epoch_id
+
+        deliveries: list[DeliveryRequestResult] = []
+        for binding in selected:
+            streaming = (
+                intent.purpose == CONVERSATION_REPLY_PURPOSE
+                and intent.preview_eligible
+                and binding.capabilities.preview_streaming
+            )
+            deliveries.append(
+                await self._outbox.request_delivery_in_transaction(
+                    DeliveryRequest(
+                        message_id=intent.message_id,
+                        channel_binding_id=binding.binding_id,
+                        mode=intent.mode,
+                        purpose=intent.purpose,
+                        occurred_at=intent.occurred_at,
+                        execution_contract=(STREAMING_FINALIZATION_CONTRACT if streaming else SEND_FRAGMENTS_CONTRACT),
+                        authority_epoch_id=authority_epoch_id if streaming else None,
+                        max_attempts=intent.max_attempts,
+                    )
+                )
+            )
+        return DeliveryPlanningResult(tuple(deliveries))

--- a/src/kai/workshop/delivery_policy.py
+++ b/src/kai/workshop/delivery_policy.py
@@ -5,10 +5,48 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from kai.workshop.domain import ChannelBindingId, ChannelId
+from kai.workshop.domain import ChannelBindingId, ChannelId, PrincipalId
 from kai.workshop.store import WorkshopEventStore
 
 _TRANSPORT_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryAdapterCapabilities:
+    """Immutable delivery features declared by one enabled adapter."""
+
+    transport: str
+    final_text: bool = True
+    preview_streaming: bool = False
+    message_editing: bool = False
+    replies: bool = False
+    threads: bool = False
+    attachments: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.transport, str) or not _TRANSPORT_PATTERN.fullmatch(self.transport):
+            raise ValueError("transport must be a lowercase transport identifier")
+        for field_name in (
+            "final_text",
+            "preview_streaming",
+            "message_editing",
+            "replies",
+            "threads",
+            "attachments",
+        ):
+            if not isinstance(getattr(self, field_name), bool):
+                raise ValueError(f"{field_name} must be a boolean")
+        if self.preview_streaming and (not self.final_text or not self.message_editing):
+            raise ValueError("preview_streaming requires final_text and message_editing")
+
+
+@dataclass(frozen=True, slots=True)
+class EligibleDeliveryBinding:
+    """One persisted destination paired with its current adapter capabilities."""
+
+    binding_id: ChannelBindingId
+    transport: str
+    capabilities: DeliveryAdapterCapabilities
 
 
 @dataclass(frozen=True, slots=True)
@@ -20,6 +58,7 @@ class WorkshopDeliveryBindingPolicy:
     """
 
     enabled_transports: frozenset[str]
+    adapter_capabilities: tuple[DeliveryAdapterCapabilities, ...] = ()
 
     def __post_init__(self) -> None:
         if not isinstance(self.enabled_transports, frozenset):
@@ -29,6 +68,18 @@ class WorkshopDeliveryBindingPolicy:
             for transport in self.enabled_transports
         ):
             raise ValueError("enabled_transports must contain lowercase transport identifiers")
+        if not isinstance(self.adapter_capabilities, tuple) or any(
+            not isinstance(capabilities, DeliveryAdapterCapabilities) for capabilities in self.adapter_capabilities
+        ):
+            raise TypeError("adapter_capabilities must contain DeliveryAdapterCapabilities values")
+        transports = tuple(capabilities.transport for capabilities in self.adapter_capabilities)
+        if len(set(transports)) != len(transports):
+            raise ValueError("adapter_capabilities must identify unique transports")
+        declared = set(transports)
+        if declared - self.enabled_transports:
+            raise ValueError("adapter_capabilities cannot describe a disabled transport")
+        if self.enabled_transports - declared:
+            raise ValueError("every enabled transport must declare adapter capabilities")
 
     @classmethod
     def disabled(cls) -> WorkshopDeliveryBindingPolicy:
@@ -38,6 +89,63 @@ class WorkshopDeliveryBindingPolicy:
         if not isinstance(transport, str) or not _TRANSPORT_PATTERN.fullmatch(transport):
             raise ValueError("transport must be a lowercase transport identifier")
         return transport in self.enabled_transports
+
+    def capabilities_for(self, transport: str) -> DeliveryAdapterCapabilities | None:
+        """Return declared capabilities for one enabled transport."""
+        if not self.is_enabled(transport):
+            return None
+        for capabilities in self.adapter_capabilities:
+            if capabilities.transport == transport:
+                return capabilities
+        raise RuntimeError("Enabled adapter has no capability declaration")
+
+    async def bindings(
+        self,
+        store: WorkshopEventStore,
+        channel_id: ChannelId,
+        *,
+        principal_id: PrincipalId | None = None,
+    ) -> tuple[EligibleDeliveryBinding, ...]:
+        """Return binding destinations currently eligible for publication."""
+        if not isinstance(channel_id, ChannelId):
+            raise ValueError("channel_id must be a ChannelId")
+        if principal_id is not None and not isinstance(principal_id, PrincipalId):
+            raise ValueError("principal_id must be a PrincipalId when supplied")
+        if not self.enabled_transports:
+            return ()
+        placeholders = ", ".join("?" for _ in self.enabled_transports)
+        identity_filter = (
+            "AND EXISTS (SELECT 1 FROM external_identities ei "
+            "WHERE ei.principal_id = ? AND ei.provider = cb.transport "
+            "AND ei.external_subject = cb.external_channel_id) "
+            if principal_id is not None
+            else ""
+        )
+        parameters: tuple[object, ...] = (
+            channel_id,
+            *sorted(self.enabled_transports),
+            *((principal_id,) if principal_id is not None else ()),
+        )
+        async with store.connection.execute(
+            "SELECT cb.id, cb.transport FROM channel_bindings cb "
+            f"WHERE cb.channel_id = ? AND cb.transport IN ({placeholders}) "
+            f"{identity_filter}ORDER BY cb.id",
+            parameters,
+        ) as cursor:
+            rows = tuple(await cursor.fetchall())
+        bindings: list[EligibleDeliveryBinding] = []
+        for row in rows:
+            transport = str(row[1])
+            capabilities = self.capabilities_for(transport)
+            assert capabilities is not None
+            bindings.append(
+                EligibleDeliveryBinding(
+                    binding_id=ChannelBindingId(str(row[0])),
+                    transport=transport,
+                    capabilities=capabilities,
+                )
+            )
+        return tuple(bindings)
 
     async def binding_ids(
         self,
@@ -49,14 +157,5 @@ class WorkshopDeliveryBindingPolicy:
         """Return stable bindings eligible under the current adapter policy."""
         if not isinstance(channel_id, ChannelId):
             raise ValueError("channel_id must be a ChannelId")
-        transports = self.enabled_transports
-        if transport is not None:
-            transports = frozenset({transport}) if self.is_enabled(transport) else frozenset()
-        if not transports:
-            return ()
-        placeholders = ", ".join("?" for _ in transports)
-        async with store.connection.execute(
-            f"SELECT id FROM channel_bindings WHERE channel_id = ? AND transport IN ({placeholders}) ORDER BY id",
-            (channel_id, *sorted(transports)),
-        ) as cursor:
-            return tuple(ChannelBindingId(str(row[0])) for row in await cursor.fetchall())
+        bindings = await self.bindings(store, channel_id)
+        return tuple(binding.binding_id for binding in bindings if transport is None or binding.transport == transport)

--- a/src/kai/workshop/integration_notifications.py
+++ b/src/kai/workshop/integration_notifications.py
@@ -8,12 +8,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from kai.workshop.delivery_outbox import (
-    NOTIFICATION_PURPOSE,
-    DeliveryRequest,
-    DeliveryRequestResult,
-    WorkshopDeliveryOutbox,
-)
+from kai.workshop.delivery_outbox import NOTIFICATION_PURPOSE, DeliveryRequestResult
+from kai.workshop.delivery_planning import CanonicalDeliveryIntent, WorkshopDeliveryPlanner
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     ChannelBindingId,
@@ -96,8 +92,7 @@ class WorkshopIntegrationNotificationService:
 
     def __init__(self, store: WorkshopEventStore, delivery_policy: WorkshopDeliveryBindingPolicy) -> None:
         self._store = store
-        self._delivery_policy = delivery_policy
-        self._outbox = WorkshopDeliveryOutbox(store)
+        self._delivery_planner = WorkshopDeliveryPlanner(store, delivery_policy)
         self._lock = asyncio.Lock()
         self._closed = False
 
@@ -453,22 +448,16 @@ class WorkshopIntegrationNotificationService:
 
             projection = CanonicalConversationProjection()
             await self._store.project_pending_in_transaction(projection)
-            binding_ids = await self._delivery_policy.binding_ids(self._store, channel_id)
-            deliveries = tuple(
-                [
-                    await self._outbox.request_delivery_in_transaction(
-                        DeliveryRequest(
-                            message_id=message_id,
-                            channel_binding_id=binding_id,
-                            mode="text",
-                            purpose=NOTIFICATION_PURPOSE,
-                            occurred_at=occurred_at,
-                            max_attempts=5,
-                        )
-                    )
-                    for binding_id in binding_ids
-                ]
+            planning = await self._delivery_planner.plan_in_transaction(
+                CanonicalDeliveryIntent(
+                    message_id=message_id,
+                    channel_id=channel_id,
+                    mode="text",
+                    purpose=NOTIFICATION_PURPOSE,
+                    occurred_at=occurred_at,
+                )
             )
+            deliveries = planning.deliveries
             if inserted and any(not delivery.inserted for delivery in deliveries):
                 raise IntegrationNotificationError(
                     "Canonical notification message and deliveries do not share one prior state"

--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -6,25 +6,13 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 
-from kai.telegram_utils import chunk_text
-from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
-from kai.workshop.delivery_fragments import (
-    EDIT_OPERATION,
-    SEND_OPERATION,
-    DeliveryFragmentOperation,
-    DeliveryFragmentPlanResult,
-    WorkshopDeliveryFragments,
-)
 from kai.workshop.delivery_outbox import (
     CONVERSATION_REPLY_PURPOSE,
-    STREAMING_FINALIZATION_CONTRACT,
-    DeliveryRequest,
     DeliveryRequestResult,
-    WorkshopDeliveryOutbox,
 )
+from kai.workshop.delivery_planning import CanonicalDeliveryIntent, WorkshopDeliveryPlanner
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
-    ChannelBindingId,
     ChannelId,
     DeliveryId,
     EventEnvelope,
@@ -36,7 +24,6 @@ from kai.workshop.domain import (
 )
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.store import AppendResult, IdempotencyConflictError, WorkshopEventStore
-from kai.workshop.streaming_preview import resolve_telegram_finalization_target
 
 _IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 
@@ -45,16 +32,8 @@ class OutboundMessageNotFoundError(LookupError):
     """A referenced canonical message or its unique agent binding was not found."""
 
 
-class OutboundDeliveryBindingError(LookupError):
-    """The reply channel does not have exactly one canonical Telegram binding."""
-
-
 class OutboundDeliveryStateConflictError(RuntimeError):
     """Only one half of an atomic outbound message and delivery already exists."""
-
-
-class OutboundStreamingPreviewConflictError(RuntimeError):
-    """A persisted preview no longer matches its canonical routing identities."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,24 +76,37 @@ class _ResolvedOutbound:
     workshop_id: WorkshopId
     channel_id: ChannelId
     agent_principal_id: PrincipalId
+    recipient_principal_id: PrincipalId
 
 
 @dataclass(frozen=True, slots=True)
 class OutboundDeliveryResult:
     message: AppendResult
-    delivery: DeliveryRequestResult
+    deliveries: tuple[DeliveryRequestResult, ...]
+
+    @property
+    def delivery(self) -> DeliveryRequestResult | None:
+        return self.deliveries[0] if len(self.deliveries) == 1 else None
 
 
 @dataclass(frozen=True, slots=True)
 class OutboundStreamingFinalizationResult:
     message: AppendResult
-    delivery: DeliveryRequestResult | None
-    plan: DeliveryFragmentPlanResult | None
+    deliveries: tuple[DeliveryRequestResult, ...]
+
+    @property
+    def delivery(self) -> DeliveryRequestResult | None:
+        return self.deliveries[0] if len(self.deliveries) == 1 else None
+
+    @property
+    def plan(self) -> None:
+        """Adapter operation plans are no longer created by core finalization."""
+        return None
 
 
 async def _resolve_outbound(store: WorkshopEventStore, message_id: MessageId) -> _ResolvedOutbound:
     async with store.connection.execute(
-        "SELECT c.workshop_id, m.channel_id, a.principal_id "
+        "SELECT c.workshop_id, m.channel_id, a.principal_id, m.author_principal_id "
         "FROM messages m "
         "JOIN principals author ON author.id = m.author_principal_id AND author.kind = 'human' "
         "JOIN channels c ON c.id = m.channel_id "
@@ -130,6 +122,7 @@ async def _resolve_outbound(store: WorkshopEventStore, message_id: MessageId) ->
         workshop_id=WorkshopId(str(rows[0][0])),
         channel_id=ChannelId(str(rows[0][1])),
         agent_principal_id=PrincipalId(str(rows[0][2])),
+        recipient_principal_id=PrincipalId(str(rows[0][3])),
     )
 
 
@@ -183,66 +176,6 @@ async def _existing_outbound(
     return AppendResult(event=existing, inserted=False)
 
 
-async def _resolve_telegram_binding(
-    store: WorkshopEventStore,
-    channel_id: ChannelId,
-    delivery_policy: WorkshopDeliveryBindingPolicy,
-) -> ChannelBindingId:
-    binding_ids = await delivery_policy.binding_ids(store, channel_id, transport="telegram")
-    if len(binding_ids) != 1:
-        raise OutboundDeliveryBindingError("Canonical reply channel must have exactly one Telegram binding")
-    return binding_ids[0]
-
-
-async def _confirmed_preview_message_id(
-    store: WorkshopEventStore,
-    *,
-    inbound_message_id: MessageId,
-    workshop_id: WorkshopId,
-    channel_id: ChannelId,
-    channel_binding_id: ChannelBindingId,
-) -> int | None:
-    async with store.connection.execute(
-        "SELECT workshop_id, channel_id, channel_binding_id, external_message_id, state "
-        "FROM telegram_streaming_previews WHERE inbound_message_id = ?",
-        (inbound_message_id,),
-    ) as cursor:
-        row = await cursor.fetchone()
-    if row is None:
-        return None
-    if (
-        str(row[0]) != workshop_id
-        or str(row[1]) != channel_id
-        or str(row[2]) != channel_binding_id
-        or str(row[4]) != "confirmed_non_final"
-    ):
-        raise OutboundStreamingPreviewConflictError(
-            "Confirmed streaming preview does not match the canonical reply target"
-        )
-    external_message_id = int(row[3])
-    if external_message_id <= 0:
-        raise OutboundStreamingPreviewConflictError("Confirmed streaming preview has an invalid message ID")
-    return external_message_id
-
-
-def _streaming_finalization_operations(
-    body: str,
-    *,
-    preview_message_id: int | None,
-) -> tuple[DeliveryFragmentOperation, ...]:
-    bodies = tuple(chunk_text(body, max_len=4096))
-    if preview_message_id is None:
-        return tuple(DeliveryFragmentOperation(SEND_OPERATION, fragment) for fragment in bodies)
-    return (
-        DeliveryFragmentOperation(
-            EDIT_OPERATION,
-            bodies[0],
-            target_external_message_id=preview_message_id,
-        ),
-        *(DeliveryFragmentOperation(SEND_OPERATION, fragment) for fragment in bodies[1:]),
-    )
-
-
 async def record_outbound_message(store: WorkshopEventStore, message: OutboundMessage) -> AppendResult:
     """Append one canonical assistant reply to an existing inbound message."""
     binding = await _resolve_outbound(store, message.in_reply_to_message_id)
@@ -262,7 +195,7 @@ async def record_outbound_message_with_delivery(
     *,
     delivery_policy: WorkshopDeliveryBindingPolicy,
 ) -> OutboundDeliveryResult:
-    """Atomically create one canonical reply and its pending Telegram text delivery.
+    """Atomically create one canonical reply and eligible adapter deliveries.
 
     This service is deliberately production-unused. It accepts no transport or
     destination identity from its caller and does not send or register a worker.
@@ -271,7 +204,6 @@ async def record_outbound_message_with_delivery(
     try:
         await connection.execute("BEGIN IMMEDIATE")
         binding = await _resolve_outbound(store, message.in_reply_to_message_id)
-        channel_binding_id = await _resolve_telegram_binding(store, binding.channel_id, delivery_policy)
         message_result = await _existing_outbound(store, binding, message)
         if message_result is None:
             message_result = await store.append_in_transaction(_outbound_envelope(binding, message))
@@ -281,23 +213,23 @@ async def record_outbound_message_with_delivery(
         message_id = message_result.event.envelope.aggregate_id
         if not isinstance(message_id, MessageId):
             raise RuntimeError("Canonical outbound event did not identify a message")
-        delivery_result = await WorkshopDeliveryOutbox(store).request_delivery_in_transaction(
-            DeliveryRequest(
+        planning = await WorkshopDeliveryPlanner(store, delivery_policy).plan_in_transaction(
+            CanonicalDeliveryIntent(
                 message_id=message_id,
-                channel_binding_id=channel_binding_id,
+                channel_id=binding.channel_id,
                 mode="text",
                 purpose=CONVERSATION_REPLY_PURPOSE,
                 occurred_at=message.occurred_at,
-                max_attempts=5,
+                recipient_principal_id=binding.recipient_principal_id,
             )
         )
-        if message_result.inserted != delivery_result.inserted:
+        if any(message_result.inserted != delivery.inserted for delivery in planning.deliveries):
             raise OutboundDeliveryStateConflictError(
                 "Canonical reply and delivery request did not share one prior state"
             )
         await store.project_pending_in_transaction(projection)
         await connection.commit()
-        return OutboundDeliveryResult(message=message_result, delivery=delivery_result)
+        return OutboundDeliveryResult(message=message_result, deliveries=planning.deliveries)
     except Exception:
         await connection.rollback()
         raise
@@ -309,12 +241,12 @@ async def record_outbound_message_with_streaming_finalization(
     *,
     delivery_policy: WorkshopDeliveryBindingPolicy,
 ) -> OutboundStreamingFinalizationResult:
-    """Atomically persist a reply, delivery request, and immutable operation plan.
+    """Atomically persist a reply and capability-selected delivery requests.
 
     The authenticated private-text route calls this service after agent
-    completion. Its only routing input is the canonical inbound message ID. It
-    resolves the direct Telegram binding and any confirmed non-final preview
-    internally, and it neither sends nor edits Telegram itself.
+    completion. Its only routing input is the canonical inbound message ID.
+    Formatting, chunking, preview resolution, and provider operations belong to
+    the adapter that claims each independently durable request.
     """
     connection = store.connection
     try:
@@ -338,37 +270,12 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
     delivery_policy: WorkshopDeliveryBindingPolicy,
     request_delivery: bool = True,
 ) -> OutboundStreamingFinalizationResult:
-    """Persist a reply and immutable delivery plan in a caller-owned transaction."""
+    """Persist a reply and adapter delivery intents in a caller-owned transaction."""
     if not store.connection.in_transaction:
         raise RuntimeError(
             "record_outbound_message_with_streaming_finalization_in_transaction requires an active transaction"
         )
     binding = await _resolve_outbound(store, message.in_reply_to_message_id)
-    streaming_target = (
-        await resolve_telegram_finalization_target(
-            store,
-            message.in_reply_to_message_id,
-        )
-        if request_delivery and delivery_policy.is_enabled("telegram")
-        else None
-    )
-    if streaming_target is not None and (
-        streaming_target.workshop_id != binding.workshop_id or streaming_target.channel_id != binding.channel_id
-    ):
-        raise OutboundStreamingPreviewConflictError(
-            "Telegram streaming target does not match the canonical agent reply target"
-        )
-    preview_message_id = (
-        await _confirmed_preview_message_id(
-            store,
-            inbound_message_id=message.in_reply_to_message_id,
-            workshop_id=binding.workshop_id,
-            channel_id=binding.channel_id,
-            channel_binding_id=streaming_target.channel_binding_id,
-        )
-        if streaming_target is not None and streaming_target.preview_eligible
-        else None
-    )
     message_result = await _existing_outbound(store, binding, message)
     if message_result is None:
         message_result = await store.append_in_transaction(_outbound_envelope(binding, message))
@@ -378,46 +285,30 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
     message_id = message_result.event.envelope.aggregate_id
     if not isinstance(message_id, MessageId):
         raise RuntimeError("Canonical outbound event did not identify a message")
-    delivery_result = None
-    plan_result = None
-    if streaming_target is not None:
-        operations = _streaming_finalization_operations(
-            message.body,
-            preview_message_id=preview_message_id,
-        )
-        authority_epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch_in_transaction()
-        assert authority_epoch is not None
-        delivery_result = await WorkshopDeliveryOutbox(store).request_delivery_in_transaction(
-            DeliveryRequest(
+    planning = (
+        await WorkshopDeliveryPlanner(store, delivery_policy).plan_in_transaction(
+            CanonicalDeliveryIntent(
                 message_id=message_id,
-                channel_binding_id=streaming_target.channel_binding_id,
+                channel_id=binding.channel_id,
                 mode="text",
                 purpose=CONVERSATION_REPLY_PURPOSE,
                 occurred_at=message.occurred_at,
-                execution_contract=STREAMING_FINALIZATION_CONTRACT,
-                authority_epoch_id=authority_epoch.epoch_id,
-                max_attempts=5,
+                recipient_principal_id=binding.recipient_principal_id,
+                preview_eligible=True,
             )
         )
-        plan_result = await WorkshopDeliveryFragments(store).prepare_operations_in_transaction(
-            delivery_result.delivery.delivery_id,
-            operations,
-            occurred_at=message.occurred_at,
-        )
+        if request_delivery
+        else None
+    )
+    deliveries = planning.deliveries if planning is not None else ()
     prior_states = {message_result.inserted}
-    if delivery_result is not None:
-        prior_states.add(delivery_result.inserted)
-    if plan_result is not None:
-        prior_states.add(plan_result.inserted)
+    prior_states.update(delivery.inserted for delivery in deliveries)
     if len(prior_states) != 1:
-        raise OutboundDeliveryStateConflictError(
-            "Canonical reply, delivery request, and operation plan did not share one prior state"
-        )
+        raise OutboundDeliveryStateConflictError("Canonical reply and delivery requests did not share one prior state")
     await store.project_pending_in_transaction(projection)
     return OutboundStreamingFinalizationResult(
         message=message_result,
-        delivery=delivery_result,
-        plan=plan_result,
+        deliveries=deliveries,
     )
 
 

--- a/src/kai/workshop/proactive_publication.py
+++ b/src/kai/workshop/proactive_publication.py
@@ -14,12 +14,8 @@ from kai.workshop.artifacts import (
     WorkshopArtifactService,
     record_published_artifact_in_transaction,
 )
-from kai.workshop.delivery_outbox import (
-    NOTIFICATION_PURPOSE,
-    DeliveryRequest,
-    DeliveryRequestResult,
-    WorkshopDeliveryOutbox,
-)
+from kai.workshop.delivery_outbox import NOTIFICATION_PURPOSE, DeliveryRequestResult
+from kai.workshop.delivery_planning import CanonicalDeliveryIntent, WorkshopDeliveryPlanner
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     AgentId,
@@ -89,7 +85,7 @@ class WorkshopProactivePublicationService:
         self._store = store
         self._artifacts = artifacts
         self._artifact_storage_root = artifact_storage_root.resolve()
-        self._delivery_policy = delivery_policy
+        self._delivery_planner = WorkshopDeliveryPlanner(store, delivery_policy)
         self._lock = asyncio.Lock()
 
     async def validate_authority(self, authority: ProactivePublicationAuthority) -> None:
@@ -222,22 +218,17 @@ class WorkshopProactivePublicationService:
                     artifact.for_message(message_id),
                     storage_root=self._artifact_storage_root,
                 )
-            binding_ids = await self._delivery_policy.binding_ids(self._store, authority.channel_id)
-            deliveries = tuple(
-                [
-                    await WorkshopDeliveryOutbox(self._store).request_delivery_in_transaction(
-                        DeliveryRequest(
-                            message_id=message_id,
-                            channel_binding_id=binding_id,
-                            mode=mode,
-                            purpose=NOTIFICATION_PURPOSE,
-                            occurred_at=occurred_at,
-                            max_attempts=5,
-                        )
-                    )
-                    for binding_id in binding_ids
-                ]
+            planning = await self._delivery_planner.plan_in_transaction(
+                CanonicalDeliveryIntent(
+                    message_id=message_id,
+                    channel_id=authority.channel_id,
+                    mode=mode,
+                    purpose=NOTIFICATION_PURPOSE,
+                    occurred_at=occurred_at,
+                    content_kind="attachment" if artifact is not None else "text",
+                )
             )
+            deliveries = planning.deliveries
             prior_states = {inserted, *(delivery.inserted for delivery in deliveries)}
             if artifact_result is not None:
                 prior_states.add(artifact_result.inserted)

--- a/src/kai/workshop/scheduled_notifications.py
+++ b/src/kai/workshop/scheduled_notifications.py
@@ -6,12 +6,8 @@ import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from kai.workshop.delivery_outbox import (
-    NOTIFICATION_PURPOSE,
-    DeliveryRequest,
-    DeliveryRequestResult,
-    WorkshopDeliveryOutbox,
-)
+from kai.workshop.delivery_outbox import NOTIFICATION_PURPOSE, DeliveryRequestResult
+from kai.workshop.delivery_planning import CanonicalDeliveryIntent, WorkshopDeliveryPlanner
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     ChannelId,
@@ -37,7 +33,11 @@ class ScheduledReminder:
 @dataclass(frozen=True, slots=True)
 class ScheduledReminderRecord:
     message_id: MessageId
-    delivery: DeliveryRequestResult | None
+    deliveries: tuple[DeliveryRequestResult, ...]
+
+    @property
+    def delivery(self) -> DeliveryRequestResult | None:
+        return self.deliveries[0] if len(self.deliveries) == 1 else None
 
 
 class WorkshopScheduledReminderRecorder:
@@ -45,7 +45,7 @@ class WorkshopScheduledReminderRecorder:
 
     def __init__(self, store: WorkshopEventStore, delivery_policy: WorkshopDeliveryBindingPolicy) -> None:
         self._store = store
-        self._delivery_policy = delivery_policy
+        self._delivery_planner = WorkshopDeliveryPlanner(store, delivery_policy)
         self._lock = asyncio.Lock()
 
     async def record(self, reminder: ScheduledReminder) -> ScheduledReminderRecord:
@@ -107,30 +107,20 @@ class WorkshopScheduledReminderRecorder:
                 raise IdempotencyConflictError(f"Event identity {idempotency_key!r} was reused with different content")
             projection = CanonicalConversationProjection()
             await self._store.project_pending_in_transaction(projection)
-            bindings = await self._delivery_policy.binding_ids(
-                self._store,
-                channel_id,
-                transport="telegram",
-            )
-            if len(bindings) > 1:
-                raise RuntimeError("Scheduled reminder channel has ambiguous Telegram bindings")
-            delivery = None
-            if bindings:
-                delivery = await WorkshopDeliveryOutbox(self._store).request_delivery_in_transaction(
-                    DeliveryRequest(
-                        message_id=message_id,
-                        channel_binding_id=bindings[0],
-                        mode="text",
-                        purpose=NOTIFICATION_PURPOSE,
-                        occurred_at=occurred_at,
-                        max_attempts=5,
-                    )
+            planning = await self._delivery_planner.plan_in_transaction(
+                CanonicalDeliveryIntent(
+                    message_id=message_id,
+                    channel_id=channel_id,
+                    mode="text",
+                    purpose=NOTIFICATION_PURPOSE,
+                    occurred_at=occurred_at,
                 )
-                if delivery.inserted != inserted:
-                    raise RuntimeError("Scheduled reminder and delivery do not share one prior state")
+            )
+            if any(delivery.inserted != inserted for delivery in planning.deliveries):
+                raise RuntimeError("Scheduled reminder and deliveries do not share one prior state")
             await self._store.project_pending_in_transaction(projection)
             await connection.commit()
-            return ScheduledReminderRecord(message_id, delivery)
+            return ScheduledReminderRecord(message_id, planning.deliveries)
         except Exception:
             await connection.rollback()
             raise

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 29
+WORKSHOP_SCHEMA_VERSION = 30
 
 
 @dataclass(frozen=True, slots=True)
@@ -1325,6 +1325,224 @@ _CANONICAL_SCHEDULED_JOB_SCHEMA = SchemaMigration(
     ),
 )
 
+_ADAPTER_PLUGGABLE_DELIVERY_SCHEMA = SchemaMigration(
+    version=30,
+    name="adapter_pluggable_delivery_authority",
+    statements=(
+        # Replace the transport-named authority lane without losing durable
+        # outbox, attempt, or fragment state. SQLite cannot alter the lane
+        # CHECK constraint or retarget the dependent foreign keys in place.
+        """
+        CREATE TABLE delivery_authority_epochs_v30 (
+            id TEXT PRIMARY KEY,
+            lane TEXT NOT NULL CHECK (lane = 'conversation_streaming_finalization'),
+            status TEXT NOT NULL CHECK (status IN ('active', 'deactivated')),
+            activated_at TEXT NOT NULL,
+            deactivated_at TEXT,
+            terminal_failures_acknowledged_at TEXT,
+            CHECK (
+                (status = 'active' AND deactivated_at IS NULL)
+                OR (status = 'deactivated' AND deactivated_at IS NOT NULL)
+            ),
+            CHECK (
+                status = 'deactivated' OR terminal_failures_acknowledged_at IS NULL
+            )
+        )
+        """,
+        """
+        INSERT INTO delivery_authority_epochs_v30 (
+            id, lane, status, activated_at, deactivated_at,
+            terminal_failures_acknowledged_at
+        ) SELECT
+            id, 'conversation_streaming_finalization', status, activated_at,
+            deactivated_at, terminal_failures_acknowledged_at
+        FROM delivery_authority_epochs
+        """,
+        """
+        CREATE TABLE delivery_outbox_v30 (
+            id TEXT PRIMARY KEY,
+            workshop_id TEXT NOT NULL,
+            channel_id TEXT NOT NULL,
+            channel_binding_id TEXT NOT NULL,
+            message_id TEXT NOT NULL,
+            transport TEXT NOT NULL,
+            mode TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (
+                status IN ('pending', 'leased', 'retry_wait', 'succeeded', 'failed')
+            ),
+            max_attempts INTEGER NOT NULL CHECK (max_attempts BETWEEN 1 AND 20),
+            attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (
+                attempt_count >= 0 AND attempt_count <= max_attempts
+            ),
+            available_at TEXT NOT NULL,
+            lease_id TEXT,
+            lease_owner TEXT,
+            lease_expires_at TEXT,
+            last_error_code TEXT,
+            requested_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT,
+            purpose TEXT NOT NULL DEFAULT 'qualification' CHECK (
+                purpose IN ('conversation_reply', 'notification', 'qualification')
+            ),
+            execution_contract TEXT NOT NULL DEFAULT 'send_fragments' CHECK (
+                execution_contract IN ('send_fragments', 'streaming_finalization')
+            ),
+            authority_epoch_id TEXT
+                REFERENCES delivery_authority_epochs_v30(id) ON DELETE RESTRICT,
+            UNIQUE (message_id, channel_binding_id, mode),
+            CHECK (
+                (
+                    status = 'leased'
+                    AND lease_id IS NOT NULL
+                    AND lease_owner IS NOT NULL
+                    AND lease_expires_at IS NOT NULL
+                ) OR (
+                    status != 'leased'
+                    AND lease_id IS NULL
+                    AND lease_owner IS NULL
+                    AND lease_expires_at IS NULL
+                )
+            ),
+            CHECK (
+                (status IN ('succeeded', 'failed') AND completed_at IS NOT NULL)
+                OR (status NOT IN ('succeeded', 'failed') AND completed_at IS NULL)
+            )
+        )
+        """,
+        """
+        INSERT INTO delivery_outbox_v30 (
+            id, workshop_id, channel_id, channel_binding_id, message_id,
+            transport, mode, status, max_attempts, attempt_count, available_at,
+            lease_id, lease_owner, lease_expires_at, last_error_code,
+            requested_event_position, created_at, updated_at, completed_at,
+            purpose, execution_contract, authority_epoch_id
+        ) SELECT
+            id, workshop_id, channel_id, channel_binding_id, message_id,
+            transport, mode, status, max_attempts, attempt_count, available_at,
+            lease_id, lease_owner, lease_expires_at, last_error_code,
+            requested_event_position, created_at, updated_at, completed_at,
+            purpose, execution_contract, authority_epoch_id
+        FROM delivery_outbox
+        """,
+        """
+        CREATE TABLE delivery_attempts_v30 (
+            id TEXT PRIMARY KEY,
+            delivery_id TEXT NOT NULL REFERENCES delivery_outbox_v30(id) ON DELETE CASCADE,
+            attempt_number INTEGER NOT NULL CHECK (attempt_number > 0),
+            worker_id TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            lease_expires_at TEXT NOT NULL,
+            completed_at TEXT,
+            outcome TEXT CHECK (
+                outcome IN ('succeeded', 'retry_scheduled', 'failed', 'lease_expired')
+            ),
+            error_code TEXT,
+            UNIQUE (delivery_id, attempt_number),
+            CHECK (
+                (completed_at IS NULL AND outcome IS NULL)
+                OR (completed_at IS NOT NULL AND outcome IS NOT NULL)
+            )
+        )
+        """,
+        """
+        INSERT INTO delivery_attempts_v30 (
+            id, delivery_id, attempt_number, worker_id, started_at,
+            lease_expires_at, completed_at, outcome, error_code
+        ) SELECT
+            id, delivery_id, attempt_number, worker_id, started_at,
+            lease_expires_at, completed_at, outcome, error_code
+        FROM delivery_attempts
+        """,
+        """
+        CREATE TABLE delivery_fragments_v30 (
+            delivery_id TEXT NOT NULL
+                REFERENCES delivery_outbox_v30(id) ON DELETE CASCADE,
+            fragment_index INTEGER NOT NULL CHECK (fragment_index >= 0),
+            fragment_count INTEGER NOT NULL CHECK (fragment_count > 0),
+            body TEXT NOT NULL CHECK (length(body) BETWEEN 1 AND 1000000),
+            status TEXT NOT NULL CHECK (
+                status IN ('pending', 'sending', 'sent', 'uncertain')
+            ),
+            attempt_id TEXT REFERENCES delivery_attempts_v30(id) ON DELETE RESTRICT,
+            external_message_id TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            sent_at TEXT,
+            operation TEXT NOT NULL DEFAULT 'send' CHECK (
+                operation IN ('send', 'edit')
+            ),
+            target_external_message_id TEXT CHECK (
+                (operation = 'send' AND target_external_message_id IS NULL)
+                OR (operation = 'edit' AND length(target_external_message_id) BETWEEN 1 AND 255)
+            ),
+            PRIMARY KEY (delivery_id, fragment_index),
+            CHECK (fragment_index < fragment_count),
+            CHECK (
+                (
+                    status = 'pending'
+                    AND attempt_id IS NULL
+                    AND external_message_id IS NULL
+                    AND sent_at IS NULL
+                ) OR (
+                    status IN ('sending', 'uncertain')
+                    AND attempt_id IS NOT NULL
+                    AND external_message_id IS NULL
+                    AND sent_at IS NULL
+                ) OR (
+                    status = 'sent'
+                    AND attempt_id IS NOT NULL
+                    AND external_message_id IS NOT NULL
+                    AND sent_at IS NOT NULL
+                )
+            )
+        )
+        """,
+        """
+        INSERT INTO delivery_fragments_v30 (
+            delivery_id, fragment_index, fragment_count, body, status,
+            attempt_id, external_message_id, created_at, updated_at, sent_at,
+            operation, target_external_message_id
+        ) SELECT
+            delivery_id, fragment_index, fragment_count, body, status,
+            attempt_id, external_message_id, created_at, updated_at, sent_at,
+            operation, target_external_message_id
+        FROM delivery_fragments
+        """,
+        "DROP TABLE delivery_fragments",
+        "DROP TABLE delivery_attempts",
+        "DROP TABLE delivery_outbox",
+        "DROP TABLE delivery_authority_epochs",
+        "ALTER TABLE delivery_authority_epochs_v30 RENAME TO delivery_authority_epochs",
+        "ALTER TABLE delivery_outbox_v30 RENAME TO delivery_outbox",
+        "ALTER TABLE delivery_attempts_v30 RENAME TO delivery_attempts",
+        "ALTER TABLE delivery_fragments_v30 RENAME TO delivery_fragments",
+        "CREATE UNIQUE INDEX delivery_authority_epochs_active_lane_idx "
+        "ON delivery_authority_epochs (lane) WHERE status = 'active'",
+        "CREATE INDEX delivery_outbox_due_idx ON delivery_outbox (status, available_at, requested_event_position)",
+        "CREATE INDEX delivery_outbox_lease_expiry_idx ON delivery_outbox (status, lease_expires_at)",
+        "CREATE INDEX delivery_outbox_binding_order_idx ON delivery_outbox "
+        "(channel_binding_id, requested_event_position, status)",
+        "CREATE INDEX delivery_outbox_purpose_due_idx ON delivery_outbox "
+        "(purpose, status, available_at, requested_event_position)",
+        "CREATE INDEX delivery_outbox_purpose_binding_order_idx ON delivery_outbox "
+        "(purpose, channel_binding_id, requested_event_position, status)",
+        "CREATE INDEX delivery_outbox_contract_due_idx ON delivery_outbox "
+        "(execution_contract, purpose, status, available_at, requested_event_position)",
+        "CREATE INDEX delivery_outbox_contract_binding_order_idx ON delivery_outbox "
+        "(execution_contract, purpose, channel_binding_id, requested_event_position, status)",
+        "CREATE INDEX delivery_outbox_authority_due_idx ON delivery_outbox "
+        "(authority_epoch_id, execution_contract, purpose, status, available_at, requested_event_position)",
+        "CREATE INDEX delivery_outbox_authority_binding_order_idx ON delivery_outbox "
+        "(authority_epoch_id, execution_contract, purpose, channel_binding_id, "
+        "requested_event_position, status)",
+        "CREATE INDEX delivery_attempts_delivery_idx ON delivery_attempts (delivery_id, attempt_number)",
+        "CREATE INDEX delivery_fragments_status_idx ON delivery_fragments (delivery_id, status, fragment_index)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1355,6 +1573,7 @@ _MIGRATIONS = (
     _GITHUB_AUTOMATION_SCHEMA,
     _INTEGRATION_ROUTE_SCHEMA,
     _CANONICAL_SCHEDULED_JOB_SCHEMA,
+    _ADAPTER_PLUGGABLE_DELIVERY_SCHEMA,
 )
 
 

--- a/src/kai/workshop/telegram_delivery.py
+++ b/src/kai/workshop/telegram_delivery.py
@@ -35,6 +35,7 @@ from kai.workshop.delivery_fragments import (
     EDIT_OPERATION,
     SEND_OPERATION,
     DeliveryFragment,
+    DeliveryFragmentOperation,
     WorkshopDeliveryFragments,
 )
 from kai.workshop.delivery_outbox import (
@@ -517,6 +518,62 @@ class WorkshopTelegramStreamingFinalizationAdapter:
         return message_id
 
 
+class WorkshopTelegramFinalizationPlanner:
+    """Build Telegram-specific finalization operations after durable claim."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def operations(self, claim: DeliveryClaim) -> tuple[DeliveryFragmentOperation, ...]:
+        if not isinstance(claim, DeliveryClaim):
+            raise ValueError("claim must be a DeliveryClaim")
+        if claim.execution_contract != STREAMING_FINALIZATION_CONTRACT:
+            raise TelegramDeliveryContractError("telegram_execution_contract_mismatch")
+        if claim.transport != "telegram":
+            raise TelegramDeliveryContractError("telegram_transport_mismatch")
+        if claim.mode != "text":
+            raise TelegramDeliveryContractError("telegram_mode_unsupported")
+
+        fragments = _telegram_fragments(_telegram_delivery_body(claim))
+        async with self._store.connection.execute(
+            "SELECT reply_to_message_id FROM messages WHERE id = ? AND channel_id = ?",
+            (claim.message_id, claim.channel_id),
+        ) as cursor:
+            message_row = await cursor.fetchone()
+        if message_row is None:
+            raise TelegramDeliveryContractError("telegram_canonical_message_missing")
+
+        inbound_message_id = message_row[0]
+        preview_message_id: int | None = None
+        if inbound_message_id is not None:
+            async with self._store.connection.execute(
+                "SELECT workshop_id, channel_id, channel_binding_id, "
+                "external_message_id, state FROM telegram_streaming_previews "
+                "WHERE inbound_message_id = ? AND channel_binding_id = ?",
+                (str(inbound_message_id), claim.channel_binding_id),
+            ) as cursor:
+                preview_row = await cursor.fetchone()
+            if preview_row is not None:
+                if (
+                    str(preview_row[0]) != claim.workshop_id
+                    or str(preview_row[1]) != claim.channel_id
+                    or str(preview_row[2]) != claim.channel_binding_id
+                ):
+                    raise TelegramDeliveryContractError("telegram_preview_routing_invalid")
+                if str(preview_row[4]) != "confirmed_non_final":
+                    raise TelegramDeliveryContractError("telegram_preview_state_invalid")
+                preview_message_id = int(preview_row[3])
+
+        operations = [DeliveryFragmentOperation(SEND_OPERATION, fragment) for fragment in fragments]
+        if preview_message_id is not None:
+            operations[0] = DeliveryFragmentOperation(
+                EDIT_OPERATION,
+                fragments[0],
+                target_external_message_id=preview_message_id,
+            )
+        return tuple(operations)
+
+
 class WorkshopTelegramDeliveryWorker:
     """Claim and settle one explicitly assigned lane of Telegram text work."""
 
@@ -660,6 +717,7 @@ class WorkshopTelegramStreamingFinalizationWorker:
         outbox: WorkshopDeliveryOutbox,
         fragments: WorkshopDeliveryFragments,
         adapter: WorkshopTelegramStreamingFinalizationAdapter,
+        planner: WorkshopTelegramFinalizationPlanner,
         *,
         worker_id: str,
         authority_epoch_id: DeliveryAuthorityEpochId,
@@ -673,6 +731,7 @@ class WorkshopTelegramStreamingFinalizationWorker:
         self._outbox = outbox
         self._fragments = fragments
         self._adapter = adapter
+        self._planner = planner
         self._worker_id = worker_id
         self._authority_epoch_id = authority_epoch_id
         self._lease_duration = lease_duration
@@ -719,6 +778,13 @@ class WorkshopTelegramStreamingFinalizationWorker:
         if claim.execution_contract != STREAMING_FINALIZATION_CONTRACT:
             raise RuntimeError("Finalization worker claimed another execution contract")
 
+        try:
+            if not await self._fragments.fragments(claim.delivery_id):
+                operations = await self._planner.operations(claim)
+                await self._fragments.prepare_operations(claim, operations)
+        except TelegramDeliveryFailure as failure:
+            return await self._settle_failure(claim, None, failure)
+
         while True:
             fragment = await self._fragments.begin_next(claim)
             if fragment is None:
@@ -759,13 +825,14 @@ class WorkshopTelegramStreamingFinalizationWorker:
     async def _settle_failure(
         self,
         claim: DeliveryClaim,
-        fragment: DeliveryFragment,
+        fragment: DeliveryFragment | None,
         failure: TelegramDeliveryFailure,
     ) -> TelegramWorkResult:
-        if failure.ambiguous:
-            await self._fragments.mark_uncertain(claim, fragment)
-        else:
-            await self._fragments.release_after_definitive_failure(claim, fragment)
+        if fragment is not None:
+            if failure.ambiguous:
+                await self._fragments.mark_uncertain(claim, fragment)
+            else:
+                await self._fragments.release_after_definitive_failure(claim, fragment)
         state = await self._outbox.mark_failed(
             claim,
             retryable=failure.retryable and not failure.ambiguous,

--- a/src/kai/workshop/telegram_delivery_runtime.py
+++ b/src/kai/workshop/telegram_delivery_runtime.py
@@ -27,6 +27,7 @@ from kai.workshop.telegram_delivery import (
     WorkshopTelegramArtifactDeliveryWorker,
     WorkshopTelegramDeliveryAdapter,
     WorkshopTelegramDeliveryWorker,
+    WorkshopTelegramFinalizationPlanner,
     WorkshopTelegramStreamingFinalizationAdapter,
     WorkshopTelegramStreamingFinalizationWorker,
 )
@@ -269,6 +270,7 @@ class WorkshopTelegramConversationDeliveryService:
                 outbox,
                 fragments,
                 WorkshopTelegramStreamingFinalizationAdapter(cast(TelegramTextBot, bot)),
+                WorkshopTelegramFinalizationPlanner(store),
                 worker_id=worker_id,
                 authority_epoch_id=epoch.epoch_id,
             )

--- a/src/kai/workshop/terminal_transactions.py
+++ b/src/kai/workshop/terminal_transactions.py
@@ -282,7 +282,7 @@ class WorkshopRunTerminalTransactionCoordinator:
                         occurred_at=occurred_at,
                     )
                 except RuntimeSessionStateConflictError:
-                    # The answer, delivery plan, and fenced run settlement are
+                    # The answer, delivery intents, and fenced run settlement are
                     # primary facts. An operator reassignment or stale
                     # continuity row must not discard an answer the backend
                     # has already produced. Missing/stale continuity remains
@@ -297,10 +297,7 @@ class WorkshopRunTerminalTransactionCoordinator:
                 finalization.message.inserted,
                 execution.changed,
             }
-            if finalization.delivery is not None:
-                prior_states.add(finalization.delivery.inserted)
-            if finalization.plan is not None:
-                prior_states.add(finalization.plan.inserted)
+            prior_states.update(delivery.inserted for delivery in finalization.deliveries)
             if runtime_session_result is not None:
                 prior_states.add(runtime_session_result.changed)
             if len(prior_states) != 1:

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -16,6 +16,7 @@ from kai.workshop.bootstrap import (
 )
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RunExecutionOwnerId
 from kai.workshop.execution_state import (
     WorkshopExecutionStateNamespace,
@@ -37,6 +38,7 @@ from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageRegistry,
 )
 from kai.workshop.store import WorkshopEventStore
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 from tests.workshop_profiles import profile_id, profile_registry
 
 
@@ -251,6 +253,7 @@ def _host() -> KaiApplicationHost:
         internal_api_contexts=SimpleNamespace(contexts=()),  # type: ignore[arg-type]
         services_info=[],
         registered_backend_ids=frozenset({"codex"}),
+        delivery_policy=WorkshopDeliveryBindingPolicy.disabled(),
     )
 
 
@@ -456,6 +459,7 @@ async def test_real_core_lifecycle_uses_workshop_identity_without_telegram_appli
         internal_api_contexts=internal_contexts,
         services_info=[],
         registered_backend_ids=frozenset({"codex"}),
+        delivery_policy=WorkshopDeliveryBindingPolicy.disabled(),
     )
 
     services = await host.start()
@@ -563,6 +567,7 @@ async def test_core_activates_delivery_authority_before_recovering_expired_start
         internal_api_contexts=internal_contexts,
         services_info=[],
         registered_backend_ids=frozenset({"codex"}),
+        delivery_policy=TELEGRAM_DELIVERY_POLICY,
     )
 
     services = await host.start()

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_delivery_authority.py
+++ b/tests/test_workshop_delivery_authority.py
@@ -32,6 +32,7 @@ from kai.workshop.outbound import OutboundMessage, record_outbound_message_with_
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery import (
     TelegramWorkOutcome,
+    WorkshopTelegramFinalizationPlanner,
     WorkshopTelegramStreamingFinalizationAdapter,
     WorkshopTelegramStreamingFinalizationWorker,
 )
@@ -184,6 +185,7 @@ class TestConversationDeliveryAuthority:
             WorkshopDeliveryOutbox(store, clock=worker_clock),
             WorkshopDeliveryFragments(store, clock=worker_clock),
             WorkshopTelegramStreamingFinalizationAdapter(first_bot),
+            WorkshopTelegramFinalizationPlanner(store),
             worker_id="first-authority-worker",
             authority_epoch_id=first_epoch.epoch_id,
         )
@@ -201,6 +203,7 @@ class TestConversationDeliveryAuthority:
             WorkshopDeliveryOutbox(store, clock=worker_clock),
             WorkshopDeliveryFragments(store, clock=worker_clock),
             WorkshopTelegramStreamingFinalizationAdapter(second_bot),
+            WorkshopTelegramFinalizationPlanner(store),
             worker_id="second-authority-worker",
             authority_epoch_id=second_epoch.epoch_id,
         )
@@ -236,6 +239,7 @@ class TestConversationDeliveryAuthority:
             WorkshopDeliveryOutbox(store, clock=worker_clock),
             WorkshopDeliveryFragments(store, clock=worker_clock),
             WorkshopTelegramStreamingFinalizationAdapter(bot),
+            WorkshopTelegramFinalizationPlanner(store),
             worker_id="failed-authority-worker",
             authority_epoch_id=epoch.epoch_id,
         )

--- a/tests/test_workshop_delivery_planning.py
+++ b/tests/test_workshop_delivery_planning.py
@@ -1,0 +1,310 @@
+"""Capability-aware, transport-neutral Workshop delivery planning contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from kai.workshop.artifacts import WorkshopArtifactService
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.delivery_fragments import WorkshopDeliveryFragments
+from kai.workshop.delivery_outbox import (
+    CONVERSATION_REPLY_PURPOSE,
+    NOTIFICATION_PURPOSE,
+    SEND_FRAGMENTS_CONTRACT,
+    STREAMING_FINALIZATION_CONTRACT,
+    DeliveryClaim,
+    DeliveryId,
+    DeliveryPurpose,
+    WorkshopDeliveryOutbox,
+)
+from kai.workshop.delivery_policy import (
+    DeliveryAdapterCapabilities,
+    WorkshopDeliveryBindingPolicy,
+)
+from kai.workshop.domain import (
+    ChannelBindingId,
+    EventEnvelope,
+    ExternalIdentityId,
+    MessageId,
+    PrincipalId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
+from kai.workshop.outbound import (
+    OutboundMessage,
+    record_outbound_message_with_streaming_finalization,
+)
+from kai.workshop.proactive_publication import (
+    ProactivePublicationAuthority,
+    WorkshopProactivePublicationService,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.scheduled_notifications import (
+    ScheduledReminder,
+    WorkshopScheduledReminderRecorder,
+)
+from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
+from kai.workshop.store import WorkshopEventStore
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
+from tests.workshop_profiles import profile_id, profile_registry
+
+_NOW = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+_DESKTOP_CAPABILITIES = DeliveryAdapterCapabilities(transport="desktop")
+
+
+class _DesktopDeliveryAdapter:
+    """Small test adapter proving core delivery work needs no feature branch."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._outbox = WorkshopDeliveryOutbox(store)
+        self._fragments = WorkshopDeliveryFragments(store)
+        self.delivered: list[str] = []
+
+    async def deliver(
+        self,
+        delivery_id: DeliveryId,
+        *,
+        purpose: DeliveryPurpose,
+    ) -> DeliveryClaim:
+        claim = await self._outbox.claim_next(
+            "desktop-test-adapter",
+            purposes=(purpose,),
+            execution_contracts=(SEND_FRAGMENTS_CONTRACT,),
+            transport="desktop",
+            delivery_id=delivery_id,
+        )
+        assert claim is not None
+        await self._fragments.prepare(claim, (claim.body,))
+        fragment = await self._fragments.begin_next(claim)
+        assert fragment is not None
+        self.delivered.append(fragment.body)
+        await self._fragments.mark_sent(
+            claim,
+            fragment,
+            external_message_id=f"desktop-{len(self.delivered)}",
+        )
+        state = await self._outbox.mark_succeeded(claim)
+        assert state.status == "succeeded"
+        return claim
+
+
+async def _desktop_store(path: Path) -> tuple[WorkshopEventStore, PrincipalId, MessageId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                "Desktop Human",
+                "admin",
+                "desktop",
+                "desktop-human",
+                "desktop-human",
+                profile_id(101),
+            ),
+        ),
+    )
+    async with store.connection.execute(
+        "SELECT principal_id FROM external_identities WHERE provider = 'desktop' AND external_subject = 'desktop-human'"
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    principal_id = PrincipalId(str(row[0]))
+    inbound = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="desktop",
+            update_id="desktop-update-1",
+            message_id="desktop-message-1",
+            sender_subject="desktop-human",
+            channel_subject="desktop-human",
+            body="Hello from desktop",
+            occurred_at=_NOW,
+        ),
+    )
+    return store, principal_id, MessageId(str(inbound.event.envelope.aggregate_id))
+
+
+async def _add_telegram_destination(
+    store: WorkshopEventStore,
+    principal_id: PrincipalId,
+    inbound_id: MessageId,
+) -> None:
+    async with store.connection.execute(
+        "SELECT c.workshop_id, m.channel_id FROM messages m JOIN channels c ON c.id = m.channel_id WHERE m.id = ?",
+        (inbound_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    workshop_id = WorkshopId(str(row[0]))
+    channel_id = str(row[1])
+    await store.append(
+        EventEnvelope.create(
+            event_type=WorkshopEventType.EXTERNAL_IDENTITY_BOUND,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="external_identity",
+            aggregate_id=ExternalIdentityId.new(),
+            occurred_at=_NOW,
+            idempotency_key="test:desktop-human:telegram-identity",
+            payload={
+                "principal_id": principal_id,
+                "provider": "telegram",
+                "external_subject": "101",
+            },
+        )
+    )
+    await store.append(
+        EventEnvelope.create(
+            event_type=WorkshopEventType.TRANSPORT_CHANNEL_BOUND,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="channel_binding",
+            aggregate_id=ChannelBindingId.new(),
+            occurred_at=_NOW,
+            idempotency_key="test:desktop-channel:telegram-binding",
+            payload={
+                "channel_id": channel_id,
+                "transport": "telegram",
+                "external_channel_id": "101",
+            },
+        )
+    )
+    await store.project_pending(CanonicalConversationProjection())
+
+
+def _desktop_policy() -> WorkshopDeliveryBindingPolicy:
+    return WorkshopDeliveryBindingPolicy(
+        frozenset({"desktop"}),
+        (_DESKTOP_CAPABILITIES,),
+    )
+
+
+async def test_non_telegram_adapter_delivers_ordinary_reply_without_core_changes(tmp_path: Path):
+    store, _, inbound_id = await _desktop_store(tmp_path / "kai.db")
+    try:
+        result = await record_outbound_message_with_streaming_finalization(
+            store,
+            OutboundMessage(inbound_id, "Desktop reply", _NOW),
+            delivery_policy=_desktop_policy(),
+        )
+
+        assert len(result.deliveries) == 1
+        delivery = result.deliveries[0].delivery
+        assert (delivery.transport, delivery.execution_contract) == (
+            "desktop",
+            SEND_FRAGMENTS_CONTRACT,
+        )
+        adapter = _DesktopDeliveryAdapter(store)
+        await adapter.deliver(delivery.delivery_id, purpose=CONVERSATION_REPLY_PURPOSE)
+        assert adapter.delivered == ["Desktop reply"]
+    finally:
+        await store.close()
+
+
+async def test_multiple_adapters_have_independent_durable_outcomes(tmp_path: Path):
+    store, principal_id, inbound_id = await _desktop_store(tmp_path / "kai.db")
+    try:
+        await _add_telegram_destination(store, principal_id, inbound_id)
+        await WorkshopConversationDeliveryAuthority(store).activate()
+        policy = WorkshopDeliveryBindingPolicy(
+            frozenset({"desktop", "telegram"}),
+            (
+                _DESKTOP_CAPABILITIES,
+                TELEGRAM_DELIVERY_POLICY.adapter_capabilities[0],
+            ),
+        )
+        result = await record_outbound_message_with_streaming_finalization(
+            store,
+            OutboundMessage(inbound_id, "Fanout reply", _NOW),
+            delivery_policy=policy,
+        )
+        by_transport = {item.delivery.transport: item.delivery for item in result.deliveries}
+        assert set(by_transport) == {"desktop", "telegram"}
+        assert by_transport["desktop"].execution_contract == SEND_FRAGMENTS_CONTRACT
+        assert by_transport["telegram"].execution_contract == STREAMING_FINALIZATION_CONTRACT
+
+        adapter = _DesktopDeliveryAdapter(store)
+        await adapter.deliver(
+            by_transport["desktop"].delivery_id,
+            purpose=CONVERSATION_REPLY_PURPOSE,
+        )
+        epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch()
+        telegram_claim = await WorkshopDeliveryOutbox(store).claim_next(
+            "telegram-test-failure",
+            purposes=(CONVERSATION_REPLY_PURPOSE,),
+            execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+            transport="telegram",
+            delivery_id=by_transport["telegram"].delivery_id,
+            authority_epoch_id=epoch.epoch_id,
+        )
+        assert telegram_claim is not None
+        await WorkshopDeliveryOutbox(store).mark_failed(
+            telegram_claim,
+            retryable=False,
+            error_code="telegram_test_failure",
+        )
+        assert (await WorkshopDeliveryOutbox(store).state(by_transport["desktop"].delivery_id)).status == ("succeeded")
+        assert (await WorkshopDeliveryOutbox(store).state(by_transport["telegram"].delivery_id)).status == "failed"
+    finally:
+        await store.close()
+
+
+async def test_non_telegram_adapter_delivers_scheduled_and_proactive_messages(tmp_path: Path):
+    store, principal_id, _ = await _desktop_store(tmp_path / "kai.db")
+    profiles = profile_registry(101)
+    try:
+        contexts = await WorkshopInternalAPIContextRegistry.from_store(store, profiles)
+        context = contexts.for_runtime_profile(profile_id(101))
+        async with store.connection.execute(
+            "SELECT ca.agent_id FROM channel_agents ca WHERE ca.channel_id = ?",
+            (context.channel_id,),
+        ) as cursor:
+            agent_row = await cursor.fetchone()
+        assert agent_row is not None
+        await store.connection.execute(
+            "INSERT INTO workshop_scheduled_jobs "
+            "(id, principal_id, channel_id, agent_id, runtime_profile_id, name, "
+            "job_type, prompt, schedule_type, schedule_data) "
+            "VALUES (901, ?, ?, ?, ?, 'Desktop reminder', 'reminder', 'Remember', "
+            "'once', '{\"run_at\":\"2036-01-01T00:00:00Z\"}')",
+            (principal_id, context.channel_id, str(agent_row[0]), profile_id(101)),
+        )
+        await store.connection.commit()
+        scheduled = await WorkshopScheduledReminderRecorder(store, _desktop_policy()).record(
+            ScheduledReminder(901, "occurrence-1", "Scheduled desktop", _NOW)
+        )
+
+        storage = await WorkshopPrincipalStorageRegistry.from_store(store, profiles)
+        artifacts = WorkshopArtifactService(
+            store,
+            data_dir=tmp_path,
+            principal_storage=storage,
+            runtime_profiles=profiles,
+        )
+        proactive = await WorkshopProactivePublicationService(
+            store,
+            artifacts,
+            artifact_storage_root=tmp_path / "files",
+            delivery_policy=_desktop_policy(),
+        ).publish_text(
+            ProactivePublicationAuthority(
+                context.principal_id,
+                context.channel_id,
+                context.agent_id,
+                context.runtime_profile_id,
+            ),
+            request_id="desktop-proactive",
+            body="Proactive desktop",
+            occurred_at=_NOW,
+        )
+
+        adapter = _DesktopDeliveryAdapter(store)
+        await adapter.deliver(scheduled.deliveries[0].delivery.delivery_id, purpose=NOTIFICATION_PURPOSE)
+        await adapter.deliver(proactive.deliveries[0].delivery.delivery_id, purpose=NOTIFICATION_PURPOSE)
+        assert adapter.delivered == ["Scheduled desktop", "Proactive desktop"]
+    finally:
+        await store.close()

--- a/tests/test_workshop_delivery_policy.py
+++ b/tests/test_workshop_delivery_policy.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import pytest
 
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
-from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
+from kai.workshop.delivery_policy import (
+    DeliveryAdapterCapabilities,
+    WorkshopDeliveryBindingPolicy,
+)
 from kai.workshop.domain import ChannelId
 from kai.workshop.store import WorkshopEventStore
 
@@ -48,6 +51,30 @@ def test_policy_rejects_invalid_transport_identifiers():
         WorkshopDeliveryBindingPolicy({"telegram"})  # type: ignore[arg-type]
 
 
+def test_adapter_capabilities_are_explicit_and_internally_consistent():
+    telegram = DeliveryAdapterCapabilities(
+        transport="telegram",
+        preview_streaming=True,
+        message_editing=True,
+        replies=True,
+        threads=True,
+        attachments=True,
+    )
+    policy = WorkshopDeliveryBindingPolicy(frozenset({"telegram"}), (telegram,))
+
+    assert policy.capabilities_for("telegram") == telegram
+    assert policy.capabilities_for("desktop") is None
+    with pytest.raises(ValueError, match="requires final_text and message_editing"):
+        DeliveryAdapterCapabilities(transport="broken", preview_streaming=True)
+    with pytest.raises(ValueError, match="disabled transport"):
+        WorkshopDeliveryBindingPolicy(
+            frozenset({"desktop"}),
+            (telegram,),
+        )
+    with pytest.raises(ValueError, match="must declare"):
+        WorkshopDeliveryBindingPolicy(frozenset({"telegram"}))
+
+
 async def test_disabled_policy_retains_bindings_without_making_them_eligible(tmp_path: Path):
     store, channel_id = await _store_with_bindings(tmp_path / "kai.db")
     try:
@@ -67,8 +94,13 @@ async def test_disabled_policy_retains_bindings_without_making_them_eligible(tmp
 async def test_policy_selects_only_bindings_for_enabled_transports(tmp_path: Path):
     store, channel_id = await _store_with_bindings(tmp_path / "kai.db")
     try:
-        telegram_only = WorkshopDeliveryBindingPolicy(frozenset({"telegram"}))
-        mixed = WorkshopDeliveryBindingPolicy(frozenset({"desktop", "telegram"}))
+        telegram = DeliveryAdapterCapabilities(transport="telegram")
+        desktop = DeliveryAdapterCapabilities(transport="desktop")
+        telegram_only = WorkshopDeliveryBindingPolicy(frozenset({"telegram"}), (telegram,))
+        mixed = WorkshopDeliveryBindingPolicy(
+            frozenset({"desktop", "telegram"}),
+            (desktop, telegram),
+        )
 
         telegram_bindings = await telegram_only.binding_ids(store, channel_id)
         assert len(telegram_bindings) == 1

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -57,7 +57,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -204,7 +204,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 29
+        assert await workshop_store.schema_version() == 30
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -217,13 +217,52 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 29
+        assert await second.schema_version() == 30
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
             row = await cursor.fetchone()
         assert row[0] == 1
         await second.close()
+
+    async def test_version_twenty_nine_authority_lane_migrates_without_losing_epoch(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        from kai.workshop import schema
+
+        path = tmp_path / "workshop.db"
+        epoch_id = "dae_00000000000000000000000000000001"
+        with monkeypatch.context() as migration_context:
+            migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 29)
+            migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:29])
+            version_twenty_nine = await WorkshopEventStore.open(path)
+            await version_twenty_nine.connection.execute(
+                "INSERT INTO delivery_authority_epochs "
+                "(id, lane, status, activated_at) VALUES "
+                "(?, 'telegram_conversation_streaming_finalization', 'active', ?)",
+                (epoch_id, "2026-08-25T12:00:00.000000Z"),
+            )
+            await version_twenty_nine.connection.commit()
+            await version_twenty_nine.close()
+
+        upgraded = await WorkshopEventStore.open(path)
+        try:
+            assert await upgraded.schema_version() == 30
+            async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
+                assert tuple(await cursor.fetchone()) == (
+                    epoch_id,
+                    "conversation_streaming_finalization",
+                    "active",
+                )
+            async with upgraded.connection.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'delivery_fragments'"
+            ) as cursor:
+                table_sql = str((await cursor.fetchone())[0])
+            assert "target_external_message_id TEXT" in table_sql
+        finally:
+            await upgraded.close()
 
     async def test_version_one_database_upgrades_additively(self, tmp_path: Path, monkeypatch):
         from kai.workshop import schema
@@ -238,7 +277,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -285,6 +324,7 @@ class TestWorkshopSchema:
                     27,
                     28,
                     29,
+                    30,
                 ]
         finally:
             await upgraded.close()
@@ -307,7 +347,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -348,7 +388,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -401,7 +441,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -445,7 +485,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -489,7 +529,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -533,7 +573,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -637,7 +677,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -764,7 +804,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_github_notifications.py
+++ b/tests/test_workshop_github_notifications.py
@@ -16,7 +16,10 @@ from kai.workshop.bootstrap import (
     bootstrap_default_workshop,
 )
 from kai.workshop.delivery_outbox import NOTIFICATION_PURPOSE
-from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
+from kai.workshop.delivery_policy import (
+    DeliveryAdapterCapabilities,
+    WorkshopDeliveryBindingPolicy,
+)
 from kai.workshop.domain import ChannelId
 from kai.workshop.integration_notifications import (
     IntegrationNotification,
@@ -174,7 +177,10 @@ class TestWorkshopIntegrationNotificationService:
         )
         await store.connection.commit()
         try:
-            desktop_policy = WorkshopDeliveryBindingPolicy(frozenset({"desktop"}))
+            desktop_policy = WorkshopDeliveryBindingPolicy(
+                frozenset({"desktop"}),
+                (DeliveryAdapterCapabilities(transport="desktop"),),
+            )
             result = await WorkshopIntegrationNotificationService(store, desktop_policy).record_for_channel(
                 _notification(),
                 channel_id,

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -521,7 +521,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_outbound.py
+++ b/tests/test_workshop_outbound.py
@@ -22,7 +22,6 @@ from kai.workshop.domain import (
 from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.outbound import (
     DeliveryObservation,
-    OutboundDeliveryBindingError,
     OutboundDeliveryStateConflictError,
     OutboundMessage,
     OutboundMessageNotFoundError,
@@ -284,20 +283,19 @@ class TestAtomicOutboundDelivery:
         finally:
             await store.close()
 
-    async def test_missing_telegram_binding_rolls_back_without_creating_reply(self, tmp_path: Path):
+    async def test_missing_enabled_adapter_binding_records_canonical_reply_only(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:
             await store.connection.execute("DELETE FROM channel_bindings")
             await store.connection.commit()
 
-            with pytest.raises(OutboundDeliveryBindingError):
-                await record_outbound_message_with_delivery(store, _outbound(inbound_id))
-
-            await self._assert_no_outbound_delivery_state(store, inbound_id)
+            result = await record_outbound_message_with_delivery(store, _outbound(inbound_id))
+            assert result.message.inserted is True
+            assert result.deliveries == ()
         finally:
             await store.close()
 
-    async def test_ambiguous_telegram_binding_rolls_back_without_guessing(self, tmp_path: Path):
+    async def test_direct_reply_uses_only_binding_owned_by_canonical_recipient(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:
             async with store.connection.execute(
@@ -327,10 +325,14 @@ class TestAtomicOutboundDelivery:
             )
             await store.project_pending(CanonicalConversationProjection())
 
-            with pytest.raises(OutboundDeliveryBindingError):
-                await record_outbound_message_with_delivery(store, _outbound(inbound_id))
-
-            await self._assert_no_outbound_delivery_state(store, inbound_id)
+            result = await record_outbound_message_with_delivery(store, _outbound(inbound_id))
+            assert len(result.deliveries) == 1
+            assert result.deliveries[0].delivery.transport == "telegram"
+            async with store.connection.execute(
+                "SELECT cb.external_channel_id FROM delivery_outbox d "
+                "JOIN channel_bindings cb ON cb.id = d.channel_binding_id"
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == "101"
         finally:
             await store.close()
 

--- a/tests/test_workshop_proactive_publication.py
+++ b/tests/test_workshop_proactive_publication.py
@@ -23,6 +23,7 @@ from kai.workshop.proactive_publication import (
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
 from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 from tests.workshop_profiles import profile_id, profile_registry
 
 _NOW = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
@@ -61,7 +62,11 @@ async def _publication_service(
         store,
         artifacts,
         artifact_storage_root=tmp_path / "files",
-        delivery_policy=WorkshopDeliveryBindingPolicy(delivery_transports),
+        delivery_policy=(
+            TELEGRAM_DELIVERY_POLICY
+            if delivery_transports == frozenset({"telegram"})
+            else WorkshopDeliveryBindingPolicy(delivery_transports)
+        ),
     )
     authority = ProactivePublicationAuthority(
         context.principal_id,

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -411,7 +411,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-import aiosqlite
 import pytest
 
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
@@ -34,7 +33,6 @@ from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.outbound import (
     OutboundDeliveryStateConflictError,
     OutboundMessage,
-    OutboundStreamingPreviewConflictError,
     record_outbound_message,
 )
 from kai.workshop.outbound import (
@@ -49,6 +47,7 @@ from kai.workshop.telegram_delivery import (
     TelegramWorkOutcome,
     WorkshopTelegramDeliveryAdapter,
     WorkshopTelegramDeliveryWorker,
+    WorkshopTelegramFinalizationPlanner,
 )
 from tests.workshop_delivery import DISABLED_DELIVERY_POLICY, TELEGRAM_DELIVERY_POLICY
 
@@ -126,6 +125,22 @@ async def _assert_no_finalization_state(store: WorkshopEventStore, inbound_id: M
         "SELECT COUNT(*) FROM messages WHERE reply_to_message_id = ?", (inbound_id,)
     ) as cursor:
         assert (await cursor.fetchone())[0] == 0
+
+
+async def _claim_finalization(store: WorkshopEventStore, delivery_id: DeliveryId):
+    epoch = await WorkshopConversationDeliveryAuthority(store).active_epoch()
+    claim = await WorkshopDeliveryOutbox(
+        store,
+        clock=lambda: _NOW + timedelta(seconds=3),
+    ).claim_next(
+        "telegram-adapter-planner",
+        purposes=(CONVERSATION_REPLY_PURPOSE,),
+        execution_contracts=(STREAMING_FINALIZATION_CONTRACT,),
+        delivery_id=delivery_id,
+        authority_epoch_id=epoch.epoch_id,
+    )
+    assert claim is not None
+    return claim
     async with store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
         assert (await cursor.fetchone())[0] == 0
     async with store.connection.execute("SELECT COUNT(*) FROM delivery_fragments") as cursor:
@@ -157,7 +172,7 @@ class TestAtomicStreamingFinalization:
         finally:
             await store.close()
 
-    async def test_short_reply_with_preview_is_one_explicit_edit_operation(self, tmp_path: Path):
+    async def test_short_reply_defers_preview_edit_planning_to_adapter_claim(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:
             await _bind_preview(store, inbound_id)
@@ -169,18 +184,19 @@ class TestAtomicStreamingFinalization:
 
             assert result.message.inserted is True
             assert result.delivery.inserted is True
-            assert result.plan.inserted is True
+            assert result.plan is None
             assert result.delivery.delivery.purpose == CONVERSATION_REPLY_PURPOSE
             assert result.delivery.delivery.execution_contract == STREAMING_FINALIZATION_CONTRACT
             assert result.delivery.delivery.status == "pending"
             assert result.delivery.delivery.attempt_count == 0
-            assert len(result.plan.fragments) == 1
-            operation = result.plan.fragments[0]
+            assert await WorkshopDeliveryFragments(store).fragments(result.delivery.delivery.delivery_id) == ()
+            claim = await _claim_finalization(store, result.delivery.delivery.delivery_id)
+            operations = await WorkshopTelegramFinalizationPlanner(store).operations(claim)
+            assert len(operations) == 1
+            operation = operations[0]
             assert operation.operation == EDIT_OPERATION
             assert operation.target_external_message_id == 7001
             assert operation.body == "Final answer"
-            assert operation.status == "pending"
-            assert operation.external_message_id is None
         finally:
             await store.close()
 
@@ -194,7 +210,9 @@ class TestAtomicStreamingFinalization:
                 _outbound(inbound_id, body="Already published final snapshot"),
             )
 
-            assert [(item.operation, item.target_external_message_id, item.body) for item in result.plan.fragments] == [
+            claim = await _claim_finalization(store, result.delivery.delivery.delivery_id)
+            operations = await WorkshopTelegramFinalizationPlanner(store).operations(claim)
+            assert [(item.operation, item.target_external_message_id, item.body) for item in operations] == [
                 (EDIT_OPERATION, 7002, "Already published final snapshot")
             ]
         finally:
@@ -208,10 +226,11 @@ class TestAtomicStreamingFinalization:
 
             result = await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id, body))
 
-            assert [fragment.operation for fragment in result.plan.fragments] == [EDIT_OPERATION, SEND_OPERATION]
-            assert [fragment.target_external_message_id for fragment in result.plan.fragments] == [7001, None]
-            assert "".join(fragment.body for fragment in result.plan.fragments) == "A" * 4096 + "B" * 20
-            assert {fragment.fragment_count for fragment in result.plan.fragments} == {2}
+            claim = await _claim_finalization(store, result.delivery.delivery.delivery_id)
+            operations = await WorkshopTelegramFinalizationPlanner(store).operations(claim)
+            assert [item.operation for item in operations] == [EDIT_OPERATION, SEND_OPERATION]
+            assert [item.target_external_message_id for item in operations] == [7001, None]
+            assert "".join(item.body for item in operations) == "A" * 4096 + "B" * 20
         finally:
             await store.close()
 
@@ -222,8 +241,10 @@ class TestAtomicStreamingFinalization:
 
             result = await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id, body))
 
-            assert [fragment.operation for fragment in result.plan.fragments] == [SEND_OPERATION, SEND_OPERATION]
-            assert all(fragment.target_external_message_id is None for fragment in result.plan.fragments)
+            claim = await _claim_finalization(store, result.delivery.delivery.delivery_id)
+            operations = await WorkshopTelegramFinalizationPlanner(store).operations(claim)
+            assert [item.operation for item in operations] == [SEND_OPERATION, SEND_OPERATION]
+            assert all(item.target_external_message_id is None for item in operations)
         finally:
             await store.close()
 
@@ -242,28 +263,28 @@ class TestAtomicStreamingFinalization:
             )
             assert retry.message.inserted is False
             assert retry.delivery.inserted is False
-            assert retry.plan.inserted is False
+            assert retry.plan is None
             assert retry.message.event == first.message.event
             assert retry.delivery.delivery == first.delivery.delivery
-            assert retry.plan.fragments == first.plan.fragments
+            assert await WorkshopDeliveryFragments(reopened).fragments(retry.delivery.delivery.delivery_id) == ()
         finally:
             await reopened.close()
 
-    async def test_preview_bound_after_all_send_finalization_cannot_mutate_plan(self, tmp_path: Path):
+    async def test_preview_bound_before_adapter_claim_is_used_by_adapter_plan(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:
             first = await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id))
             await _bind_preview(store, inbound_id)
 
-            with pytest.raises(RuntimeError, match="immutable"):
-                await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id))
-
-            persisted = await WorkshopDeliveryFragments(store).fragments(first.delivery.delivery.delivery_id)
-            assert [fragment.operation for fragment in persisted] == [SEND_OPERATION]
+            retry = await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id))
+            claim = await _claim_finalization(store, first.delivery.delivery.delivery_id)
+            operations = await WorkshopTelegramFinalizationPlanner(store).operations(claim)
+            assert retry.delivery.delivery == first.delivery.delivery
+            assert [item.operation for item in operations] == [EDIT_OPERATION]
         finally:
             await store.close()
 
-    async def test_tampered_preview_routing_fails_before_creating_reply(self, tmp_path: Path):
+    async def test_tampered_preview_routing_fails_at_telegram_adapter_boundary(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:
             await _bind_preview(store, inbound_id)
@@ -273,13 +294,14 @@ class TestAtomicStreamingFinalization:
             )
             await store.connection.commit()
 
-            with pytest.raises(OutboundStreamingPreviewConflictError):
-                await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id))
-            await _assert_no_finalization_state(store, inbound_id)
+            result = await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id))
+            claim = await _claim_finalization(store, result.delivery.delivery.delivery_id)
+            with pytest.raises(Exception, match="telegram_preview_routing_invalid"):
+                await WorkshopTelegramFinalizationPlanner(store).operations(claim)
         finally:
             await store.close()
 
-    async def test_fragment_insert_failure_rolls_back_message_delivery_and_plan(self, tmp_path: Path):
+    async def test_core_commit_does_not_touch_adapter_fragment_table(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:
             await store.connection.execute(
@@ -288,9 +310,10 @@ class TestAtomicStreamingFinalization:
             )
             await store.connection.commit()
 
-            with pytest.raises(aiosqlite.IntegrityError, match="test plan rejection"):
-                await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id))
-            await _assert_no_finalization_state(store, inbound_id)
+            result = await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id))
+            assert result.message.inserted is True
+            assert result.delivery.inserted is True
+            assert result.plan is None
         finally:
             await store.close()
 
@@ -313,7 +336,7 @@ class TestAtomicStreamingFinalization:
         finally:
             await store.close()
 
-    async def test_preexisting_message_and_delivery_without_plan_is_rejected_as_half_state(self, tmp_path: Path):
+    async def test_preexisting_message_and_delivery_without_adapter_plan_is_valid_core_state(self, tmp_path: Path):
         store, inbound_id = await _open_with_inbound(tmp_path / "kai.db")
         try:
             prior = await record_outbound_message(store, _outbound(inbound_id))
@@ -337,9 +360,9 @@ class TestAtomicStreamingFinalization:
                 )
             )
 
-            with pytest.raises(OutboundDeliveryStateConflictError):
-                await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id))
-
+            retry = await record_outbound_message_with_streaming_finalization(store, _outbound(inbound_id))
+            assert retry.delivery.delivery == delivery.delivery
+            assert retry.plan is None
             assert (await WorkshopDeliveryOutbox(store).state(delivery.delivery.delivery_id)).status == "pending"
             assert await WorkshopDeliveryFragments(store).fragments(delivery.delivery.delivery_id) == ()
         finally:
@@ -501,7 +524,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 29
+            assert await upgraded.schema_version() == 30
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_telegram_streaming_finalization.py
+++ b/tests/test_workshop_telegram_streaming_finalization.py
@@ -53,6 +53,7 @@ from kai.workshop.telegram_delivery import (
     TelegramDeliveryContractError,
     TelegramDeliveryFailure,
     TelegramWorkOutcome,
+    WorkshopTelegramFinalizationPlanner,
     WorkshopTelegramStreamingFinalizationAdapter,
     WorkshopTelegramStreamingFinalizationWorker,
 )
@@ -177,6 +178,7 @@ async def _worker(
         WorkshopDeliveryOutbox(store, clock=effective_clock),
         WorkshopDeliveryFragments(store, clock=effective_clock),
         WorkshopTelegramStreamingFinalizationAdapter(bot),
+        WorkshopTelegramFinalizationPlanner(store),
         worker_id="telegram-finalization-worker",
         authority_epoch_id=authority_epoch.epoch_id,
         lease_duration=lease_duration,
@@ -498,6 +500,10 @@ class TestTelegramStreamingFinalizationWorker:
             authority_epoch_id=authority_epoch.epoch_id,
         )
         assert claim is not None
+        await fragments.prepare_operations(
+            claim,
+            await WorkshopTelegramFinalizationPlanner(store).operations(claim),
+        )
         started = await fragments.begin_next(claim)
         assert started is not None and started.operation == EDIT_OPERATION
         await store.close()

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -11,7 +11,6 @@ import pytest
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
-from kai.workshop.delivery_fragments import SEND_OPERATION
 from kai.workshop.delivery_outbox import STREAMING_FINALIZATION_CONTRACT
 from kai.workshop.domain import ChannelId, MessageId, PrincipalId, RunExecutionOwnerId
 from kai.workshop.inbound import ClientInboundMessage, InboundMessage, record_inbound_message
@@ -237,12 +236,13 @@ class TestAtomicTerminalTransactions:
             assert result.execution.attempt.status == RunAttemptStatus.COMPLETED
             assert result.execution.run.result_message_id == result.finalization.message.event.envelope.aggregate_id
             assert result.finalization.delivery.delivery.authority_epoch_id is not None
-            assert [fragment.body for fragment in result.finalization.plan.fragments] == ["Canonical result"]
+            assert result.finalization.plan is None
+            assert result.finalization.message.event.envelope.payload["body"] == "Canonical result"
             assert retry.changed is False
             assert retry.finalization.message.event == result.finalization.message.event
             assert retry.finalization.delivery.delivery == result.finalization.delivery.delivery
-            assert retry.finalization.plan.fragments == result.finalization.plan.fragments
-            assert await _terminal_rows(store) == (1, 1, 1)
+            assert retry.finalization.plan is None
+            assert await _terminal_rows(store) == (1, 1, 0)
             async with store.connection.execute(
                 "SELECT event_type FROM event_log WHERE position >= ? ORDER BY position",
                 (result.finalization.message.event.position,),
@@ -287,7 +287,7 @@ class TestAtomicTerminalTransactions:
             assert result.execution.run.status == RunStatus.COMPLETED
             assert result.runtime_session is None
             assert await load_runtime_session(store, run.channel_id, run.agent_id) is None
-            assert await _terminal_rows(store) == (1, 1, 1)
+            assert await _terminal_rows(store) == (1, 1, 0)
         finally:
             await store.close()
 
@@ -332,7 +332,7 @@ class TestAtomicTerminalTransactions:
             session = await load_runtime_session(store, run.channel_id, run.agent_id)
             assert session is not None
             assert session.provider_session_id == "provider-session-original"
-            assert await _terminal_rows(store) == (1, 1, 1)
+            assert await _terminal_rows(store) == (1, 1, 0)
         finally:
             await store.close()
 
@@ -348,13 +348,11 @@ class TestAtomicTerminalTransactions:
             assert result.outcome == TerminalOutcome.COMPLETED
             assert result.execution.run.status == RunStatus.COMPLETED
             assert result.finalization.delivery.delivery.execution_contract == STREAMING_FINALIZATION_CONTRACT
-            assert [
-                (fragment.operation, fragment.target_external_message_id, fragment.body)
-                for fragment in result.finalization.plan.fragments
-            ] == [(SEND_OPERATION, None, "WORKSHOP-COMMAND-OK")]
+            assert result.finalization.plan is None
+            assert result.finalization.message.event.envelope.payload["body"] == "WORKSHOP-COMMAND-OK"
             # The browser command's attributed echo precedes the assistant
             # finalization and both remain durable outbox work.
-            assert await _terminal_rows(store) == (1, 2, 1)
+            assert await _terminal_rows(store) == (1, 2, 0)
         finally:
             await store.close()
 
@@ -399,9 +397,10 @@ class TestAtomicTerminalTransactions:
             assert result.execution.run.status == RunStatus.FAILED
             assert result.execution.run.terminal_code == "authentication_expired"
             assert result.execution.attempt.status == RunAttemptStatus.FAILED
-            assert [fragment.body for fragment in result.finalization.plan.fragments] == [
+            assert result.finalization.plan is None
+            assert result.finalization.message.event.envelope.payload["body"] == (
                 "Authentication for the configured agent has expired. Kai did not complete this request."
-            ]
+            )
             with pytest.raises(ValueError, match="TerminalFailureCode"):
                 await WorkshopRunTerminalTransactionCoordinator(authority).fail(
                     claim,
@@ -428,7 +427,8 @@ class TestAtomicTerminalTransactions:
             assert result.execution.run.status == RunStatus.CANCELLED
             assert result.execution.run.terminal_code == "requested_by_human"
             assert result.execution.attempt.status == RunAttemptStatus.CANCELLED
-            assert [fragment.body for fragment in result.finalization.plan.fragments] == ["This request was cancelled."]
+            assert result.finalization.plan is None
+            assert result.finalization.message.event.envelope.payload["body"] == "This request was cancelled."
         finally:
             await store.close()
 
@@ -453,7 +453,7 @@ class TestAtomicTerminalTransactions:
         finally:
             await store.close()
 
-    async def test_plan_failure_rolls_back_message_delivery_and_run_settlement(self, tmp_path: Path):
+    async def test_adapter_plan_storage_is_not_part_of_core_terminal_transaction(self, tmp_path: Path):
         store, authority, claim = await _started_run(tmp_path / "kai.db")
         try:
             await store.connection.execute(
@@ -462,16 +462,15 @@ class TestAtomicTerminalTransactions:
             )
             await store.connection.commit()
 
-            with pytest.raises(aiosqlite.IntegrityError, match="terminal plan rejected"):
-                await WorkshopRunTerminalTransactionCoordinator(authority).complete(
-                    claim,
-                    body="Must roll back",
-                    occurred_at=_NOW + timedelta(seconds=4),
-                )
+            result = await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+                claim,
+                body="Core-owned result",
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
 
-            assert await _terminal_rows(store) == (0, 0, 0)
-            assert (await WorkshopRunLifecycle(store).state(claim.run_id)).status == RunStatus.STARTED
-            assert (await authority.attempt(claim.attempt_id)).status == RunAttemptStatus.STARTED
+            assert result.outcome == TerminalOutcome.COMPLETED
+            assert result.finalization.plan is None
+            assert await _terminal_rows(store) == (1, 1, 0)
         finally:
             await store.close()
 
@@ -498,7 +497,7 @@ class TestAtomicTerminalTransactions:
 
             assert (await WorkshopRunLifecycle(store).state(claim.run_id)).status == RunStatus.STARTED
             assert (await authority.attempt(claim.attempt_id)).status == RunAttemptStatus.STARTED
-            assert await _terminal_rows(store) == (1, 1, 1)
+            assert await _terminal_rows(store) == (1, 1, 0)
         finally:
             await store.close()
 
@@ -522,7 +521,7 @@ class TestAtomicTerminalTransactions:
             run = await WorkshopRunLifecycle(store).state(claim.run_id)
             assert run.status == RunStatus.COMPLETED
             assert run.result_message_id == completed.finalization.message.event.envelope.aggregate_id
-            assert await _terminal_rows(store) == (1, 1, 1)
+            assert await _terminal_rows(store) == (1, 1, 0)
             async with store.connection.execute(
                 "SELECT COUNT(*) FROM event_log WHERE event_type IN ('run.failed', 'run_attempt.failed')"
             ) as cursor:
@@ -553,7 +552,7 @@ class TestAtomicTerminalTransactions:
 
             assert result.changed is False
             assert commit_calls == 2
-            assert await _terminal_rows(store) == (1, 1, 1)
+            assert await _terminal_rows(store) == (1, 1, 0)
             assert result.execution.run.status == RunStatus.COMPLETED
         finally:
             await store.close()

--- a/tests/workshop_delivery.py
+++ b/tests/workshop_delivery.py
@@ -1,6 +1,10 @@
 """Shared delivery-policy fixtures for Workshop contract tests."""
 
+from kai.telegram_adapter import TELEGRAM_DELIVERY_CAPABILITIES
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 
-TELEGRAM_DELIVERY_POLICY = WorkshopDeliveryBindingPolicy(frozenset({"telegram"}))
+TELEGRAM_DELIVERY_POLICY = WorkshopDeliveryBindingPolicy(
+    frozenset({"telegram"}),
+    (TELEGRAM_DELIVERY_CAPABILITIES,),
+)
 DISABLED_DELIVERY_POLICY = WorkshopDeliveryBindingPolicy.disabled()


### PR DESCRIPTION
Closes #1108.

## Summary

- add a core-owned, capability-aware delivery planner that fans canonical intents out to every eligible enabled adapter binding
- make Telegram declare its delivery capabilities and move Telegram chunking, Markdown, preview-edit selection, and Bot API limits into the Telegram worker after durable claim
- route ordinary replies, Workshop browser echoes, schedules, proactive publications, and integration notifications through the shared planner
- generalize durable fragment storage for non-integer provider message IDs and non-Telegram fragment sizes
- migrate the transport-named delivery-authority lane to a canonical conversation-finalization lane without losing outbox, attempt, or fragment state
- prove a non-Telegram test adapter can deliver ordinary replies, scheduled reminders, and proactive messages, and prove mixed-adapter outcomes settle independently

## Validation

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q` — 6006 passed
