### PR TITLE
Centralize canonical post-run effects

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -25,6 +25,7 @@ from kai.workshop.github_automation import WorkshopGitHubAutomationService
 from kai.workshop.integration_notifications import WorkshopIntegrationNotificationService
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
+from kai.workshop.post_run_effects import WorkshopPostRunEffectService
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.proactive_publication import (
     ProactivePublicationAuthority,
@@ -80,6 +81,7 @@ class KaiCoreReadiness:
     store: bool
     scheduler: bool
     github_automation: bool
+    post_run_effects: bool
 
     @property
     def ready(self) -> bool:
@@ -91,6 +93,7 @@ class KaiCoreReadiness:
                 self.store,
                 self.scheduler,
                 self.github_automation,
+                self.post_run_effects,
             )
         )
 
@@ -105,6 +108,7 @@ class KaiCoreReadiness:
                 "store": self.store,
                 "scheduler": self.scheduler,
                 "github_automation": self.github_automation,
+                "post_run_effects": self.post_run_effects,
             },
         }
 
@@ -131,6 +135,7 @@ class KaiCoreServices:
     proactive_publication: WorkshopProactivePublicationService
     integration_notifications: WorkshopIntegrationNotificationService
     github_automation: WorkshopGitHubAutomationService
+    post_run_effects: WorkshopPostRunEffectService
     delivery_policy: WorkshopDeliveryBindingPolicy
 
 
@@ -184,6 +189,7 @@ class KaiApplicationHost:
             store=services is not None,
             scheduler=services is not None and services.scheduler.readiness.ready,
             github_automation=services is not None and services.github_automation.ready,
+            post_run_effects=services is not None and services.post_run_effects.ready,
         )
 
     @property
@@ -203,6 +209,7 @@ class KaiApplicationHost:
         scheduler: WorkshopCanonicalScheduler | None = None
         integration_notifications: WorkshopIntegrationNotificationService | None = None
         github_automation: WorkshopGitHubAutomationService | None = None
+        post_run_effects: WorkshopPostRunEffectService | None = None
         try:
             delivery_policy = self._delivery_policy
             subprocess_pool = SubprocessPool(
@@ -212,6 +219,7 @@ class KaiApplicationHost:
                 internal_api_contexts=self._internal_api_contexts,
             )
             runtime_pool = WorkshopRuntimePool(subprocess_pool, self._runtime_profiles)
+            compatibility_state = WorkshopCompatibilityStateWriter(self._config, runtime_pool)
             conversation_runs = WorkshopConversationRunService(
                 runtime_pool,
                 sessions.resolve_workshop_conversation_run,
@@ -229,18 +237,19 @@ class KaiApplicationHost:
                 registered_backend_ids=self._registered_backend_ids,
                 delivery_policy=delivery_policy,
             )
+            post_run_effects = await WorkshopPostRunEffectService.open_and_start(
+                Path(self._config.session_db_path),
+                compatibility_state,
+            )
             run_previews = WorkshopRunPreviewRegistry()
             client_commands = WorkshopClientCommandExecutor(
                 private_execution,
-                WorkshopCompatibilityStateWriter(self._config, runtime_pool),
                 run_previews=run_previews,
             )
             await client_commands.start()
-            compatibility_state = WorkshopCompatibilityStateWriter(self._config, runtime_pool)
             scheduler = await WorkshopCanonicalScheduler.open_and_start(
                 Path(self._config.session_db_path),
                 private_execution,
-                compatibility_state,
                 delivery_policy,
             )
             artifacts = WorkshopArtifactService(
@@ -308,6 +317,7 @@ class KaiApplicationHost:
                 proactive_publication=proactive_publication,
                 integration_notifications=integration_notifications,
                 github_automation=github_automation,
+                post_run_effects=post_run_effects,
                 delivery_policy=delivery_policy,
             )
             self._state = KaiApplicationState.READY
@@ -322,6 +332,8 @@ class KaiApplicationHost:
                 await integration_notifications.close()
             if client_commands is not None:
                 await client_commands.stop()
+            if post_run_effects is not None:
+                await post_run_effects.stop()
             if client_store is not None:
                 await client_store.close()
             if private_execution is not None:
@@ -355,6 +367,7 @@ class KaiApplicationHost:
             self.services.private_text_execution.wait(),
             self.services.scheduler.wait(),
             self.services.github_automation.wait(),
+            self.services.post_run_effects.wait(),
             *(adapter.wait() for adapter in self._adapters.values()),
         )
 
@@ -380,6 +393,7 @@ class KaiApplicationHost:
             services.github_automation.stop,
             services.integration_notifications.close,
             services.client_commands.stop,
