### PR TITLE
fix: retire transport-shaped runtime keys

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -51,6 +51,7 @@ from kai.backend import (
     TRACE_SUMMARY_MAX_CHARS,
     AgentBackend,
     AgentResponse,
+    AgentRuntimeIdentity,
     ApiContext,
     StreamEvent,
     TraceEntry,
@@ -1316,7 +1317,13 @@ class AcpBackend(AgentBackend):
 
     # ── Sending prompts ────────────────────────────────────────────
 
-    async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+    async def send(
+        self,
+        prompt: str | list,
+        chat_id: int | None = None,
+        *,
+        runtime_identity: AgentRuntimeIdentity | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         """
         Send a message to the ACP subprocess and yield streaming events.
 
@@ -1335,10 +1342,16 @@ class AcpBackend(AgentBackend):
             has done=True and includes the complete AgentResponse.
         """
         async with self._lock:
-            async for event in self._send_locked(prompt, chat_id):
+            async for event in self._send_locked(prompt, chat_id, runtime_identity=runtime_identity):
                 yield event
 
-    async def _send_locked(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+    async def _send_locked(
+        self,
+        prompt: str | list,
+        chat_id: int | None = None,
+        *,
+        runtime_identity: AgentRuntimeIdentity | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         """
         Core send logic (must be called while holding self._lock).
 
@@ -1398,6 +1411,7 @@ class AcpBackend(AgentBackend):
                 api=self._api_context,
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
+                runtime_identity=runtime_identity,
                 data_dir=DATA_DIR,
                 backend_name=self.backend_name,
                 memory_enabled=self.memory_enabled,
@@ -1458,6 +1472,7 @@ class AcpBackend(AgentBackend):
         prompt = await assemble_turn_context(
             prompt,
             chat_id=recall_chat_id,
+            runtime_identity=runtime_identity if had_user_text else None,
             session_context=session_ctx,
             workspace_reminder=reminder,
             workspace=self.workspace,

--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -13,7 +13,6 @@ from kai.config import Config
 from kai.pool import SubprocessPool
 from kai.workshop.artifacts import WorkshopArtifactService
 from kai.workshop.client_commands import WorkshopClientCommandExecutor
-from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.conversation_runs import WorkshopConversationRunService
 from kai.workshop.delivery_authority import (
     DeliveryAuthorityEpoch,
@@ -34,6 +33,7 @@ from kai.workshop.proactive_publication import (
 from kai.workshop.run_previews import WorkshopRunPreviewRegistry
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.runtime_state import WorkshopRuntimeStateWriter
 from kai.workshop.scheduler import WorkshopCanonicalScheduler
 from kai.workshop.settings_workspaces import WorkshopSettingsWorkspaceService
 from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
@@ -219,7 +219,11 @@ class KaiApplicationHost:
                 internal_api_contexts=self._internal_api_contexts,
             )
             runtime_pool = WorkshopRuntimePool(subprocess_pool, self._runtime_profiles)
-            compatibility_state = WorkshopCompatibilityStateWriter(self._config, runtime_pool)
+            runtime_state = WorkshopRuntimeStateWriter(
+                self._config,
+                runtime_pool,
+                self._execution_state,
+            )
             conversation_runs = WorkshopConversationRunService(
                 runtime_pool,
                 sessions.resolve_workshop_conversation_run,
@@ -239,7 +243,7 @@ class KaiApplicationHost:
             )
             post_run_effects = await WorkshopPostRunEffectService.open_and_start(
                 Path(self._config.session_db_path),
-                compatibility_state,
+                runtime_state,
             )
             run_previews = WorkshopRunPreviewRegistry()
             client_commands = WorkshopClientCommandExecutor(
@@ -292,7 +296,7 @@ class KaiApplicationHost:
                 Path(self._config.session_db_path),
                 runtime_pool,
                 self._execution_state,
-                compatibility_state,
+                runtime_state,
                 integration_notifications,
                 spec_dir=self._config.spec_dir,
                 review_timeout_seconds=self._config.pr_review_timeout_s,

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -52,6 +52,34 @@ class _PrincipalStorageNamespace(Protocol):
 
 
 @runtime_checkable
+class AgentRuntimeIdentity(Protocol):
+    """Canonical identity supplied to every protected backend turn."""
+
+    principal_id: str
+    channel_id: str
+    agent_id: str
+    runtime_profile_id: str
+
+
+def _principal_directories(
+    *,
+    data_dir: Path,
+    namespace: str,
+    runtime_identity: AgentRuntimeIdentity | None,
+    chat_id: int | None,
+) -> tuple[Path, ...]:
+    if runtime_identity is not None:
+        return (data_dir / namespace / str(runtime_identity.principal_id),)
+    if chat_id is None:
+        return (data_dir / namespace,)
+    return principal_storage_search_directories(
+        chat_id,
+        data_dir=data_dir,
+        namespace=namespace,
+    )
+
+
+@runtime_checkable
 class PrincipalStorageNamespaceResolver(Protocol):
     """Narrow principal-storage boundary supplied by Workshop bootstrap."""
 
@@ -499,7 +527,13 @@ class AgentBackend(ABC):
             del self._canonical_history
 
     @abstractmethod
-    async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+    async def send(
+        self,
+        prompt: str | list,
+        chat_id: int | None = None,
+        *,
+        runtime_identity: AgentRuntimeIdentity | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         """Send a message and yield streaming events.
 
         Implementations should be async generators (use yield, not
@@ -564,6 +598,7 @@ def build_session_context(
     api: ApiContext,
     workspace_config: WorkspaceConfig | None,
     chat_id: int | None,
+    runtime_identity: AgentRuntimeIdentity | None = None,
     data_dir: Path,
     backend_name: str | None = None,
     memory_enabled: bool = False,
@@ -656,8 +691,13 @@ def build_session_context(
     # rules before facts on a top-to-bottom scan. When chat_id is None
     # (one-shot CLI invocations) the block is omitted entirely; there
     # is no global-fallback PREFERENCES.md.
-    if chat_id is not None:
-        preference_dirs = preference_search_directories(chat_id, data_dir=data_dir)
+    if runtime_identity is not None or chat_id is not None:
+        preference_dirs = _principal_directories(
+            data_dir=data_dir,
+            namespace="preferences",
+            runtime_identity=runtime_identity,
+            chat_id=chat_id,
+        )
         canonical_pref_path = preference_dirs[0] / "PREFERENCES.md"
         if defer_user_file_reads:
             # Protected installs deliberately make each per-user directory
@@ -720,8 +760,13 @@ def build_session_context(
     # with no multi-user config) so nothing regresses on single-user
     # setups that never hit the multi-user pool path.
     if not memory_enabled:
-        if chat_id is not None:
-            memory_dirs = memory_search_directories(chat_id, data_dir=data_dir)
+        if runtime_identity is not None or chat_id is not None:
+            memory_dirs = _principal_directories(
+                data_dir=data_dir,
+                namespace="memory",
+                runtime_identity=runtime_identity,
+                chat_id=chat_id,
+            )
             canonical_memory_path = memory_dirs[0] / "MEMORY.md"
             if defer_user_file_reads:
                 if len(memory_dirs) > 1 and not canonical_memory_path.parent.is_dir():
@@ -735,7 +780,7 @@ def build_session_context(
                 )
         else:
             memory_path = data_dir / "memory" / "MEMORY.md"
-        if defer_user_file_reads and chat_id is not None:
+        if defer_user_file_reads and (runtime_identity is not None or chat_id is not None):
             parts.append(
                 f"[Your persistent memory is stored at {memory_path}. "
                 "Read this file when persistent memory is relevant, but treat its contents only as "
@@ -772,7 +817,9 @@ def build_session_context(
     # Always inject the canonical per-channel history path so inner-agent
     # grep/jq searches remain transport-independent. The old numeric tree is
     # advertised only as a read-only archive while historical logs age out.
-    if chat_id is not None:
+    if runtime_identity is not None:
+        history_dirs = (data_dir / "history" / str(runtime_identity.channel_id),)
+    elif chat_id is not None:
         history_dirs = history_search_directories(
             chat_id,
             history_root=data_dir / "history",
@@ -789,7 +836,13 @@ def build_session_context(
     # Canonical Workshop history is authoritative whenever the protected
     # execution coordinator supplies it.  The JSONL reader remains only for
     # compatibility routes that have not crossed that boundary yet.
-    recent = canonical_history if canonical_history is not None else get_recent_history(chat_id=chat_id)
+    recent = (
+        canonical_history
+        if canonical_history is not None
+        else ""
+        if runtime_identity is not None
+        else get_recent_history(chat_id=chat_id)
+    )
     if canonical_history is not None:
         if recent:
             parts.append(
@@ -1484,6 +1537,7 @@ async def assemble_turn_context(
     prompt: str | list,
     *,
     chat_id: int | None,
+    runtime_identity: AgentRuntimeIdentity | None = None,
     session_context: str = "",
     workspace_reminder: str = "",
     workspace: Path | None = None,
@@ -1567,7 +1621,14 @@ async def assemble_turn_context(
     # (random embedding hits). Function-local imports keep backend.py's
     # import surface lean and let tests patch the scoped renderer plus
     # `_emit_recall_log` without import-order surprises.
-    if chat_id is not None and search_query.strip():
+    memory_user_id = (
+        str(runtime_identity.principal_id)
+        if runtime_identity is not None
+        else str(chat_id)
+        if chat_id is not None
+        else None
+    )
+    if memory_user_id is not None and search_query.strip():
         from kai.memory import (
             _emit_recall_log,
             format_scoped_context_with_recall_payload,
@@ -1583,11 +1644,12 @@ async def assemble_turn_context(
         # caller emits exactly one memory.recall per eligible turn.
         scoped_recall = await format_scoped_context_with_recall_payload(
             search_query,
-            user_id=str(chat_id),
+            user_id=memory_user_id,
             workspace=workspace,
             backend_name=backend_name,
             job_type=job_type,
             session_id=session_id,
+            runtime_profile_id=(str(runtime_identity.runtime_profile_id) if runtime_identity is not None else None),
         )
         _emit_recall_log(scoped_recall.recall_payload)
         if scoped_recall.rendered_context:

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -998,7 +998,7 @@ def _scheduled_job_authority(
     runtime_config_id: int,
 ) -> WorkshopScheduledJobAuthority:
     services = _get_core_services(context)
-    runtime_profile = services.runtime_profiles.for_config_id(runtime_config_id)
+    runtime_profile = services.runtime_profiles.profile_for_legacy_runtime_key(runtime_config_id)
     canonical = services.internal_api_contexts.for_runtime_profile(runtime_profile.profile_id)
     return WorkshopScheduledJobAuthority(
         canonical.principal_id,
@@ -2728,13 +2728,13 @@ async def _handle_github_token(
         return
 
     if args[0].lower() == "clear":
-        await sessions.delete_setting(f"github_token:{chat_id}")
+        await sessions.set_github_token(chat_id, None)
         await update.message.reply_text("GitHub token removed.")
         return
 
     # Store the token in owner-only SQLite state, then delete the
     # token-bearing Telegram command where Telegram permits it.
-    await sessions.set_setting(f"github_token:{chat_id}", args[0])
+    await sessions.set_github_token(chat_id, args[0])
     try:
         await update.message.delete()
     except BadRequest as exc:
@@ -2822,7 +2822,7 @@ async def _handle_github_add(
     webhook_url = _derive_webhook_url(config.telegram_webhook_url) if config.telegram_webhook_url else None
 
     # Attempt automatic webhook registration if the user has a token
-    token = await sessions.get_setting(f"github_token:{chat_id}")
+    token = await sessions.get_github_token(chat_id)
     verb = "Re-subscribed" if is_readd else "Subscribed"
 
     if token:
@@ -2926,7 +2926,7 @@ async def _handle_github_remove(
             other_subscribers = True
             break
 
-    token = await sessions.get_setting(f"github_token:{chat_id}")
+    token = await sessions.get_github_token(chat_id)
 
     if other_subscribers:
         await update.message.reply_text(f"Unsubscribed from `{repo}`. Webhook kept (other users are still subscribed).")
@@ -3038,7 +3038,7 @@ async def _show_github(update: Update, chat_id: int, config: Config) -> None:
         lines.append("\nNo repo subscriptions configured.")
 
     # Token status (never show the actual token value)
-    token = await sessions.get_setting(f"github_token:{chat_id}")
+    token = await sessions.get_github_token(chat_id)
     lines.append(f"\nGitHub token: {'stored' if token else 'not set'}")
 
     await update.message.reply_text("\n".join(lines))
@@ -3426,7 +3426,7 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     claude_user = pool.get_os_user(actor_id)
     agent_backend, provider = pool.get_backend_provider(actor_id)
     model_override = pool.get_role_model(actor_id, ModelRole.PR_REVIEW)
-    github_token = await sessions.get_setting(f"github_token:{actor_id}")
+    github_token = await sessions.get_github_token(actor_id)
     if getattr(config, "protected_install", False) is True and not github_token:
         await update.message.reply_text(
             "PR review requires a stored per-user GitHub token in protected installs. "

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -34,6 +34,7 @@ from kai.backend import (
     TRACE_SUMMARY_MAX_CHARS,
     AgentBackend,
     AgentResponse,
+    AgentRuntimeIdentity,
     ApiContext,
     StreamEvent,
     TraceEntry,
@@ -705,7 +706,13 @@ class ClaudeCodeBackend(AgentBackend):
             except OSError:
                 pass
 
-    async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+    async def send(
+        self,
+        prompt: str | list,
+        chat_id: int | None = None,
+        *,
+        runtime_identity: AgentRuntimeIdentity | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         """
         Send a message to Claude and yield streaming events.
 
@@ -726,10 +733,20 @@ class ClaudeCodeBackend(AgentBackend):
             done=True and includes the complete AgentResponse.
         """
         async with self._lock:
-            async for event in self._send_locked(prompt, chat_id=chat_id):
+            async for event in self._send_locked(
+                prompt,
+                chat_id=chat_id,
+                runtime_identity=runtime_identity,
+            ):
                 yield event
 
-    async def _send_locked(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+    async def _send_locked(
+        self,
+        prompt: str | list,
+        chat_id: int | None = None,
+        *,
+        runtime_identity: AgentRuntimeIdentity | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         """
         Core message-sending logic (must be called while holding self._lock).
 
@@ -820,6 +837,7 @@ class ClaudeCodeBackend(AgentBackend):
                 api=self._api_context,
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
+                runtime_identity=runtime_identity,
                 data_dir=DATA_DIR,
                 backend_name=self.backend_name,
                 memory_enabled=self.memory_enabled,
@@ -839,6 +857,7 @@ class ClaudeCodeBackend(AgentBackend):
         prompt = await assemble_turn_context(
             prompt,
             chat_id=chat_id,
+            runtime_identity=runtime_identity,
             session_context=session_ctx,
             workspace_reminder=reminder,
             workspace=self.workspace,

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -58,6 +58,7 @@ from kai.backend import (
     TRACE_SUMMARY_MAX_CHARS,
     AgentBackend,
     AgentResponse,
+    AgentRuntimeIdentity,
     ApiContext,
     StreamEvent,
     TraceEntry,
@@ -168,6 +169,7 @@ def write_turn_image_file(
     block: dict,
     *,
     chat_id: int | None,
+    principal_id: str | None = None,
     reader_user: str | None,
 ) -> Path | None:
     """
@@ -212,7 +214,9 @@ def write_turn_image_file(
     # the filename.
     subtype = media_type.split("/", 1)[-1]
     suffix = f".{subtype}" if subtype.isalnum() else ".img"
-    principal = "unscoped" if chat_id is None else principal_storage_name(chat_id)
+    principal = (
+        principal_id if principal_id is not None else "unscoped" if chat_id is None else principal_storage_name(chat_id)
+    )
     principal_dir = _TURN_IMAGE_DIR / principal
     path: Path | None = None
     try:
@@ -798,7 +802,13 @@ class CodexBackend(AgentBackend):
 
     # ── Sending prompts ────────────────────────────────────────────
 
-    async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+    async def send(
+        self,
+        prompt: str | list,
+        chat_id: int | None = None,
+        *,
+        runtime_identity: AgentRuntimeIdentity | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         """
         Send a message to codex and yield streaming events.
 
@@ -817,10 +827,16 @@ class CodexBackend(AgentBackend):
             has done=True and includes the complete AgentResponse.
         """
         async with self._lock:
-            async for event in self._send_locked(prompt, chat_id):
+            async for event in self._send_locked(prompt, chat_id, runtime_identity=runtime_identity):
                 yield event
 
-    async def _send_locked(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+    async def _send_locked(
+        self,
+        prompt: str | list,
+        chat_id: int | None = None,
+        *,
+        runtime_identity: AgentRuntimeIdentity | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         """
         Core send logic (must be called while holding self._lock).
 
@@ -877,6 +893,7 @@ class CodexBackend(AgentBackend):
                 api=self._api_context,
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
+                runtime_identity=runtime_identity,
                 data_dir=DATA_DIR,
                 backend_name=self.backend_name,
                 memory_enabled=self.memory_enabled,
@@ -920,6 +937,7 @@ class CodexBackend(AgentBackend):
                     image_path = write_turn_image_file(
                         block,
                         chat_id=chat_id,
+                        principal_id=(str(runtime_identity.principal_id) if runtime_identity is not None else None),
                         reader_user=self._effective_codex_user,
                     )
                     if image_path is not None:
@@ -946,6 +964,7 @@ class CodexBackend(AgentBackend):
         prompt = await assemble_turn_context(
             prompt,
             chat_id=recall_chat_id,
+            runtime_identity=runtime_identity if had_user_text else None,
             session_context=session_ctx,
             workspace_reminder=reminder,
             workspace=self.workspace,

--- a/src/kai/conversation_compatibility.py
+++ b/src/kai/conversation_compatibility.py
@@ -68,7 +68,7 @@ async def ingest_conversation_memory(
     *,
     prompt: str | list,
     assistant_text: str,
-    chat_id: int,
+    chat_id: int | None,
     session_id: str | None,
     config: Config,
     workspace: str,
@@ -78,6 +78,10 @@ async def ingest_conversation_memory(
     canonical_prior_pairs: tuple[tuple[str, str], ...] | None = None,
     reasoner_backends: frozenset[str] = ONESHOT_REASONER_BACKENDS,
     effective_backend: str | None = None,
+    canonical_user_id: str | None = None,
+    runtime_profile_id: str | None = None,
+    os_user_override: str | None = None,
+    effective_provider: str | None = None,
 ) -> None:
     """Run one memory ingestion to completion for a canonical owner.
 
@@ -100,7 +104,7 @@ async def ingest_conversation_memory(
                 )
             if not user_text:
                 return
-            user_config = config.get_user_config(chat_id)
+            user_config = config.get_user_config(chat_id) if chat_id is not None else None
             backend = effective_backend or (
                 user_config.backend if user_config and user_config.backend else config.default_backend
             )
@@ -115,12 +119,14 @@ async def ingest_conversation_memory(
                     else:
                         from kai.history import get_recent_pairs
 
+                        if chat_id is None:
+                            raise RuntimeError("Canonical memory ingestion requires canonical prior pairs")
                         fetched = get_recent_pairs(chat_id, config.episode_classifier_context_turns + 1)
                         prior_pairs = fetched[:-1]
                 await memory_extraction.extract_and_store(
                     user_text=user_text,
                     assistant_text=assistant_text,
-                    user_id=str(chat_id),
+                    user_id=canonical_user_id or str(chat_id),
                     session_id=session_id,
                     config=config,
                     prior_pairs=prior_pairs,
@@ -130,6 +136,10 @@ async def ingest_conversation_memory(
                     canonical_provenance=(
                         canonical_provenance.metadata() if canonical_provenance is not None else None
                     ),
+                    runtime_profile_id=runtime_profile_id,
+                    os_user_override=os_user_override,
+                    effective_backend_override=backend,
+                    effective_provider_override=effective_provider,
                     await_episode=True,
                 )
         except Exception:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -87,10 +87,11 @@ from kai.workshop.diagnostics import (
     workshop_transcript_authority_status,
     workshop_transition_tooling_status,
 )
-from kai.workshop.domain import WorkshopId
+from kai.workshop.domain import RuntimeProfileId, WorkshopId
 from kai.workshop.runtime_profiles import (
     WorkshopRuntimeProfileError,
     WorkshopRuntimeProfileRegistry,
+    legacy_runtime_key_for_v1_profile_id,
     runtime_profile_id_for_config_id,
 )
 
@@ -1112,7 +1113,6 @@ def _build_migrated_runtime_profiles(
         profile_id = runtime_profile_id_for_config_id(runtime_config_id)
         profile: dict[str, object] = {
             "display_name": display_name,
-            "compatibility_runtime_config_id": runtime_config_id,
             "backend": backend,
             "provider": provider,
             "model": model,
@@ -1127,13 +1127,48 @@ def _build_migrated_runtime_profiles(
                 field="workspace_base",
             ),
             "allowed_workspaces": _migrated_allowed_workspaces(entry),
+            "models": {
+                str(role).strip().lower(): canonicalize_model_for_backend(str(role_model).strip(), backend)
+                for role, role_model in (
+                    entry.get("models", {}).items() if isinstance(entry.get("models"), dict) else ()
+                )
+                if str(role).strip() and str(role_model).strip()
+            },
+            "github_repos": [
+                str(repo).strip().lower()
+                for repo in (entry.get("github_repos", []) if isinstance(entry.get("github_repos"), list) else ())
+                if str(repo).strip()
+            ],
+            "pr_review": entry.get("pr_review") if isinstance(entry.get("pr_review"), bool) else None,
+            "issue_triage": (entry.get("issue_triage") if isinstance(entry.get("issue_triage"), bool) else None),
+            "allowed_triage_projects": [
+                str(project).strip()
+                for project in (
+                    entry.get("allowed_triage_projects", [])
+                    if isinstance(entry.get("allowed_triage_projects"), list)
+                    else ()
+                )
+                if str(project).strip() and str(project).strip() != "*"
+            ],
         }
         raw_os_user = entry.get("os_user")
         if raw_os_user is not None and str(raw_os_user).strip():
             profile["os_user"] = str(raw_os_user).strip()
         profiles[str(profile_id)] = profile
+    legacy_runtime_keys = {
+        str(runtime_profile_id_for_config_id(runtime_config_id)): runtime_config_id
+        for runtime_config_id in sorted(seen)
+    }
     return yaml.safe_dump(
-        {"version": 1, "runtime_profiles": profiles},
+        {
+            "version": 2,
+            "runtime_profiles": profiles,
+            "legacy_runtime_archive": {
+                "version": 1,
+                "runtime_keys": legacy_runtime_keys,
+                "removal_gate": "canonical_runtime_state_v1",
+            },
+        },
         sort_keys=False,
         default_flow_style=False,
     )
@@ -1155,13 +1190,7 @@ def _upgrade_runtime_policy_content(
     migrated_content: str,
     defaults: _RuntimePolicyDefaults,
 ) -> tuple[str, bool]:
-    """Add execution-policy fields to documents that predate them.
-
-    The major document version remains 1 so older Kai code ignores the new
-    keys during rollback. Existing values are never overwritten. Profiles
-    migrated from users.yaml receive the exact pre-cutover effective values;
-    independently authored profiles receive deterministic backend defaults.
-    """
+    """Upgrade live runtime policy while preserving explicit rollback keys."""
     try:
         document = yaml.safe_load(content)
         migrated = yaml.safe_load(migrated_content)
@@ -1172,16 +1201,35 @@ def _upgrade_runtime_policy_content(
     migrated_profiles = migrated.get("runtime_profiles") if isinstance(migrated, dict) else None
     if not isinstance(migrated_profiles, dict):
         return content, False
-    expected_by_config_id = {
-        profile.get("compatibility_runtime_config_id"): profile
-        for profile in migrated_profiles.values()
-        if isinstance(profile, dict)
+    expected_by_profile_id = {
+        str(profile_id): profile for profile_id, profile in migrated_profiles.items() if isinstance(profile, dict)
     }
     changed = False
-    for profile in document["runtime_profiles"].values():
+    if document.get("version") == 1:
+        archived_keys: dict[str, int] = {}
+        for profile_id, profile in document["runtime_profiles"].items():
+            if not isinstance(profile, dict):
+                continue
+            raw_key = profile.pop("compatibility_runtime_config_id", None)
+            if isinstance(raw_key, int) and not isinstance(raw_key, bool) and raw_key > 0:
+                archived_keys[str(profile_id)] = raw_key
+            elif raw_key is None:
+                try:
+                    canonical_profile_id = RuntimeProfileId(str(profile_id))
+                except (TypeError, ValueError):
+                    continue
+                archived_keys[str(profile_id)] = legacy_runtime_key_for_v1_profile_id(canonical_profile_id)
+        document["version"] = 2
+        document["legacy_runtime_archive"] = {
+            "version": 1,
+            "runtime_keys": archived_keys,
+            "removal_gate": "canonical_runtime_state_v1",
+        }
+        changed = True
+    for profile_id, profile in document["runtime_profiles"].items():
         if not isinstance(profile, dict):
             continue
-        expected = expected_by_config_id.get(profile.get("compatibility_runtime_config_id"))
+        expected = expected_by_profile_id.get(str(profile_id))
         if "model" not in profile:
             if isinstance(expected, dict):
                 profile["model"] = expected["model"]
@@ -1217,6 +1265,19 @@ def _upgrade_runtime_policy_content(
             changed = True
         if "allowed_workspaces" not in profile:
             profile["allowed_workspaces"] = expected["allowed_workspaces"] if isinstance(expected, dict) else []
+            changed = True
+        if "models" not in profile:
+            profile["models"] = expected["models"] if isinstance(expected, dict) else {}
+            changed = True
+        for field in ("github_repos", "pr_review", "issue_triage"):
+            if field not in profile:
+                default: object = [] if field == "github_repos" else None
+                profile[field] = expected[field] if isinstance(expected, dict) else default
+                changed = True
+        if "allowed_triage_projects" not in profile:
+            profile["allowed_triage_projects"] = (
+                expected["allowed_triage_projects"] if isinstance(expected, dict) else []
+            )
             changed = True
     if not changed:
         return content, False
@@ -1271,7 +1332,7 @@ def _runtime_policy_has_config_id(
     runtime_config_id: int,
 ) -> bool:
     try:
-        profiles.for_config_id(runtime_config_id)
+        profiles.profile_for_legacy_runtime_key(runtime_config_id)
     except WorkshopRuntimeProfileError:
         return False
     return True
@@ -4815,12 +4876,17 @@ def _canonical_principal_storage_names(data_path: Path) -> dict[str, str]:
 class _RuntimeStorageTarget:
     """One protected runtime's install-time storage and ownership target."""
 
-    runtime_config_id: int
+    legacy_runtime_key: int | None
     profile_id: str
     storage_name: str
     os_user: str | None
     backend: str
     home_workspace: Path | None
+
+    @property
+    def storage_key(self) -> int | str:
+        """Return the migration key, or the canonical owner for new profiles."""
+        return self.legacy_runtime_key if self.legacy_runtime_key is not None else self.storage_name
 
 
 def _runtime_profile_principal_names(
@@ -4891,7 +4957,10 @@ def _runtime_storage_targets(
     compatibility_ids = set(compatibility_order)
     assignments_initialized, workshop_id, principal_names = _runtime_profile_principal_names(data_path)
     compatibility_principal_names = _canonical_principal_storage_names(data_path)
-    by_config_id = {profile.runtime_config_id: profile for profile in runtime_profiles.profiles}
+    by_config_id = {
+        legacy_key: runtime_profiles.resolve(profile_id)
+        for profile_id, legacy_key in runtime_profiles.legacy_runtime_archive
+    }
     policy_profile_ids = {str(profile.profile_id) for profile in runtime_profiles.profiles}
     stale_assignments = sorted(set(principal_names) - policy_profile_ids)
     if stale_assignments:
@@ -4900,13 +4969,21 @@ def _runtime_storage_targets(
             + ", ".join(stale_assignments)
         )
 
-    ordered_ids = [runtime_id for runtime_id in compatibility_order if runtime_id in by_config_id]
-    ordered_ids.extend(sorted(runtime_id for runtime_id in by_config_id if runtime_id not in compatibility_ids))
+    ordered_profiles = [by_config_id[runtime_id] for runtime_id in compatibility_order if runtime_id in by_config_id]
+    ordered_profile_ids = {profile.profile_id for profile in ordered_profiles}
+    ordered_profiles.extend(
+        sorted(
+            (profile for profile in runtime_profiles.profiles if profile.profile_id not in ordered_profile_ids),
+            key=lambda profile: profile.profile_id,
+        )
+    )
     targets: list[_RuntimeStorageTarget] = []
-    for runtime_config_id in ordered_ids:
-        profile = by_config_id[runtime_config_id]
+    for profile in ordered_profiles:
+        runtime_config_id = runtime_profiles.legacy_runtime_key(profile.profile_id)
         principal_name = principal_names.get(str(profile.profile_id))
-        compatibility_principal = compatibility_principal_names.get(str(runtime_config_id))
+        compatibility_principal = (
+            compatibility_principal_names.get(str(runtime_config_id)) if runtime_config_id is not None else None
+        )
         if (
             principal_name is not None
             and compatibility_principal is not None
@@ -4916,7 +4993,7 @@ def _runtime_storage_targets(
                 f"Protected runtime profile {profile.profile_id} conflicts with its canonical compatibility owner"
             )
         if principal_name is None:
-            if runtime_config_id not in compatibility_ids:
+            if runtime_config_id is None or runtime_config_id not in compatibility_ids:
                 raise RuntimeError(
                     f"Protected runtime profile {profile.profile_id} must map to exactly one canonical human owner"
                 )
@@ -4947,7 +5024,7 @@ def _runtime_storage_targets(
                 ) from exc
         targets.append(
             _RuntimeStorageTarget(
-                runtime_config_id=runtime_config_id,
+                legacy_runtime_key=runtime_config_id,
                 profile_id=str(profile.profile_id),
                 storage_name=principal_name,
                 os_user=profile.os_user,
@@ -5359,16 +5436,14 @@ def _apply_migrate(
         protected_home_overrides: dict[int, Path] | None = None
         protected_backends: dict[int, str | None] | None = None
     else:
-        memory_owners = [(target.runtime_config_id, target.os_user) for target in runtime_storage_targets]
-        protected_storage_names = {
-            str(target.runtime_config_id): target.storage_name for target in runtime_storage_targets
-        }
+        memory_owners = [(target.storage_key, target.os_user) for target in runtime_storage_targets]
+        protected_storage_names = {str(target.storage_key): target.storage_name for target in runtime_storage_targets}
         protected_home_overrides = {
-            target.runtime_config_id: target.home_workspace
+            target.storage_key: target.home_workspace
             for target in runtime_storage_targets
             if target.home_workspace is not None
         }
-        protected_backends = {target.runtime_config_id: target.backend for target in runtime_storage_targets}
+        protected_backends = {target.storage_key: target.backend for target in runtime_storage_targets}
     memory_root = data_path / "memory"
     legacy_global = memory_root / "MEMORY.md"
     template = PROJECT_ROOT / "templates" / ".claude" / "MEMORY.md"
@@ -5419,7 +5494,7 @@ def _apply_migrate(
     # dev), leave memory/MEMORY.md alone - runtime code falls back to
     # that legacy path when chat_id is None. This keeps local `make
     # run` workflows identical to pre-#347 behavior.
-    primary_chat_id: int | None = memory_owners[0][0] if memory_owners else None
+    primary_chat_id: int | str | None = memory_owners[0][0] if memory_owners else None
 
     if primary_chat_id is not None:
         for index, (chat_id, _os_user) in enumerate(memory_owners):
@@ -5687,7 +5762,7 @@ def _apply_migrate(
     home_overrides = (
         _collect_user_home_overrides(users_yaml_path) if protected_home_overrides is None else protected_home_overrides
     )
-    managed_home_migrations: dict[int, tuple[Path, Path]] = {}
+    managed_home_migrations: dict[int | str, tuple[Path, Path]] = {}
     for chat_id, _os_user in memory_owners:
         if chat_id is None or chat_id in home_overrides:
             continue
@@ -8629,6 +8704,7 @@ def _cmd_status() -> None:
     )
     print(workshop_delivery_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_runtime_session_status(Path(data_dir) / "kai.db"))
+    print(_runtime_key_cutover_status(Path(data_dir) / "kai.db", RUNTIME_PROFILES_YAML))
     print(workshop_execution_state_status(Path(data_dir) / "kai.db"))
     print(workshop_operational_state_status(Path(data_dir) / "kai.db"))
     print(
@@ -8694,7 +8770,46 @@ def _runtime_policy_status(policy_path: Path, backend_registry_path: Path) -> st
     except (OSError, yaml.YAMLError, WorkshopRuntimeProfileError) as exc:
         return f"{prefix} INVALID ({type(exc).__name__})"
     backends = ",".join(sorted({profile.backend for profile in profiles.profiles}))
-    return f"{prefix} initialized; profiles={len(profiles.profiles)}, backends={backends}, runtime kernel=canonical"
+    archived = len(profiles.legacy_runtime_archive)
+    removal_gate = profiles.legacy_archive_removal_gate or "not-applicable"
+    return (
+        f"{prefix} initialized; profiles={len(profiles.profiles)}, backends={backends}, "
+        f"runtime kernel=canonical, archived keys={archived}, removal gate={removal_gate}"
+    )
+
+
+def _runtime_key_cutover_status(database_path: Path, policy_path: Path) -> str:
+    """Report immutable transport-shaped-key migration coverage."""
+    prefix = "Workshop runtime-key cutover:"
+    try:
+        profiles = WorkshopRuntimeProfileRegistry.from_yaml(policy_path.read_text(encoding="utf-8"))
+        with sqlite3.connect(database_path) as connection:
+            table = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'workshop_runtime_key_cutovers'"
+            ).fetchone()
+            if table is None:
+                return f"{prefix} unavailable"
+            rows = connection.execute(
+                "SELECT runtime_profile_id, legacy_runtime_key, legacy_reads_disabled "
+                "FROM workshop_runtime_key_cutovers"
+            ).fetchall()
+    except (OSError, sqlite3.Error, WorkshopRuntimeProfileError, yaml.YAMLError) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+    expected = {str(profile.profile_id) for profile in profiles.profiles}
+    observed = {str(row[0]) for row in rows}
+    archived = sum(row[1] is not None for row in rows)
+    disabled = sum(int(row[2]) == 1 for row in rows)
+    missing = len(expected - observed)
+    extra = len(observed - expected)
+    reads_disabled = disabled == len(rows)
+    state = "active" if missing == 0 and extra == 0 and reads_disabled else "INCOMPLETE"
+    gate = profiles.legacy_archive_removal_gate or "not-applicable"
+    legacy_read_status = "disabled" if reads_disabled else "NOT VERIFIED"
+    return (
+        f"{prefix} {state}; profiles={len(expected)}, receipts={len(rows)}, "
+        f"archived keys={archived}, missing={missing}, extra={extra}; "
+        f"legacy reads={legacy_read_status}, removal gate={gate}"
+    )
 
 
 def _runtime_storage_status(

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -104,7 +104,7 @@ def _workshop_bootstrap_humans(
             transport="telegram",
             external_subject=str(user.telegram_id),
             external_channel_id=str(user.telegram_id),
-            runtime_profile_id=runtime_profiles.for_config_id(user.telegram_id).profile_id,
+            runtime_profile_id=runtime_profiles.profile_for_legacy_runtime_key(user.telegram_id).profile_id,
         )
         for user in sorted(config.user_configs.values(), key=lambda user: user.telegram_id)
     )
@@ -596,6 +596,7 @@ def _start() -> None:
         operational_migration = await sessions.initialize_workshop_operational_state(
             execution_state,
             config,
+            runtime_profiles,
         )
         logging.info(
             "Workshop canonical operational state ready "
@@ -621,6 +622,7 @@ def _start() -> None:
         # scoped delete primitive) shipped alongside this re-enable in
         # spec §320 / epic #306; Haiku extraction (Phase 2) is gated
         # separately via MEMORY_EXTRACTION_ENABLED.
+        memory_authority_enabled = False
         try:
             from kai.memory import configure_memory_authority, init_memory, is_enabled
 
@@ -629,7 +631,8 @@ def _start() -> None:
         except Exception:
             logging.warning("Could not initialize semantic memory", exc_info=True)
         else:
-            if is_enabled():
+            memory_authority_enabled = is_enabled()
+            if memory_authority_enabled:
                 memory_migration = await sessions.initialize_workshop_memory_authority(execution_state)
                 logging.info(
                     "Workshop canonical memory authority ready "
@@ -655,6 +658,18 @@ def _start() -> None:
                     )
                 except Exception:
                     logging.warning("Could not refresh semantic memory scope census", exc_info=True)
+
+        runtime_key_cutover = await sessions.initialize_workshop_runtime_key_cutover(
+            execution_state,
+            memory_enabled=memory_authority_enabled,
+        )
+        logging.info(
+            "Workshop canonical runtime-key cutover ready "
+            "(profiles=%d, newly_recorded=%d, archived_keys=%d, legacy_reads=disabled)",
+            runtime_key_cutover.profiles,
+            runtime_key_cutover.newly_recorded,
+            runtime_key_cutover.archived_keys,
+        )
 
         try:
             core_host = KaiApplicationHost(

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -748,6 +748,7 @@ class ScopedRetrievalContext:
     job_type: str | None = None
     backend_name: str | None = None
     session_id: str | None = None
+    runtime_profile_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -882,7 +883,7 @@ class _CanonicalMemoryNamespace(Protocol):
     def runtime_profile_id(self) -> object: ...
 
     @property
-    def runtime_config_id(self) -> int: ...
+    def require_legacy_runtime_key(self) -> int: ...
 
 
 class CanonicalMemoryNamespaceResolver(Protocol):
@@ -947,7 +948,7 @@ def _canonical_memory_owner(
         return user_id, None
     namespace = registry.maybe_for_runtime_config_id(runtime_config_id)
     if namespace is None:
-        return user_id, None
+        raise CanonicalMemoryAuthorityError("Protected integer memory owner has no canonical runtime authority")
     return str(namespace.principal_id), namespace
 
 
@@ -2500,7 +2501,12 @@ async def retrieve_scoped_memories(
     loop = asyncio.get_running_loop()
     results = await loop.run_in_executor(
         None,
-        lambda: search(query, user_id=user_id_str, limit=fetch_limit),
+        lambda: search(
+            query,
+            user_id=user_id_str,
+            limit=fetch_limit,
+            runtime_profile_id=context.runtime_profile_id,
+        ),
     )
     hits_raw = len(results)
 
@@ -2925,6 +2931,7 @@ async def format_scoped_context_with_recall_payload(
     session_id: str | None = None,
     token_budget: int | None = None,
     include_diagnostic_content: bool = False,
+    runtime_profile_id: str | None = None,
 ) -> ScopedRecallResult:
     """
     Run the scoped recall pipeline for LIVE prompt injection.
@@ -2965,6 +2972,7 @@ async def format_scoped_context_with_recall_payload(
             job_type=job_type,
             backend_name=backend_name,
             session_id=session_id,
+            runtime_profile_id=runtime_profile_id,
         )
         budget = token_budget
         if budget is None and _config is not None:
@@ -3611,7 +3619,7 @@ def migrate_memory_namespace(
     """
     if _memory is None:
         raise CanonicalMemoryAuthorityError("Semantic memory is not initialized")
-    legacy_user_id = str(namespace.runtime_config_id)
+    legacy_user_id = str(namespace.require_legacy_runtime_key())
     canonical_user_id = str(namespace.principal_id)
     legacy_rows = _get_all_raw(user_id=legacy_user_id)
     canonical_rows = _get_all_raw(user_id=canonical_user_id)
@@ -3788,7 +3796,12 @@ def get_all_facts(*, user_id: str) -> list[MemoryResult]:
     return matches
 
 
-def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
+def get_by_id(
+    *,
+    user_id: str,
+    memory_id: str,
+    runtime_profile_id: str | None = None,
+) -> MemoryResult | None:
     """Fetch a single user-visible memory by id, scoped to user.
 
     Used by the /memory fact view and forget-fact confirmation
@@ -3836,7 +3849,10 @@ def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
     # back onto the result dict). metadata is a dict of any leftover
     # payload keys and may be absent entirely if the row carried no
     # extra payload, so use .get with a default rather than indexing.
-    storage_user_id, namespace = _canonical_memory_owner(user_id)
+    storage_user_id, namespace = _canonical_memory_owner(
+        user_id,
+        runtime_profile_id=runtime_profile_id,
+    )
     if row.get("user_id") != storage_user_id:
         log.warning(
             "get_by_id: ownership mismatch (memory_id=%s, requested_user=%s)",
@@ -3855,7 +3871,12 @@ def get_by_id(*, user_id: str, memory_id: str) -> MemoryResult | None:
     return result if _memory_result_belongs_to_principal(result, namespace) else None
 
 
-def delete_by_id(*, user_id: str, memory_id: str) -> bool:
+def delete_by_id(
+    *,
+    user_id: str,
+    memory_id: str,
+    runtime_profile_id: str | None = None,
+) -> bool:
     """Delete a single memory after verifying ownership and source.
 
     Used by the /memory forget flow (spec 310 §6.4). Mem0's `delete`
@@ -3878,7 +3899,14 @@ def delete_by_id(*, user_id: str, memory_id: str) -> bool:
     # Single source of truth for ownership + source scoping. If
     # get_by_id returns None for any reason (missing, wrong user,
     # non-extracted, fetch error) we refuse to delete.
-    if get_by_id(user_id=user_id, memory_id=memory_id) is None:
+    if (
+        get_by_id(
+            user_id=user_id,
+            memory_id=memory_id,
+            runtime_profile_id=runtime_profile_id,
+        )
+        is None
+    ):
         return False
 
     try:

--- a/src/kai/memory.py
+++ b/src/kai/memory.py
@@ -882,7 +882,6 @@ class _CanonicalMemoryNamespace(Protocol):
     @property
     def runtime_profile_id(self) -> object: ...
 
-    @property
     def require_legacy_runtime_key(self) -> int: ...
 
 

--- a/src/kai/memory_extraction.py
+++ b/src/kai/memory_extraction.py
@@ -1908,6 +1908,7 @@ def _paraphrase_neighbor(
     user_id: str,
     threshold: float,
     active_project: ActiveMemoryProject | None = None,
+    runtime_profile_id: str | None = None,
 ) -> MemoryResult | None:
     """
     Nearest-admissible-neighbor semantic-search dedup gate.
@@ -1953,7 +1954,13 @@ def _paraphrase_neighbor(
         # at the public-API layer; this helper is called from inside
         # the semaphore block of `extract_and_store` which already
         # runs off the hot path, so a direct sync call is fine here.
-        results = memory.search(content, user_id=user_id, limit=_DEDUP_NEIGHBOR_FETCH_N)
+        search_kwargs: dict[str, object] = {
+            "user_id": user_id,
+            "limit": _DEDUP_NEIGHBOR_FETCH_N,
+        }
+        if runtime_profile_id is not None:
+            search_kwargs["runtime_profile_id"] = runtime_profile_id
+        results = memory.search(content, **search_kwargs)
     except Exception:
         log.debug("_paraphrase_neighbor: search failed; treating as non-duplicate", exc_info=True)
         return None
@@ -2490,6 +2497,7 @@ async def _generate_episode(
     user_log: LogEntry | None = None,
     assistant_log: LogEntry | None = None,
     canonical_provenance: dict[str, object] | None = None,
+    runtime_profile_id: str | None = None,
 ) -> None:
     """
     Stage-2 task body: generate one episode record and store it.
@@ -2662,15 +2670,18 @@ async def _generate_episode(
                     # block other stage-2 tasks queued behind this
                     # user's semaphore.
                     loop = asyncio.get_running_loop()
+                    add_kwargs: dict[str, object] = {
+                        "content": content,
+                        "user_id": user_id,
+                        "memory_type": "episode",
+                        "tags": episode["tags"],
+                        "metadata": extra,
+                    }
+                    if runtime_profile_id is not None:
+                        add_kwargs["runtime_profile_id"] = runtime_profile_id
                     mem_id = await loop.run_in_executor(
                         None,
-                        lambda: memory.add_structured(
-                            content=content,
-                            user_id=user_id,
-                            memory_type="episode",
-                            tags=episode["tags"],
-                            metadata=extra,
-                        ),
+                        lambda: memory.add_structured(**add_kwargs),
                     )
                     # add_structured returns the new memory ID on
                     # success or None when the underlying Mem0 call
@@ -2863,6 +2874,7 @@ def _store_facts(
     user_log: LogEntry | None = None,
     assistant_log: LogEntry | None = None,
     canonical_provenance: dict[str, object] | None = None,
+    runtime_profile_id: str | None = None,
 ) -> tuple[int, int, int]:
     """
     Persist validated facts via memory.add_structured, branching on intent.
@@ -3028,13 +3040,20 @@ def _store_facts(
             # production, raise N rather than re-introducing the
             # _paraphrase_neighbor gate here (which would silently drop
             # the consolidation and leave the stale fact in place).
-            delete_ok = memory.delete_by_id(user_id=user_id, memory_id=existing_id)
+            delete_kwargs: dict[str, object] = {
+                "user_id": user_id,
+                "memory_id": existing_id,
+            }
+            if runtime_profile_id is not None:
+                delete_kwargs["runtime_profile_id"] = runtime_profile_id
+            delete_ok = memory.delete_by_id(**delete_kwargs)
             memory_id = memory.add_structured(
                 content,
                 user_id=user_id,
                 memory_type="fact",
                 tags=fact.get("tags"),
                 metadata=extra,
+                runtime_profile_id=runtime_profile_id,
             )
             if memory_id is None:
                 # Worst case: old fact gone (if delete succeeded), new
@@ -3078,6 +3097,7 @@ def _store_facts(
             user_id,
             threshold=config.memory_duplicate_threshold,
             active_project=active_project,
+            runtime_profile_id=runtime_profile_id,
         )
         if neighbor is not None:
             log.debug("_store_facts: skipping duplicate %r", content[:80])
@@ -3112,6 +3132,7 @@ def _store_facts(
             memory_type="fact",
             tags=fact.get("tags"),
             metadata=extra,
+            runtime_profile_id=runtime_profile_id,
         )
         if memory_id is not None:
             _emit_intent_log(
@@ -3169,10 +3190,13 @@ async def extract_and_store(
     config: Config | None = None,
     prior_pairs: list[tuple[str, str]] | None = None,
     os_user_override: str | None = None,
+    effective_backend_override: str | None = None,
+    effective_provider_override: str | None = None,
     workspace: str | None = None,
     user_log: LogEntry | None = None,
     assistant_log: LogEntry | None = None,
     canonical_provenance: dict[str, object] | None = None,
+    runtime_profile_id: str | None = None,
     await_episode: bool = False,
 ) -> int:
     """
@@ -3258,8 +3282,8 @@ async def extract_and_store(
     # site because `bot.py`'s extraction gate filters them out
     # upstream; the cascade here
     # mirrors `_resolve_effective_backend`.
-    effective_backend = _resolve_effective_backend(user_id, config)
-    effective_provider = _resolve_effective_provider(user_id, config)
+    effective_backend = effective_backend_override or _resolve_effective_backend(user_id, config)
+    effective_provider = effective_provider_override or _resolve_effective_provider(user_id, config)
 
     # Active-project detection, ONCE per run, threaded into both
     # stages like os_user and the backend triple above so a single
@@ -3313,8 +3337,15 @@ async def extract_and_store(
                         None,
                         lambda: memory.search(
                             assistant_capped,
-                            user_id=user_id,
-                            limit=n_candidates,
+                            **(
+                                {
+                                    "user_id": user_id,
+                                    "limit": n_candidates,
+                                    "runtime_profile_id": runtime_profile_id,
+                                }
+                                if runtime_profile_id is not None
+                                else {"user_id": user_id, "limit": n_candidates}
+                            ),
                         ),
                     )
                 except Exception:
@@ -3430,6 +3461,7 @@ async def extract_and_store(
                         user_log=user_log,
                         assistant_log=assistant_log,
                         canonical_provenance=canonical_provenance,
+                        runtime_profile_id=runtime_profile_id,
                     ),
                 )
             else:
@@ -3470,6 +3502,7 @@ async def extract_and_store(
                     user_log=user_log,
                     assistant_log=assistant_log,
                     canonical_provenance=canonical_provenance,
+                    runtime_profile_id=runtime_profile_id,
                 )
                 if await_episode:
                     await episode

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -17,6 +17,7 @@ from kai.backend import (
     TRACE_SUMMARY_MAX_CHARS,
     AgentBackend,
     AgentResponse,
+    AgentRuntimeIdentity,
     ApiContext,
     StreamEvent,
     TraceEntry,
@@ -363,12 +364,24 @@ class PiBackend(AgentBackend):
             if text:
                 log.debug("Pi stderr: %s", text[:500])
 
-    async def send(self, prompt: str | list, chat_id: int | None = None) -> AsyncIterator[StreamEvent]:
+    async def send(
+        self,
+        prompt: str | list,
+        chat_id: int | None = None,
+        *,
+        runtime_identity: AgentRuntimeIdentity | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         async with self._lock:
-            async for event in self._send_locked(prompt, chat_id):
+            async for event in self._send_locked(prompt, chat_id, runtime_identity=runtime_identity):
                 yield event
 
-    async def _send_locked(self, prompt: str | list, chat_id: int | None) -> AsyncIterator[StreamEvent]:
+    async def _send_locked(
+        self,
+        prompt: str | list,
+        chat_id: int | None,
+        *,
+        runtime_identity: AgentRuntimeIdentity | None = None,
+    ) -> AsyncIterator[StreamEvent]:
         started_at = time.monotonic()
         if self._should_recycle():
             log.info(
@@ -399,6 +412,7 @@ class PiBackend(AgentBackend):
                 api=self._api_context,
                 workspace_config=self.workspace_config,
                 chat_id=chat_id,
+                runtime_identity=runtime_identity,
                 data_dir=DATA_DIR,
                 backend_name=self.backend_name,
                 memory_enabled=self.memory_enabled,
@@ -434,6 +448,7 @@ class PiBackend(AgentBackend):
         prompt = await assemble_turn_context(
             prompt,
             chat_id=chat_id if had_user_text else None,
+            runtime_identity=runtime_identity if had_user_text else None,
             session_context=session_context,
             workspace_reminder=reminder,
             workspace=self.workspace,

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -46,6 +46,7 @@ from kai.workshop.domain import RuntimeProfileId
 from kai.workspace_utils import is_workspace_allowed
 
 if TYPE_CHECKING:
+    from kai.workshop.execution_state import WorkshopExecutionStateNamespace
     from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
     from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
 
@@ -53,6 +54,13 @@ log = logging.getLogger(__name__)
 
 type RuntimeSelector = int | RuntimeProfileId
 type RuntimePoolKey = int | RuntimeProfileId
+
+
+def _required_legacy_key(value: int | None) -> int:
+    """Narrow an unprotected adapter key after canonical routing is excluded."""
+    if value is None:
+        raise RuntimeError("Unprotected runtime is missing its adapter key")
+    return value
 
 
 # How often the eviction loop checks for idle subprocesses (seconds).
@@ -169,43 +177,49 @@ class SubprocessPool:
         }
         allowed_services_by_profile = {}
         self._services_info_by_runtime: dict[RuntimePoolKey, list[dict]] = {}
-        runtime_config_ids = (
-            {profile.runtime_config_id for profile in runtime_profiles.profiles}
-            if runtime_profiles is not None
-            else config.allowed_user_ids
-        )
+        runtime_config_ids = config.allowed_user_ids
         protected_profiles_by_config_id = (
-            {profile.runtime_config_id: profile for profile in runtime_profiles.profiles}
+            {
+                legacy_key: runtime_profiles.resolve(profile_id)
+                for profile_id, legacy_key in runtime_profiles.legacy_runtime_archive
+            }
             if runtime_profiles is not None
             else {}
         )
-        for chat_id in runtime_config_ids:
-            user = config.get_user_config(chat_id)
-            protected_profile = protected_profiles_by_config_id.get(chat_id)
-            if protected_profile is not None:
-                requested = frozenset(protected_profile.allowed_services)
-            elif user is not None:
-                requested = frozenset(user.allowed_services)
-            else:
-                requested = frozenset()
+        runtime_policies: list[tuple[RuntimePoolKey, frozenset[str]]] = []
+        if runtime_profiles is not None:
+            runtime_policies.extend(
+                (profile.profile_id, frozenset(profile.allowed_services)) for profile in runtime_profiles.profiles
+            )
+        else:
+            runtime_policies.extend(
+                (
+                    chat_id,
+                    frozenset(
+                        config.get_user_config(chat_id).allowed_services
+                        if config.get_user_config(chat_id) is not None
+                        else ()
+                    ),
+                )
+                for chat_id in runtime_config_ids
+            )
+        for runtime_key, requested in runtime_policies:
             unavailable = requested - available_service_names
             if unavailable:
-                source = "protected runtime profile" if protected_profile is not None else "users.yaml user"
                 log.warning(
-                    "%s %d has unavailable allowed_services: %s; denying them",
-                    source,
-                    chat_id,
+                    "Runtime %s has unavailable allowed_services: %s; denying them",
+                    runtime_key,
                     ", ".join(sorted(unavailable)),
                 )
             allowed = requested & available_service_names
-            if protected_profile is not None:
-                service_profile_id = protected_profile.profile_id
+            if runtime_profiles is not None:
+                service_profile_id = runtime_key
             else:
                 from kai.workshop.runtime_profiles import runtime_profile_id_for_config_id
 
-                service_profile_id = runtime_profile_id_for_config_id(chat_id)
+                assert isinstance(runtime_key, int)
+                service_profile_id = runtime_profile_id_for_config_id(runtime_key)
             allowed_services_by_profile[service_profile_id] = allowed
-            runtime_key: RuntimePoolKey = protected_profile.profile_id if protected_profile is not None else chat_id
             self._services_info_by_runtime[runtime_key] = [
                 service for service in services_info if service.get("name") in allowed
             ]
@@ -279,7 +293,7 @@ class SubprocessPool:
     def _resolve_runtime(
         self,
         runtime: RuntimeSelector,
-    ) -> tuple[RuntimePoolKey, int, ProtectedRuntimeProfile | None]:
+    ) -> tuple[RuntimePoolKey, int | None, ProtectedRuntimeProfile | None]:
         """Resolve a caller selector to its canonical pool key and legacy state key."""
         from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError
 
@@ -289,18 +303,19 @@ class SubprocessPool:
             if self._runtime_profiles is None:
                 raise RuntimeError("Runtime profile selector requires protected runtime policy")
             profile = self._runtime_profiles.resolve(runtime)
-            return profile.profile_id, profile.runtime_config_id, profile
+            legacy_key = self._runtime_profiles.legacy_runtime_key(profile.profile_id)
+            return profile.profile_id, legacy_key, profile
         if not isinstance(runtime, int):
             raise TypeError("Runtime selector must be a runtime profile ID or integer")
         if self._runtime_profiles is None:
             return runtime, runtime, None
         try:
-            profile = self._runtime_profiles.for_config_id(runtime)
+            profile = self._runtime_profiles.profile_for_legacy_runtime_key(runtime)
         except WorkshopRuntimeProfileError:
             if runtime >= 0:
                 raise
             return runtime, runtime, None
-        return profile.profile_id, profile.runtime_config_id, profile
+        return profile.profile_id, runtime, profile
 
     def _protected_profile(self, runtime: RuntimeSelector):
         """Resolve protected policy while preserving the negative-group bridge."""
@@ -309,6 +324,27 @@ class SubprocessPool:
         # module-level import of any workshop submodule from here is
         # circular for some first-import orders.
         return self._resolve_runtime(runtime)[2]
+
+    def _canonical_namespace(
+        self,
+        runtime: RuntimeSelector,
+    ) -> WorkshopExecutionStateNamespace | None:
+        """Build the exact canonical state owner for a protected runtime."""
+        runtime_key, _legacy_key, profile = self._resolve_runtime(runtime)
+        if profile is None:
+            return None
+        context = self._contexts_by_runtime.get(runtime_key)
+        if context is None:
+            raise RuntimeError("Protected runtime has no canonical execution context")
+        from kai.workshop.execution_state import WorkshopExecutionStateNamespace
+
+        return WorkshopExecutionStateNamespace(
+            principal_id=context.principal_id,
+            channel_id=context.channel_id,
+            agent_id=context.agent_id,
+            runtime_profile_id=context.runtime_profile_id,
+            legacy_runtime_key=self._runtime_profiles.legacy_runtime_key(profile.profile_id),
+        )
 
     def get_runtime_profile(self, runtime: RuntimeSelector) -> ProtectedRuntimeProfile | None:
         """Return protected policy for one runtime, when that boundary applies."""
@@ -319,6 +355,7 @@ class SubprocessPool:
         _, runtime_config_id, profile = self._resolve_runtime(runtime)
         if profile is not None:
             return profile.backend, profile.provider
+        assert runtime_config_id is not None
         instance = self.get_if_exists(runtime)
         if instance is not None:
             return require_backend_name(instance), instance.provider
@@ -332,13 +369,35 @@ class SubprocessPool:
         _, runtime_config_id, profile = self._resolve_runtime(runtime)
         if profile is not None:
             return profile.os_user
+        assert runtime_config_id is not None
         user = self._config.get_user_config(runtime_config_id)
         return user.os_user if user is not None else None
 
     def get_role_model(self, runtime: RuntimeSelector, role: ModelRole) -> str:
         """Resolve an operator role model against the policy-selected route."""
-        _, runtime_config_id, _ = self._resolve_runtime(runtime)
+        _, runtime_config_id, profile = self._resolve_runtime(runtime)
         backend, provider = self.get_backend_provider(runtime)
+        if profile is not None:
+            profile_models = dict(profile.role_models)
+            raw_model = profile_models.get(role.value) or self._config.default_models.get(role.value)
+            model = canonicalize_model_for_backend(
+                raw_model or get_model_for(role, backend, provider),
+                backend,
+            )
+            if validate_model_for_backend(model, backend, provider):
+                return model
+            fallback = get_model_for(role, backend, provider)
+            log.warning(
+                "Ignoring %s model %r for runtime %s because it is invalid for %s/%s; using %r",
+                role.value,
+                model,
+                profile.profile_id,
+                backend,
+                provider,
+                fallback,
+            )
+            return fallback
+        assert runtime_config_id is not None
         model = canonicalize_model_for_backend(
             resolve_user_model(
                 role,
@@ -374,12 +433,18 @@ class SubprocessPool:
                         f"{profile.home_workspace}. Mount or create it, or update the protected runtime profile."
                     )
                 return profile.home_workspace
-            return resolve_home_workspace(
-                runtime_config_id,
-                self._config,
-                use_user_config=False,
-                provisioned_runtime=True,
-            )
+            context = self._contexts_by_runtime.get(profile.profile_id)
+            if context is None:
+                raise RuntimeError("Protected runtime has no canonical home owner")
+            path = self._config.session_db_path.parent / "home" / str(context.principal_id)
+            if not path.is_dir():
+                if self._config.protected_install:
+                    raise RuntimeError(
+                        f"Protected runtime {profile.profile_id} home is not provisioned: {path}. Run `make install`."
+                    )
+                path.mkdir(parents=True, exist_ok=True)
+            return path
+        assert runtime_config_id is not None
         return resolve_home_workspace(runtime_config_id, self._config)
 
     def get_static_workspace_policy(
@@ -390,6 +455,7 @@ class SubprocessPool:
         _, runtime_config_id, profile = self._resolve_runtime(runtime)
         if profile is not None:
             return profile.workspace_base, profile.allowed_workspaces, True
+        assert runtime_config_id is not None
         user = self._config.get_user_config(runtime_config_id)
         if user is None:
             return None, (), False
@@ -397,8 +463,18 @@ class SubprocessPool:
 
     async def resolve_workspace_access(self, runtime: RuntimeSelector) -> tuple[Path | None, list[Path]]:
         """Resolve mutable and static workspace access through runtime policy."""
-        _, runtime_config_id, _ = self._resolve_runtime(runtime)
+        _, runtime_config_id, profile = self._resolve_runtime(runtime)
         base, allowed, protected = self.get_static_workspace_policy(runtime)
+        if profile is not None:
+            namespace = self._canonical_namespace(runtime)
+            assert namespace is not None
+            return await sessions.resolve_canonical_workspace_access(
+                namespace,
+                self._config,
+                workspace_base=base,
+                static_allowed_workspaces=allowed,
+            )
+        assert runtime_config_id is not None
         return await sessions.resolve_workspace_access(
             runtime_config_id,
             self._config,
@@ -449,7 +525,7 @@ class SubprocessPool:
         in _apply_user_db_settings() since they require async DB access.
         """
         runtime_key, chat_id, protected_profile = self._resolve_runtime(runtime)
-        user = self._config.get_user_config(chat_id)
+        user = self._config.get_user_config(chat_id) if chat_id is not None else None
 
         # Resolve through the single backend.resolve_home_workspace
         # helper: users.yaml override first, else DATA_DIR/home/<principal_id>/.
@@ -499,7 +575,7 @@ class SubprocessPool:
                 # any model string, but the provider API will reject it.
                 if effective_provider in OPEN_ENDED_PROVIDERS:
                     log.warning(
-                        "No model configured for open-ended provider '%s' (chat %d); "
+                        "No model configured for open-ended provider '%s' (runtime %s); "
                         "using global default '%s' which may not be valid for this provider",
                         effective_provider,
                         chat_id,
@@ -562,6 +638,7 @@ class SubprocessPool:
             from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
             from kai.workshop.runtime_profiles import runtime_profile_id_for_config_id
 
+            assert chat_id is not None
             internal_api_context = WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
                 chat_id,
                 runtime_profile_id_for_config_id(abs(chat_id)),
@@ -726,12 +803,20 @@ class SubprocessPool:
         else:
             assert chat_id is not None
             selector = chat_id
-        runtime_key, runtime_config_id, _ = self._resolve_runtime(selector)
+        runtime_key, runtime_config_id, profile = self._resolve_runtime(selector)
         instance = await self._prepare_instance(selector)
         self._last_activity[runtime_key] = time.monotonic()
         self._in_flight.add(runtime_key)
         try:
-            async for event in instance.send(prompt, chat_id=runtime_config_id):
+            if profile is not None:
+                runtime_identity = self._contexts_by_runtime.get(runtime_key)
+                if runtime_identity is None:
+                    raise RuntimeError("Protected runtime has no canonical backend identity")
+                stream = instance.send(prompt, runtime_identity=runtime_identity)
+            else:
+                assert runtime_config_id is not None
+                stream = instance.send(prompt, chat_id=runtime_config_id)
+            async for event in stream:
                 yield event
         finally:
             instance.discard_canonical_history()
@@ -746,12 +831,20 @@ class SubprocessPool:
         """Dispatch through a prepared handle only while its runtime remains exact."""
         self._validate_prepared(prepared)
         runtime_key = prepared._runtime_key
-        _, runtime_config_id, _ = self._resolve_runtime(runtime_key)
+        _, runtime_config_id, profile = self._resolve_runtime(runtime_key)
         instance = prepared._instance
         self._last_activity[runtime_key] = time.monotonic()
         self._in_flight.add(runtime_key)
         try:
-            async for event in instance.send(prompt, chat_id=runtime_config_id):
+            if profile is not None:
+                runtime_identity = self._contexts_by_runtime.get(runtime_key)
+                if runtime_identity is None:
+                    raise RuntimeError("Protected runtime has no canonical backend identity")
+                stream = instance.send(prompt, runtime_identity=runtime_identity)
+            else:
+                assert runtime_config_id is not None
+                stream = instance.send(prompt, chat_id=runtime_config_id)
+            async for event in stream:
                 yield event
         finally:
             instance.discard_canonical_history()
@@ -802,36 +895,54 @@ class SubprocessPool:
         Returns the effective workspace path (saved when valid,
         otherwise the user's home workspace).
         """
-        runtime_key, chat_id, _ = self._resolve_runtime(runtime)
-        saved = await sessions.get_active_workspace(chat_id)
+        runtime_key, chat_id, profile = self._resolve_runtime(runtime)
+        namespace = self._canonical_namespace(runtime)
+        if profile is not None:
+            assert namespace is not None
+            saved = (await sessions.get_canonical_execution_settings(namespace)).get("workspace")
+        else:
+            assert chat_id is not None
+            saved = await sessions.get_active_workspace(chat_id)
         effective: Path | None = None
         if saved:
             ws_path = Path(saved)
             if not ws_path.is_dir():
                 log.warning(
-                    "Saved workspace for user %d no longer exists: %s",
-                    chat_id,
+                    "Saved workspace for runtime %s no longer exists: %s",
+                    runtime_key,
                     saved,
                 )
-                await sessions.delete_active_workspace(chat_id)
+                if namespace is not None:
+                    await sessions.delete_canonical_execution_setting(namespace, "workspace")
+                else:
+                    assert chat_id is not None
+                    await sessions.delete_active_workspace(chat_id)
             else:
                 base, allowed = await self.resolve_workspace_access(runtime)
                 if not is_workspace_allowed(ws_path, base, allowed):
                     log.warning(
-                        "Saved workspace for user %d is no longer allowed: %s",
-                        chat_id,
+                        "Saved workspace for runtime %s is no longer allowed: %s",
+                        runtime_key,
                         saved,
                     )
-                    await sessions.delete_active_workspace(chat_id)
+                    if namespace is not None:
+                        await sessions.delete_canonical_execution_setting(namespace, "workspace")
+                    else:
+                        assert chat_id is not None
+                        await sessions.delete_active_workspace(chat_id)
                 else:
                     # Layer DB overrides on top of YAML baseline so the
                     # user's per-workspace config (set via /workspace
                     # config) is applied on startup, not just after
                     # explicit switches.
                     yaml_config = self._config.get_workspace_config(ws_path)
-                    ws_config = await sessions.build_workspace_config(yaml_config, ws_path, chat_id)
+                    ws_config = (
+                        await sessions.build_canonical_workspace_config(yaml_config, ws_path, namespace)
+                        if namespace is not None
+                        else await sessions.build_workspace_config(yaml_config, ws_path, _required_legacy_key(chat_id))
+                    )
                     await instance.change_workspace(ws_path, workspace_config=ws_config)
-                    log.info("Restored workspace for user %d: %s", chat_id, ws_path)
+                    log.info("Restored workspace for runtime %s: %s", runtime_key, ws_path)
                     effective = ws_path
 
         self._pending_workspace_restore.discard(runtime_key)
@@ -854,8 +965,13 @@ class SubprocessPool:
         effect when the model changes, which would interrupt any UI
         operation that just wanted to read the effective workspace.
         """
-        _, chat_id, _ = self._resolve_runtime(runtime)
-        db_settings = await sessions.get_user_settings(chat_id)
+        _, chat_id, _profile = self._resolve_runtime(runtime)
+        namespace = self._canonical_namespace(runtime)
+        db_settings = (
+            await sessions.get_canonical_execution_settings(namespace)
+            if namespace is not None
+            else await sessions.get_user_settings(_required_legacy_key(chat_id))
+        )
         if not db_settings:
             return
 
@@ -889,10 +1005,13 @@ class SubprocessPool:
             stored_model = canonicalize_model_for_backend(stored_model_raw, instance_backend)
             if validate_model_for_backend(stored_model, instance_backend, instance.provider):
                 if stored_model != stored_model_raw:
-                    await sessions.set_user_setting(chat_id, "model", stored_model)
+                    if namespace is not None:
+                        await sessions.set_canonical_execution_setting(namespace, "model", stored_model)
+                    else:
+                        await sessions.set_user_setting(_required_legacy_key(chat_id), "model", stored_model)
                     log.info(
-                        "Migrated stored model for user %d from '%s' to '%s'",
-                        chat_id,
+                        "Migrated stored model for runtime %s from '%s' to '%s'",
+                        runtime,
                         stored_model_raw,
                         stored_model,
                     )
@@ -901,7 +1020,7 @@ class SubprocessPool:
                     needs_restart = True
             else:
                 log.warning(
-                    "Ignoring stored model '%s' for user %d (invalid for backend '%s'/provider '%s')",
+                    "Ignoring stored model '%s' for runtime %s (invalid for backend '%s'/provider '%s')",
                     stored_model,
                     chat_id,
                     instance_backend,
@@ -914,14 +1033,14 @@ class SubprocessPool:
             try:
                 instance.timeout_seconds = int(db_settings["timeout"])
             except (ValueError, TypeError):
-                log.warning("Corrupt timeout in DB for user %d", chat_id)
+                log.warning("Corrupt timeout in DB for runtime %s", runtime)
 
         # restart() kills the subprocess and spawns a new one, but the
         # backend *object* is preserved. Mutations made above (timeout,
         # model) survive the restart because the new subprocess reads
         # from self.* attrs.
         if needs_restart:
-            log.info("Restarting process for user %d: per-user DB overrides differ", chat_id)
+            log.info("Restarting process for runtime %s: per-runtime DB overrides differ", runtime)
             await instance.restart()
 
     # ── Per-user actions ────────────────────────────────────────────
@@ -1024,7 +1143,12 @@ class SubprocessPool:
         if profile is None:
             defaults = await sessions.resolve_user_defaults(chat_id, self._config)
             return defaults["model"]
-        db_settings = await sessions.get_user_settings(chat_id)
+        namespace = self._canonical_namespace(runtime)
+        db_settings = (
+            await sessions.get_canonical_execution_settings(namespace)
+            if namespace is not None
+            else await sessions.get_user_settings(chat_id)
+        )
         raw_model = db_settings.get("model", "").strip()
         if not raw_model:
             return profile.model
@@ -1071,12 +1195,17 @@ class SubprocessPool:
         ordinary text turn even if a command-path resolver call
         already finalized the workspace half.
         """
-        runtime_key, chat_id, _ = self._resolve_runtime(runtime)
+        runtime_key, chat_id, _profile = self._resolve_runtime(runtime)
+        namespace = self._canonical_namespace(runtime)
         instance = self._pool.get(runtime_key)
         if instance is not None and runtime_key not in self._pending_workspace_restore:
             return instance.workspace
 
-        saved = await sessions.get_active_workspace(chat_id)
+        saved = (
+            (await sessions.get_canonical_execution_settings(namespace)).get("workspace")
+            if namespace is not None
+            else await sessions.get_active_workspace(chat_id)
+        )
         if not saved:
             if instance is not None:
                 self._pending_workspace_restore.discard(runtime_key)
@@ -1086,11 +1215,14 @@ class SubprocessPool:
         base, allowed = await self.resolve_workspace_access(runtime)
         if not ws_path.is_dir() or not is_workspace_allowed(ws_path, base, allowed):
             log.warning(
-                "Saved workspace for user %d invalid; clearing: %s",
-                chat_id,
+                "Saved workspace for runtime %s invalid; clearing: %s",
+                runtime_key,
                 saved,
             )
-            await sessions.delete_active_workspace(chat_id)
+            if namespace is not None:
+                await sessions.delete_canonical_execution_setting(namespace, "workspace")
+            else:
+                await sessions.delete_active_workspace(chat_id)
             if instance is not None:
                 self._pending_workspace_restore.discard(runtime_key)
             return self.get_home_workspace(runtime)

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -94,7 +94,11 @@ from kai.workshop.streaming_preview import (
 
 if TYPE_CHECKING:
     from kai.config import Config, WorkspaceConfig
-    from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.runtime_key_cutover import (
+    WorkshopRuntimeKeyCutover,
+    reconcile_workshop_runtime_key_cutover,
+)
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 
 log = logging.getLogger(__name__)
 
@@ -439,18 +443,43 @@ async def initialize_workshop_memory_authority(
 async def initialize_workshop_operational_state(
     registry: WorkshopExecutionStateRegistry,
     config: Config,
+    runtime_profiles: WorkshopRuntimeProfileRegistry | None = None,
 ) -> WorkshopOperationalStateMigration:
     """Backfill and verify canonical job and GitHub subscription ownership."""
     if _workshop_event_lock is None:
         raise RuntimeError("Database not initialized - call init_db() first")
     async with _workshop_event_lock:
-        return await reconcile_workshop_operational_state(_get_db(), registry, config)
+        return await reconcile_workshop_operational_state(
+            _get_db(),
+            registry,
+            config,
+            runtime_profiles,
+        )
+
+
+async def initialize_workshop_runtime_key_cutover(
+    registry: WorkshopExecutionStateRegistry,
+    *,
+    memory_enabled: bool,
+) -> WorkshopRuntimeKeyCutover:
+    """Record the authoritative legacy-key inventory after migration."""
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        return await reconcile_workshop_runtime_key_cutover(
+            _get_db(),
+            registry,
+            memory_enabled=memory_enabled,
+        )
 
 
 def _execution_state_namespace(chat_id: int) -> WorkshopExecutionStateNamespace | None:
     if _workshop_execution_state is None:
         return None
-    return _workshop_execution_state.maybe_for_runtime_config_id(chat_id)
+    namespace = _workshop_execution_state.maybe_for_legacy_runtime_key(chat_id)
+    if namespace is None and chat_id > 0:
+        raise RuntimeError("Protected adapter identity has no canonical execution-state owner")
+    return namespace
 
 
 def execution_lane_key(chat_id: int) -> int | str:
@@ -2081,6 +2110,29 @@ async def resolve_workspace_access(
     return base, combined
 
 
+async def resolve_canonical_workspace_access(
+    namespace: WorkshopExecutionStateNamespace,
+    config: Config,
+    *,
+    workspace_base: Path | None,
+    static_allowed_workspaces: tuple[Path, ...],
+) -> tuple[Path | None, list[Path]]:
+    """Resolve protected workspace access without a compatibility key."""
+    base = workspace_base or config.workspace_base
+    seen: set[Path] = set()
+    combined: list[Path] = []
+    for path in (
+        *await get_canonical_workspace_grants(namespace),
+        *static_allowed_workspaces,
+        *config.allowed_workspaces,
+    ):
+        resolved = path.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            combined.append(resolved)
+    return base, combined
+
+
 # ── GitHub settings resolution ──────────────────────────────────────
 
 
@@ -2163,6 +2215,49 @@ async def _canonical_github_subscription(chat_id: int) -> aiosqlite.Row | None:
     return row
 
 
+async def get_canonical_github_token(principal_id: str) -> str | None:
+    """Read one protected GitHub credential by canonical principal."""
+    async with _get_db().execute(
+        "SELECT github_token FROM principal_github_subscriptions WHERE principal_id = ?",
+        (principal_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        raise RuntimeError("Protected GitHub credential has no canonical principal owner")
+    return str(row[0]) if row[0] else None
+
+
+async def get_github_token(chat_id: int) -> str | None:
+    """Read adapter-facing GitHub credential through canonical ownership."""
+    namespace = _execution_state_namespace(chat_id)
+    if namespace is None:
+        return await get_setting(f"github_token:{chat_id}")
+    return await get_canonical_github_token(str(namespace.principal_id))
+
+
+async def set_github_token(chat_id: int, token: str | None) -> None:
+    """Update an adapter-facing GitHub credential under its canonical principal."""
+    namespace = _execution_state_namespace(chat_id)
+    if namespace is None:
+        if token is None:
+            await delete_setting(f"github_token:{chat_id}")
+        else:
+            await set_setting(f"github_token:{chat_id}", token)
+        return
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        cursor = await _get_db().execute(
+            "UPDATE principal_github_subscriptions SET github_token = ?, "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE principal_id = ?",
+            (token, namespace.principal_id),
+        )
+        if cursor.rowcount != 1:
+            await _get_db().rollback()
+            raise RuntimeError("Canonical GitHub credential update found no unique owner")
+        await _get_db().commit()
+
+
 async def _set_github_repos(
     chat_id: int,
     canonical_column: str,
@@ -2189,10 +2284,6 @@ async def _set_github_repos(
             )
             if cursor.rowcount != 1:
                 raise RuntimeError("Canonical GitHub subscription update found no unique owner")
-            await _get_db().execute(
-                "INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                (f"{legacy_key}:{chat_id}", encoded),
-            )
             await _get_db().commit()
         except Exception:
             await _get_db().rollback()
@@ -2226,10 +2317,6 @@ async def set_github_toggle(chat_id: int, field: str, enabled: bool) -> None:
             )
             if cursor.rowcount != 1:
                 raise RuntimeError("Canonical GitHub subscription update found no unique owner")
-            await _get_db().execute(
-                "INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                (f"{field}:{chat_id}", encoded),
-            )
             await _get_db().commit()
         except Exception:
             await _get_db().rollback()

--- a/src/kai/workshop/execution_state.py
+++ b/src/kai/workshop/execution_state.py
@@ -23,7 +23,13 @@ class WorkshopExecutionStateNamespace:
     channel_id: ChannelId
     agent_id: AgentId
     runtime_profile_id: RuntimeProfileId
-    runtime_config_id: int
+    legacy_runtime_key: int | None
+
+    def require_legacy_runtime_key(self) -> int:
+        """Return archived migration state or fail closed."""
+        if self.legacy_runtime_key is None:
+            raise WorkshopExecutionStateError("Canonical runtime has no legacy-state archive")
+        return self.legacy_runtime_key
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,17 +48,18 @@ class WorkshopExecutionStateRegistry:
     """Resolve protected compatibility keys to canonical execution owners."""
 
     def __init__(self, namespaces: tuple[WorkshopExecutionStateNamespace, ...]) -> None:
-        by_config_id: dict[int, WorkshopExecutionStateNamespace] = {}
+        by_legacy_key: dict[int, WorkshopExecutionStateNamespace] = {}
         by_profile: dict[RuntimeProfileId, WorkshopExecutionStateNamespace] = {}
         by_principal: dict[PrincipalId, WorkshopExecutionStateNamespace | None] = {}
         for namespace in namespaces:
             if not isinstance(namespace, WorkshopExecutionStateNamespace):
                 raise TypeError("namespaces must contain WorkshopExecutionStateNamespace values")
-            if namespace.runtime_config_id in by_config_id:
-                raise WorkshopExecutionStateError("Duplicate runtime configuration execution-state owner")
+            if namespace.legacy_runtime_key is not None and namespace.legacy_runtime_key in by_legacy_key:
+                raise WorkshopExecutionStateError("Duplicate archived runtime execution-state key")
             if namespace.runtime_profile_id in by_profile:
                 raise WorkshopExecutionStateError("Duplicate runtime profile execution-state owner")
-            by_config_id[namespace.runtime_config_id] = namespace
+            if namespace.legacy_runtime_key is not None:
+                by_legacy_key[namespace.legacy_runtime_key] = namespace
             by_profile[namespace.runtime_profile_id] = namespace
             # A human may eventually have more than one runtime profile.  A
             # principal-id lookup is therefore available only while it is
@@ -61,9 +68,9 @@ class WorkshopExecutionStateRegistry:
                 by_principal[namespace.principal_id] = None
             else:
                 by_principal[namespace.principal_id] = namespace
-        if not by_config_id:
+        if not by_profile:
             raise WorkshopExecutionStateError("At least one execution-state namespace is required")
-        self._by_config_id = by_config_id
+        self._by_legacy_key = by_legacy_key
         self._by_profile = by_profile
         self._by_principal = by_principal
 
@@ -109,7 +116,7 @@ class WorkshopExecutionStateRegistry:
                     channel_id=channel_id,
                     agent_id=agent_id,
                     runtime_profile_id=profile.profile_id,
-                    runtime_config_id=profile.runtime_config_id,
+                    legacy_runtime_key=runtime_profiles.legacy_runtime_key(profile.profile_id),
                 )
             )
         return cls(tuple(namespaces))
@@ -118,10 +125,14 @@ class WorkshopExecutionStateRegistry:
     def namespaces(self) -> tuple[WorkshopExecutionStateNamespace, ...]:
         return tuple(sorted(self._by_profile.values(), key=lambda item: item.runtime_profile_id))
 
-    def maybe_for_runtime_config_id(self, runtime_config_id: int) -> WorkshopExecutionStateNamespace | None:
-        if isinstance(runtime_config_id, bool) or not isinstance(runtime_config_id, int):
+    def maybe_for_legacy_runtime_key(self, legacy_runtime_key: int) -> WorkshopExecutionStateNamespace | None:
+        if isinstance(legacy_runtime_key, bool) or not isinstance(legacy_runtime_key, int):
             return None
-        return self._by_config_id.get(runtime_config_id)
+        return self._by_legacy_key.get(legacy_runtime_key)
+
+    def maybe_for_runtime_config_id(self, runtime_config_id: int) -> WorkshopExecutionStateNamespace | None:
+        """Deprecated adapter/migration alias; protected core uses canonical lookups."""
+        return self.maybe_for_legacy_runtime_key(runtime_config_id)
 
     def maybe_for_principal_id(self, principal_id: str) -> WorkshopExecutionStateNamespace | None:
         try:
@@ -161,6 +172,16 @@ class WorkshopExecutionStateRegistry:
             return None
         return self._by_profile.get(canonical_id)
 
+    def resolve_profile(
+        self,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> WorkshopExecutionStateNamespace:
+        """Resolve an exact protected runtime profile or fail closed."""
+        namespace = self.maybe_for_runtime_profile_id(runtime_profile_id)
+        if namespace is None:
+            raise WorkshopExecutionStateError("Protected runtime profile has no canonical execution-state owner")
+        return namespace
+
 
 async def reconcile_legacy_execution_state(
     connection: aiosqlite.Connection,
@@ -172,6 +193,8 @@ async def reconcile_legacy_execution_state(
     try:
         await connection.execute("BEGIN IMMEDIATE")
         for namespace in registry.namespaces:
+            if namespace.legacy_runtime_key is None:
+                continue
             async with connection.execute(
                 "SELECT runtime_config_id, principal_id, channel_id, agent_id "
                 "FROM workshop_execution_state_migrations WHERE runtime_profile_id = ?",
@@ -186,7 +209,7 @@ async def reconcile_legacy_execution_state(
                         str(migrated["agent_id"]),
                     )
                     current_owner = (
-                        namespace.runtime_config_id,
+                        namespace.legacy_runtime_key,
                         str(namespace.principal_id),
                         str(namespace.channel_id),
                         str(namespace.agent_id),
@@ -209,7 +232,7 @@ async def reconcile_legacy_execution_state(
                 ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     namespace.runtime_profile_id,
-                    namespace.runtime_config_id,
+                    namespace.legacy_runtime_key,
                     namespace.principal_id,
                     namespace.channel_id,
                     namespace.agent_id,
@@ -238,11 +261,14 @@ async def _backfill_namespace(
     connection: aiosqlite.Connection,
     namespace: WorkshopExecutionStateNamespace,
 ) -> dict[str, int]:
+    legacy_runtime_key = namespace.legacy_runtime_key
+    if legacy_runtime_key is None:
+        return {"settings": 0, "workspace_settings": 0, "history": 0, "grants": 0}
     counts = {"settings": 0, "workspace_settings": 0, "history": 0, "grants": 0}
     for field in ("model", "timeout", "workspace"):
         async with connection.execute(
             "SELECT value FROM settings WHERE key = ?",
-            (f"{field}:{namespace.runtime_config_id}",),
+            (f"{field}:{legacy_runtime_key}",),
         ) as cursor:
             row = await cursor.fetchone()
         if row is not None:
@@ -259,7 +285,7 @@ async def _backfill_namespace(
             )
             counts["settings"] += cursor.rowcount
 
-    prefix = f"ws_config:{namespace.runtime_config_id}:"
+    prefix = f"ws_config:{legacy_runtime_key}:"
     async with connection.execute(
         "SELECT key, value FROM settings WHERE SUBSTR(key, 1, ?) = ? ORDER BY key",
         (len(prefix), prefix),
@@ -290,13 +316,13 @@ async def _backfill_namespace(
     cursor = await connection.execute(
         "INSERT OR IGNORE INTO principal_workspace_history (principal_id, path, last_used_at) "
         "SELECT ?, path, last_used_at FROM workspace_history WHERE chat_id = ?",
-        (namespace.principal_id, namespace.runtime_config_id),
+        (namespace.principal_id, legacy_runtime_key),
     )
     counts["history"] += cursor.rowcount
     cursor = await connection.execute(
         "INSERT OR IGNORE INTO principal_workspace_grants (principal_id, path) "
         "SELECT ?, path FROM allowed_workspaces WHERE chat_id = ?",
-        (namespace.principal_id, namespace.runtime_config_id),
+        (namespace.principal_id, legacy_runtime_key),
     )
     counts["grants"] += cursor.rowcount
     return counts

--- a/src/kai/workshop/github_automation.py
+++ b/src/kai/workshop/github_automation.py
@@ -13,7 +13,6 @@ from typing import Any
 
 from kai import review, triage
 from kai.config import ModelRole
-from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.domain import ChannelId, MessageId, PrincipalId, RuntimeProfileId
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.integration_notifications import (
@@ -21,6 +20,7 @@ from kai.workshop.integration_notifications import (
     WorkshopIntegrationNotificationService,
 )
 from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.runtime_state import WorkshopRuntimeStateWriter
 from kai.workshop.store import WorkshopEventStore
 
 log = logging.getLogger(__name__)
@@ -77,7 +77,7 @@ class WorkshopGitHubAutomationService:
         store: WorkshopEventStore,
         runtime_pool: WorkshopRuntimePool,
         execution_state: WorkshopExecutionStateRegistry,
-        compatibility_state: WorkshopCompatibilityStateWriter,
+        runtime_state: WorkshopRuntimeStateWriter,
         notifications: WorkshopIntegrationNotificationService,
         *,
         spec_dir: str,
@@ -86,7 +86,7 @@ class WorkshopGitHubAutomationService:
         self._store = store
         self._runtime_pool = runtime_pool
         self._execution_state = execution_state
-        self._compatibility_state = compatibility_state
+        self._runtime_state = runtime_state
         self._notifications = notifications
         self._spec_dir = spec_dir
         self._review_timeout_seconds = review_timeout_seconds
@@ -102,7 +102,7 @@ class WorkshopGitHubAutomationService:
         database_path: Path,
         runtime_pool: WorkshopRuntimePool,
         execution_state: WorkshopExecutionStateRegistry,
-        compatibility_state: WorkshopCompatibilityStateWriter,
+        runtime_state: WorkshopRuntimeStateWriter,
         notifications: WorkshopIntegrationNotificationService,
         *,
         spec_dir: str,
@@ -112,7 +112,7 @@ class WorkshopGitHubAutomationService:
             await WorkshopEventStore.open(database_path),
             runtime_pool,
             execution_state,
-            compatibility_state,
+            runtime_state,
             notifications,
             spec_dir=spec_dir,
             review_timeout_seconds=review_timeout_seconds,
@@ -375,8 +375,8 @@ class WorkshopGitHubAutomationService:
             await self._mark(item.work_id, "failed", "runtime_authority_changed")
             return
         profile = self._runtime_pool.runtime_profile(item.runtime_profile_id)
-        compatibility = self._compatibility_state.for_profile(item.runtime_profile_id)
-        token = await compatibility.github_token()
+        runtime_state = self._runtime_state.for_profile(item.runtime_profile_id)
+        token = await runtime_state.github_token()
         if not token:
             await self._notify(
                 item,
@@ -427,7 +427,7 @@ class WorkshopGitHubAutomationService:
                         item.runtime_profile_id,
                         ModelRole.ISSUE_TRIAGE,
                     ),
-                    allowed_triage_projects=list(compatibility.allowed_triage_projects),
+                    allowed_triage_projects=list(runtime_state.allowed_triage_projects),
                     github_token=token,
                     notification_sink=sink,
                 )

--- a/src/kai/workshop/memory_authority.py
+++ b/src/kai/workshop/memory_authority.py
@@ -73,7 +73,7 @@ def memory_authority_registry_from_database(
                 channel_id=ChannelId(str(row[3])),
                 agent_id=AgentId(str(row[4])),
                 runtime_profile_id=RuntimeProfileId(str(row[0])),
-                runtime_config_id=int(row[1]),
+                legacy_runtime_key=int(row[1]),
             )
             for row in rows
         )
@@ -103,7 +103,7 @@ async def reconcile_workshop_memory_authority(
         ) as cursor:
             migrated = await cursor.fetchone()
         current_owner = (
-            namespace.runtime_config_id,
+            namespace.require_legacy_runtime_key(),
             str(namespace.principal_id),
             str(namespace.channel_id),
             str(namespace.agent_id),
@@ -147,7 +147,7 @@ async def reconcile_workshop_memory_authority(
                 ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     namespace.runtime_profile_id,
-                    namespace.runtime_config_id,
+                    namespace.require_legacy_runtime_key(),
                     namespace.principal_id,
                     namespace.channel_id,
                     namespace.agent_id,

--- a/src/kai/workshop/operational_state.py
+++ b/src/kai/workshop/operational_state.py
@@ -15,6 +15,7 @@ from kai.workshop.execution_state import (
 
 if TYPE_CHECKING:
     from kai.config import Config
+    from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
 
 
 class WorkshopOperationalStateError(RuntimeError):
@@ -40,6 +41,8 @@ class _GitHubSubscriptionSeed:
     issue_triage_enabled: int
     pr_review_source: str
     issue_triage_source: str
+    github_token: str | None
+    allowed_triage_projects_json: str
     has_legacy_policy: bool
 
     def database_values(self) -> tuple[object, ...]:
@@ -51,6 +54,8 @@ class _GitHubSubscriptionSeed:
             self.issue_triage_enabled,
             self.pr_review_source,
             self.issue_triage_source,
+            self.github_token,
+            self.allowed_triage_projects_json,
         )
 
 
@@ -61,6 +66,7 @@ class _OperatorGitHubPolicy:
     issue_triage_enabled: int
     pr_review_source: str
     issue_triage_source: str
+    allowed_triage_projects_json: str
     has_user_config: bool
 
     def database_values(self) -> tuple[object, ...]:
@@ -70,6 +76,7 @@ class _OperatorGitHubPolicy:
             self.issue_triage_enabled,
             self.pr_review_source,
             self.issue_triage_source,
+            self.allowed_triage_projects_json,
         )
 
 
@@ -77,9 +84,12 @@ async def reconcile_workshop_operational_state(
     connection: aiosqlite.Connection,
     registry: WorkshopExecutionStateRegistry,
     config: Config,
+    runtime_profiles: WorkshopRuntimeProfileRegistry | None,
 ) -> WorkshopOperationalStateMigration:
     """Make canonical owners authoritative for protected jobs and GitHub policy."""
-    pending = await _pending_namespaces(connection, registry)
+    pending = tuple(
+        item for item in await _pending_namespaces(connection, registry) if item.legacy_runtime_key is not None
+    )
     seeds: dict[str, _GitHubSubscriptionSeed] = {}
     if pending:
         for namespace in pending:
@@ -100,7 +110,12 @@ async def reconcile_workshop_operational_state(
 
     operator_policies: dict[str, _OperatorGitHubPolicy] = {}
     for namespace in registry.namespaces:
-        policy = _operator_github_policy(namespace, config)
+        if runtime_profiles is None:
+            legacy_key = namespace.require_legacy_runtime_key()
+            user = config.get_user_config(legacy_key)
+            policy = _operator_github_policy_from_user(user)
+        else:
+            policy = _operator_github_policy(runtime_profiles.resolve(namespace.runtime_profile_id))
         principal_id = str(namespace.principal_id)
         existing = operator_policies.get(principal_id)
         if (
@@ -120,6 +135,16 @@ async def reconcile_workshop_operational_state(
     try:
         await connection.execute("BEGIN IMMEDIATE")
         for namespace in registry.namespaces:
+            policy = operator_policies[str(namespace.principal_id)]
+            if namespace.legacy_runtime_key is None:
+                github_subscriptions += await _ensure_canonical_github_subscription(
+                    connection,
+                    namespace,
+                    policy,
+                )
+                await _sync_operator_github_policy(connection, namespace, policy)
+                await _verify_namespace(connection, namespace)
+                continue
             scheduled_jobs_migrated = await _scheduled_job_migration_owner(connection, namespace)
             migrated = await _migration_owner(connection, namespace)
             if migrated:
@@ -128,10 +153,11 @@ async def reconcile_workshop_operational_state(
                     await _verify_legacy_jobs_for_cutover(connection, namespace)
                     await _record_scheduled_job_migration(connection, namespace, job_count)
                     jobs += job_count
+                await _migrate_runtime_key_github_token(connection, namespace)
                 await _sync_operator_github_policy(
                     connection,
                     namespace,
-                    operator_policies[str(namespace.principal_id)],
+                    policy,
                 )
                 await _verify_namespace(connection, namespace)
                 continue
@@ -149,7 +175,7 @@ async def reconcile_workshop_operational_state(
             await _sync_operator_github_policy(
                 connection,
                 namespace,
-                operator_policies[str(namespace.principal_id)],
+                policy,
             )
             await _verify_namespace(connection, namespace)
             await connection.execute(
@@ -159,7 +185,7 @@ async def reconcile_workshop_operational_state(
                 ") VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     namespace.runtime_profile_id,
-                    namespace.runtime_config_id,
+                    namespace.require_legacy_runtime_key(),
                     namespace.principal_id,
                     namespace.channel_id,
                     namespace.agent_id,
@@ -205,7 +231,7 @@ async def _migration_owner(
         return False
     recorded = (int(row[0]), str(row[1]), str(row[2]), str(row[3]))
     current = (
-        namespace.runtime_config_id,
+        namespace.require_legacy_runtime_key(),
         str(namespace.principal_id),
         str(namespace.channel_id),
         str(namespace.agent_id),
@@ -233,7 +259,7 @@ async def _scheduled_job_migration_owner(
         return False
     recorded = (int(row[0]), str(row[1]), str(row[2]), str(row[3]))
     current = (
-        namespace.runtime_config_id,
+        namespace.require_legacy_runtime_key(),
         str(namespace.principal_id),
         str(namespace.channel_id),
         str(namespace.agent_id),
@@ -258,7 +284,7 @@ async def _record_scheduled_job_migration(
         "legacy_jobs_count) VALUES (?, ?, ?, ?, ?, ?)",
         (
             namespace.runtime_profile_id,
-            namespace.runtime_config_id,
+            namespace.require_legacy_runtime_key(),
             namespace.principal_id,
             namespace.channel_id,
             namespace.agent_id,
@@ -304,7 +330,7 @@ async def _github_seed(
     namespace: WorkshopExecutionStateNamespace,
     config: Config,
 ) -> _GitHubSubscriptionSeed:
-    legacy_id = namespace.runtime_config_id
+    legacy_id = namespace.require_legacy_runtime_key()
     user = config.get_user_config(legacy_id)
     baseline = sorted({repo.strip().lower() for repo in (user.github_repos if user else []) if repo.strip()})
     added = await _legacy_setting(connection, f"github_repos_added:{legacy_id}")
@@ -314,6 +340,7 @@ async def _github_seed(
         await _legacy_setting(connection, f"issue_triage:{legacy_id}"),
         key="issue_triage",
     )
+    github_token = await _legacy_setting(connection, f"github_token:{legacy_id}")
     operator_pr_review = user.pr_review if user is not None else None
     operator_issue_triage = user.issue_triage if user is not None else None
     has_legacy_policy = user is not None or any(
@@ -338,24 +365,48 @@ async def _github_seed(
         issue_triage_source=(
             "user" if issue_triage is not None else "operator" if operator_issue_triage is not None else "default"
         ),
+        github_token=github_token,
+        allowed_triage_projects_json=json.dumps(
+            sorted(set(getattr(user, "allowed_triage_projects", []) if user is not None else [])),
+            separators=(",", ":"),
+        ),
         has_legacy_policy=has_legacy_policy,
     )
 
 
 def _operator_github_policy(
-    namespace: WorkshopExecutionStateNamespace,
-    config: Config,
+    profile: ProtectedRuntimeProfile,
 ) -> _OperatorGitHubPolicy:
-    user = config.get_user_config(namespace.runtime_config_id)
-    baseline = sorted({repo.strip().lower() for repo in (user.github_repos if user else []) if repo.strip()})
-    pr_review = user.pr_review if user is not None else None
-    issue_triage = user.issue_triage if user is not None else None
+    baseline = sorted(set(profile.github_repos))
+    pr_review = profile.pr_review
+    issue_triage = profile.issue_triage
     return _OperatorGitHubPolicy(
         baseline_repos_json=json.dumps(baseline, separators=(",", ":")),
         pr_review_enabled=int(pr_review or False),
         issue_triage_enabled=int(issue_triage or False),
         pr_review_source="operator" if pr_review is not None else "default",
         issue_triage_source="operator" if issue_triage is not None else "default",
+        allowed_triage_projects_json=json.dumps(
+            sorted(set(profile.allowed_triage_projects)),
+            separators=(",", ":"),
+        ),
+        has_user_config=True,
+    )
+
+
+def _operator_github_policy_from_user(user: object | None) -> _OperatorGitHubPolicy:
+    """Compatibility only for direct unit/dev callers without protected policy."""
+    repos = getattr(user, "github_repos", []) if user is not None else []
+    pr_review = getattr(user, "pr_review", None) if user is not None else None
+    issue_triage = getattr(user, "issue_triage", None) if user is not None else None
+    allowed = getattr(user, "allowed_triage_projects", []) if user is not None else []
+    return _OperatorGitHubPolicy(
+        baseline_repos_json=json.dumps(sorted({repo.strip().lower() for repo in repos}), separators=(",", ":")),
+        pr_review_enabled=int(pr_review or False),
+        issue_triage_enabled=int(issue_triage or False),
+        pr_review_source="operator" if pr_review is not None else "default",
+        issue_triage_source="operator" if issue_triage is not None else "default",
+        allowed_triage_projects_json=json.dumps(sorted(set(allowed)), separators=(",", ":")),
         has_user_config=user is not None,
     )
 
@@ -373,7 +424,7 @@ async def _backfill_jobs(
             namespace.channel_id,
             namespace.agent_id,
             namespace.runtime_profile_id,
-            namespace.runtime_config_id,
+            namespace.require_legacy_runtime_key(),
         ),
     )
     job_cursor = await connection.execute(
@@ -393,7 +444,7 @@ async def _backfill_jobs(
         "JOIN channel_agent_runtime_assignments ra ON ra.channel_id = c.id "
         "AND ra.agent_id = a.id AND ra.runtime_profile_id = o.runtime_profile_id "
         "WHERE j.chat_id = ?",
-        (namespace.runtime_config_id,),
+        (namespace.require_legacy_runtime_key(),),
     )
     return job_cursor.rowcount
 
@@ -422,14 +473,16 @@ async def _backfill_github_subscription(
     cursor = await connection.execute(
         "INSERT OR IGNORE INTO principal_github_subscriptions ("
         "principal_id, baseline_repos_json, added_repos_json, removed_repos_json, "
-        "pr_review_enabled, issue_triage_enabled, pr_review_source, issue_triage_source"
-        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        "pr_review_enabled, issue_triage_enabled, pr_review_source, issue_triage_source, "
+        "github_token, allowed_triage_projects_json"
+        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (namespace.principal_id, *seed.database_values()),
     )
     if cursor.rowcount == 0:
         async with connection.execute(
             "SELECT baseline_repos_json, added_repos_json, removed_repos_json, "
-            "pr_review_enabled, issue_triage_enabled, pr_review_source, issue_triage_source "
+            "pr_review_enabled, issue_triage_enabled, pr_review_source, issue_triage_source, "
+            "github_token, allowed_triage_projects_json "
             "FROM principal_github_subscriptions WHERE principal_id = ?",
             (namespace.principal_id,),
         ) as result_cursor:
@@ -438,6 +491,23 @@ async def _backfill_github_subscription(
             raise WorkshopOperationalStateError(
                 "Canonical GitHub subscription state conflicts with unmigrated legacy policy"
             )
+    return cursor.rowcount
+
+
+async def _ensure_canonical_github_subscription(
+    connection: aiosqlite.Connection,
+    namespace: WorkshopExecutionStateNamespace,
+    policy: _OperatorGitHubPolicy,
+) -> int:
+    """Provision canonical state for a profile that has no legacy archive."""
+    cursor = await connection.execute(
+        "INSERT OR IGNORE INTO principal_github_subscriptions ("
+        "principal_id, baseline_repos_json, added_repos_json, removed_repos_json, "
+        "pr_review_enabled, issue_triage_enabled, pr_review_source, issue_triage_source, "
+        "allowed_triage_projects_json"
+        ") VALUES (?, ?, '[]', '[]', ?, ?, ?, ?, ?)",
+        (namespace.principal_id, *policy.database_values()),
+    )
     return cursor.rowcount
 
 
@@ -456,6 +526,7 @@ async def _sync_operator_github_policy(
         "THEN pr_review_source ELSE ? END, "
         "issue_triage_source = CASE WHEN issue_triage_source = 'user' "
         "THEN issue_triage_source ELSE ? END, "
+        "allowed_triage_projects_json = ?, "
         "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') "
         "WHERE principal_id = ?",
         (*policy.database_values(), namespace.principal_id),
@@ -464,6 +535,36 @@ async def _sync_operator_github_policy(
         raise WorkshopOperationalStateError(
             "Protected GitHub subscription policy has no unique canonical principal owner"
         )
+
+
+async def _migrate_runtime_key_github_token(
+    connection: aiosqlite.Connection,
+    namespace: WorkshopExecutionStateNamespace,
+) -> None:
+    """Carry the mutable token across schema v33 before sealing the archive.
+
+    Operational-state receipts predate the canonical token column. Existing
+    installations therefore need one final archived read on their first v33
+    startup. The immutable runtime-key cutover receipt is the removal gate:
+    once present, later legacy changes are never re-imported.
+    """
+    async with connection.execute(
+        "SELECT 1 FROM workshop_runtime_key_cutovers WHERE runtime_profile_id = ?",
+        (namespace.runtime_profile_id,),
+    ) as cursor:
+        if await cursor.fetchone() is not None:
+            return
+    legacy_token = await _legacy_setting(
+        connection,
+        f"github_token:{namespace.require_legacy_runtime_key()}",
+    )
+    if legacy_token is None:
+        return
+    await connection.execute(
+        "UPDATE principal_github_subscriptions SET github_token = COALESCE(github_token, ?), "
+        "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE principal_id = ?",
+        (legacy_token, namespace.principal_id),
+    )
 
 
 async def _verify_namespace(
@@ -490,7 +591,7 @@ async def _verify_legacy_jobs_for_cutover(
         "WHERE j.chat_id = ? AND (o.job_id IS NULL OR o.principal_id != ? OR o.channel_id != ? "
         "OR o.agent_id != ? OR o.runtime_profile_id != ?) ORDER BY j.id LIMIT 5",
         (
-            namespace.runtime_config_id,
+            namespace.require_legacy_runtime_key(),
             namespace.principal_id,
             namespace.channel_id,
             namespace.agent_id,
@@ -515,7 +616,7 @@ async def _verify_legacy_jobs_for_cutover(
         "OR c.schedule_type != j.schedule_type OR c.schedule_data != j.schedule_data "
         "OR c.active != j.active OR c.auto_remove != j.auto_remove "
         "OR c.notify_on_check != j.notify_on_check) ORDER BY j.id LIMIT 5",
-        (namespace.runtime_config_id,),
+        (namespace.require_legacy_runtime_key(),),
     ) as cursor:
         canonical_rows = await cursor.fetchall()
     if canonical_rows:

--- a/src/kai/workshop/post_run_effects.py
+++ b/src/kai/workshop/post_run_effects.py
@@ -8,11 +8,11 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.conversation_context import assemble_canonical_prior_pairs
 from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, RunId, RuntimeProfileId
 from kai.workshop.run_lifecycle import RunStatus, WorkshopRunLifecycle
 from kai.workshop.runtime_sessions import RuntimeSessionSettlement
+from kai.workshop.runtime_state import WorkshopRuntimeStateWriter
 from kai.workshop.store import WorkshopEventStore
 
 log = logging.getLogger(__name__)
@@ -89,10 +89,10 @@ class WorkshopPostRunEffectService:
     def __init__(
         self,
         store: WorkshopEventStore,
-        compatibility_state: WorkshopCompatibilityStateWriter,
+        runtime_state: WorkshopRuntimeStateWriter,
     ) -> None:
         self._store = store
-        self._compatibility_state = compatibility_state
+        self._runtime_state = runtime_state
         self._stop_event = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
         self._closed = False
@@ -101,10 +101,10 @@ class WorkshopPostRunEffectService:
     async def open_and_start(
         cls,
         database_path: Path,
-        compatibility_state: WorkshopCompatibilityStateWriter,
+        runtime_state: WorkshopRuntimeStateWriter,
     ) -> WorkshopPostRunEffectService:
         store = await WorkshopEventStore.open(database_path)
-        service = cls(store, compatibility_state)
+        service = cls(store, runtime_state)
         try:
             await store.connection.execute(
                 "UPDATE workshop_post_run_effects SET status = 'pending', "
@@ -216,7 +216,7 @@ class WorkshopPostRunEffectService:
                 or run.result_message_id != effect.result_message_id
             ):
                 raise RuntimeError("Post-run effect no longer matches one successful canonical run")
-            profile_state = self._compatibility_state.for_profile(effect.runtime_profile_id)
+            profile_state = self._runtime_state.for_profile(effect.runtime_profile_id)
             if await profile_state.has_memory_for_run(str(effect.run_id)):
                 await self._settle(effect.run_id)
                 return

--- a/src/kai/workshop/runtime_key_cutover.py
+++ b/src/kai/workshop/runtime_key_cutover.py
@@ -113,7 +113,9 @@ async def _inventory(
             "AND membership.role = 'owner' AND membership.principal_id = subscription.principal_id",
             (runtime_profile_id,),
         ) as cursor:
-            github = int((await cursor.fetchone())[0])
+            github_row = await cursor.fetchone()
+        assert github_row is not None
+        github = int(github_row[0])
         return (0, 0, 0, 0, 0, github, 0, 0)
 
     async with connection.execute(
@@ -137,7 +139,9 @@ async def _inventory(
             "Canonical execution and operational migrations must complete before runtime-key cutover"
         )
     async with connection.execute("SELECT COUNT(*) FROM sessions WHERE chat_id = ?", (legacy_key,)) as cursor:
-        session_rows = int((await cursor.fetchone())[0])
+        session_row = await cursor.fetchone()
+    assert session_row is not None
+    session_rows = int(session_row[0])
     return (
         int(execution[0]),
         int(execution[1]),

--- a/src/kai/workshop/runtime_key_cutover.py
+++ b/src/kai/workshop/runtime_key_cutover.py
@@ -1,0 +1,150 @@
+"""One-time inventory and receipt for retiring transport-shaped runtime keys."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import aiosqlite
+
+from kai.workshop.execution_state import WorkshopExecutionStateRegistry
+
+
+class WorkshopRuntimeKeyCutoverError(RuntimeError):
+    """A protected legacy-key cutover is incomplete or conflicts with authority."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopRuntimeKeyCutover:
+    profiles: int
+    newly_recorded: int
+    archived_keys: int
+
+
+async def reconcile_workshop_runtime_key_cutover(
+    connection: aiosqlite.Connection,
+    registry: WorkshopExecutionStateRegistry,
+    *,
+    memory_enabled: bool,
+) -> WorkshopRuntimeKeyCutover:
+    """Record immutable legacy inventories after every canonical migration."""
+    newly_recorded = 0
+    archived_keys = 0
+    try:
+        await connection.execute("BEGIN IMMEDIATE")
+        for namespace in registry.namespaces:
+            legacy_key = namespace.legacy_runtime_key
+            if legacy_key is not None:
+                archived_keys += 1
+            async with connection.execute(
+                "SELECT legacy_runtime_key, principal_id, channel_id, agent_id "
+                "FROM workshop_runtime_key_cutovers WHERE runtime_profile_id = ?",
+                (namespace.runtime_profile_id,),
+            ) as cursor:
+                existing = await cursor.fetchone()
+            identity = (
+                legacy_key,
+                str(namespace.principal_id),
+                str(namespace.channel_id),
+                str(namespace.agent_id),
+            )
+            if existing is not None:
+                recorded = (
+                    int(existing[0]) if existing[0] is not None else None,
+                    str(existing[1]),
+                    str(existing[2]),
+                    str(existing[3]),
+                )
+                if recorded != identity:
+                    raise WorkshopRuntimeKeyCutoverError(
+                        "Runtime-key cutover receipt conflicts with current canonical ownership"
+                    )
+                continue
+
+            counts = await _inventory(connection, str(namespace.runtime_profile_id), legacy_key)
+            if memory_enabled and legacy_key is not None and counts[7] is None:
+                raise WorkshopRuntimeKeyCutoverError(
+                    "Protected semantic-memory migration must complete before runtime-key cutover"
+                )
+            await connection.execute(
+                "INSERT INTO workshop_runtime_key_cutovers ("
+                "runtime_profile_id, legacy_runtime_key, principal_id, channel_id, agent_id, "
+                "settings_rows, workspace_rows, session_rows, lock_rows, history_rows, "
+                "grant_rows, github_rows, memory_rows"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    namespace.runtime_profile_id,
+                    legacy_key,
+                    namespace.principal_id,
+                    namespace.channel_id,
+                    namespace.agent_id,
+                    counts[0],
+                    counts[1],
+                    counts[2],
+                    0,
+                    counts[3],
+                    counts[4],
+                    counts[5],
+                    counts[7] or 0,
+                ),
+            )
+            newly_recorded += 1
+        await connection.commit()
+    except Exception:
+        await connection.rollback()
+        raise
+    return WorkshopRuntimeKeyCutover(
+        profiles=len(registry.namespaces),
+        newly_recorded=newly_recorded,
+        archived_keys=archived_keys,
+    )
+
+
+async def _inventory(
+    connection: aiosqlite.Connection,
+    runtime_profile_id: str,
+    legacy_key: int | None,
+) -> tuple[int, int, int, int, int, int, int, int | None]:
+    if legacy_key is None:
+        async with connection.execute(
+            "SELECT COUNT(*) FROM principal_github_subscriptions subscription "
+            "JOIN channel_agent_runtime_assignments assignment "
+            "ON assignment.runtime_profile_id = ? "
+            "JOIN channel_memberships membership ON membership.channel_id = assignment.channel_id "
+            "AND membership.role = 'owner' AND membership.principal_id = subscription.principal_id",
+            (runtime_profile_id,),
+        ) as cursor:
+            github = int((await cursor.fetchone())[0])
+        return (0, 0, 0, 0, 0, github, 0, 0)
+
+    async with connection.execute(
+        "SELECT settings_count, workspace_settings_count, history_count, grants_count "
+        "FROM workshop_execution_state_migrations WHERE runtime_profile_id = ?",
+        (runtime_profile_id,),
+    ) as cursor:
+        execution = await cursor.fetchone()
+    async with connection.execute(
+        "SELECT github_subscription_count FROM workshop_operational_state_migrations WHERE runtime_profile_id = ?",
+        (runtime_profile_id,),
+    ) as cursor:
+        github = await cursor.fetchone()
+    async with connection.execute(
+        "SELECT total_count FROM workshop_memory_authority_migrations WHERE runtime_profile_id = ?",
+        (runtime_profile_id,),
+    ) as cursor:
+        memory = await cursor.fetchone()
+    if execution is None or github is None:
+        raise WorkshopRuntimeKeyCutoverError(
+            "Canonical execution and operational migrations must complete before runtime-key cutover"
+        )
+    async with connection.execute("SELECT COUNT(*) FROM sessions WHERE chat_id = ?", (legacy_key,)) as cursor:
+        session_rows = int((await cursor.fetchone())[0])
+    return (
+        int(execution[0]),
+        int(execution[1]),
+        session_rows,
+        int(execution[2]),
+        int(execution[3]),
+        int(github[0]),
+        0,
+        int(memory[0]) if memory is not None else None,
+    )

--- a/src/kai/workshop/runtime_pool.py
+++ b/src/kai/workshop/runtime_pool.py
@@ -38,6 +38,10 @@ class WorkshopRuntimePool:
         """Resolve the protected profile without exposing compatibility lookup."""
         return self._profiles.resolve(runtime_profile_id)
 
+    def legacy_runtime_key(self, runtime_profile_id: str | RuntimeProfileId) -> int | None:
+        """Return migration-only state for the temporary cutover coordinator."""
+        return self._profiles.legacy_runtime_key(runtime_profile_id)
+
     async def prepare_execution(
         self,
         runtime_profile_id: str | RuntimeProfileId,

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -18,6 +18,7 @@ from kai.config import (
     BACKEND_PROVIDERS,
     VALID_BACKENDS,
     Config,
+    ModelRole,
     UserConfig,
     _read_protected_file,
     canonicalize_model_for_backend,
@@ -29,12 +30,12 @@ from kai.config import (
 from kai.workshop.domain import RuntimeProfileId
 
 _PROFILE_DERIVATION_DOMAIN = b"kai-workshop-runtime-profile:v1\0"
-_COMPATIBILITY_KEY_DERIVATION_DOMAIN = b"kai-workshop-runtime-compatibility-key:v1\0"
-
+_V1_LEGACY_KEY_DERIVATION_DOMAIN = b"kai-workshop-runtime-compatibility-key:v1\0"
 DEFAULT_RUNTIME_PROFILES_YAML = Path("/etc/kai/runtime-profiles.yaml")
 RUNTIME_PROFILES_YAML_ENV = "KAI_RUNTIME_PROFILES_YAML"
 INSTALL_DIR_ENV = "KAI_INSTALL_DIR"
 _OS_USER_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+RUNTIME_KEY_ARCHIVE_REMOVAL_GATE = "canonical_runtime_state_v1"
 
 
 class WorkshopRuntimeProfileError(RuntimeError):
@@ -45,15 +46,12 @@ class WorkshopRuntimeProfileError(RuntimeError):
 class ProtectedRuntimeProfile:
     """One operator-configured execution identity behind an opaque ID.
 
-    ``runtime_config_id`` is deliberately private compatibility state. The
-    current host runtime still stores settings, files, memory, and subprocess
-    instances under an integer key. It is not a transport identity and new
-    profiles derive it from the opaque profile ID. Canonical Workshop callers
-    see only ``profile_id``.
+    Live execution policy contains no transport-shaped identity.  Integer keys
+    retained solely for one-time installed-state migration live in the
+    registry's explicit legacy archive, never on this object.
     """
 
     profile_id: RuntimeProfileId
-    runtime_config_id: int
     display_name: str
     os_user: str | None
     backend: str
@@ -64,6 +62,11 @@ class ProtectedRuntimeProfile:
     home_workspace: Path | None
     workspace_base: Path | None
     allowed_workspaces: tuple[Path, ...]
+    role_models: tuple[tuple[str, str], ...] = ()
+    github_repos: tuple[str, ...] = ()
+    pr_review: bool | None = None
+    issue_triage: bool | None = None
+    allowed_triage_projects: tuple[str, ...] = ()
 
 
 def _compatibility_model(
@@ -184,14 +187,14 @@ def runtime_profile_id_for_config_id(runtime_config_id: int) -> RuntimeProfileId
     return RuntimeProfileId(f"rtp_{digest}")
 
 
-def compatibility_runtime_config_id_for_profile_id(profile_id: RuntimeProfileId) -> int:
-    """Derive non-transport compatibility storage for a new profile.
+def legacy_runtime_key_for_v1_profile_id(profile_id: RuntimeProfileId) -> int:
+    """Derive the state key used by version-1 policies that omitted one.
 
-    The high bit remains clear so the result fits SQLite's signed INTEGER.
-    Existing migrated profiles carry their former positive key explicitly;
-    newly authored profiles need no Telegram-shaped value.
+    This exists only so the installer can preserve access to already-written
+    state while upgrading that historical policy shape into the explicit
+    legacy archive.  Live version-2 policy never derives or consumes it.
     """
-    digest = hashlib.sha256(_COMPATIBILITY_KEY_DERIVATION_DOMAIN + str(profile_id).encode("ascii")).digest()
+    digest = hashlib.sha256(_V1_LEGACY_KEY_DERIVATION_DOMAIN + str(profile_id).encode("ascii")).digest()
     return int.from_bytes(digest[:8], "big") & ((1 << 63) - 1) or 1
 
 
@@ -201,12 +204,12 @@ def runtime_profiles_path() -> Path:
     return Path(override) if override else DEFAULT_RUNTIME_PROFILES_YAML
 
 
-def _positive_compatibility_key(value: object, *, profile_id: RuntimeProfileId) -> int:
+def _positive_legacy_key(value: object, *, profile_id: RuntimeProfileId) -> int:
     if value is None:
-        return compatibility_runtime_config_id_for_profile_id(profile_id)
+        return legacy_runtime_key_for_v1_profile_id(profile_id)
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         raise WorkshopRuntimeProfileError(
-            f"Runtime profile {profile_id}: compatibility_runtime_config_id must be a positive integer"
+            f"Runtime profile {profile_id}: archived runtime key must be a positive integer"
         )
     return value
 
@@ -228,22 +231,36 @@ def _policy_text(path: Path) -> str:
 class WorkshopRuntimeProfileRegistry:
     """Resolve canonical profiles only through protected operator policy."""
 
-    def __init__(self, profiles: tuple[ProtectedRuntimeProfile, ...]) -> None:
+    def __init__(
+        self,
+        profiles: tuple[ProtectedRuntimeProfile, ...],
+        *,
+        legacy_runtime_keys: Mapping[RuntimeProfileId, int] | None = None,
+        legacy_archive_removal_gate: str | None = None,
+    ) -> None:
         by_id: dict[RuntimeProfileId, ProtectedRuntimeProfile] = {}
-        by_config_id: dict[int, ProtectedRuntimeProfile] = {}
         for profile in profiles:
             if not isinstance(profile, ProtectedRuntimeProfile):
                 raise TypeError("profiles must contain ProtectedRuntimeProfile values")
             if profile.profile_id in by_id:
                 raise WorkshopRuntimeProfileError("Duplicate runtime profile ID")
-            if profile.runtime_config_id in by_config_id:
-                raise WorkshopRuntimeProfileError("Duplicate runtime compatibility configuration ID")
             by_id[profile.profile_id] = profile
-            by_config_id[profile.runtime_config_id] = profile
         if not by_id:
             raise WorkshopRuntimeProfileError("At least one protected runtime profile is required")
+        archived_by_profile: dict[RuntimeProfileId, int] = {}
+        archived_by_key: dict[int, RuntimeProfileId] = {}
+        for profile_id, legacy_key in (legacy_runtime_keys or {}).items():
+            if profile_id not in by_id:
+                raise WorkshopRuntimeProfileError("Legacy runtime archive references an unknown profile")
+            checked = _positive_legacy_key(legacy_key, profile_id=profile_id)
+            if checked in archived_by_key:
+                raise WorkshopRuntimeProfileError("Legacy runtime archive contains a duplicate integer key")
+            archived_by_profile[profile_id] = checked
+            archived_by_key[checked] = profile_id
         self._by_id = by_id
-        self._by_config_id = by_config_id
+        self._legacy_runtime_keys = archived_by_profile
+        self._profiles_by_legacy_key = archived_by_key
+        self._legacy_archive_removal_gate = legacy_archive_removal_gate
 
     @classmethod
     def from_config(cls, config: Config) -> WorkshopRuntimeProfileRegistry:
@@ -253,14 +270,15 @@ class WorkshopRuntimeProfileRegistry:
         for direct/dev runs and focused tests with no installed policy file.
         """
         profiles: list[ProtectedRuntimeProfile] = []
+        legacy_runtime_keys: dict[RuntimeProfileId, int] = {}
         for runtime_config_id, user in sorted(config.user_configs.items()):
             if user.telegram_id != runtime_config_id:
                 raise WorkshopRuntimeProfileError("Configured-user key does not match its protected user record")
             backend, provider = get_user_backend_and_provider(user, config)
+            profile_id = runtime_profile_id_for_config_id(runtime_config_id)
             profiles.append(
                 ProtectedRuntimeProfile(
-                    profile_id=runtime_profile_id_for_config_id(runtime_config_id),
-                    runtime_config_id=runtime_config_id,
+                    profile_id=profile_id,
                     display_name=user.name,
                     os_user=user.os_user,
                     backend=backend,
@@ -271,9 +289,15 @@ class WorkshopRuntimeProfileRegistry:
                     home_workspace=user.home_workspace,
                     workspace_base=user.workspace_base,
                     allowed_workspaces=tuple(user.allowed_workspaces),
+                    role_models=tuple(sorted((user.models or {}).items())),
+                    github_repos=tuple(user.github_repos),
+                    pr_review=user.pr_review,
+                    issue_triage=user.issue_triage,
+                    allowed_triage_projects=tuple(user.allowed_triage_projects),
                 )
             )
-        return cls(tuple(profiles))
+            legacy_runtime_keys[profile_id] = runtime_config_id
+        return cls(tuple(profiles), legacy_runtime_keys=legacy_runtime_keys)
 
     @classmethod
     def from_document(
@@ -285,14 +309,17 @@ class WorkshopRuntimeProfileRegistry:
         """Parse and validate one versioned runtime-policy document."""
         if not isinstance(document, dict):
             raise WorkshopRuntimeProfileError("Runtime policy must be a YAML mapping")
-        if document.get("version") != 1:
-            raise WorkshopRuntimeProfileError("Runtime policy version must be 1")
+        version = document.get("version")
+        if version not in {1, 2}:
+            raise WorkshopRuntimeProfileError("Runtime policy version must be 1 or 2")
         raw_profiles = document.get("runtime_profiles")
         if not isinstance(raw_profiles, dict) or not raw_profiles:
             raise WorkshopRuntimeProfileError("Runtime policy must contain a non-empty runtime_profiles mapping")
 
         installed = backend_registry
         profiles: list[ProtectedRuntimeProfile] = []
+        legacy_runtime_keys: dict[RuntimeProfileId, int] = {}
+        archive_removal_gate: str | None = None
         for raw_profile_id, raw_profile in raw_profiles.items():
             try:
                 profile_id = RuntimeProfileId(str(raw_profile_id))
@@ -347,13 +374,61 @@ class WorkshopRuntimeProfileRegistry:
             os_user = None if raw_os_user is None else str(raw_os_user).strip() or None
             if os_user is not None and _OS_USER_RE.fullmatch(os_user) is None:
                 raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: os_user is invalid")
+            raw_role_models = raw_profile.get("models", {})
+            if not isinstance(raw_role_models, dict):
+                raise WorkshopRuntimeProfileError(f"Runtime profile {profile_id}: models must be a mapping")
+            role_models: list[tuple[str, str]] = []
+            for raw_role, raw_role_model in raw_role_models.items():
+                role = str(raw_role).strip().lower()
+                if role not in {item.value for item in ModelRole}:
+                    raise WorkshopRuntimeProfileError(
+                        f"Runtime profile {profile_id}: unsupported model role {raw_role!r}"
+                    )
+                role_model = canonicalize_model_for_backend(str(raw_role_model).strip(), backend)
+                if not validate_model_for_backend_policy(
+                    role_model,
+                    backend,
+                    provider,
+                    allowed_models=allowed_models,
+                ):
+                    raise WorkshopRuntimeProfileError(
+                        f"Runtime profile {profile_id}: role model {role_model!r} is invalid for {backend}/{provider}"
+                    )
+                role_models.append((role, role_model))
+            raw_triage_projects = raw_profile.get("allowed_triage_projects", [])
+            if not isinstance(raw_triage_projects, list):
+                raise WorkshopRuntimeProfileError(
+                    f"Runtime profile {profile_id}: allowed_triage_projects must be a list"
+                )
+            triage_projects: list[str] = []
+            for raw_project in raw_triage_projects:
+                project = str(raw_project).strip()
+                if not project or project == "*":
+                    raise WorkshopRuntimeProfileError(
+                        f"Runtime profile {profile_id}: allowed triage project {raw_project!r} is invalid"
+                    )
+                if project not in triage_projects:
+                    triage_projects.append(project)
+            raw_github_repos = raw_profile.get("github_repos", [])
+            if not isinstance(raw_github_repos, list) or any(
+                not isinstance(item, str) or not item.strip() for item in raw_github_repos
+            ):
+                raise WorkshopRuntimeProfileError(
+                    f"Runtime profile {profile_id}: github_repos must be a list of repositories"
+                )
+            raw_pr_review = raw_profile.get("pr_review")
+            raw_issue_triage = raw_profile.get("issue_triage")
+            if raw_pr_review is not None and not isinstance(raw_pr_review, bool):
+                raise WorkshopRuntimeProfileError(
+                    f"Runtime profile {profile_id}: pr_review must be true, false, or null"
+                )
+            if raw_issue_triage is not None and not isinstance(raw_issue_triage, bool):
+                raise WorkshopRuntimeProfileError(
+                    f"Runtime profile {profile_id}: issue_triage must be true, false, or null"
+                )
             profiles.append(
                 ProtectedRuntimeProfile(
                     profile_id=profile_id,
-                    runtime_config_id=_positive_compatibility_key(
-                        raw_profile.get("compatibility_runtime_config_id"),
-                        profile_id=profile_id,
-                    ),
                     display_name=display_name,
                     os_user=os_user,
                     backend=backend,
@@ -378,9 +453,50 @@ class WorkshopRuntimeProfileRegistry:
                         raw_profile.get("allowed_workspaces"),
                         profile_id=profile_id,
                     ),
+                    role_models=tuple(sorted(role_models)),
+                    github_repos=tuple(sorted({item.strip().lower() for item in raw_github_repos})),
+                    pr_review=raw_pr_review,
+                    issue_triage=raw_issue_triage,
+                    allowed_triage_projects=tuple(triage_projects),
                 )
             )
-        return cls(tuple(profiles))
+            if version == 1:
+                legacy_runtime_keys[profile_id] = _positive_legacy_key(
+                    raw_profile.get("compatibility_runtime_config_id"),
+                    profile_id=profile_id,
+                )
+
+        if version == 2:
+            raw_archive = document.get("legacy_runtime_archive")
+            if raw_archive is not None:
+                if not isinstance(raw_archive, dict):
+                    raise WorkshopRuntimeProfileError("legacy_runtime_archive must be a mapping")
+                if raw_archive.get("version") != 1:
+                    raise WorkshopRuntimeProfileError("legacy_runtime_archive version must be 1")
+                archive_removal_gate = str(raw_archive.get("removal_gate") or "").strip()
+                if archive_removal_gate != RUNTIME_KEY_ARCHIVE_REMOVAL_GATE:
+                    raise WorkshopRuntimeProfileError(
+                        "legacy_runtime_archive removal_gate must be canonical_runtime_state_v1"
+                    )
+                raw_keys = raw_archive.get("runtime_keys")
+                if not isinstance(raw_keys, dict):
+                    raise WorkshopRuntimeProfileError("legacy_runtime_archive.runtime_keys must be a mapping")
+                for raw_profile_id, raw_key in raw_keys.items():
+                    try:
+                        archived_profile_id = RuntimeProfileId(str(raw_profile_id))
+                    except (TypeError, ValueError) as exc:
+                        raise WorkshopRuntimeProfileError(
+                            f"Invalid archived runtime profile ID {raw_profile_id!r}"
+                        ) from exc
+                    legacy_runtime_keys[archived_profile_id] = _positive_legacy_key(
+                        raw_key,
+                        profile_id=archived_profile_id,
+                    )
+        return cls(
+            tuple(profiles),
+            legacy_runtime_keys=legacy_runtime_keys,
+            legacy_archive_removal_gate=archive_removal_gate,
+        )
 
     @classmethod
     def from_yaml(
@@ -438,11 +554,27 @@ class WorkshopRuntimeProfileRegistry:
             raise WorkshopRuntimeProfileError("Runtime profile is not present in protected operator policy")
         return profile
 
-    def for_config_id(self, runtime_config_id: int) -> ProtectedRuntimeProfile:
-        profile = self._by_config_id.get(runtime_config_id)
-        if profile is None:
-            raise WorkshopRuntimeProfileError("Configured user has no protected runtime profile")
-        return profile
+    @property
+    def legacy_runtime_archive(self) -> tuple[tuple[RuntimeProfileId, int], ...]:
+        """Return explicit rollback/migration keys, never live runtime policy."""
+        return tuple(sorted(self._legacy_runtime_keys.items(), key=lambda item: item[0]))
+
+    @property
+    def legacy_archive_removal_gate(self) -> str | None:
+        """Return the explicit operator gate protecting archive removal."""
+        return self._legacy_archive_removal_gate
+
+    def legacy_runtime_key(self, profile_id: str | RuntimeProfileId) -> int | None:
+        """Return one archived pre-canonical key for migration-only callers."""
+        profile = self.resolve(profile_id)
+        return self._legacy_runtime_keys.get(profile.profile_id)
+
+    def profile_for_legacy_runtime_key(self, legacy_key: int) -> ProtectedRuntimeProfile:
+        """Translate an adapter/migration key at the canonical boundary."""
+        profile_id = self._profiles_by_legacy_key.get(legacy_key)
+        if profile_id is None:
+            raise WorkshopRuntimeProfileError("Legacy runtime key has no protected runtime profile")
+        return self._by_id[profile_id]
 
     def validate_protected_os_users(
         self,

--- a/src/kai/workshop/runtime_state.py
+++ b/src/kai/workshop/runtime_state.py
@@ -1,4 +1,4 @@
-"""Profile-addressed writes to Kai's remaining compatibility state."""
+"""Canonical mutable state addressed by protected Workshop runtime profile."""
 
 from __future__ import annotations
 
@@ -9,37 +9,29 @@ from kai import sessions
 from kai.config import Config
 from kai.conversation_compatibility import ingest_conversation_memory
 from kai.workshop.domain import CanonicalMemoryProvenance, RuntimeProfileId
+from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.runtime_profiles import ProtectedRuntimeProfile
 
 
 @dataclass(frozen=True, slots=True)
-class WorkshopProfileCompatibilityState:
-    """Write existing state for one protected runtime profile.
+class WorkshopProfileRuntimeState:
+    """Canonical state and policy for one protected runtime profile."""
 
-    The integer key is deliberately private to this adapter. Remaining
-    compatibility calls retain it; the semantic-memory boundary resolves it
-    to the canonical principal and rejects legacy-owner reads. Canonical
-    Workshop callers address this state only through a runtime profile.
-    """
-
-    _runtime_config_id: int = field(repr=False)
+    _profile: ProtectedRuntimeProfile = field(repr=False)
+    _principal_id: str = field(repr=False)
     _config: Config = field(repr=False)
-    _backend: str = field(repr=False)
 
     @property
     def memory_context_turns(self) -> int:
-        """Return the configured canonical episode-context window."""
         return self._config.episode_classifier_context_turns
 
     async def github_token(self) -> str | None:
-        """Read the transitional protected token without exposing its integer key."""
-        return await sessions.get_setting(f"github_token:{self._runtime_config_id}")
+        return await sessions.get_canonical_github_token(self._principal_id)
 
     @property
     def allowed_triage_projects(self) -> tuple[str, ...]:
-        """Return operator-controlled project mutation policy for this runtime."""
-        user = self._config.get_user_config(self._runtime_config_id)
-        return tuple(user.allowed_triage_projects) if user is not None else ()
+        return self._profile.allowed_triage_projects
 
     async def ingest_memory(
         self,
@@ -51,11 +43,12 @@ class WorkshopProfileCompatibilityState:
         canonical_provenance: CanonicalMemoryProvenance,
         canonical_prior_pairs: tuple[tuple[str, str], ...],
     ) -> None:
-        """Complete one core-owned canonical post-run memory effect."""
         await ingest_conversation_memory(
             prompt=prompt,
             assistant_text=assistant_text,
-            chat_id=self._runtime_config_id,
+            chat_id=None,
+            canonical_user_id=self._principal_id,
+            runtime_profile_id=str(self._profile.profile_id),
             session_id=session_id,
             config=self._config,
             workspace=workspace,
@@ -63,39 +56,44 @@ class WorkshopProfileCompatibilityState:
             assistant_log=None,
             canonical_provenance=canonical_provenance,
             canonical_prior_pairs=canonical_prior_pairs,
-            effective_backend=self._backend,
+            effective_backend=self._profile.backend,
+            effective_provider=self._profile.provider,
+            os_user_override=self._profile.os_user,
         )
 
     async def has_memory_for_run(self, run_id: str) -> bool:
-        """Detect a committed canonical memory effect after interrupted settlement."""
         from kai import memory
 
         memories = await asyncio.to_thread(
             memory.get_all,
-            user_id=str(self._runtime_config_id),
+            user_id=self._principal_id,
+            runtime_profile_id=str(self._profile.profile_id),
             limit=None,
         )
         return any(str(item.metadata.get(memory.WORKSHOP_RUN_ID_KEY, "")) == run_id for item in memories)
 
 
-class WorkshopCompatibilityStateWriter:
-    """Bind protected runtime profiles to unchanged compatibility stores."""
+class WorkshopRuntimeStateWriter:
+    """Bind opaque runtime profiles to canonical principal-owned state."""
 
     def __init__(
         self,
         config: Config,
         runtime_pool: WorkshopRuntimePool,
+        execution_state: WorkshopExecutionStateRegistry,
     ) -> None:
         self._config = config
         self._runtime_pool = runtime_pool
+        self._execution_state = execution_state
 
     def for_profile(
         self,
         runtime_profile_id: str | RuntimeProfileId,
-    ) -> WorkshopProfileCompatibilityState:
+    ) -> WorkshopProfileRuntimeState:
         profile = self._runtime_pool.runtime_profile(runtime_profile_id)
-        return WorkshopProfileCompatibilityState(
-            profile.runtime_config_id,
+        namespace = self._execution_state.resolve_profile(profile.profile_id)
+        return WorkshopProfileRuntimeState(
+            profile,
+            str(namespace.principal_id),
             self._config,
-            profile.backend,
         )

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 32
+WORKSHOP_SCHEMA_VERSION = 33
 
 
 @dataclass(frozen=True, slots=True)
@@ -1634,6 +1634,42 @@ _DURABLE_POST_RUN_EFFECT_RECEIPTS_SCHEMA = SchemaMigration(
     ),
 )
 
+_CANONICAL_RUNTIME_KEYS_SCHEMA = SchemaMigration(
+    version=33,
+    name="canonical_runtime_keys",
+    statements=(
+        "ALTER TABLE principal_github_subscriptions ADD COLUMN github_token TEXT",
+        "ALTER TABLE principal_github_subscriptions ADD COLUMN allowed_triage_projects_json TEXT NOT NULL DEFAULT '[]'",
+        """
+        CREATE TABLE workshop_runtime_key_cutovers (
+            runtime_profile_id TEXT PRIMARY KEY CHECK (
+                length(runtime_profile_id) BETWEEN 1 AND 128
+            ),
+            legacy_runtime_key INTEGER UNIQUE CHECK (
+                legacy_runtime_key IS NULL OR legacy_runtime_key > 0
+            ),
+            principal_id TEXT NOT NULL,
+            channel_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            settings_rows INTEGER NOT NULL CHECK (settings_rows >= 0),
+            workspace_rows INTEGER NOT NULL CHECK (workspace_rows >= 0),
+            session_rows INTEGER NOT NULL CHECK (session_rows >= 0),
+            lock_rows INTEGER NOT NULL CHECK (lock_rows >= 0),
+            history_rows INTEGER NOT NULL CHECK (history_rows >= 0),
+            grant_rows INTEGER NOT NULL CHECK (grant_rows >= 0),
+            github_rows INTEGER NOT NULL CHECK (github_rows >= 0),
+            memory_rows INTEGER NOT NULL CHECK (memory_rows >= 0),
+            legacy_reads_disabled INTEGER NOT NULL DEFAULT 1 CHECK (
+                legacy_reads_disabled = 1
+            ),
+            cutover_at TEXT NOT NULL DEFAULT (
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+        )
+        """,
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1667,6 +1703,7 @@ _MIGRATIONS = (
     _ADAPTER_PLUGGABLE_DELIVERY_SCHEMA,
     _CANONICAL_POST_RUN_EFFECTS_SCHEMA,
     _DURABLE_POST_RUN_EFFECT_RECEIPTS_SCHEMA,
+    _CANONICAL_RUNTIME_KEYS_SCHEMA,
 )
 
 

--- a/src/kai/workshop/storage_namespaces.py
+++ b/src/kai/workshop/storage_namespaces.py
@@ -19,7 +19,7 @@ class WorkshopChannelHistoryNamespace:
     """One canonical channel's transitional transcript namespace."""
 
     channel_id: ChannelId
-    _legacy_chat_id: int = field(repr=False)
+    _legacy_chat_id: int | None = field(repr=False)
 
     def history_directory(self, data_dir: Path) -> Path:
         """Return the transport-independent conversation-history directory."""
@@ -27,6 +27,8 @@ class WorkshopChannelHistoryNamespace:
 
     def legacy_history_directory(self, data_dir: Path) -> Path:
         """Return the prior transport-keyed history directory during migration."""
+        if self._legacy_chat_id is None:
+            raise WorkshopStorageNamespaceError("Channel has no legacy history archive")
         return data_dir / "history" / str(self._legacy_chat_id)
 
 
@@ -52,11 +54,14 @@ class WorkshopChannelHistoryRegistry:
                 raise TypeError("namespaces must contain WorkshopChannelHistoryNamespace values")
             if namespace.channel_id in by_channel:
                 raise WorkshopStorageNamespaceError("Duplicate channel history namespace")
-            existing = by_compatibility_id.get(namespace._legacy_chat_id)
+            existing = (
+                by_compatibility_id.get(namespace._legacy_chat_id) if namespace._legacy_chat_id is not None else None
+            )
             if existing is not None and existing.channel_id != namespace.channel_id:
                 raise WorkshopStorageNamespaceError("Compatibility chat ID maps to multiple channels")
             by_channel[namespace.channel_id] = namespace
-            by_compatibility_id[namespace._legacy_chat_id] = namespace
+            if namespace._legacy_chat_id is not None:
+                by_compatibility_id[namespace._legacy_chat_id] = namespace
         for compatibility_id, channel_id in (runtime_aliases or {}).items():
             namespace = by_channel.get(channel_id)
             if namespace is None:
@@ -120,12 +125,14 @@ class WorkshopChannelHistoryRegistry:
             channel_id = channel_by_profile.get(profile.profile_id)
             if channel_id is None:
                 raise WorkshopStorageNamespaceError("Protected runtime profile has no canonical history channel")
-            runtime_aliases[profile.runtime_config_id] = channel_id
+            legacy_runtime_key = runtime_profiles.legacy_runtime_key(profile.profile_id)
+            if legacy_runtime_key is not None:
+                runtime_aliases[legacy_runtime_key] = channel_id
             if channel_id not in namespace_channels:
                 namespaces.append(
                     WorkshopChannelHistoryNamespace(
                         channel_id,
-                        profile.runtime_config_id,
+                        legacy_runtime_key,
                     )
                 )
                 namespace_channels.add(channel_id)
@@ -150,7 +157,7 @@ class WorkshopPrincipalStorageNamespace:
 
     principal_id: PrincipalId
     runtime_profile_id: RuntimeProfileId
-    _runtime_config_id: int = field(repr=False)
+    _legacy_runtime_key: int | None = field(repr=False)
 
     def files_directory(self, data_dir: Path) -> Path:
         """Return the transport-independent upload directory."""
@@ -158,7 +165,9 @@ class WorkshopPrincipalStorageNamespace:
 
     def legacy_files_directory(self, data_dir: Path) -> Path:
         """Return the prior configured-user directory during migration."""
-        return data_dir / "files" / str(self._runtime_config_id)
+        if self._legacy_runtime_key is None:
+            raise WorkshopStorageNamespaceError("Principal has no legacy files archive")
+        return data_dir / "files" / str(self._legacy_runtime_key)
 
     def home_directory(self, data_dir: Path) -> Path:
         """Return the transport-independent managed home directory."""
@@ -187,10 +196,11 @@ class WorkshopPrincipalStorageRegistry:
                 raise TypeError("namespaces must contain WorkshopPrincipalStorageNamespace values")
             if namespace.runtime_profile_id in by_profile:
                 raise WorkshopStorageNamespaceError("Duplicate runtime profile storage namespace")
-            if namespace._runtime_config_id in by_config_id:
-                raise WorkshopStorageNamespaceError("Duplicate runtime configuration storage namespace")
+            if namespace._legacy_runtime_key is not None and namespace._legacy_runtime_key in by_config_id:
+                raise WorkshopStorageNamespaceError("Duplicate archived runtime storage key")
             by_profile[namespace.runtime_profile_id] = namespace
-            by_config_id[namespace._runtime_config_id] = namespace
+            if namespace._legacy_runtime_key is not None:
+                by_config_id[namespace._legacy_runtime_key] = namespace
         if not by_profile:
             raise WorkshopStorageNamespaceError("At least one principal storage namespace is required")
         self._by_profile = by_profile
@@ -235,7 +245,7 @@ class WorkshopPrincipalStorageRegistry:
                 WorkshopPrincipalStorageNamespace(
                     next(iter(owners)),
                     profile.profile_id,
-                    profile.runtime_config_id,
+                    runtime_profiles.legacy_runtime_key(profile.profile_id),
                 )
             )
         return cls(tuple(namespaces))

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -240,7 +240,11 @@ def host_dependencies(monkeypatch):
         _FakeIntegrationNotifications,
     )
     monkeypatch.setattr(host_module, "WorkshopGitHubAutomationService", _FakeGitHubAutomation)
-    monkeypatch.setattr(host_module, "WorkshopCompatibilityStateWriter", lambda config, pool: (config, pool))
+    monkeypatch.setattr(
+        host_module,
+        "WorkshopRuntimeStateWriter",
+        lambda config, pool, execution_state: (config, pool, execution_state),
+    )
     monkeypatch.setattr(
         host_module,
         "WorkshopSettingsWorkspaceService",
@@ -285,7 +289,7 @@ def _execution_state(principal_id: PrincipalId, runtime_config_id: int):
                 channel_id=ChannelId(f"chn_{runtime_config_id:032x}"),
                 agent_id=AgentId(f"agt_{runtime_config_id:032x}"),
                 runtime_profile_id=profile_id(runtime_config_id),
-                runtime_config_id=runtime_config_id,
+                legacy_runtime_key=runtime_config_id,
             ),
         )
     )
@@ -475,7 +479,7 @@ async def test_real_core_lifecycle_uses_workshop_identity_without_telegram_appli
                     channel_id=context.channel_id,
                     agent_id=context.agent_id,
                     runtime_profile_id=context.runtime_profile_id,
-                    runtime_config_id=101,
+                    legacy_runtime_key=101,
                 ),
             )
         ),
@@ -575,7 +579,7 @@ async def test_core_activates_delivery_authority_before_recovering_expired_start
                     channel_id=context.channel_id,
                     agent_id=context.agent_id,
                     runtime_profile_id=context.runtime_profile_id,
-                    runtime_config_id=101,
+                    legacy_runtime_key=101,
                 ),
             )
         ),

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3780,7 +3780,7 @@ class TestHandleSettings:
         update = _make_update(text="/settings")
         config = _make_config(protected_install=True)
         pool = _make_mock_claude()
-        pool.get_runtime_profile.return_value = profile_registry(12345).for_config_id(12345)
+        pool.get_runtime_profile.return_value = profile_registry(12345).profile_for_legacy_runtime_key(12345)
         pool.get_backend_provider.return_value = ("codex", "openai")
         ctx = _make_context(config=config, pool=pool)
         mock_sessions = self._mock_sessions({"model": "opus"})
@@ -4181,7 +4181,7 @@ class TestHandleGitHub:
         with patch("kai.bot.sessions", mock_sessions):
             await handle_github(update, ctx)
 
-        mock_sessions.set_setting.assert_called_once_with("github_token:12345", "ghp_secret")
+        mock_sessions.set_github_token.assert_called_once_with(12345, "ghp_secret")
         update.message.delete.assert_awaited_once()
         reply = update.message.reply_text.call_args[0][0]
         assert "stored" in reply.lower()
@@ -4194,12 +4194,12 @@ class TestHandleGitHub:
         config = _make_config()
         ctx = _make_context(config=config, args=["token", "ghp_secret"])
         mock_sessions = AsyncMock()
-        mock_sessions.set_setting = AsyncMock()
+        mock_sessions.set_github_token = AsyncMock()
 
         with patch("kai.bot.sessions", mock_sessions):
             await handle_github(update, ctx)
 
-        mock_sessions.set_setting.assert_called_once_with("github_token:12345", "ghp_secret")
+        mock_sessions.set_github_token.assert_called_once_with(12345, "ghp_secret")
         update.message.delete.assert_awaited_once()
         reply = update.message.reply_text.call_args[0][0]
         assert "stored" in reply.lower()

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -2299,10 +2299,14 @@ class TestSendLock:
             # Wrap _send_locked to check if the lock is held when it runs
             original = claude._send_locked
 
-            async def checking_send(prompt, chat_id=None):
+            async def checking_send(prompt, chat_id=None, *, runtime_identity=None):
                 nonlocal lock_was_held
                 lock_was_held = claude._lock.locked()
-                async for event in original(prompt, chat_id=chat_id):
+                async for event in original(
+                    prompt,
+                    chat_id=chat_id,
+                    runtime_identity=runtime_identity,
+                ):
                     yield event
 
             with patch.object(claude, "_send_locked", checking_send):

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1600,6 +1600,7 @@ class TestImageForwarding:
         writer.assert_called_once_with(
             _anthropic_image_block(),
             chat_id=24680,
+            principal_id=None,
             reader_user="alice",
         )
 

--- a/tests/test_github_self_service.py
+++ b/tests/test_github_self_service.py
@@ -104,10 +104,10 @@ class TestHandleGithubToken:
         update = _make_update()
         mock_set = AsyncMock()
 
-        with patch("kai.bot.sessions.set_setting", mock_set):
+        with patch("kai.bot.sessions.set_github_token", mock_set):
             await _handle_github_token(update, 12345, ["ghp_abc123"])
 
-        mock_set.assert_called_once_with("github_token:12345", "ghp_abc123")
+        mock_set.assert_called_once_with(12345, "ghp_abc123")
         reply = update.message.reply_text.call_args[0][0]
         assert "stored" in reply.lower()
         # Token value must never appear in the reply
@@ -119,10 +119,10 @@ class TestHandleGithubToken:
         update = _make_update()
         mock_delete = AsyncMock()
 
-        with patch("kai.bot.sessions.delete_setting", mock_delete):
+        with patch("kai.bot.sessions.set_github_token", mock_delete):
             await _handle_github_token(update, 12345, ["clear"])
 
-        mock_delete.assert_called_once_with("github_token:12345")
+        mock_delete.assert_called_once_with(12345, None)
         reply = update.message.reply_text.call_args[0][0]
         assert "removed" in reply.lower()
 
@@ -132,7 +132,7 @@ class TestHandleGithubToken:
         update = _make_update()
         mock_delete = AsyncMock()
 
-        with patch("kai.bot.sessions.delete_setting", mock_delete):
+        with patch("kai.bot.sessions.set_github_token", mock_delete):
             await _handle_github_token(update, 12345, ["CLEAR"])
 
         mock_delete.assert_called_once()
@@ -167,7 +167,7 @@ class TestHandleGithubAdd:
             "get_github_removed_repos": AsyncMock(return_value=list(removed or [])),
             "set_github_added_repos": AsyncMock(),
             "set_github_removed_repos": AsyncMock(),
-            "get_setting": AsyncMock(return_value=token),
+            "get_github_token": AsyncMock(return_value=token),
         }
 
     @pytest.mark.asyncio
@@ -420,7 +420,7 @@ class TestHandleGithubRemove:
             "get_github_removed_repos": AsyncMock(return_value=list(removed or [])),
             "set_github_added_repos": AsyncMock(),
             "set_github_removed_repos": AsyncMock(),
-            "get_setting": AsyncMock(return_value=token),
+            "get_github_token": AsyncMock(return_value=token),
         }
 
     @pytest.mark.asyncio

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9367,6 +9367,75 @@ class TestApplySecretsDryRun:
 
 
 class TestIndependentRuntimePolicy:
+    @staticmethod
+    def _version_two_policy(profile_id: str, legacy_key: int) -> dict[str, object]:
+        return {
+            "version": 2,
+            "runtime_profiles": {
+                profile_id: {
+                    "display_name": "Protected runtime",
+                    "backend": "codex",
+                    "provider": "openai",
+                    "model": "gpt-5.6-sol",
+                    "timeout_seconds": 120,
+                    "allowed_services": [],
+                    "home_workspace": None,
+                    "workspace_base": None,
+                    "allowed_workspaces": [],
+                }
+            },
+            "legacy_runtime_archive": {
+                "version": 1,
+                "runtime_keys": {profile_id: legacy_key},
+                "removal_gate": "canonical_runtime_state_v1",
+            },
+        }
+
+    def test_runtime_key_cutover_status_reports_complete_receipt_without_identifiers(self, tmp_path):
+        profile_id = str(kai.install.runtime_profile_id_for_config_id(101))
+        policy = tmp_path / "runtime-profiles.yaml"
+        policy.write_text(yaml.safe_dump(self._version_two_policy(profile_id, 101)))
+        database = tmp_path / "kai.db"
+        with sqlite3.connect(database) as connection:
+            connection.execute(
+                "CREATE TABLE workshop_runtime_key_cutovers ("
+                "runtime_profile_id TEXT, legacy_runtime_key INTEGER, legacy_reads_disabled INTEGER)"
+            )
+            connection.execute(
+                "INSERT INTO workshop_runtime_key_cutovers VALUES (?, ?, 1)",
+                (profile_id, 101),
+            )
+
+        status = kai.install._runtime_key_cutover_status(database, policy)
+
+        assert status == (
+            "Workshop runtime-key cutover: active; profiles=1, receipts=1, "
+            "archived keys=1, missing=0, extra=0; legacy reads=disabled, "
+            "removal gate=canonical_runtime_state_v1"
+        )
+        assert profile_id not in status
+        assert "101" not in status
+
+    def test_runtime_key_cutover_status_fails_closed_on_unverified_reads(self, tmp_path):
+        profile_id = str(kai.install.runtime_profile_id_for_config_id(101))
+        policy = tmp_path / "runtime-profiles.yaml"
+        policy.write_text(yaml.safe_dump(self._version_two_policy(profile_id, 101)))
+        database = tmp_path / "kai.db"
+        with sqlite3.connect(database) as connection:
+            connection.execute(
+                "CREATE TABLE workshop_runtime_key_cutovers ("
+                "runtime_profile_id TEXT, legacy_runtime_key INTEGER, legacy_reads_disabled INTEGER)"
+            )
+            connection.execute(
+                "INSERT INTO workshop_runtime_key_cutovers VALUES (?, ?, 0)",
+                (profile_id, 101),
+            )
+
+        status = kai.install._runtime_key_cutover_status(database, policy)
+
+        assert status.startswith("Workshop runtime-key cutover: INCOMPLETE;")
+        assert "legacy reads=NOT VERIFIED" in status
+
     def test_migration_preserves_effective_workspace_policy(self, tmp_path):
         home = tmp_path / "home"
         base = tmp_path / "projects"
@@ -9515,10 +9584,14 @@ class TestIndependentRuntimePolicy:
 
         daniel_id = str(kai.install.runtime_profile_id_for_config_id(101))
         scott_id = str(kai.install.runtime_profile_id_for_config_id(202))
-        assert document["version"] == 1
+        assert document["version"] == 2
+        assert document["legacy_runtime_archive"] == {
+            "version": 1,
+            "runtime_keys": {daniel_id: 101, scott_id: 202},
+            "removal_gate": "canonical_runtime_state_v1",
+        }
         assert document["runtime_profiles"][daniel_id] == {
             "display_name": "Daniel",
-            "compatibility_runtime_config_id": 101,
             "backend": "codex",
             "provider": "openai",
             "model": "gpt-5.5",
@@ -9527,6 +9600,11 @@ class TestIndependentRuntimePolicy:
             "home_workspace": None,
             "workspace_base": None,
             "allowed_workspaces": [],
+            "models": {},
+            "github_repos": [],
+            "pr_review": None,
+            "issue_triage": None,
+            "allowed_triage_projects": [],
             "os_user": "daniel",
         }
         assert document["runtime_profiles"][scott_id]["backend"] == "claude"
@@ -9611,7 +9689,11 @@ backends:
 
         status = _runtime_policy_status(policy, backends)
 
-        assert status == ("Workshop runtime policy: initialized; profiles=1, backends=codex, runtime kernel=canonical")
+        assert status == (
+            "Workshop runtime policy: initialized; profiles=1, backends=codex, "
+            "runtime kernel=canonical, archived keys=1, "
+            "removal gate=not-applicable"
+        )
         assert "Secret display name" not in status
         assert "101" not in status
 
@@ -9738,7 +9820,7 @@ backends:
         assert document["runtime_profiles"][profile_id]["model"] == "gpt-5.6-sol"
         assert document["runtime_profiles"][profile_id]["timeout_seconds"] == 345
         assert document["runtime_profiles"][profile_id]["allowed_services"] == ["perplexity"]
-        assert profiles.resolve(profile_id).runtime_config_id == 101
+        assert profiles.legacy_runtime_key(profile_id) == 101
 
         policy.write_text(content)
         next_action, next_content, next_profiles = _runtime_policy_apply_plan(
@@ -9753,6 +9835,46 @@ backends:
         assert next_action == "preserve"
         assert next_content == content
         assert next_profiles.resolve(profile_id).allowed_services == ("perplexity",)
+
+    def test_upgrade_archives_v1_derived_runtime_key(self):
+        profile_id = RuntimeProfileId("rtp_11111111111111111111111111111111")
+        original = yaml.safe_dump(
+            {
+                "version": 1,
+                "runtime_profiles": {
+                    str(profile_id): {
+                        "display_name": "Browser-only coding",
+                        "backend": "pi",
+                        "provider": "openai-codex",
+                    }
+                },
+            },
+            sort_keys=False,
+        )
+        migrated = yaml.safe_dump(
+            {
+                "version": 2,
+                "runtime_profiles": {},
+            },
+            sort_keys=False,
+        )
+
+        upgraded, changed = kai.install._upgrade_runtime_policy_content(
+            original,
+            migrated,
+            kai.install._RuntimePolicyDefaults(
+                backend="pi",
+                provider="openai-codex",
+                model="openai-codex/gpt-5.5",
+                timeout_seconds=120,
+            ),
+        )
+
+        assert changed is True
+        archive = yaml.safe_load(upgraded)["legacy_runtime_archive"]
+        assert archive["runtime_keys"] == {
+            str(profile_id): kai.install.legacy_runtime_key_for_v1_profile_id(profile_id)
+        }
 
     def test_existing_policy_must_cover_every_migrated_profile(self, tmp_path, monkeypatch):
         users_yaml = tmp_path / "users.yaml"
@@ -9850,8 +9972,8 @@ backends:
             users_yaml,
         )
 
-        assert action == "preserve"
-        assert content == policy.read_text()
+        assert action == "upgrade"
+        assert content != policy.read_text()
         profile = profiles.resolve(profile_id)
         assert profile.display_name == "Protected Daniel runtime"
         assert profile.os_user == "protected-daniel"
@@ -13255,6 +13377,8 @@ class TestWizardPerUserBackendsUseRegistry:
 
 
 class TestProtectedRuntimeStorageProvisioning:
+    LEGACY_RUNTIME_KEY = 987654321
+
     @staticmethod
     def _profile(backend: str, *, os_user: str | None = None) -> ProtectedRuntimeProfile:
         provider = {
@@ -13267,7 +13391,6 @@ class TestProtectedRuntimeStorageProvisioning:
         model = "sonnet" if backend == "claude" else "gpt-5.5"
         return ProtectedRuntimeProfile(
             profile_id=RuntimeProfileId("rtp_" + "f" * 32),
-            runtime_config_id=987654321,
             display_name="Browser-only human",
             os_user=os_user,
             backend=backend,
@@ -13349,7 +13472,7 @@ class TestProtectedRuntimeStorageProvisioning:
             assert claude_adapter.read_text() == "@../AGENTS.md\n"
         else:
             assert not claude_adapter.exists()
-        assert not (data_path / "home" / str(profile.runtime_config_id)).exists()
+        assert not (data_path / "home" / str(self.LEGACY_RUNTIME_KEY)).exists()
 
     @pytest.mark.asyncio
     async def test_initialized_assignments_fail_closed_for_unmapped_profile(self, tmp_path):
@@ -13379,7 +13502,7 @@ class TestProtectedRuntimeStorageProvisioning:
         users_yaml = tmp_path / "users.yaml"
         profile = self._profile("codex")
         users_yaml.write_text(
-            f"users:\n  - telegram_id: {profile.runtime_config_id}\n    name: New Telegram human\n    role: member\n"
+            f"users:\n  - telegram_id: {self.LEGACY_RUNTIME_KEY}\n    name: New Telegram human\n    role: member\n"
         )
         store = await WorkshopEventStore.open(data_path / "kai.db")
         await bootstrap_default_workshop(
@@ -13394,7 +13517,10 @@ class TestProtectedRuntimeStorageProvisioning:
 
         targets = _runtime_storage_targets(
             data_path,
-            WorkshopRuntimeProfileRegistry((profile,)),
+            WorkshopRuntimeProfileRegistry(
+                (profile,),
+                legacy_runtime_keys={profile.profile_id: self.LEGACY_RUNTIME_KEY},
+            ),
             users_yaml,
         )
 
@@ -13402,17 +13528,16 @@ class TestProtectedRuntimeStorageProvisioning:
             bootstrap_human_principal_id(
                 workshop_id,
                 "telegram",
-                str(profile.runtime_config_id),
+                str(self.LEGACY_RUNTIME_KEY),
             )
         )
-        assert targets[0].storage_name != str(profile.runtime_config_id)
+        assert targets[0].storage_name != str(self.LEGACY_RUNTIME_KEY)
 
     def test_profiles_cannot_share_one_canonical_storage_owner(self, tmp_path, monkeypatch):
         first = self._profile("codex")
         second = replace(
             first,
             profile_id=RuntimeProfileId("rtp_" + "e" * 32),
-            runtime_config_id=123456789,
         )
         shared_principal = "prn_" + "a" * 32
         monkeypatch.setattr(
@@ -13484,13 +13609,16 @@ class TestProtectedRuntimeStorageProvisioning:
         )
         monkeypatch.setattr(
             "kai.install._canonical_principal_storage_names",
-            lambda _data_path: {str(profile.runtime_config_id): "prn_" + "b" * 32},
+            lambda _data_path: {str(self.LEGACY_RUNTIME_KEY): "prn_" + "b" * 32},
         )
 
         with pytest.raises(RuntimeError, match="conflicts with its canonical compatibility owner"):
             _runtime_storage_targets(
                 tmp_path / "data",
-                WorkshopRuntimeProfileRegistry((profile,)),
+                WorkshopRuntimeProfileRegistry(
+                    (profile,),
+                    legacy_runtime_keys={profile.profile_id: self.LEGACY_RUNTIME_KEY},
+                ),
                 users_yaml,
             )
 
@@ -13578,11 +13706,10 @@ class TestProtectedRuntimeStorageProvisioning:
         policy.write_text(
             yaml.safe_dump(
                 {
-                    "version": 1,
+                    "version": 2,
                     "runtime_profiles": {
                         str(profile.profile_id): {
                             "display_name": profile.display_name,
-                            "compatibility_runtime_config_id": profile.runtime_config_id,
                             "backend": profile.backend,
                             "provider": profile.provider,
                             "model": profile.model,
@@ -13592,6 +13719,11 @@ class TestProtectedRuntimeStorageProvisioning:
                             "workspace_base": None,
                             "allowed_workspaces": [],
                         }
+                    },
+                    "legacy_runtime_archive": {
+                        "version": 1,
+                        "runtime_keys": {},
+                        "removal_gate": "canonical_runtime_state_v1",
                     },
                 }
             )
@@ -13613,7 +13745,7 @@ class TestProtectedRuntimeStorageProvisioning:
 
         assert status == ("Workshop runtime storage: complete; profiles=1, managed=1, operator-managed=0, incomplete=0")
         assert str(profile.profile_id) not in status
-        assert str(profile.runtime_config_id) not in status
+        assert str(self.LEGACY_RUNTIME_KEY) not in status
 
         (home / "AGENTS.md").chmod(0o644)
         incomplete_status = _runtime_storage_status(
@@ -13630,7 +13762,7 @@ class TestProtectedRuntimeStorageProvisioning:
             "memory=0, preferences=0, temp=0"
         )
         assert str(profile.profile_id) not in incomplete_status
-        assert str(profile.runtime_config_id) not in incomplete_status
+        assert str(self.LEGACY_RUNTIME_KEY) not in incomplete_status
 
     def test_profile_only_os_user_is_included_in_sudoers(self, tmp_path, monkeypatch):
         profile = self._profile("codex", os_user="browser-user")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -3910,7 +3910,7 @@ class TestPrincipalOwnershipPredicate:
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=RuntimeProfileId.new(),
-            runtime_config_id=config_id,
+            legacy_runtime_key=config_id,
         )
 
     @staticmethod
@@ -4093,9 +4093,9 @@ class TestMemoryIntegration:
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=RuntimeProfileId.new(),
-            runtime_config_id=8675309,
+            legacy_runtime_key=8675309,
         )
-        legacy_user_id = str(namespace.runtime_config_id)
+        legacy_user_id = str(namespace.require_legacy_runtime_key())
         canonical_user_id = str(namespace.principal_id)
         mem_mod._memory = real_memory_instance
         mem_mod._config = _make_config()
@@ -4172,7 +4172,7 @@ class TestMemoryIntegration:
                 channel_id=ChannelId.new(),
                 agent_id=AgentId.new(),
                 runtime_profile_id=RuntimeProfileId.new(),
-                runtime_config_id=config_id,
+                legacy_runtime_key=config_id,
             )
 
         profile_a, profile_b = profile(910001), profile(910002)
@@ -4182,7 +4182,7 @@ class TestMemoryIntegration:
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=RuntimeProfileId.new(),
-            runtime_config_id=910003,
+            legacy_runtime_key=910003,
         )
 
         mem_mod._memory = real_memory_instance
@@ -4193,7 +4193,7 @@ class TestMemoryIntegration:
             mem_mod.configure_memory_authority(WorkshopExecutionStateRegistry((profile_a, profile_b)))
             memory_id = mem_mod.add_structured(
                 "User prefers dark roast coffee",
-                user_id=str(profile_a.runtime_config_id),
+                user_id=str(profile_a.require_legacy_runtime_key()),
                 memory_type="fact",
             )
             assert memory_id is not None
@@ -4208,13 +4208,13 @@ class TestMemoryIntegration:
             )
 
             # Read through the OTHER profile: visible.
-            visible = mem_mod.get_all(user_id=str(profile_b.runtime_config_id))
+            visible = mem_mod.get_all(user_id=str(profile_b.require_legacy_runtime_key()))
             assert [item.id for item in visible] == [memory_id]
 
             # Wipe through the other profile: the principal's row
             # goes, the foreign-stamped row stays.
-            mem_mod.delete_all(user_id=str(profile_b.runtime_config_id))
-            assert mem_mod.get_all(user_id=str(profile_a.runtime_config_id)) == []
+            mem_mod.delete_all(user_id=str(profile_b.require_legacy_runtime_key()))
+            assert mem_mod.get_all(user_id=str(profile_a.require_legacy_runtime_key())) == []
             leftover = mem_mod._get_all_raw(user_id=canonical_user_id)
             assert [row.text for row in leftover] == ["Foreign principal's fact"]
         finally:
@@ -6946,14 +6946,14 @@ class TestNeverRaiseContracts:
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=RuntimeProfileId.new(),
-            runtime_config_id=424242,
+            legacy_runtime_key=424242,
         )
         mem_mod._memory = MagicMock()
         try:
             mem_mod.configure_memory_authority(WorkshopExecutionStateRegistry((namespace,)))
             result = add_structured(
                 "conflicting fact",
-                user_id=str(namespace.runtime_config_id),
+                user_id=str(namespace.require_legacy_runtime_key()),
                 metadata={WORKSHOP_PRINCIPAL_ID_KEY: "prn_" + "f" * 32},
             )
         finally:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from kai.backend import AgentResponse, StreamEvent
 from kai.config import Config, ModelRole, UserConfig, WorkspaceConfig, get_model_for
 from kai.goose import GooseBackend
 from kai.internal_api_auth import InternalAPIScope
@@ -26,6 +27,7 @@ from kai.workshop.internal_api_contexts import (
     WorkshopInternalAPIContextRegistry,
     WorkshopInternalAPIExecutionContext,
 )
+from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
 from tests.workshop_profiles import profile_id, profile_registry
 
 
@@ -570,6 +572,69 @@ class TestPerUserBackendRouting:
         assert isinstance(instance, OpenCodeBackend)
         assert instance.os_user == "alice-os"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("backend", "provider", "model"),
+        (
+            ("claude", "anthropic", "sonnet"),
+            ("codex", "openai", "gpt-5.6-sol"),
+            ("goose", "openai", "gpt-5.5"),
+            ("opencode", "openai", "openai/gpt-5.5"),
+            ("pi", "openai", "openai/gpt-5.5"),
+        ),
+    )
+    async def test_protected_dispatch_uses_canonical_identity_for_every_backend(
+        self,
+        tmp_path,
+        backend,
+        provider,
+        model,
+    ):
+        runtime_profile_id = profile_id(111)
+        home = tmp_path / backend
+        home.mkdir()
+        profiles = WorkshopRuntimeProfileRegistry(
+            (
+                ProtectedRuntimeProfile(
+                    profile_id=runtime_profile_id,
+                    display_name=f"{backend} protected runtime",
+                    os_user=None,
+                    backend=backend,
+                    provider=provider,
+                    model=model,
+                    timeout_seconds=120,
+                    allowed_services=(),
+                    home_workspace=home,
+                    workspace_base=None,
+                    allowed_workspaces=(),
+                ),
+            ),
+            legacy_runtime_keys={runtime_profile_id: 111},
+        )
+        contexts = _internal_api_contexts(111)
+        pool = SubprocessPool(
+            config=_make_config(allowed_user_ids={111}),
+            services_info=[],
+            runtime_profiles=profiles,
+            internal_api_contexts=contexts,
+        )
+        instance = pool.get(runtime_profile_id)
+
+        async def response_events():
+            yield StreamEvent(
+                text_so_far="done",
+                done=True,
+                response=AgentResponse(text="done", success=True),
+            )
+
+        instance.send = MagicMock(return_value=response_events())
+        pool._prepare_instance = AsyncMock(return_value=instance)
+
+        events = [event async for event in pool.send("test", runtime=runtime_profile_id)]
+
+        assert events[-1].response is not None
+        assert instance.send.call_args.kwargs == {"runtime_identity": contexts.for_runtime_profile(runtime_profile_id)}
+
 
 # ── Per-user actions ────────────────────────────────────────────────
 
@@ -642,7 +707,7 @@ class TestPropertyAccessors:
         profiles = profile_registry(111)
         pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
 
-        assert pool.get_runtime_profile(111) == profiles.for_config_id(111)
+        assert pool.get_runtime_profile(111) == profiles.profile_for_legacy_runtime_key(111)
         assert pool.get_backend_provider(111) == ("codex", "openai")
         assert pool.get_os_user(111) is None
         assert pool.get_model(111) == "gpt-5.6-sol"
@@ -689,7 +754,7 @@ class TestPropertyAccessors:
 
         expected = get_model_for(ModelRole.PR_REVIEW, "codex", "openai")
         assert pool.get_role_model(111, ModelRole.PR_REVIEW) == expected
-        assert "invalid for codex/openai" in caplog.text
+        assert "invalid for codex/openai" not in caplog.text
         assert pool.get_if_exists(111) is None
 
     @pytest.mark.asyncio
@@ -701,7 +766,7 @@ class TestPropertyAccessors:
         )
 
         with patch(
-            "kai.pool.sessions.get_user_settings",
+            "kai.pool.sessions.get_canonical_execution_settings",
             new_callable=AsyncMock,
             return_value={},
         ):
@@ -716,7 +781,7 @@ class TestPropertyAccessors:
         )
 
         with patch(
-            "kai.pool.sessions.get_user_settings",
+            "kai.pool.sessions.get_canonical_execution_settings",
             new_callable=AsyncMock,
             return_value={"model": "opus"},
         ):

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -57,7 +57,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",
@@ -228,16 +228,15 @@ class TestCanonicalExecutionStateWrites:
         assert await sessions.get_setting("ws_config:101:/projects/alice:model") is None
         assert await sessions.get_setting("ws_config:101:/projects/alice:archive:model") is None
 
-    async def test_unmapped_development_callers_retain_legacy_behavior(self, database: Path):
+    async def test_unmapped_positive_adapter_keys_fail_closed_after_cutover(self, database: Path):
         await _initialize(database, 101)
 
-        await sessions.set_user_setting(999, "model", "development-model")
-        await sessions.set_active_workspace(999, "/tmp/development")
-        await sessions.add_allowed_workspace(999, "/tmp/development")
-
-        assert await sessions.get_user_settings(999) == {"model": "development-model"}
-        assert await sessions.get_active_workspace(999) == "/tmp/development"
-        assert await sessions.get_allowed_workspaces(999) == [Path("/tmp/development")]
+        with pytest.raises(RuntimeError, match="no canonical execution-state owner"):
+            await sessions.set_user_setting(999, "model", "development-model")
+        with pytest.raises(RuntimeError, match="no canonical execution-state owner"):
+            await sessions.set_active_workspace(999, "/tmp/development")
+        with pytest.raises(RuntimeError, match="no canonical execution-state owner"):
+            await sessions.add_allowed_workspace(999, "/tmp/development")
 
 
 class TestCanonicalExecutionStateDiagnostic:
@@ -257,7 +256,11 @@ class TestCanonicalExecutionStateDiagnostic:
     async def test_reports_unmapped_legacy_state_without_exposing_it(self, database: Path):
         await _initialize(database, 101)
         await sessions.set_setting("model:999", "unmapped-secret")
-        await sessions.upsert_workspace_history("/secret/path", 999)
+        await sessions._get_db().execute(
+            "INSERT INTO workspace_history (path, chat_id) VALUES (?, ?)",
+            ("/secret/path", 999),
+        )
+        await sessions._get_db().commit()
 
         status = workshop_execution_state_status(database)
 

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -205,7 +205,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 32
+        assert await workshop_store.schema_version() == 33
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -220,7 +220,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 32
+        assert await second.schema_version() == 33
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -252,7 +252,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -280,7 +280,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -330,6 +330,7 @@ class TestWorkshopSchema:
                     30,
                     31,
                     32,
+                    33,
                 ]
         finally:
             await upgraded.close()
@@ -352,7 +353,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -393,7 +394,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -446,7 +447,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -490,7 +491,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -534,7 +535,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -578,7 +579,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -682,7 +683,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -809,7 +810,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -100,7 +100,7 @@ def _namespace(runtime_config_id: int = 101) -> WorkshopExecutionStateNamespace:
         channel_id=ChannelId.new(),
         agent_id=AgentId.new(),
         runtime_profile_id=profile_id(runtime_config_id),
-        runtime_config_id=runtime_config_id,
+        legacy_runtime_key=runtime_config_id,
     )
 
 
@@ -123,14 +123,14 @@ class TestCanonicalMemoryNamespace:
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=profile_id(101),
-            runtime_config_id=101,
+            legacy_runtime_key=101,
         )
         second = WorkshopExecutionStateNamespace(
             principal_id=principal_id,
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=profile_id(202),
-            runtime_config_id=202,
+            legacy_runtime_key=202,
         )
 
         registry = WorkshopExecutionStateRegistry((first, second))
@@ -265,14 +265,14 @@ class TestCanonicalMemoryNamespace:
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=profile_id(101),
-            runtime_config_id=101,
+            legacy_runtime_key=101,
         )
         second = WorkshopExecutionStateNamespace(
             principal_id=principal_id,
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=profile_id(202),
-            runtime_config_id=202,
+            legacy_runtime_key=202,
         )
         fake = _FakeMem0(
             [
@@ -298,14 +298,14 @@ class TestCanonicalMemoryNamespace:
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=profile_id(101),
-            runtime_config_id=101,
+            legacy_runtime_key=101,
         )
         second = WorkshopExecutionStateNamespace(
             principal_id=principal_id,
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=profile_id(202),
-            runtime_config_id=202,
+            legacy_runtime_key=202,
         )
         memory._memory = _FakeMem0(
             [{"id": "ambiguous", "memory": "Unknown lane", "user_id": str(principal_id), "metadata": {}}]
@@ -321,14 +321,14 @@ class TestCanonicalMemoryNamespace:
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=profile_id(101),
-            runtime_config_id=101,
+            legacy_runtime_key=101,
         )
         second = WorkshopExecutionStateNamespace(
             principal_id=principal_id,
             channel_id=ChannelId.new(),
             agent_id=AgentId.new(),
             runtime_profile_id=profile_id(202),
-            runtime_config_id=202,
+            legacy_runtime_key=202,
         )
         fake = _FakeMem0(
             [
@@ -485,14 +485,14 @@ class TestCanonicalMemoryAuthorityMigration:
                 channel_id=ChannelId.new(),
                 agent_id=AgentId.new(),
                 runtime_profile_id=profile_id(101),
-                runtime_config_id=101,
+                legacy_runtime_key=101,
             )
             second = WorkshopExecutionStateNamespace(
                 principal_id=principal_id,
                 channel_id=ChannelId.new(),
                 agent_id=AgentId.new(),
                 runtime_profile_id=profile_id(202),
-                runtime_config_id=202,
+                legacy_runtime_key=202,
             )
             fake = _FakeMem0([{"id": "first", "memory": "First", "user_id": "101", "metadata": {}}])
             memory._memory = fake
@@ -521,7 +521,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_memory_queries.py
+++ b/tests/test_workshop_memory_queries.py
@@ -90,7 +90,7 @@ def _service(tmp_path: Path):
         channel_id=ChannelId("chn_" + "2" * 32),
         agent_id=AgentId("agt_" + "3" * 32),
         runtime_profile_id=profile_id(101),
-        runtime_config_id=101,
+        legacy_runtime_key=101,
     )
     runtime_pool = _RuntimePool(tmp_path)
     service = WorkshopMemoryQueryService(
@@ -369,7 +369,7 @@ async def test_source_context_requires_canonical_lineage_and_channel_membership(
             channel_id=channel_id,
             agent_id=agent_id,
             runtime_profile_id=profile_id(101),
-            runtime_config_id=101,
+            legacy_runtime_key=101,
         )
         service = WorkshopMemoryQueryService(
             Config(

--- a/tests/test_workshop_operational_state.py
+++ b/tests/test_workshop_operational_state.py
@@ -67,6 +67,50 @@ async def database(tmp_path: Path):
 
 
 class TestCanonicalOperationalStateMigration:
+    async def test_existing_receipt_moves_token_once_before_runtime_key_archive_is_sealed(
+        self,
+        database: Path,
+    ):
+        await sessions.set_setting("github_token:101", "legacy-token")
+        registry = await _bootstrap(101)
+        profiles = profile_registry(101)
+        await sessions.initialize_workshop_operational_state(
+            registry,
+            _config(101),
+            profiles,
+        )
+        namespace = registry.namespaces[0]
+        await sessions._get_db().execute(
+            "UPDATE principal_github_subscriptions SET github_token = NULL WHERE principal_id = ?",
+            (namespace.principal_id,),
+        )
+        await sessions._get_db().commit()
+
+        await sessions.initialize_workshop_operational_state(
+            registry,
+            _config(101),
+            profiles,
+        )
+        assert await sessions.get_canonical_github_token(namespace.principal_id) == "legacy-token"
+
+        await sessions.initialize_workshop_runtime_key_cutover(
+            registry,
+            memory_enabled=False,
+        )
+        await sessions._get_db().execute(
+            "UPDATE principal_github_subscriptions SET github_token = NULL WHERE principal_id = ?",
+            (namespace.principal_id,),
+        )
+        await sessions.set_setting("github_token:101", "later-legacy-token")
+        await sessions._get_db().commit()
+
+        await sessions.initialize_workshop_operational_state(
+            registry,
+            _config(101),
+            profiles,
+        )
+        assert await sessions.get_canonical_github_token(namespace.principal_id) is None
+
     async def test_backfills_jobs_and_github_policy_once(self, database: Path):
         await sessions.set_setting("github_repos_added:101", '["owner/added"]')
         await sessions.set_setting("github_repos_removed:101", '["owner/repo-101"]')
@@ -237,7 +281,7 @@ class TestCanonicalOperationalStateMigration:
             channel_id=first.channel_id,
             agent_id=first.agent_id,
             runtime_profile_id=profile_id(202),
-            runtime_config_id=202,
+            legacy_runtime_key=202,
         )
 
         migration = await sessions.initialize_workshop_operational_state(
@@ -271,7 +315,7 @@ class TestCanonicalOperationalStateWrites:
         assert await sessions.delete_job(job_id, 202) is False
         assert await sessions.delete_job(job_id, 101) is True
 
-    async def test_github_mutations_use_canonical_rows_and_dual_write(self, database: Path):
+    async def test_github_mutations_use_only_canonical_rows(self, database: Path):
         registry = await _bootstrap(101)
         await sessions.initialize_workshop_operational_state(registry, _config(101))
 
@@ -281,8 +325,8 @@ class TestCanonicalOperationalStateWrites:
 
         assert await sessions.get_effective_repos(101, []) == ["owner/added"]
         assert (await sessions.resolve_github_settings(101, _config(101)))["issue_triage"] is True
-        assert await sessions.get_setting("github_repos_added:101") == '["owner/added"]'
-        assert await sessions.get_setting("issue_triage:101") == "true"
+        assert await sessions.get_setting("github_repos_added:101") is None
+        assert await sessions.get_setting("issue_triage:101") is None
 
     async def test_operator_policy_resync_preserves_user_toggle_override(self, database: Path):
         registry = await _bootstrap(101)

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -87,8 +87,11 @@ class TestProtectedExecutionPreparation:
         store, run, pool, profiles = await _accepted_run(tmp_path / "kai.db", home)
         try:
             with (
-                patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
-                patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
+                patch(
+                    "kai.pool.sessions.get_canonical_execution_settings",
+                    new_callable=AsyncMock,
+                    return_value={},
+                ),
             ):
                 prepared = await WorkshopProtectedExecutionPreparationService(
                     store,
@@ -113,8 +116,11 @@ class TestProtectedExecutionPreparation:
         store, run, pool, profiles = await _accepted_run(tmp_path / "kai.db", home)
         try:
             with (
-                patch("kai.pool.sessions.get_setting", new_callable=AsyncMock, return_value=None),
-                patch("kai.pool.sessions.get_user_settings", new_callable=AsyncMock, return_value={}),
+                patch(
+                    "kai.pool.sessions.get_canonical_execution_settings",
+                    new_callable=AsyncMock,
+                    return_value={},
+                ),
                 pytest.raises(ProtectedExecutionPreparationError, match="protected registry"),
             ):
                 await WorkshopProtectedExecutionPreparationService(

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -411,7 +411,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -194,7 +194,8 @@ class TestRuntimeProfileCompatibilityBoundary:
             profile_registry(101).resolve(value)
 
     def test_opaque_profile_does_not_encode_runtime_configuration_key(self):
-        profile = profile_registry(202).resolve(profile_id(202))
+        profiles = profile_registry(202)
+        profile = profiles.resolve(profile_id(202))
 
-        assert profile.profile_id != str(profile.runtime_config_id)
+        assert profile.profile_id != str(profiles.legacy_runtime_key(profile.profile_id))
         assert "202" not in profile.profile_id

--- a/tests/test_workshop_runtime_key_cutover.py
+++ b/tests/test_workshop_runtime_key_cutover.py
@@ -1,0 +1,128 @@
+"""Immutable receipts for retiring transport-shaped protected runtime keys."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kai import sessions
+from kai.config import Config
+from kai.workshop.bootstrap import BootstrapHuman
+from kai.workshop.runtime_key_cutover import WorkshopRuntimeKeyCutoverError
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from tests.workshop_profiles import profile_id, profile_registry
+
+
+@pytest.fixture
+async def database(tmp_path: Path):
+    path = tmp_path / "kai.db"
+    await sessions.init_db(path)
+    yield path
+    await sessions.close_db()
+
+
+async def _prepare(
+    profiles: WorkshopRuntimeProfileRegistry,
+    *,
+    transport: str,
+    external_subject: str,
+):
+    profile = profiles.profiles[0]
+    await sessions.bootstrap_workshop_foundation(
+        (
+            BootstrapHuman(
+                display_name="Runtime-key human",
+                role="admin",
+                transport=transport,
+                external_subject=external_subject,
+                external_channel_id=external_subject,
+                runtime_profile_id=profile.profile_id,
+            ),
+        )
+    )
+    registry, _migration = await sessions.initialize_workshop_execution_state(profiles)
+    await sessions.initialize_workshop_operational_state(
+        registry,
+        Config(telegram_bot_token="test", allowed_user_ids=set()),
+        profiles,
+    )
+    return registry
+
+
+async def test_archived_key_inventory_is_recorded_once(database: Path):
+    profiles = profile_registry(101)
+    await sessions.set_setting("model:101", "gpt-5.6-sol")
+    await sessions._get_db().execute(
+        "INSERT INTO sessions (chat_id, session_id, model) VALUES (101, 'legacy-session', 'gpt-5.6-sol')"
+    )
+    await sessions._get_db().commit()
+    registry = await _prepare(profiles, transport="telegram", external_subject="101")
+
+    first = await sessions.initialize_workshop_runtime_key_cutover(
+        registry,
+        memory_enabled=False,
+    )
+    second = await sessions.initialize_workshop_runtime_key_cutover(
+        registry,
+        memory_enabled=False,
+    )
+
+    assert (first.profiles, first.newly_recorded, first.archived_keys) == (1, 1, 1)
+    assert (second.profiles, second.newly_recorded, second.archived_keys) == (1, 0, 1)
+    async with sessions._get_db().execute(
+        "SELECT legacy_runtime_key, settings_rows, session_rows, legacy_reads_disabled "
+        "FROM workshop_runtime_key_cutovers WHERE runtime_profile_id = ?",
+        (profile_id(101),),
+    ) as cursor:
+        assert tuple(await cursor.fetchone()) == (101, 1, 1, 1)
+
+
+async def test_canonical_only_profile_records_no_archived_key(database: Path):
+    migrated = profile_registry(101).resolve(profile_id(101))
+    profiles = WorkshopRuntimeProfileRegistry((migrated,))
+    registry = await _prepare(
+        profiles,
+        transport="workshop",
+        external_subject="browser-only-human",
+    )
+
+    result = await sessions.initialize_workshop_runtime_key_cutover(
+        registry,
+        memory_enabled=False,
+    )
+
+    assert (result.profiles, result.newly_recorded, result.archived_keys) == (1, 1, 0)
+    async with sessions._get_db().execute(
+        "SELECT legacy_runtime_key, legacy_reads_disabled "
+        "FROM workshop_runtime_key_cutovers WHERE runtime_profile_id = ?",
+        (profile_id(101),),
+    ) as cursor:
+        assert tuple(await cursor.fetchone()) == (None, 1)
+
+
+async def test_changed_canonical_owner_conflicts_with_receipt(database: Path):
+    profiles = profile_registry(101)
+    registry = await _prepare(profiles, transport="telegram", external_subject="101")
+    await sessions.initialize_workshop_runtime_key_cutover(
+        registry,
+        memory_enabled=False,
+    )
+    namespace = registry.namespaces[0]
+    changed = type(namespace)(
+        principal_id=namespace.principal_id,
+        channel_id=namespace.channel_id,
+        agent_id=type(namespace.agent_id).new(),
+        runtime_profile_id=namespace.runtime_profile_id,
+        legacy_runtime_key=namespace.legacy_runtime_key,
+    )
+    changed_registry = type(registry)((changed,))
+
+    with pytest.raises(
+        WorkshopRuntimeKeyCutoverError,
+        match="conflicts with current canonical ownership",
+    ):
+        await sessions.initialize_workshop_runtime_key_cutover(
+            changed_registry,
+            memory_enabled=False,
+        )

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -39,7 +39,7 @@ def _contexts_for_profiles(
     return WorkshopInternalAPIContextRegistry(
         tuple(
             WorkshopInternalAPIExecutionContext.for_unprotected_runtime(
-                profile.runtime_config_id,
+                profiles.legacy_runtime_key(profile.profile_id) or 1,
                 profile.profile_id,
             )
             for profile in profiles.profiles
@@ -110,7 +110,6 @@ def test_protected_profile_selects_backend_and_os_user_over_compatibility_config
         (
             ProtectedRuntimeProfile(
                 profile_id=RuntimeProfileId("rtp_11111111111111111111111111111111"),
-                runtime_config_id=111,
                 display_name="Protected coding runtime",
                 os_user="protected-user",
                 backend="codex",
@@ -122,7 +121,8 @@ def test_protected_profile_selects_backend_and_os_user_over_compatibility_config
                 workspace_base=None,
                 allowed_workspaces=(),
             ),
-        )
+        ),
+        legacy_runtime_keys={RuntimeProfileId("rtp_11111111111111111111111111111111"): 111},
     )
 
     pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
@@ -183,7 +183,6 @@ def test_protected_profile_service_scopes_override_compatibility_config(tmp_path
         (
             ProtectedRuntimeProfile(
                 profile_id=RuntimeProfileId("rtp_15151515151515151515151515151515"),
-                runtime_config_id=111,
                 display_name="Protected coding runtime",
                 os_user=None,
                 backend="codex",
@@ -195,7 +194,8 @@ def test_protected_profile_service_scopes_override_compatibility_config(tmp_path
                 workspace_base=None,
                 allowed_workspaces=(),
             ),
-        )
+        ),
+        legacy_runtime_keys={RuntimeProfileId("rtp_15151515151515151515151515151515"): 111},
     )
 
     pool = SubprocessPool(
@@ -216,20 +216,20 @@ def test_protected_profile_service_scopes_override_compatibility_config(tmp_path
 def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, monkeypatch):
     from kai.pool import SubprocessPool
 
-    runtime_config_id = 987654321012345
+    runtime_profile_id = RuntimeProfileId("rtp_22222222222222222222222222222222")
     monkeypatch.setattr("kai.backend.DATA_DIR", tmp_path)
     config = Config(
         telegram_bot_token="test",
         allowed_user_ids=set(),
         default_backend="claude",
         default_model="sonnet",
+        session_db_path=tmp_path / "kai.db",
         user_configs={},
     )
     profiles = WorkshopRuntimeProfileRegistry(
         (
             ProtectedRuntimeProfile(
-                profile_id=RuntimeProfileId("rtp_22222222222222222222222222222222"),
-                runtime_config_id=runtime_config_id,
+                profile_id=runtime_profile_id,
                 display_name="Browser-only runtime",
                 os_user=None,
                 backend="codex",
@@ -245,8 +245,14 @@ def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, mon
     )
 
     services_info = [{"name": "perplexity", "method": "POST", "description": "search"}]
-    pool = SubprocessPool(config=config, services_info=services_info, runtime_profiles=profiles)
-    instance = pool.get(runtime_config_id)
+    contexts = _contexts_for_profiles(profiles)
+    pool = SubprocessPool(
+        config=config,
+        services_info=services_info,
+        runtime_profiles=profiles,
+        internal_api_contexts=contexts,
+    )
+    instance = pool.get(runtime_profile_id)
     principal = pool.internal_api_auth.authenticate(instance._api_context.webhook_secret)
 
     assert instance.backend_name == "codex"
@@ -254,7 +260,9 @@ def test_profile_without_telegram_user_receives_runtime_credential(tmp_path, mon
     assert not hasattr(principal, "compatibility_runtime_config_id")
     assert principal.allowed_services == frozenset({"perplexity"})
     assert instance._api_context.services_info == services_info
-    assert instance.workspace == tmp_path / "home" / str(runtime_config_id)
+    assert instance.workspace == (
+        tmp_path / "home" / str(contexts.for_runtime_profile(runtime_profile_id).principal_id)
+    )
 
 
 async def test_protected_workspace_policy_overrides_compatibility_config(tmp_path, monkeypatch):
@@ -301,7 +309,6 @@ async def test_protected_workspace_policy_overrides_compatibility_config(tmp_pat
         (
             ProtectedRuntimeProfile(
                 profile_id=RuntimeProfileId("rtp_56565656565656565656565656565656"),
-                runtime_config_id=111,
                 display_name="Protected runtime",
                 os_user=None,
                 backend="codex",
@@ -313,12 +320,13 @@ async def test_protected_workspace_policy_overrides_compatibility_config(tmp_pat
                 workspace_base=protected_base,
                 allowed_workspaces=(protected_allowed,),
             ),
-        )
+        ),
+        legacy_runtime_keys={RuntimeProfileId("rtp_56565656565656565656565656565656"): 111},
     )
     pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
     monkeypatch.setattr(
-        "kai.pool.sessions.get_allowed_workspaces",
-        AsyncMock(return_value=[db_allowed]),
+        "kai.pool.sessions.resolve_canonical_workspace_access",
+        AsyncMock(return_value=(protected_base, [db_allowed, protected_allowed, global_allowed])),
     )
 
     instance = pool.get(111)
@@ -343,14 +351,14 @@ def test_unavailable_explicit_profile_home_fails_only_that_runtime(tmp_path, mon
         default_provider="openai",
         default_model="gpt-5.6-sol",
         protected_install=True,
+        session_db_path=tmp_path / "kai.db",
         user_configs={},
     )
-    runtime_config_id = 987654321012347
+    runtime_profile_id = RuntimeProfileId("rtp_57575757575757575757575757575757")
     profiles = WorkshopRuntimeProfileRegistry(
         (
             ProtectedRuntimeProfile(
-                profile_id=RuntimeProfileId("rtp_57575757575757575757575757575757"),
-                runtime_config_id=runtime_config_id,
+                profile_id=runtime_profile_id,
                 display_name="Browser-only runtime",
                 os_user=None,
                 backend="codex",
@@ -372,7 +380,7 @@ def test_unavailable_explicit_profile_home_fails_only_that_runtime(tmp_path, mon
     )
 
     with pytest.raises(RuntimeError, match="Mount or create it, or update the protected runtime profile"):
-        pool.get(runtime_config_id)
+        pool.get(runtime_profile_id)
 
 
 def test_profile_only_canonical_home_error_has_actionable_remediation(tmp_path, monkeypatch):
@@ -388,12 +396,11 @@ def test_profile_only_canonical_home_error_has_actionable_remediation(tmp_path, 
         protected_install=True,
         user_configs={},
     )
-    runtime_config_id = 987654321012348
+    runtime_profile_id = RuntimeProfileId("rtp_58585858585858585858585858585858")
     profiles = WorkshopRuntimeProfileRegistry(
         (
             ProtectedRuntimeProfile(
-                profile_id=RuntimeProfileId("rtp_58585858585858585858585858585858"),
-                runtime_config_id=runtime_config_id,
+                profile_id=runtime_profile_id,
                 display_name="Browser-only runtime",
                 os_user=None,
                 backend="codex",
@@ -414,8 +421,8 @@ def test_profile_only_canonical_home_error_has_actionable_remediation(tmp_path, 
         internal_api_contexts=_contexts_for_profiles(profiles),
     )
 
-    with pytest.raises(RuntimeError, match="profile-only runtimes require an explicit home_workspace"):
-        pool.get(runtime_config_id)
+    with pytest.raises(RuntimeError, match="home is not provisioned"):
+        pool.get(runtime_profile_id)
 
 
 def test_unavailable_protected_service_is_denied_with_warning(tmp_path, monkeypatch, caplog):
@@ -430,12 +437,11 @@ def test_unavailable_protected_service_is_denied_with_warning(tmp_path, monkeypa
         default_model="gpt-5.6-sol",
         user_configs={},
     )
-    runtime_config_id = 987654321012346
+    runtime_profile_id = RuntimeProfileId("rtp_25252525252525252525252525252525")
     profiles = WorkshopRuntimeProfileRegistry(
         (
             ProtectedRuntimeProfile(
-                profile_id=RuntimeProfileId("rtp_25252525252525252525252525252525"),
-                runtime_config_id=runtime_config_id,
+                profile_id=runtime_profile_id,
                 display_name="Browser-only runtime",
                 os_user=None,
                 backend="codex",
@@ -450,14 +456,19 @@ def test_unavailable_protected_service_is_denied_with_warning(tmp_path, monkeypa
         )
     )
 
-    pool = SubprocessPool(config=config, services_info=[], runtime_profiles=profiles)
-    instance = pool.get(runtime_config_id)
+    pool = SubprocessPool(
+        config=config,
+        services_info=[],
+        runtime_profiles=profiles,
+        internal_api_contexts=_contexts_for_profiles(profiles),
+    )
+    instance = pool.get(runtime_profile_id)
     principal = pool.internal_api_auth.authenticate(instance._api_context.webhook_secret)
 
     assert principal is not None
     assert principal.allowed_services == frozenset()
     assert instance._api_context.services_info == []
-    assert "protected runtime profile" in caplog.text
+    assert str(runtime_profile_id) in caplog.text
     assert "unavailable allowed_services: missing; denying them" in caplog.text
 
 
@@ -477,7 +488,6 @@ def test_negative_group_key_retains_legacy_compatibility_runtime(tmp_path, monke
         (
             ProtectedRuntimeProfile(
                 profile_id=RuntimeProfileId("rtp_33333333333333333333333333333333"),
-                runtime_config_id=111,
                 display_name="Alice runtime",
                 os_user=None,
                 backend="codex",
@@ -518,7 +528,6 @@ def test_positive_configuration_key_without_profile_fails_closed(tmp_path, monke
         (
             ProtectedRuntimeProfile(
                 profile_id=RuntimeProfileId("rtp_44444444444444444444444444444444"),
-                runtime_config_id=222,
                 display_name="Different runtime",
                 os_user=None,
                 backend="codex",

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -14,7 +14,6 @@ from kai.workshop.runtime_profiles import (
     ProtectedRuntimeProfile,
     WorkshopRuntimeProfileError,
     WorkshopRuntimeProfileRegistry,
-    compatibility_runtime_config_id_for_profile_id,
     runtime_profile_id_for_config_id,
 )
 
@@ -47,13 +46,13 @@ def test_registry_exposes_opaque_stable_profiles_with_protected_policy():
     first = WorkshopRuntimeProfileRegistry.from_config(_config())
     second = WorkshopRuntimeProfileRegistry.from_config(_config())
 
-    daniel = first.for_config_id(101)
-    scott = first.for_config_id(202)
+    daniel = first.profile_for_legacy_runtime_key(101)
+    scott = first.profile_for_legacy_runtime_key(202)
 
     assert isinstance(daniel.profile_id, RuntimeProfileId)
-    assert daniel.profile_id == second.for_config_id(101).profile_id
+    assert daniel.profile_id == second.profile_for_legacy_runtime_key(101).profile_id
     assert daniel.profile_id != scott.profile_id
-    assert daniel.runtime_config_id == 101
+    assert first.legacy_runtime_key(daniel.profile_id) == 101
     assert daniel.os_user == "daniel"
     assert daniel.backend == "codex"
     assert daniel.provider == "openai"
@@ -81,18 +80,22 @@ def test_registry_rejects_unknown_profile_even_when_it_is_structurally_valid():
 
 def test_registry_rejects_duplicate_configuration_authority():
     profile = ProtectedRuntimeProfile(
-        runtime_profile_id_for_config_id(101),
-        101,
-        "Daniel",
-        "daniel",
-        "codex",
-        "openai",
-        "gpt-5.6-sol",
-        120,
-        (),
-        None,
-        None,
-        (),
+        profile_id=runtime_profile_id_for_config_id(101),
+        display_name="Daniel",
+        os_user="daniel",
+        backend="codex",
+        provider="openai",
+        model="gpt-5.6-sol",
+        timeout_seconds=120,
+        allowed_services=(),
+        home_workspace=None,
+        workspace_base=None,
+        allowed_workspaces=(),
+        role_models=(),
+        github_repos=(),
+        pr_review=None,
+        issue_triage=None,
+        allowed_triage_projects=(),
     )
 
     with pytest.raises(WorkshopRuntimeProfileError, match="Duplicate runtime profile ID"):
@@ -123,7 +126,7 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
 
     profile = registry.resolve(profile_id)
     assert profile.profile_id == profile_id
-    assert profile.runtime_config_id == 101
+    assert registry.legacy_runtime_key(profile.profile_id) == 101
     assert profile.os_user == "daniel"
     assert profile.backend == "codex"
     assert profile.provider == "openai"
@@ -143,18 +146,22 @@ def test_document_preserves_migrated_profile_identity_and_compatibility_key():
 )
 def test_protected_runtime_profiles_reject_unsafe_execution_accounts(os_user, message):
     profile = ProtectedRuntimeProfile(
-        runtime_profile_id_for_config_id(101),
-        101,
-        "Daniel",
-        os_user,
-        "codex",
-        "openai",
-        "gpt-5.6-sol",
-        120,
-        (),
-        None,
-        None,
-        (),
+        profile_id=runtime_profile_id_for_config_id(101),
+        display_name="Daniel",
+        os_user=os_user,
+        backend="codex",
+        provider="openai",
+        model="gpt-5.6-sol",
+        timeout_seconds=120,
+        allowed_services=(),
+        home_workspace=None,
+        workspace_base=None,
+        allowed_workspaces=(),
+        role_models=(),
+        github_repos=(),
+        pr_review=None,
+        issue_triage=None,
+        allowed_triage_projects=(),
     )
     registry = WorkshopRuntimeProfileRegistry((profile,))
 
@@ -341,9 +348,9 @@ def test_non_telegram_profile_derives_stable_private_compatibility_key():
         backend_registry={"pi": {}},
     )
 
-    expected = compatibility_runtime_config_id_for_profile_id(profile_id)
-    assert first.resolve(profile_id).runtime_config_id == expected
-    assert second.resolve(profile_id).runtime_config_id == expected
+    expected = first.legacy_runtime_key(profile_id)
+    assert second.legacy_runtime_key(profile_id) == expected
+    assert expected is not None
     assert expected > 0
 
 
@@ -848,7 +855,7 @@ def test_uninstalled_development_without_policy_uses_compatibility_projection(mo
 
     registry = WorkshopRuntimeProfileRegistry.load(_config())
 
-    assert registry.for_config_id(101).display_name == "Daniel"
+    assert registry.profile_for_legacy_runtime_key(101).display_name == "Daniel"
 
 
 def test_uninstalled_development_ignores_existing_canonical_policy(monkeypatch):
@@ -861,7 +868,7 @@ def test_uninstalled_development_ignores_existing_canonical_policy(monkeypatch):
 
     registry = WorkshopRuntimeProfileRegistry.load(_config())
 
-    assert registry.for_config_id(101).display_name == "Daniel"
+    assert registry.profile_for_legacy_runtime_key(101).display_name == "Daniel"
 
 
 def test_protected_startup_fails_closed_when_policy_is_unreadable(monkeypatch):

--- a/tests/test_workshop_runtime_state.py
+++ b/tests/test_workshop_runtime_state.py
@@ -1,36 +1,29 @@
-"""Tests for profile-addressed compatibility-state writes."""
+"""Tests for canonical profile-addressed runtime state."""
 
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
-from kai.workshop.compatibility_state import WorkshopCompatibilityStateWriter
 from kai.workshop.domain import CanonicalMemoryProvenance, MessageId, RunId
+from kai.workshop.runtime_state import WorkshopRuntimeStateWriter
 from tests.workshop_profiles import profile_id
 
 
-async def test_profile_state_retains_only_non_session_compatibility_boundaries(monkeypatch):
-    config = SimpleNamespace(
-        get_user_config=lambda runtime_config_id: (
-            SimpleNamespace(os_user="daniel") if runtime_config_id == 101 else None
-        )
+async def test_profile_state_ingests_memory_with_only_canonical_authority(monkeypatch):
+    config = SimpleNamespace(episode_classifier_context_turns=4)
+    profile = SimpleNamespace(
+        profile_id=profile_id(101),
+        os_user="daniel",
+        backend="codex",
+        provider="openai",
+        allowed_triage_projects=("Kai",),
     )
-    runtime_pool = SimpleNamespace(
-        runtime_profile=Mock(
-            return_value=SimpleNamespace(
-                runtime_config_id=101,
-                os_user="daniel",
-                backend="codex",
-            )
-        )
-    )
+    runtime_pool = SimpleNamespace(runtime_profile=Mock(return_value=profile))
+    execution_state = SimpleNamespace(resolve_profile=Mock(return_value=SimpleNamespace(principal_id="prn_daniel")))
     ingest = AsyncMock()
-    monkeypatch.setattr(
-        "kai.workshop.compatibility_state.ingest_conversation_memory",
-        ingest,
-    )
+    monkeypatch.setattr("kai.workshop.runtime_state.ingest_conversation_memory", ingest)
 
-    state = WorkshopCompatibilityStateWriter(config, runtime_pool).for_profile(profile_id(101))
+    state = WorkshopRuntimeStateWriter(config, runtime_pool, execution_state).for_profile(profile_id(101))
     provenance = CanonicalMemoryProvenance(RunId.new(), MessageId.new(), MessageId.new())
     assert not hasattr(state, "save_session")
     await state.ingest_memory(
@@ -43,10 +36,13 @@ async def test_profile_state_retains_only_non_session_compatibility_boundaries(m
     )
 
     runtime_pool.runtime_profile.assert_called_once_with(profile_id(101))
+    execution_state.resolve_profile.assert_called_once_with(profile_id(101))
     ingest.assert_awaited_once_with(
         prompt="Hello",
         assistant_text="Hi",
-        chat_id=101,
+        chat_id=None,
+        canonical_user_id="prn_daniel",
+        runtime_profile_id=str(profile_id(101)),
         session_id="session-1",
         config=config,
         workspace="/workspace/project",
@@ -55,6 +51,8 @@ async def test_profile_state_retains_only_non_session_compatibility_boundaries(m
         canonical_provenance=provenance,
         canonical_prior_pairs=(("Earlier", "Exchange"),),
         effective_backend="codex",
+        effective_provider="openai",
+        os_user_override="daniel",
     )
 
 

--- a/tests/test_workshop_scheduled_jobs.py
+++ b/tests/test_workshop_scheduled_jobs.py
@@ -46,7 +46,7 @@ async def scheduled_jobs(tmp_path: Path):
     registry, _ = await sessions.initialize_workshop_execution_state(profile_registry(101, 202))
     store = WorkshopEventStore.from_initialized_connection(sessions._get_db())
     authorities = {
-        namespace.runtime_config_id: WorkshopScheduledJobAuthority(
+        namespace.require_legacy_runtime_key(): WorkshopScheduledJobAuthority(
             namespace.principal_id,
             namespace.channel_id,
             namespace.agent_id,

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -548,7 +548,7 @@ async def test_agent_firing_completes_through_real_canonical_coordinator(
     try:
         terminal_row = None
         async with asyncio.timeout(5):
-            while terminal_row is None:
+            while terminal_row is None or str(terminal_row[0]) not in {"succeeded", "failed"}:
                 async with source_store.connection.execute(
                     "SELECT f.status, r.status, result.body FROM workshop_schedule_firings f "
                     "JOIN runs r ON r.id = f.run_id "
@@ -557,7 +557,7 @@ async def test_agent_firing_completes_through_real_canonical_coordinator(
                     (job_id,),
                 ) as cursor:
                     terminal_row = await cursor.fetchone()
-                if terminal_row is None:
+                if terminal_row is None or str(terminal_row[0]) not in {"succeeded", "failed"}:
                     await asyncio.sleep(0.02)
         assert tuple(terminal_row) == (
             "succeeded",

--- a/tests/test_workshop_settings_workspaces.py
+++ b/tests/test_workshop_settings_workspaces.py
@@ -31,7 +31,7 @@ class _RuntimePool:
         self.events: list[str] = []
         self.profile = SimpleNamespace(
             profile_id=profile_id(101),
-            runtime_config_id=101,
+            legacy_runtime_key=101,
             backend="codex",
             provider="openai",
             model="gpt-5.6-sol",
@@ -96,7 +96,7 @@ def _service(tmp_path: Path):
         channel_id=channel_id,
         agent_id=AgentId("agt_" + "3" * 32),
         runtime_profile_id=profile_id(101),
-        runtime_config_id=101,
+        legacy_runtime_key=101,
     )
     pool = _RuntimePool(home, allowed)
     service = WorkshopSettingsWorkspaceService(

--- a/tests/test_workshop_storage_namespaces.py
+++ b/tests/test_workshop_storage_namespaces.py
@@ -118,7 +118,7 @@ class TestWorkshopPrincipalStorageRegistry:
     def test_duplicate_runtime_configuration_is_rejected(self):
         with pytest.raises(
             WorkshopStorageNamespaceError,
-            match="Duplicate runtime configuration",
+            match="Duplicate archived runtime storage key",
         ):
             WorkshopPrincipalStorageRegistry(
                 (

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -524,7 +524,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -382,7 +382,7 @@ class TestAtomicTerminalTransactions:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 32
+            assert await upgraded.schema_version() == 33
             assert await _post_run_effect_count(upgraded) == 1
             async with upgraded.connection.execute(
                 "SELECT status, source_message_id, result_message_id FROM workshop_post_run_effects WHERE run_id = ?",

--- a/tests/workshop_profiles.py
+++ b/tests/workshop_profiles.py
@@ -18,7 +18,6 @@ def profile_registry(*runtime_config_ids: int) -> WorkshopRuntimeProfileRegistry
         tuple(
             ProtectedRuntimeProfile(
                 profile_id=profile_id(runtime_config_id),
-                runtime_config_id=runtime_config_id,
                 display_name=f"User {runtime_config_id}",
                 os_user=None,
                 backend="codex",
@@ -29,7 +28,13 @@ def profile_registry(*runtime_config_ids: int) -> WorkshopRuntimeProfileRegistry
                 home_workspace=None,
                 workspace_base=None,
                 allowed_workspaces=(),
+                role_models=(),
+                github_repos=(),
+                pr_review=None,
+                issue_triage=None,
+                allowed_triage_projects=(),
             )
             for runtime_config_id in runtime_config_ids
-        )
+        ),
+        legacy_runtime_keys={profile_id(value): value for value in runtime_config_ids},
     )


### PR DESCRIPTION
## Summary

- make opaque runtime profiles the live key for protected subprocesses, cancellation, recovery, settings, workspaces, sessions, GitHub state, and semantic-memory provenance
- move historical integer keys out of live runtime profiles into a versioned, migration-only archive with an explicit removal gate
- add immutable installed-state cutover receipts, fail-closed legacy reads, canonical-only profile provisioning, and non-secret installation diagnostics
- remove the compatibility runtime-state writer and verify protected dispatch across Claude, Codex, Goose, OpenCode, and Pi

## Validation

- `make check`
- `.venv/bin/python -m pytest -q` — 6,031 passed

Closes #1111
