### PR TITLE
fix: preserve post-run receipts across rebuilds

### DIFF
--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 31
+WORKSHOP_SCHEMA_VERSION = 32
 
 
 @dataclass(frozen=True, slots=True)
@@ -1579,6 +1579,61 @@ _CANONICAL_POST_RUN_EFFECTS_SCHEMA = SchemaMigration(
     ),
 )
 
+# These IDs deliberately are not foreign keys. Runs and messages are a
+# rebuildable projection: startup deletes and replays them from event_log.
+# The effect receipt is an independent durable ledger and must survive that
+# temporary absence. The worker validates all three IDs against the rebuilt
+# canonical run before executing pending work.
+_DURABLE_POST_RUN_EFFECT_RECEIPTS_SCHEMA = SchemaMigration(
+    version=32,
+    name="durable_post_run_effect_receipts",
+    statements=(
+        """
+        CREATE TABLE workshop_post_run_effects_durable (
+            run_id TEXT PRIMARY KEY,
+            effect_type TEXT NOT NULL CHECK (
+                effect_type = 'semantic_memory_ingestion'
+            ),
+            runtime_profile_id TEXT NOT NULL CHECK (
+                length(runtime_profile_id) BETWEEN 1 AND 128
+            ),
+            source_message_id TEXT NOT NULL,
+            result_message_id TEXT NOT NULL,
+            workspace TEXT NOT NULL CHECK (length(trim(workspace)) > 0),
+            provider_session_id TEXT,
+            status TEXT NOT NULL CHECK (
+                status IN ('pending', 'executing', 'succeeded', 'failed')
+            ),
+            attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+            last_error_code TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            completed_at TEXT,
+            CHECK (
+                (status IN ('succeeded', 'failed') AND completed_at IS NOT NULL)
+                OR (status IN ('pending', 'executing') AND completed_at IS NULL)
+            )
+        )
+        """,
+        """
+        INSERT INTO workshop_post_run_effects_durable (
+            run_id, effect_type, runtime_profile_id, source_message_id,
+            result_message_id, workspace, provider_session_id, status,
+            attempt_count, last_error_code, created_at, updated_at, completed_at
+        )
+        SELECT
+            run_id, effect_type, runtime_profile_id, source_message_id,
+            result_message_id, workspace, provider_session_id, status,
+            attempt_count, last_error_code, created_at, updated_at, completed_at
+        FROM workshop_post_run_effects
+        """,
+        "DROP TABLE workshop_post_run_effects",
+        "ALTER TABLE workshop_post_run_effects_durable RENAME TO workshop_post_run_effects",
+        "CREATE INDEX workshop_post_run_effects_status_idx ON workshop_post_run_effects (status, created_at, run_id)",
+        "CREATE INDEX workshop_post_run_effects_profile_idx ON workshop_post_run_effects (runtime_profile_id, status)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1611,6 +1666,7 @@ _MIGRATIONS = (
     _CANONICAL_SCHEDULED_JOB_SCHEMA,
     _ADAPTER_PLUGGABLE_DELIVERY_SCHEMA,
     _CANONICAL_POST_RUN_EFFECTS_SCHEMA,
+    _DURABLE_POST_RUN_EFFECT_RECEIPTS_SCHEMA,
 )
 
 

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -57,7 +57,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -205,12 +205,14 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 31
+        assert await workshop_store.schema_version() == 32
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
         assert "delivery_outbox_purpose_due_idx" in indexes
         assert "delivery_outbox_purpose_binding_order_idx" in indexes
+        async with workshop_store.connection.execute("PRAGMA foreign_key_list(workshop_post_run_effects)") as cursor:
+            assert await cursor.fetchall() == []
 
     async def test_schema_migration_is_idempotent(self, tmp_path: Path):
         path = tmp_path / "workshop.db"
@@ -218,7 +220,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 31
+        assert await second.schema_version() == 32
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -250,7 +252,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -278,7 +280,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -327,6 +329,7 @@ class TestWorkshopSchema:
                     29,
                     30,
                     31,
+                    32,
                 ]
         finally:
             await upgraded.close()
@@ -349,7 +352,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -390,7 +393,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -443,7 +446,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -487,7 +490,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -531,7 +534,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -575,7 +578,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -679,7 +682,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -806,7 +809,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -521,7 +521,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -411,7 +411,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -524,7 +524,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 31
+            assert await upgraded.schema_version() == 32
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -294,6 +294,112 @@ class TestAtomicTerminalTransactions:
         finally:
             await store.close()
 