+            services.post_run_effects.stop,
             services.client_store.close,
             services.private_text_execution.stop,
             services.subprocess_pool.shutdown,

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -40,7 +40,6 @@ from kai import github_api, memory_command, review, sessions, webhook
 from kai.application_host import KaiCoreServices
 from kai.config import (
     DATA_DIR,
-    ONESHOT_REASONER_BACKENDS,
     OPEN_ENDED_PROVIDERS,
     PROVIDER_DEFAULTS,
     Config,
@@ -54,9 +53,6 @@ from kai.config import (
 from kai.conversation_compatibility import (
     _pending_memory_tasks as _shared_pending_memory_tasks,
 )
-from kai.conversation_compatibility import (
-    schedule_memory_ingestion,
-)
 from kai.locks import get_stop_event
 from kai.pool import SubprocessPool
 from kai.streaming_text import stream_publishable_prefix as _stream_publishable_prefix
@@ -65,7 +61,7 @@ from kai.telegram_utils import chunk_text
 from kai.transcribe import TranscriptionError, transcribe_voice
 from kai.tts import DEFAULT_VOICE, VOICES, TTSError, synthesize_speech
 from kai.workshop.artifacts import StagedArtifact
-from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, PrincipalId, RunId
+from kai.workshop.domain import MessageId, PrincipalId, RunId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
     CanonicalExecutionDisposition,
@@ -4233,35 +4229,6 @@ async def _handle_workshop_private_text(
         raise RuntimeError("Canonical execution settled without a terminal transaction")
 
     final_text = result.terminal.body
-    if result.session_id and result.selection is not None:
-        await sessions.save_session(chat_id, result.session_id, result.selection.model)
-    if result.disposition == CanonicalExecutionDisposition.COMPLETED and result.workspace is not None:
-        result_message_id = result.terminal.finalization.message.event.envelope.aggregate_id
-        if not isinstance(result_message_id, MessageId):
-            raise RuntimeError("Workshop execution returned a non-message result aggregate")
-        prior_pairs = await execution.prior_conversation_pairs(
-            run_id,
-            limit=config.episode_classifier_context_turns,
-        )
-        schedule_memory_ingestion(
-            prompt=prompt,
-            assistant_text=final_text,
-            chat_id=chat_id,
-            session_id=result.session_id,
-            config=config,
-            workspace=result.workspace,
-            user_log=None,
-            assistant_log=None,
-            canonical_provenance=CanonicalMemoryProvenance(
-                run_id=run_id,
-                source_message_id=inbound_message_id,
-                result_message_id=result_message_id,
-            ),
-            canonical_prior_pairs=prior_pairs,
-            reasoner_backends=ONESHOT_REASONER_BACKENDS,
-            effective_backend=_get_pool(context).get_backend_provider(chat_id)[0],
-        )
-
     if result.disposition == CanonicalExecutionDisposition.COMPLETED and voice_audio is not None:
         try:
             await context.bot.send_voice(chat_id=chat_id, voice=voice_audio)

--- a/src/kai/conversation_compatibility.py
+++ b/src/kai/conversation_compatibility.py
@@ -44,54 +44,93 @@ def schedule_memory_ingestion(
     from kai.memory import is_enabled as memory_is_enabled
 
     if memory_is_enabled():
-
-        async def ingest_memory() -> None:
-            try:
-                from kai import memory_extraction
-
-                if isinstance(prompt, str):
-                    user_text = prompt
-                else:
-                    user_text = next(
-                        (block["text"] for block in prompt if block.get("type") == "text"),
-                        "",
-                    )
-                if not user_text:
-                    return
-                user_config = config.get_user_config(chat_id)
-                backend = effective_backend or (
-                    user_config.backend if user_config and user_config.backend else config.default_backend
-                )
-                if config.memory_extraction_enabled and backend in reasoner_backends:
-                    prior_pairs: list[tuple[str, str]] = []
-                    if config.episode_classifier_context_turns > 0:
-                        if canonical_provenance is not None:
-                            # Canonical callers supply completed exchanges from
-                            # the exact principal/channel/agent run lane. Never
-                            # fall back to compatibility JSONL for this path.
-                            prior_pairs = list(canonical_prior_pairs or ())
-                        else:
-                            from kai.history import get_recent_pairs
-
-                            fetched = get_recent_pairs(chat_id, config.episode_classifier_context_turns + 1)
-                            prior_pairs = fetched[:-1]
-                    await memory_extraction.extract_and_store(
-                        user_text=user_text,
-                        assistant_text=assistant_text,
-                        user_id=str(chat_id),
-                        session_id=session_id,
-                        config=config,
-                        prior_pairs=prior_pairs,
-                        workspace=workspace,
-                        user_log=user_log,
-                        assistant_log=assistant_log,
-                        canonical_provenance=(
-                            canonical_provenance.metadata() if canonical_provenance is not None else None
-                        ),
-                    )
-            except Exception:
-                log.warning("Memory ingestion failed", exc_info=True)
-
-        task = asyncio.create_task(ingest_memory())
+        task = asyncio.create_task(
+            ingest_conversation_memory(
+                prompt=prompt,
+                assistant_text=assistant_text,
+                chat_id=chat_id,
+                session_id=session_id,
+                config=config,
+                workspace=workspace,
+                user_log=user_log,
+                assistant_log=assistant_log,
+                canonical_provenance=canonical_provenance,
+                canonical_prior_pairs=canonical_prior_pairs,
+                reasoner_backends=reasoner_backends,
+                effective_backend=effective_backend,
+            )
+        )
         _pending_memory_tasks.add(task)
         task.add_done_callback(_pending_memory_tasks.discard)
+
+
+async def ingest_conversation_memory(
+    *,
+    prompt: str | list,
+    assistant_text: str,
+    chat_id: int,
+    session_id: str | None,
+    config: Config,
+    workspace: str,
+    user_log: LogEntry | None,
+    assistant_log: LogEntry | None,
+    canonical_provenance: CanonicalMemoryProvenance | None = None,
+    canonical_prior_pairs: tuple[tuple[str, str], ...] | None = None,
+    reasoner_backends: frozenset[str] = ONESHOT_REASONER_BACKENDS,
+    effective_backend: str | None = None,
+) -> None:
+    """Run one memory ingestion to completion for a canonical owner.
+
+    Legacy callers may still wrap this coroutine in a fire-and-forget task.
+    The canonical post-run worker awaits it, including episode generation, so
+    its durable receipt represents the complete transport-neutral effect.
+    """
+    from kai.memory import is_enabled as memory_is_enabled
+
+    if memory_is_enabled():
+        try:
+            from kai import memory_extraction
+
+            if isinstance(prompt, str):
+                user_text = prompt
+            else:
+                user_text = next(
+                    (block["text"] for block in prompt if block.get("type") == "text"),
+                    "",
+                )
+            if not user_text:
+                return
+            user_config = config.get_user_config(chat_id)
+            backend = effective_backend or (
+                user_config.backend if user_config and user_config.backend else config.default_backend
+            )
+            if config.memory_extraction_enabled and backend in reasoner_backends:
+                prior_pairs: list[tuple[str, str]] = []
+                if config.episode_classifier_context_turns > 0:
+                    if canonical_provenance is not None:
+                        # Canonical callers supply completed exchanges from the
+                        # exact principal/channel/agent run lane. Never fall back
+                        # to compatibility JSONL for this path.
+                        prior_pairs = list(canonical_prior_pairs or ())
+                    else:
+                        from kai.history import get_recent_pairs
+
+                        fetched = get_recent_pairs(chat_id, config.episode_classifier_context_turns + 1)
+                        prior_pairs = fetched[:-1]
+                await memory_extraction.extract_and_store(
+                    user_text=user_text,
+                    assistant_text=assistant_text,
+                    user_id=str(chat_id),
+                    session_id=session_id,
+                    config=config,
+                    prior_pairs=prior_pairs,
+                    workspace=workspace,
+                    user_log=user_log,
+                    assistant_log=assistant_log,
+                    canonical_provenance=(
+                        canonical_provenance.metadata() if canonical_provenance is not None else None
+                    ),
+                    await_episode=True,
+                )
+        except Exception:
+            log.warning("Memory ingestion failed", exc_info=True)

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -8593,6 +8593,7 @@ def _cmd_status() -> None:
     print(_github_automation_status(Path(data_dir) / "kai.db"))
     print(_integration_route_status(Path(data_dir) / "kai.db"))
     print(_internal_api_authority_status(Path(data_dir) / "kai.db"))
+    print(_post_run_effect_status(Path(data_dir) / "kai.db"))
     if conf_env is None:
         print("Client adapters (install.conf artifact): unavailable")
     else:
@@ -8980,6 +8981,39 @@ def _github_automation_status(db_path: Path) -> str:
         f"{prefix} {status}; pending={pending}, executing={executing}, "
         f"succeeded={succeeded}, failed={failed}, uncertain={uncertain}; "
         "subscription routing=canonical"
+    )
+
+
+def _post_run_effect_status(db_path: Path) -> str:
+    """Report durable common work following successful canonical runs."""
+    prefix = "Workshop post-run effects:"
+    if not db_path.is_file():
+        return f"{prefix} NOT VERIFIED (database unavailable)"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            table = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'workshop_post_run_effects'"
+            ).fetchone()
+            if table is None:
+                return f"{prefix} pending; canonical queue unavailable"
+            counts = connection.execute(
+                "SELECT "
+                "SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN status = 'executing' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN status = 'succeeded' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) "
+                "FROM workshop_post_run_effects"
+            ).fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        return f"{prefix} NOT VERIFIED ({exc})"
+    pending, executing, succeeded, failed = tuple(int(value or 0) for value in (counts or (0, 0, 0, 0)))
+    status = "active" if failed == 0 else "ATTENTION"
+    return (
+        f"{prefix} {status}; pending={pending}, executing={executing}, "
+        f"succeeded={succeeded}, failed={failed}; owner=canonical worker"
     )
 
 

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -3173,6 +3173,7 @@ async def extract_and_store(
     user_log: LogEntry | None = None,
     assistant_log: LogEntry | None = None,
     canonical_provenance: dict[str, object] | None = None,
+    await_episode: bool = False,
 ) -> int:
     """
     Run Haiku extraction on an exchange and store the resulting facts.
@@ -3456,25 +3457,29 @@ async def extract_and_store(
                 # `_pending_episode_tasks` set is the primary
                 # operational tool here; the name is a secondary
                 # affordance for ad-hoc debugging.
-                ep_task = asyncio.create_task(
-                    _generate_episode(
-                        user_text=user_text,
-                        assistant_text=assistant_text,
-                        user_id=user_id,
-                        session_id=session_id,
-                        config=config,
-                        effective_backend=effective_backend,
-                        effective_provider=effective_provider,
-                        os_user=os_user,
-                        active_project=active_project,
-                        user_log=user_log,
-                        assistant_log=assistant_log,
-                        canonical_provenance=canonical_provenance,
-                    ),
-                    name=f"episode-{user_id}",
+                episode = _generate_episode(
+                    user_text=user_text,
+                    assistant_text=assistant_text,
+                    user_id=user_id,
+                    session_id=session_id,
+                    config=config,
+                    effective_backend=effective_backend,
+                    effective_provider=effective_provider,
+                    os_user=os_user,
+                    active_project=active_project,
+                    user_log=user_log,
+                    assistant_log=assistant_log,
+                    canonical_provenance=canonical_provenance,
                 )
-                _pending_episode_tasks.add(ep_task)
-                ep_task.add_done_callback(_pending_episode_tasks.discard)
+                if await_episode:
+                    await episode
+                else:
+                    ep_task = asyncio.create_task(
+                        episode,
+                        name=f"episode-{user_id}",
+                    )
+                    _pending_episode_tasks.add(ep_task)
+                    ep_task.add_done_callback(_pending_episode_tasks.discard)
     except FileNotFoundError:
         # `claude` binary missing on PATH. Graceful degradation: no
         # facts this turn, system continues running. Same outcome as

--- a/src/kai/workshop/client_commands.py
+++ b/src/kai/workshop/client_commands.py
@@ -8,15 +8,13 @@ from dataclasses import dataclass
 
 from kai.streaming_text import stream_publishable_prefix
 from kai.workshop.artifacts import StagedArtifact
-from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.conversation_commands import (
     ClientConversationCommandAcceptance,
     ConversationCommandDisposition,
 )
-from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, RunId, RuntimeProfileId
+from kai.workshop.domain import MessageId, RunId, RuntimeProfileId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
-    CanonicalExecutionDisposition,
 )
 from kai.workshop.inbound import ClientInboundMessage
 from kai.workshop.private_text_execution import (
@@ -56,12 +54,10 @@ class WorkshopClientCommandExecutor:
     def __init__(
         self,
         execution: WorkshopPrivateTextExecutionService,
-        compatibility_state: WorkshopCompatibilityStateWriter,
         *,
         run_previews: WorkshopRunPreviewRegistry | None = None,
     ) -> None:
         self._execution = execution
-        self._compatibility_state = compatibility_state
         self._run_previews = run_previews
         self._tasks: dict[RunId, asyncio.Task[None]] = {}
         self._task_lock = asyncio.Lock()
@@ -152,33 +148,10 @@ class WorkshopClientCommandExecutor:
     async def _execute(self, context: _ClientRunContext) -> None:
         task = asyncio.current_task()
         try:
-            result = await self._execution.execute(
+            await self._execution.execute(
                 context.run_id,
                 stream_observer=await self._preview_observer(context.run_id),
             )
-            if result.terminal is None:
-                return
-            compatibility_state = self._compatibility_state.for_profile(context.runtime_profile_id)
-            if result.disposition == CanonicalExecutionDisposition.COMPLETED and result.workspace is not None:
-                result_message_id = result.terminal.finalization.message.event.envelope.aggregate_id
-                if not isinstance(result_message_id, MessageId):
-                    raise RuntimeError("Workshop execution did not identify a canonical result message")
-                prior_pairs = await self._execution.prior_conversation_pairs(
-                    context.run_id,
-                    limit=compatibility_state.memory_context_turns,
-                )
-                compatibility_state.schedule_memory_ingestion(
-                    prompt=context.body,
-                    assistant_text=result.terminal.body,
-                    session_id=result.session_id,
-                    workspace=result.workspace,
-                    canonical_provenance=CanonicalMemoryProvenance(
-                        run_id=context.run_id,
-                        source_message_id=context.inbound_message_id,
-                        result_message_id=result_message_id,
-                    ),
-                    canonical_prior_pairs=prior_pairs,
-                )
         except Exception:
             log.exception("Workshop client run task failed for %s", context.run_id)
         finally:

--- a/src/kai/workshop/compatibility_state.py
+++ b/src/kai/workshop/compatibility_state.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 
 from kai import sessions
 from kai.config import Config
-from kai.conversation_compatibility import schedule_memory_ingestion
+from kai.conversation_compatibility import ingest_conversation_memory
 from kai.workshop.domain import CanonicalMemoryProvenance, RuntimeProfileId
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 
@@ -40,7 +41,7 @@ class WorkshopProfileCompatibilityState:
         user = self._config.get_user_config(self._runtime_config_id)
         return tuple(user.allowed_triage_projects) if user is not None else ()
 
-    def schedule_memory_ingestion(
+    async def ingest_memory(
         self,
         *,
         prompt: str | list,
@@ -50,7 +51,8 @@ class WorkshopProfileCompatibilityState:
         canonical_provenance: CanonicalMemoryProvenance,
         canonical_prior_pairs: tuple[tuple[str, str], ...],
     ) -> None:
-        schedule_memory_ingestion(
+        """Complete one core-owned canonical post-run memory effect."""
+        await ingest_conversation_memory(
             prompt=prompt,
             assistant_text=assistant_text,
             chat_id=self._runtime_config_id,
@@ -63,6 +65,17 @@ class WorkshopProfileCompatibilityState:
             canonical_prior_pairs=canonical_prior_pairs,
             effective_backend=self._backend,
         )
+
+    async def has_memory_for_run(self, run_id: str) -> bool:
+        """Detect a committed canonical memory effect after interrupted settlement."""
+        from kai import memory
+
+        memories = await asyncio.to_thread(
+            memory.get_all,
+            user_id=str(self._runtime_config_id),
+            limit=None,
+        )
+        return any(str(item.metadata.get(memory.WORKSHOP_RUN_ID_KEY, "")) == run_id for item in memories)
 
 
 class WorkshopCompatibilityStateWriter:

--- a/src/kai/workshop/post_run_effects.py
+++ b/src/kai/workshop/post_run_effects.py
@@ -1,0 +1,279 @@
+"""Durable, transport-neutral effects after successful Workshop runs."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
+from kai.workshop.conversation_context import assemble_canonical_prior_pairs
+from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, RunId, RuntimeProfileId
+from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
+from kai.workshop.runtime_sessions import RuntimeSessionSettlement
+from kai.workshop.store import WorkshopEventStore
+
+log = logging.getLogger(__name__)
+
+SEMANTIC_MEMORY_EFFECT = "semantic_memory_ingestion"
+_POLL_SECONDS = 0.5
+_MAX_ATTEMPTS = 3
+
+
+def _timestamp(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("occurred_at must be timezone-aware")
+    return value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+async def enqueue_post_run_effect_in_transaction(
+    store: WorkshopEventStore,
+    *,
+    run_id: RunId,
+    source_message_id: MessageId,
+    result_message_id: MessageId,
+    runtime_session: RuntimeSessionSettlement,
+    occurred_at: datetime,
+) -> bool:
+    """Queue the one common success effect in the terminal transaction."""
+    if not store.connection.in_transaction:
+        raise RuntimeError("enqueue_post_run_effect_in_transaction requires an active transaction")
+    if runtime_session.run_id != run_id:
+        raise ValueError("runtime session and post-run effect must identify the same run")
+    now = _timestamp(occurred_at)
+    cursor = await store.connection.execute(
+        "INSERT OR IGNORE INTO workshop_post_run_effects "
+        "(run_id, effect_type, runtime_profile_id, source_message_id, result_message_id, "
+        "workspace, provider_session_id, status, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)",
+        (
+            run_id,
+            SEMANTIC_MEMORY_EFFECT,
+            runtime_session.runtime_profile_id,
+            source_message_id,
+            result_message_id,
+            runtime_session.workspace,
+            runtime_session.provider_session_id,
+            now,
+            now,
+        ),
+    )
+    return cursor.rowcount == 1
+
+
+@dataclass(frozen=True, slots=True)
+class PostRunEffectReadiness:
+    ready: bool
+    pending: int
+    executing: int
+    succeeded: int
+    failed: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ClaimedEffect:
+    run_id: RunId
+    runtime_profile_id: RuntimeProfileId
+    source_message_id: MessageId
+    result_message_id: MessageId
+    workspace: str
+    provider_session_id: str | None
+    attempt_count: int
+
+
+class WorkshopPostRunEffectService:
+    """Own semantic-memory ingestion for every successful execution trigger."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        compatibility_state: WorkshopCompatibilityStateWriter,
+    ) -> None:
+        self._store = store
+        self._compatibility_state = compatibility_state
+        self._stop_event = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    @classmethod
+    async def open_and_start(
+        cls,
+        database_path: Path,
+        compatibility_state: WorkshopCompatibilityStateWriter,
+    ) -> WorkshopPostRunEffectService:
+        store = await WorkshopEventStore.open(database_path)
+        service = cls(store, compatibility_state)
+        try:
+            await store.connection.execute(
+                "UPDATE workshop_post_run_effects SET status = 'pending', "
+                "last_error_code = 'process_restarted', "
+                "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') "
+                "WHERE status = 'executing'"
+            )
+            await store.connection.commit()
+            service._task = asyncio.create_task(
+                service._run(),
+                name="kai-workshop-post-run-effects",
+            )
+            return service
+        except BaseException:
+            await store.close()
+            raise
+
+    @property
+    def ready(self) -> bool:
+        task = self._task
+        return not self._closed and task is not None and not task.done()
+
+    async def readiness(self) -> PostRunEffectReadiness:
+        counts = {"pending": 0, "executing": 0, "succeeded": 0, "failed": 0}
+        async with self._store.connection.execute(
+            "SELECT status, COUNT(*) FROM workshop_post_run_effects GROUP BY status"
+        ) as cursor:
+            for row in await cursor.fetchall():
+                counts[str(row[0])] = int(row[1])
+        return PostRunEffectReadiness(self.ready, **counts)
+
+    async def wait(self) -> None:
+        task = self._task
+        if task is None:
+            raise RuntimeError("Workshop post-run effect service is not started")
+        await asyncio.shield(task)
+
+    async def stop(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._stop_event.set()
+        task = self._task
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+        await self._store.close()
+
+    async def _run(self) -> None:
+        while not self._stop_event.is_set():
+            claimed = await self._claim_next()
+            if claimed is None:
+                try:
+                    await asyncio.wait_for(self._stop_event.wait(), timeout=_POLL_SECONDS)
+                except TimeoutError:
+                    continue
+                return
+            await self._execute(claimed)
+
+    async def _claim_next(self) -> _ClaimedEffect | None:
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            async with connection.execute(
+                "SELECT run_id, runtime_profile_id, source_message_id, result_message_id, "
+                "workspace, provider_session_id, attempt_count "
+                "FROM workshop_post_run_effects WHERE status = 'pending' "
+                "ORDER BY created_at, run_id LIMIT 1"
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None:
+                await connection.commit()
+                return None
+            run_id = RunId(str(row[0]))
+            cursor = await connection.execute(
+                "UPDATE workshop_post_run_effects SET status = 'executing', "
+                "attempt_count = attempt_count + 1, "
+                "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') "
+                "WHERE run_id = ? AND status = 'pending'",
+                (run_id,),
+            )
+            if cursor.rowcount != 1:
+                await connection.rollback()
+                return None
+            await connection.commit()
+            return _ClaimedEffect(
+                run_id=run_id,
+                runtime_profile_id=RuntimeProfileId(str(row[1])),
+                source_message_id=MessageId(str(row[2])),
+                result_message_id=MessageId(str(row[3])),
+                workspace=str(row[4]),
+                provider_session_id=str(row[5]) if row[5] is not None else None,
+                attempt_count=int(row[6]) + 1,
+            )
+        except BaseException:
+            await connection.rollback()
+            raise
+
+    async def _execute(self, effect: _ClaimedEffect) -> None:
+        try:
+            run = await WorkshopRunLifecycle(self._store).state(effect.run_id)
+            if (
+                run.status != RunStatus.COMPLETED
+                or run.inbound_message_id != effect.source_message_id
+                or run.result_message_id != effect.result_message_id
+            ):
+                raise RuntimeError("Post-run effect no longer matches one successful canonical run")
+            profile_state = self._compatibility_state.for_profile(effect.runtime_profile_id)
+            if await profile_state.has_memory_for_run(str(effect.run_id)):
+                await self._settle(effect.run_id)
+                return
+            async with self._store.connection.execute(
+                "SELECT source.body, result.body FROM messages source, messages result "
+                "WHERE source.id = ? AND result.id = ?",
+                (effect.source_message_id, effect.result_message_id),
+            ) as cursor:
+                bodies = await cursor.fetchone()
+            if bodies is None:
+                raise RuntimeError("Post-run effect messages are unavailable")
+            prior_pairs = await assemble_canonical_prior_pairs(
+                self._store,
+                run,
+                limit=profile_state.memory_context_turns,
+            )
+            await profile_state.ingest_memory(
+                prompt=str(bodies[0]),
+                assistant_text=str(bodies[1]),
+                session_id=effect.provider_session_id,
+                workspace=effect.workspace,
+                canonical_provenance=CanonicalMemoryProvenance(
+                    run_id=effect.run_id,
+                    source_message_id=effect.source_message_id,
+                    result_message_id=effect.result_message_id,
+                ),
+                canonical_prior_pairs=prior_pairs,
+            )
+            await self._settle(effect.run_id)
+        except asyncio.CancelledError:
+            await self._retry(effect, "shutdown_interrupted")
+            raise
+        except Exception as exc:
+            log.warning("Post-run effect failed for %s", effect.run_id, exc_info=True)
+            await self._retry(effect, type(exc).__name__)
+
+    async def _retry(self, effect: _ClaimedEffect, error_code: str) -> None:
+        terminal = effect.attempt_count >= _MAX_ATTEMPTS
+        await self._store.connection.execute(
+            "UPDATE workshop_post_run_effects SET status = ?, last_error_code = ?, "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), completed_at = ? "
+            "WHERE run_id = ? AND status = 'executing'",
+            (
+                "failed" if terminal else "pending",
+                error_code,
+                _timestamp(datetime.now(UTC)) if terminal else None,
+                effect.run_id,
+            ),
+        )
+        await self._store.connection.commit()
+
+    async def _settle(self, run_id: RunId) -> None:
+        await self._store.connection.execute(
+            "UPDATE workshop_post_run_effects SET status = ?, last_error_code = NULL, "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), "
+            "completed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') "
+            "WHERE run_id = ? AND status = 'executing'",
+            ("succeeded", run_id),
+        )
+        await self._store.connection.commit()

--- a/src/kai/workshop/scheduler.py
+++ b/src/kai/workshop/scheduler.py
@@ -19,17 +19,9 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from kai.backend import AgentResponse
 from kai.job_types import JOB_TYPE_AGENT, JOB_TYPE_REMINDER
-from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
-from kai.workshop.domain import (
-    CanonicalMemoryProvenance,
-    ChannelId,
-    MessageId,
-    PrincipalId,
-    RunId,
-    RuntimeProfileId,
-)
+from kai.workshop.domain import ChannelId, MessageId, PrincipalId, RunId, RuntimeProfileId
 from kai.workshop.execution_coordinator import (
     CanonicalExecutionDisposition,
     CanonicalSuccessOutcome,
@@ -109,12 +101,10 @@ class WorkshopCanonicalScheduler:
         self,
         store: WorkshopEventStore,
         execution: WorkshopPrivateTextExecutionService,
-        compatibility_state: WorkshopCompatibilityStateWriter,
         delivery_policy: WorkshopDeliveryBindingPolicy,
     ) -> None:
         self._store = store
         self._execution = execution
-        self._compatibility_state = compatibility_state
         self._reminders = WorkshopScheduledReminderRecorder(store, delivery_policy)
         self._jobs = WorkshopScheduledJobStore(store)
         self._state = WorkshopSchedulerState.NEW
@@ -132,11 +122,10 @@ class WorkshopCanonicalScheduler:
         cls,
         database_path: Path,
         execution: WorkshopPrivateTextExecutionService,
-        compatibility_state: WorkshopCompatibilityStateWriter,
         delivery_policy: WorkshopDeliveryBindingPolicy,
     ) -> WorkshopCanonicalScheduler:
         store = await WorkshopEventStore.open(database_path)
-        service = cls(store, execution, compatibility_state, delivery_policy)
+        service = cls(store, execution, delivery_policy)
         try:
             await service._recover_interrupted_firings()
             service._scheduler.start(paused=True)
@@ -665,29 +654,6 @@ class WorkshopCanonicalScheduler:
             accepted.run.run_id,
             success_transformer=transform,
         )
-        compatibility = self._compatibility_state.for_profile(accepted.runtime_profile_id)
-        if result.disposition == CanonicalExecutionDisposition.COMPLETED and result.terminal is not None:
-            result_message_id = result.terminal.finalization.message.event.envelope.aggregate_id
-            inbound_message_id = accepted.command.message.event.envelope.aggregate_id
-            if not isinstance(result_message_id, MessageId) or not isinstance(inbound_message_id, MessageId):
-                raise RuntimeError("Scheduled execution did not identify canonical messages")
-            if result.workspace is not None:
-                prior_pairs = await self._execution.prior_conversation_pairs(
-                    accepted.run.run_id,
-                    limit=compatibility.memory_context_turns,
-                )
-                compatibility.schedule_memory_ingestion(
-                    prompt=job.prompt,
-                    assistant_text=result.terminal.body,
-                    session_id=result.session_id,
-                    workspace=result.workspace,
-                    canonical_provenance=CanonicalMemoryProvenance(
-                        run_id=accepted.run.run_id,
-                        source_message_id=inbound_message_id,
-                        result_message_id=result_message_id,
-                    ),
-                    canonical_prior_pairs=prior_pairs,
-                )
         if condition_met:
             await self._deactivate(job.job_id)
         terminal_code = result.run.terminal_code

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 30
+WORKSHOP_SCHEMA_VERSION = 31
 
 
 @dataclass(frozen=True, slots=True)
@@ -1543,6 +1543,42 @@ _ADAPTER_PLUGGABLE_DELIVERY_SCHEMA = SchemaMigration(
     ),
 )
 
+_CANONICAL_POST_RUN_EFFECTS_SCHEMA = SchemaMigration(
+    version=31,
+    name="canonical_post_run_effects",
+    statements=(
+        """
+        CREATE TABLE workshop_post_run_effects (
+            run_id TEXT PRIMARY KEY REFERENCES runs(id) ON DELETE CASCADE,
+            effect_type TEXT NOT NULL CHECK (
+                effect_type = 'semantic_memory_ingestion'
+            ),
+            runtime_profile_id TEXT NOT NULL CHECK (
+                length(runtime_profile_id) BETWEEN 1 AND 128
+            ),
+            source_message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE RESTRICT,
+            result_message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE RESTRICT,
+            workspace TEXT NOT NULL CHECK (length(trim(workspace)) > 0),
+            provider_session_id TEXT,
+            status TEXT NOT NULL CHECK (
+                status IN ('pending', 'executing', 'succeeded', 'failed')
+            ),
+            attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+            last_error_code TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT,
+            CHECK (
+                (status IN ('succeeded', 'failed') AND completed_at IS NOT NULL)
+                OR (status IN ('pending', 'executing') AND completed_at IS NULL)
+            )
+        )
+        """,
+        "CREATE INDEX workshop_post_run_effects_status_idx ON workshop_post_run_effects (status, created_at, run_id)",
+        "CREATE INDEX workshop_post_run_effects_profile_idx ON workshop_post_run_effects (runtime_profile_id, status)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1574,6 +1610,7 @@ _MIGRATIONS = (
     _INTEGRATION_ROUTE_SCHEMA,
     _CANONICAL_SCHEDULED_JOB_SCHEMA,
     _ADAPTER_PLUGGABLE_DELIVERY_SCHEMA,
+    _CANONICAL_POST_RUN_EFFECTS_SCHEMA,
 )
 
 

--- a/src/kai/workshop/terminal_transactions.py
+++ b/src/kai/workshop/terminal_transactions.py
@@ -16,6 +16,7 @@ from kai.workshop.outbound import (
     OutboundStreamingFinalizationResult,
     record_outbound_message_with_streaming_finalization_in_transaction,
 )
+from kai.workshop.post_run_effects import enqueue_post_run_effect_in_transaction
 from kai.workshop.run_execution_authority import (
     RunExecutionClaim,
     RunExecutionResult,
@@ -271,7 +272,16 @@ class WorkshopRunTerminalTransactionCoordinator:
                 )
 
             runtime_session_result = None
+            post_run_effect_inserted = None
             if outcome == TerminalOutcome.COMPLETED and runtime_session is not None:
+                post_run_effect_inserted = await enqueue_post_run_effect_in_transaction(
+                    self._store,
+                    run_id=claim.run_id,
+                    source_message_id=run.inbound_message_id,
+                    result_message_id=message_id,
+                    runtime_session=runtime_session,
+                    occurred_at=occurred_at,
+                )
                 await connection.execute("SAVEPOINT runtime_session_settlement")
                 try:
                     runtime_session_result = await settle_runtime_session_in_transaction(
@@ -300,6 +310,8 @@ class WorkshopRunTerminalTransactionCoordinator:
             prior_states.update(delivery.inserted for delivery in finalization.deliveries)
             if runtime_session_result is not None:
                 prior_states.add(runtime_session_result.changed)
+            if post_run_effect_inserted is not None:
+                prior_states.add(post_run_effect_inserted)
             if len(prior_states) != 1:
                 raise TerminalTransactionStateConflictError(
                     "Canonical outcome, delivery plan, and run settlement did not share one prior state"

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -102,7 +102,7 @@ class _FakeStore:
 class _FakeClientCommands:
     ready = False
 
-    def __init__(self, _execution, _compatibility, *, run_previews=None) -> None:
+    def __init__(self, _execution, *, run_previews=None) -> None:
         self.events = _FakeExecutionFactory.events
         self.run_previews = run_previews
 
@@ -134,6 +134,25 @@ class _FakeSchedulerFactory:
         events = _FakeExecutionFactory.events
         events.append("scheduler:start")
         return _FakeScheduler(events)
+
+
+class _FakePostRunEffects:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.ready = True
+
+    @classmethod
+    async def open_and_start(cls, *_args, **_kwargs):
+        events = _FakeExecutionFactory.events
+        events.append("post-run-effects:start")
+        return cls(events)
+
+    async def wait(self) -> None:
+        self.events.append("post-run-effects:wait")
+
+    async def stop(self) -> None:
+        self.events.append("post-run-effects:stop")
+        self.ready = False
 
 
 class _FakeIntegrationNotifications:
@@ -214,6 +233,7 @@ def host_dependencies(monkeypatch):
     monkeypatch.setattr(host_module, "WorkshopConversationDeliveryAuthority", _FakeDeliveryAuthority)
     monkeypatch.setattr(host_module, "WorkshopClientCommandExecutor", _FakeClientCommands)
     monkeypatch.setattr(host_module, "WorkshopCanonicalScheduler", _FakeSchedulerFactory)
+    monkeypatch.setattr(host_module, "WorkshopPostRunEffectService", _FakePostRunEffects)
     monkeypatch.setattr(
         host_module,
         "WorkshopIntegrationNotificationService",
@@ -300,6 +320,7 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
             "store": True,
             "scheduler": True,
             "github_automation": True,
+            "post_run_effects": True,
         },
     }
     assert services.subprocess_pool is not None
@@ -309,6 +330,7 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
         "store:open",
         "authority:activate",
         "execution:start",
+        "post-run-effects:start",
         "client:start",
         "scheduler:start",
         "integrations:open",
@@ -320,14 +342,16 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
 
     assert host.readiness.state == KaiApplicationState.STOPPED
     assert host.readiness.ready is False
-    assert host_dependencies[-10:] == [
+    assert host_dependencies[-12:] == [
         "execution:wait",
         "scheduler:wait",
         "github-automation:wait",
+        "post-run-effects:wait",
         "scheduler:stop",
         "github-automation:stop",
         "integrations:close",
         "client:stop",
+        "post-run-effects:stop",
         "store:close",
         "execution:stop",
         "pool:stop",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -72,6 +72,7 @@ from kai.install import (
     _migrate_internal_api_instructions,
     _migrate_managed_home_database_paths,
     _optional_file_checksum,
+    _post_run_effect_status,
     _probe_service_readiness,
     _prompt_choice,
     _prompt_optional_choice,
@@ -5062,6 +5063,27 @@ class TestCmdStatus:
     def test_status_reports_unavailable_github_automation_database(self, tmp_path):
         assert _github_automation_status(tmp_path / "missing.db") == (
             "Workshop GitHub automation: NOT VERIFIED (database unavailable)"
+        )
+
+    def test_status_reports_canonical_post_run_effect_queue(self, tmp_path):
+        db_path = tmp_path / "kai.db"
+        connection = sqlite3.connect(db_path)
+        connection.execute("CREATE TABLE workshop_post_run_effects (status TEXT NOT NULL)")
+        connection.executemany(
+            "INSERT INTO workshop_post_run_effects(status) VALUES (?)",
+            [("pending",), ("executing",), ("succeeded",), ("failed",)],
+        )
+        connection.commit()
+        connection.close()
+
+        assert _post_run_effect_status(db_path) == (
+            "Workshop post-run effects: ATTENTION; pending=1, executing=1, "
+            "succeeded=1, failed=1; owner=canonical worker"
+        )
+
+    def test_status_reports_unavailable_post_run_effect_database(self, tmp_path):
+        assert _post_run_effect_status(tmp_path / "missing.db") == (
+            "Workshop post-run effects: NOT VERIFIED (database unavailable)"
         )
 
     def test_status_reports_canonical_generic_integration_route(self, tmp_path):

--- a/tests/test_workshop_client_commands.py
+++ b/tests/test_workshop_client_commands.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 from kai.workshop.client_commands import WorkshopClientCommandExecutor
 from kai.workshop.conversation_commands import ConversationCommandDisposition
-from kai.workshop.domain import CanonicalMemoryProvenance, ChannelId, MessageId, PrincipalId, RunId
+from kai.workshop.domain import ChannelId, MessageId, PrincipalId, RunId
 from kai.workshop.execution_coordinator import (
     CanonicalExecutionDisposition,
     CanonicalExecutionResult,
@@ -29,7 +29,7 @@ def _message() -> ClientInboundMessage:
     )
 
 
-async def test_submission_returns_before_execution_and_preserves_compatibility_state():
+async def test_submission_returns_before_execution_without_owning_post_run_effects():
     message = _message()
     run_id = RunId.new()
     inbound_message_id = MessageId.new()
@@ -72,12 +72,7 @@ async def test_submission_returns_before_execution_and_preserves_compatibility_s
         request_run_cancellation=AsyncMock(),
         prior_conversation_pairs=AsyncMock(return_value=(("Earlier", "Exchange"),)),
     )
-    profile_state = SimpleNamespace(
-        memory_context_turns=4,
-        schedule_memory_ingestion=Mock(),
-    )
-    compatibility_state = SimpleNamespace(for_profile=Mock(return_value=profile_state))
-    executor = WorkshopClientCommandExecutor(execution, compatibility_state)
+    executor = WorkshopClientCommandExecutor(execution)
     await executor.start()
     try:
         submission = await executor.submit(message)
@@ -92,21 +87,8 @@ async def test_submission_returns_before_execution_and_preserves_compatibility_s
         release.set()
         await executor.stop()
 
-    profile_state.schedule_memory_ingestion.assert_called_once_with(
-        prompt="Hello from Workshop",
-        assistant_text="Completed through the protected lane",
-        session_id="session-1",
-        workspace="/workspace/project",
-        canonical_provenance=CanonicalMemoryProvenance(
-            run_id=run_id,
-            source_message_id=inbound_message_id,
-            result_message_id=result_message_id,
-        ),
-        canonical_prior_pairs=(("Earlier", "Exchange"),),
-    )
 
-
-async def test_terminal_replay_does_not_schedule_or_duplicate_compatibility_writes():
+async def test_terminal_replay_does_not_schedule_execution():
     message = _message()
     run_id = RunId.new()
     run = SimpleNamespace(run_id=run_id, status="completed")
@@ -122,9 +104,7 @@ async def test_terminal_replay_does_not_schedule_or_duplicate_compatibility_writ
         recoverable_client_runs=AsyncMock(return_value=()),
         request_run_cancellation=AsyncMock(),
     )
-    profile_state = SimpleNamespace(schedule_memory_ingestion=Mock())
-    compatibility_state = SimpleNamespace(for_profile=Mock(return_value=profile_state))
-    executor = WorkshopClientCommandExecutor(execution, compatibility_state)
+    executor = WorkshopClientCommandExecutor(execution)
     await executor.start()
     try:
         await executor.submit(message)
@@ -132,7 +112,6 @@ async def test_terminal_replay_does_not_schedule_or_duplicate_compatibility_writ
         await executor.stop()
 
     execution.execute.assert_not_awaited()
-    compatibility_state.for_profile.assert_not_called()
 
 
 async def test_start_reconciles_durably_accepted_browser_run():
@@ -156,7 +135,7 @@ async def test_start_reconciles_durably_accepted_browser_run():
         ),
         request_run_cancellation=AsyncMock(),
     )
-    executor = WorkshopClientCommandExecutor(execution, SimpleNamespace())
+    executor = WorkshopClientCommandExecutor(execution)
 
     await executor.start()
     await asyncio.sleep(0)

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_compatibility_state.py
+++ b/tests/test_workshop_compatibility_state.py
@@ -1,7 +1,8 @@
 """Tests for profile-addressed compatibility-state writes."""
 
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, RunId
@@ -23,16 +24,16 @@ async def test_profile_state_retains_only_non_session_compatibility_boundaries(m
             )
         )
     )
-    schedule = Mock()
+    ingest = AsyncMock()
     monkeypatch.setattr(
-        "kai.workshop.compatibility_state.schedule_memory_ingestion",
-        schedule,
+        "kai.workshop.compatibility_state.ingest_conversation_memory",
+        ingest,
     )
 
     state = WorkshopCompatibilityStateWriter(config, runtime_pool).for_profile(profile_id(101))
     provenance = CanonicalMemoryProvenance(RunId.new(), MessageId.new(), MessageId.new())
     assert not hasattr(state, "save_session")
-    state.schedule_memory_ingestion(
+    await state.ingest_memory(
         prompt="Hello",
         assistant_text="Hi",
         session_id="session-1",
@@ -42,7 +43,7 @@ async def test_profile_state_retains_only_non_session_compatibility_boundaries(m
     )
 
     runtime_pool.runtime_profile.assert_called_once_with(profile_id(101))
-    schedule.assert_called_once_with(
+    ingest.assert_awaited_once_with(
         prompt="Hello",
         assistant_text="Hi",
         chat_id=101,
@@ -55,3 +56,16 @@ async def test_profile_state_retains_only_non_session_compatibility_boundaries(m
         canonical_prior_pairs=(("Earlier", "Exchange"),),
         effective_backend="codex",
     )
+
+
+def test_execution_triggers_do_not_own_common_post_run_effects():
+    source_root = Path(__file__).parents[1] / "src" / "kai"
+    for relative_path in (
+        "bot.py",
+        "workshop/client_commands.py",
+        "workshop/scheduler.py",
+    ):
+        source = (source_root / relative_path).read_text(encoding="utf-8")
+        assert "schedule_memory_ingestion" not in source
+        assert "ingest_conversation_memory" not in source
+        assert "save_session(" not in source

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -57,7 +57,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -190,6 +190,7 @@ class TestWorkshopSchema:
             "workshop_integration_routes",
             "workshop_scheduled_jobs",
             "workshop_scheduled_job_migrations",
+            "workshop_post_run_effects",
             "messages",
             "artifacts",
             "deliveries",
@@ -204,7 +205,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 30
+        assert await workshop_store.schema_version() == 31
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -217,7 +218,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 30
+        assert await second.schema_version() == 31
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -249,7 +250,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -277,7 +278,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -325,6 +326,7 @@ class TestWorkshopSchema:
                     28,
                     29,
                     30,
+                    31,
                 ]
         finally:
             await upgraded.close()
@@ -347,7 +349,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -388,7 +390,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -441,7 +443,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -485,7 +487,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -529,7 +531,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -573,7 +575,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -677,7 +679,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -804,7 +806,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -521,7 +521,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -137,6 +137,17 @@ async def test_owner_accepts_executes_and_atomically_enqueues_terminal_reply(tmp
             "WHERE m.reply_to_message_id IS NOT NULL"
         ) as cursor:
             assert tuple(await cursor.fetchone()) == ("Durable answer", "pending")
+        async with inspection.connection.execute(
+            "SELECT status, runtime_profile_id, workspace, provider_session_id "
+            "FROM workshop_post_run_effects WHERE run_id = ?",
+            (result.run.run_id,),
+        ) as cursor:
+            assert tuple(await cursor.fetchone()) == (
+                "pending",
+                str(profile_id(101)),
+                str(tmp_path),
+                "session-1",
+            )
     finally:
         await inspection.close()
 

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -411,7 +411,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_run_previews.py
+++ b/tests/test_workshop_run_previews.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 from kai.workshop.client_commands import WorkshopClientCommandExecutor
 from kai.workshop.domain import ChannelId, RunId
@@ -120,7 +120,6 @@ async def test_executor_publishes_stable_prefixes_and_clears_at_settlement():
     )
     executor = WorkshopClientCommandExecutor(
         execution,
-        SimpleNamespace(for_profile=Mock()),
         run_previews=registry,
     )
 

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -45,10 +45,6 @@ class _UnusedExecution:
     pass
 
 
-class _UnusedCompatibilityState:
-    pass
-
-
 class _AllowRead:
     async def can_read_channel(self, principal_id: PrincipalId, channel_id: ChannelId) -> bool:
         del principal_id, channel_id
@@ -97,12 +93,6 @@ class _AgentExecution:
         )
 
 
-class _CompatibilityState:
-    def for_profile(self, runtime_profile_id):
-        assert runtime_profile_id == profile_id(101)
-        return SimpleNamespace(memory_context_turns=10)
-
-
 class _CanonicalRuntime:
     def __init__(self, workspace: Path) -> None:
         self.selection = SimpleNamespace(
@@ -127,19 +117,6 @@ class _CanonicalRuntime:
             done=True,
             response=AgentResponse(success=True, text="Scheduled agent answer"),
         )
-
-
-class _CanonicalCompatibility:
-    memory_context_turns = 10
-
-    def schedule_memory_ingestion(self, **_kwargs) -> None:
-        pass
-
-
-class _CanonicalCompatibilityState:
-    def for_profile(self, runtime_profile_id):
-        assert runtime_profile_id == profile_id(101)
-        return _CanonicalCompatibility()
 
 
 def _job(
@@ -280,7 +257,6 @@ async def test_workshop_only_reminder_fires_canonically_without_delivery(tmp_pat
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
-        _UnusedCompatibilityState(),  # type: ignore[arg-type]
         DISABLED_DELIVERY_POLICY,
     )
     try:
@@ -329,7 +305,6 @@ async def test_telegram_bound_reminder_uses_notification_outbox(tmp_path: Path) 
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
-        _UnusedCompatibilityState(),  # type: ignore[arg-type]
         TELEGRAM_DELIVERY_POLICY,
     )
     try:
@@ -352,7 +327,6 @@ async def test_disabled_telegram_adapter_does_not_enqueue_retained_reminder_bind
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
-        _UnusedCompatibilityState(),  # type: ignore[arg-type]
         DISABLED_DELIVERY_POLICY,
     )
     try:
@@ -377,7 +351,6 @@ async def test_scheduler_starts_without_legacy_jobs_table(tmp_path: Path) -> Non
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
-        _UnusedCompatibilityState(),  # type: ignore[arg-type]
         DISABLED_DELIVERY_POLICY,
     )
     try:
@@ -406,7 +379,6 @@ async def test_scheduler_fails_closed_for_active_job_without_canonical_owner(
         await WorkshopCanonicalScheduler.open_and_start(
             database,
             _UnusedExecution(),  # type: ignore[arg-type]
-            _UnusedCompatibilityState(),  # type: ignore[arg-type]
             DISABLED_DELIVERY_POLICY,
         )
     await store.close()
@@ -456,7 +428,6 @@ async def test_once_daily_and_interval_jobs_reconcile_into_core_scheduler(
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
-        _UnusedCompatibilityState(),  # type: ignore[arg-type]
         DISABLED_DELIVERY_POLICY,
     )
     try:
@@ -490,7 +461,6 @@ async def test_interrupted_reminder_firing_recovers_once(tmp_path: Path) -> None
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,
         _UnusedExecution(),  # type: ignore[arg-type]
-        _UnusedCompatibilityState(),  # type: ignore[arg-type]
         DISABLED_DELIVERY_POLICY,
     )
     try:
@@ -526,7 +496,6 @@ async def test_workshop_only_agent_job_uses_canonical_execution(tmp_path: Path) 
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,
         execution,  # type: ignore[arg-type]
-        _CompatibilityState(),  # type: ignore[arg-type]
         DISABLED_DELIVERY_POLICY,
     )
     try:
@@ -574,7 +543,6 @@ async def test_agent_firing_completes_through_real_canonical_coordinator(
     scheduler = await WorkshopCanonicalScheduler.open_and_start(
         database,
         execution,
-        _CanonicalCompatibilityState(),  # type: ignore[arg-type]
         DISABLED_DELIVERY_POLICY,
     )
     try:

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -524,7 +524,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 30
+            assert await upgraded.schema_version() == 31
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import aiosqlite
 import pytest
@@ -18,6 +21,7 @@ from kai.workshop.outbound import (
     OutboundMessage,
     record_outbound_message_with_streaming_finalization,
 )
+from kai.workshop.post_run_effects import WorkshopPostRunEffectService
 from kai.workshop.run_execution_authority import (
     RunAttemptStatus,
     RunExecutionClaim,
@@ -214,20 +218,37 @@ async def _terminal_rows(store: WorkshopEventStore) -> tuple[int, int, int]:
     return counts[0] - 1, counts[1], counts[2]
 
 
+async def _post_run_effect_count(store: WorkshopEventStore) -> int:
+    async with store.connection.execute("SELECT COUNT(*) FROM workshop_post_run_effects") as cursor:
+        return int((await cursor.fetchone())[0])
+
+
 class TestAtomicTerminalTransactions:
     async def test_success_commits_result_delivery_plan_and_fenced_settlement(self, tmp_path: Path):
         store, authority, claim = await _started_run(tmp_path / "kai.db")
+        run = await WorkshopRunLifecycle(store).state(claim.run_id)
+        runtime_session = RuntimeSessionSettlement(
+            channel_id=run.channel_id,
+            agent_id=run.agent_id,
+            runtime_profile_id=profile_id(101),
+            selection=RunExecutionSelection("codex", "gpt-5.6-sol"),
+            workspace="/private/tmp/kai-workshop-test-workspace",
+            provider_session_id="provider-session-1",
+            run_id=run.run_id,
+        )
         coordinator = WorkshopRunTerminalTransactionCoordinator(authority)
         try:
             result = await coordinator.complete(
                 claim,
                 body="Canonical result",
                 occurred_at=_NOW + timedelta(seconds=4),
+                runtime_session=runtime_session,
             )
             retry = await coordinator.complete(
                 claim,
                 body="Canonical result",
                 occurred_at=_NOW + timedelta(seconds=30),
+                runtime_session=runtime_session,
             )
 
             assert result.outcome == TerminalOutcome.COMPLETED
@@ -243,6 +264,23 @@ class TestAtomicTerminalTransactions:
             assert retry.finalization.delivery.delivery == result.finalization.delivery.delivery
             assert retry.finalization.plan is None
             assert await _terminal_rows(store) == (1, 1, 0)
+            assert await _post_run_effect_count(store) == 1
+            async with store.connection.execute(
+                "SELECT status, runtime_profile_id, source_message_id, result_message_id, "
+                "workspace, provider_session_id, attempt_count "
+                "FROM workshop_post_run_effects WHERE run_id = ?",
+                (run.run_id,),
+            ) as cursor:
+                effect = await cursor.fetchone()
+            assert tuple(effect) == (
+                "pending",
+                str(profile_id(101)),
+                str(run.inbound_message_id),
+                str(result.execution.run.result_message_id),
+                "/private/tmp/kai-workshop-test-workspace",
+                "provider-session-1",
+                0,
+            )
             async with store.connection.execute(
                 "SELECT event_type FROM event_log WHERE position >= ? ORDER BY position",
                 (result.finalization.message.event.position,),
@@ -401,6 +439,7 @@ class TestAtomicTerminalTransactions:
             assert result.finalization.message.event.envelope.payload["body"] == (
                 "Authentication for the configured agent has expired. Kai did not complete this request."
             )
+            assert await _post_run_effect_count(store) == 0
             with pytest.raises(ValueError, match="TerminalFailureCode"):
                 await WorkshopRunTerminalTransactionCoordinator(authority).fail(
                     claim,
@@ -429,11 +468,129 @@ class TestAtomicTerminalTransactions:
             assert result.execution.attempt.status == RunAttemptStatus.CANCELLED
             assert result.finalization.plan is None
             assert result.finalization.message.event.envelope.payload["body"] == "This request was cancelled."
+            assert await _post_run_effect_count(store) == 0
         finally:
             await store.close()
 
+    async def test_post_run_worker_ingests_one_non_telegram_success_exactly_once(
+        self,
+        tmp_path: Path,
+    ):
+        database = tmp_path / "kai.db"
+        store, authority, claim = await _started_workshop_only_client_run(database)
+        run = await WorkshopRunLifecycle(store).state(claim.run_id)
+        result = await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+            claim,
+            body="Transport-neutral answer",
+            occurred_at=_NOW + timedelta(seconds=4),
+            runtime_session=RuntimeSessionSettlement(
+                channel_id=run.channel_id,
+                agent_id=run.agent_id,
+                runtime_profile_id=profile_id(101),
+                selection=RunExecutionSelection("codex", "gpt-5.6-sol"),
+                workspace="/private/tmp/non-telegram-workspace",
+                provider_session_id="non-telegram-provider-session",
+                run_id=run.run_id,
+            ),
+        )
+        await store.close()
+
+        profile_state = SimpleNamespace(
+            memory_context_turns=8,
+            has_memory_for_run=AsyncMock(return_value=False),
+            ingest_memory=AsyncMock(),
+        )
+        compatibility = SimpleNamespace(for_profile=lambda _profile_id: profile_state)
+        service = await WorkshopPostRunEffectService.open_and_start(
+            database,
+            compatibility,  # type: ignore[arg-type]
+        )
+        try:
+            for _ in range(100):
+                if (await service.readiness()).succeeded == 1:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                pytest.fail("post-run effect did not settle")
+        finally:
+            await service.stop()
+
+        profile_state.has_memory_for_run.assert_awaited_once_with(str(run.run_id))
+        profile_state.ingest_memory.assert_awaited_once()
+        call = profile_state.ingest_memory.await_args.kwargs
+        assert call["prompt"] == "Perform one durable unit of work"
+        assert call["assistant_text"] == "Transport-neutral answer"
+        assert call["session_id"] == "non-telegram-provider-session"
+        assert call["workspace"] == "/private/tmp/non-telegram-workspace"
+        assert call["canonical_provenance"].run_id == run.run_id
+        assert call["canonical_provenance"].source_message_id == run.inbound_message_id
+        assert call["canonical_provenance"].result_message_id == result.execution.run.result_message_id
+
+        restarted = await WorkshopPostRunEffectService.open_and_start(
+            database,
+            compatibility,  # type: ignore[arg-type]
+        )
+        try:
+            await asyncio.sleep(0.05)
+            assert (await restarted.readiness()).succeeded == 1
+        finally:
+            await restarted.stop()
+        profile_state.ingest_memory.assert_awaited_once()
+
+    async def test_recovered_post_run_effect_does_not_duplicate_committed_memory(
+        self,
+        tmp_path: Path,
+    ):
+        database = tmp_path / "kai.db"
+        store, authority, claim = await _started_run(database)
+        run = await WorkshopRunLifecycle(store).state(claim.run_id)
+        await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+            claim,
+            body="Committed before interruption",
+            occurred_at=_NOW + timedelta(seconds=4),
+            runtime_session=RuntimeSessionSettlement(
+                channel_id=run.channel_id,
+                agent_id=run.agent_id,
+                runtime_profile_id=profile_id(101),
+                selection=RunExecutionSelection("codex", "gpt-5.6-sol"),
+                workspace="/private/tmp/kai-workshop-test-workspace",
+                provider_session_id="provider-session-before-restart",
+                run_id=run.run_id,
+            ),
+        )
+        await store.connection.execute(
+            "UPDATE workshop_post_run_effects SET status = 'executing' WHERE run_id = ?",
+            (run.run_id,),
+        )
+        await store.connection.commit()
+        await store.close()
+
+        profile_state = SimpleNamespace(
+            memory_context_turns=8,
+            has_memory_for_run=AsyncMock(return_value=True),
+            ingest_memory=AsyncMock(),
+        )
+        compatibility = SimpleNamespace(for_profile=lambda _profile_id: profile_state)
+        service = await WorkshopPostRunEffectService.open_and_start(
+            database,
+            compatibility,  # type: ignore[arg-type]
+        )
+        try:
+            for _ in range(100):
+                if (await service.readiness()).succeeded == 1:
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                pytest.fail("recovered post-run effect did not settle")
+        finally:
+            await service.stop()
+
+        profile_state.has_memory_for_run.assert_awaited_once_with(str(run.run_id))
+        profile_state.ingest_memory.assert_not_awaited()
+
     async def test_stale_fence_rolls_back_every_visible_outcome_row(self, tmp_path: Path):
         store, authority, stale_claim = await _started_run(tmp_path / "kai.db")
+        run = await WorkshopRunLifecycle(store).state(stale_claim.run_id)
         try:
             renewed = await authority.renew(
                 stale_claim,
@@ -445,9 +602,19 @@ class TestAtomicTerminalTransactions:
                     stale_claim,
                     body="Must roll back",
                     occurred_at=_NOW + timedelta(seconds=5),
+                    runtime_session=RuntimeSessionSettlement(
+                        channel_id=run.channel_id,
+                        agent_id=run.agent_id,
+                        runtime_profile_id=profile_id(101),
+                        selection=RunExecutionSelection("codex", "gpt-5.6-sol"),
+                        workspace="/private/tmp/kai-workshop-test-workspace",
+                        provider_session_id="stale-provider-session",
+                        run_id=run.run_id,
+                    ),
                 )
 
             assert await _terminal_rows(store) == (0, 0, 0)
+            assert await _post_run_effect_count(store) == 0
             assert (await WorkshopRunLifecycle(store).state(stale_claim.run_id)).status == RunStatus.STARTED
             assert (await authority.attempt(renewed.claim.attempt_id)).status == RunAttemptStatus.STARTED
         finally:
@@ -559,6 +726,7 @@ class TestAtomicTerminalTransactions:
 
     async def test_second_commit_resolution_failure_is_explicitly_uncertain(self, tmp_path: Path, monkeypatch):
         store, authority, claim = await _started_run(tmp_path / "kai.db")
+        run = await WorkshopRunLifecycle(store).state(claim.run_id)
         coordinator = WorkshopRunTerminalTransactionCoordinator(authority)
 
         async def unavailable_commit(_connection: aiosqlite.Connection) -> None:
@@ -571,9 +739,19 @@ class TestAtomicTerminalTransactions:
                     claim,
                     body="Never committed",
                     occurred_at=_NOW + timedelta(seconds=4),
+                    runtime_session=RuntimeSessionSettlement(
+                        channel_id=run.channel_id,
+                        agent_id=run.agent_id,
+                        runtime_profile_id=profile_id(101),
+                        selection=RunExecutionSelection("codex", "gpt-5.6-sol"),
+                        workspace="/private/tmp/kai-workshop-test-workspace",
+                        provider_session_id="uncertain-provider-session",
+                        run_id=run.run_id,
+                    ),
                 )
 
             assert await _terminal_rows(store) == (0, 0, 0)
+            assert await _post_run_effect_count(store) == 0
         finally:
             await store.close()
 


### PR DESCRIPTION
## Summary

- atomically enqueue semantic-memory ingestion with successful canonical run settlement
- supervise one durable post-run worker with retry, restart recovery, and run-provenance idempotency
- remove duplicate memory ingestion and provider-session writes from Telegram, Workshop, and scheduled trigger paths
- expose post-run worker readiness and installed queue diagnostics

## Design

Successful execution now commits one `workshop_post_run_effects` row in the same transaction as the canonical result, delivery work, run settlement, and runtime-session continuity. A core-owned worker consumes that row only after confirming the run is completed and its source/result messages still match.

The worker awaits both fact extraction and episode generation before settling its durable receipt. On retry or restart it checks canonical run provenance already stamped on semantic-memory rows, preventing a committed extraction from being repeated after an interrupted receipt update. Failed, cancelled, stale/superseded, and uncertain outcomes never enqueue successful-run effects.

Adapters retain presentation responsibilities only. Telegram no longer writes provider-session continuity, and Telegram, Workshop client commands, and scheduled execution no longer initiate memory ingestion.

## Verification

- `6017 passed in 83.23s`
- `make check`
- `make typecheck`
- dedicated contracts cover atomic enqueue/replay, non-Telegram execution, restart idempotency, provenance, and absence on failure/cancellation/stale/uncertain settlement

## Installed qualification after merge

Install once, confirm the new `Workshop post-run effects` status line is active, then verify one remembered marker and provider-session continuity from both Workshop and Telegram across a restart.

Closes #1110