+    async def test_projection_rebuild_preserves_post_run_effect_receipt(
+        self,
+        tmp_path: Path,
+    ):
+        store, authority, claim = await _started_run(tmp_path / "kai.db")
+        run = await WorkshopRunLifecycle(store).state(claim.run_id)
+        try:
+            result = await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+                claim,
+                body="Canonical result before projection rebuild",
+                occurred_at=_NOW + timedelta(seconds=4),
+                runtime_session=RuntimeSessionSettlement(
+                    channel_id=run.channel_id,
+                    agent_id=run.agent_id,
+                    runtime_profile_id=profile_id(101),
+                    selection=RunExecutionSelection("codex", "gpt-5.6-sol"),
+                    workspace="/private/tmp/kai-workshop-test-workspace",
+                    provider_session_id="provider-session-before-rebuild",
+                    run_id=run.run_id,
+                ),
+            )
+            assert await _post_run_effect_count(store) == 1
+
+            await bootstrap_default_workshop(
+                store,
+                (
+                    BootstrapHuman(
+                        display_name="Workshop Human",
+                        role="admin",
+                        transport="telegram",
+                        external_subject="101",
+                        external_channel_id="101",
+                        runtime_profile_id=profile_id(101),
+                    ),
+                ),
+            )
+
+            assert await _post_run_effect_count(store) == 1
+            rebuilt = await WorkshopRunLifecycle(store).state(run.run_id)
+            assert rebuilt.status == RunStatus.COMPLETED
+            assert rebuilt.result_message_id == result.execution.run.result_message_id
+            async with store.connection.execute(
+                "SELECT status, source_message_id, result_message_id FROM workshop_post_run_effects WHERE run_id = ?",
+                (run.run_id,),
+            ) as cursor:
+                effect = await cursor.fetchone()
+            assert effect is not None
+            assert tuple(effect) == (
+                "pending",
+                str(run.inbound_message_id),
+                str(result.execution.run.result_message_id),
+            )
+        finally:
+            await store.close()
+
+    async def test_version_thirty_one_receipt_survives_schema_upgrade(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+    ):
+        from kai.workshop import schema
+
+        database = tmp_path / "kai.db"
+        with monkeypatch.context() as migration_context:
+            migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 31)
+            migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:31])
+            store, authority, claim = await _started_run(database)
+            run = await WorkshopRunLifecycle(store).state(claim.run_id)
+            result = await WorkshopRunTerminalTransactionCoordinator(authority).complete(
+                claim,
+                body="Canonical result before schema upgrade",
+                occurred_at=_NOW + timedelta(seconds=4),
+                runtime_session=RuntimeSessionSettlement(
+                    channel_id=run.channel_id,
+                    agent_id=run.agent_id,
+                    runtime_profile_id=profile_id(101),
+                    selection=RunExecutionSelection("codex", "gpt-5.6-sol"),
+                    workspace="/private/tmp/kai-workshop-test-workspace",
+                    provider_session_id="provider-session-before-upgrade",
+                    run_id=run.run_id,
+                ),
+            )
+            assert await store.schema_version() == 31
+            assert await _post_run_effect_count(store) == 1
+            await store.close()
+
+        upgraded = await WorkshopEventStore.open(database)
+        try:
+            assert await upgraded.schema_version() == 32
+            assert await _post_run_effect_count(upgraded) == 1
+            async with upgraded.connection.execute(
+                "SELECT status, source_message_id, result_message_id FROM workshop_post_run_effects WHERE run_id = ?",
+                (run.run_id,),
+            ) as cursor:
+                effect = await cursor.fetchone()
+            assert effect is not None
+            assert tuple(effect) == (
+                "pending",
+                str(run.inbound_message_id),
+                str(result.execution.run.result_message_id),
+            )
+            async with upgraded.connection.execute("PRAGMA foreign_key_list(workshop_post_run_effects)") as cursor:
+                assert await cursor.fetchall() == []
+        finally:
+            await upgraded.close()
+
     async def test_runtime_reassignment_does_not_discard_completed_answer(self, tmp_path: Path):
         store, authority, claim = await _started_run(tmp_path / "kai.db")
         run = await WorkshopRunLifecycle(store).state(claim.run_id)


### PR DESCRIPTION
## Summary

- make canonical post-run effect receipts independent of rebuildable run and message projections
- migrate existing schema-v31 receipts without losing their status or provenance
- pin both startup projection-rebuild survival and v31-to-v32 receipt migration with regression tests

## Root cause

Startup rebuilds the canonical conversation projection by deleting and replaying
the `runs` and `messages` tables. The v31 post-run receipt table referenced those
projection tables, including an `ON DELETE CASCADE` relationship to `runs`, so
otherwise successful receipts disappeared during every restart.

## Verification

- `make check`
- `make typecheck`
- focused Workshop schema and terminal-transaction tests: 68 passed
- Workshop scheduler tests repeated five times: 85 passed
- complete suite: 6,019 passed

Follow-up correction for #1110 and #1117.
