### PR TITLE
Provision fresh Workshop-only installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,19 @@ make config
 The client-mode choices are explicit and reversible:
 
 - `hybrid` enables Workshop and Telegram and is the upgrade-safe default;
-- `workshop-only` switches an existing protected installation with canonical humans and runtime profiles to the browser client without constructing a Telegram application, contacting Telegram, or retaining a bot token;
+- `workshop-only` runs the browser client without constructing a Telegram application, contacting Telegram, or requiring a bot token;
 - `telegram-only` runs Telegram without publishing Workshop client routes.
 
 Re-run `make config`, select a different client mode, and apply the installation to change modes. Existing configurations without an explicit client-mode setting remain hybrid. `make install-status` reports both the deployed policy and the current `install.conf` artifact without exposing the Telegram token.
 
-The initial Workshop-only qualification is deliberately an installed-mode switch, not a fresh-host bootstrap path. Fresh protected and single-user Workshop-only provisioning still needs a canonical administration flow for creating the first human and runtime assignment; the wizard refuses those incomplete combinations instead of generating a configuration that cannot start.
+On a fresh Workshop-only configuration, the wizard creates one canonical admin,
+the Kai agent and direct channel, and a protected runtime profile and assignment.
+It prints a one-time browser enrollment token after single-user configuration or
+after a protected install reaches full readiness. The token is shown once; Kai
+stores only its hash. Enabling Telegram later links the configured Telegram
+identity to that same canonical human, channel, and runtime profile rather than
+creating a second account. Disabling Telegram again leaves that canonical state
+intact.
 
 For a `single_user` deployment, `make config` also writes the runtime files under the operator's account. Start Kai from the checkout:
 
@@ -111,12 +118,14 @@ make install-status
 `make install` invokes `sudo` internally and installs source, data, and secrets under separate protected system directories. It also generates the admin-owned `/etc/kai/backends.yaml` registry containing the discovered executable paths, allowed model surfaces, and selected default backend. Runtime configuration names backend identifiers; it cannot redirect a protected backend to an arbitrary executable. After a successful protected install, `install.conf` may be deleted because it can contain secrets; re-run `make config` before a later reconfiguration.
 
 On the first protected install, Kai seeds `/etc/kai/runtime-profiles.yaml`
-from the configured humans. After that file exists, it is the independent
+from the canonical Workshop admin or configured Telegram humans. After that
+file exists, it is the independent
 authority for each Workshop runtime's backend, provider, model baseline,
 timeout, OS execution user, service grants, and workspace policy. Later edits
 to duplicated execution fields in `users.yaml` do not replace or veto the
-protected profile. `users.yaml` remains the Telegram-human bootstrap and
-integration-policy input during the Workshop migration.
+protected profile. `users.yaml` is optional when Telegram is disabled. When
+Telegram is enabled, it defines Telegram authorization and links those external
+identities to canonical Workshop runtime profiles.
 
 Edit an installed runtime profile with `sudoedit`, validate it with
 `make install-status`, then run `make install` to reconcile OS-owned storage

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -16,6 +16,7 @@ import ipaddress
 import logging
 import os
 import pwd
+import re
 import secrets
 import subprocess
 from collections.abc import Callable
@@ -1316,6 +1317,9 @@ class UserConfig:
         role: "admin" or "user". Admins receive unattributed webhooks.
         github: GitHub username for webhook actor routing.
         os_user: OS username for subprocess isolation (Phase 3).
+        runtime_profile_id: Canonical protected runtime profile linked to this
+            external Telegram identity. Set by the installer when Telegram is
+            added to an existing Workshop-only deployment.
         home_workspace: Per-user home workspace directory.
         model: Default model name (e.g., "opus", "sonnet", "haiku").
         timeout: Default timeout in seconds for Claude responses.
@@ -1336,6 +1340,7 @@ class UserConfig:
     role: str = "user"
     github: str | None = None
     os_user: str | None = None
+    runtime_profile_id: str | None = None
     home_workspace: Path | None = None
     model: str | None = None
     timeout: int | None = None
@@ -1421,6 +1426,8 @@ class Config:
             Only used in webhook mode. Generated for the process when not explicitly set.
         allowed_user_ids: Telegram user IDs permitted to interact with the bot;
             empty when the Telegram adapter is disabled and no users file exists.
+        initial_workshop_provisioning: Opaque installer-managed policy for the
+            first canonical Workshop admin and protected runtime profile.
         default_model: Default model name, provider-dependent (e.g. sonnet, gpt-5.5-pro, gemini-2.5-pro)
         default_timeout: Seconds before an agent response is considered timed
             out, on every backend
@@ -1449,6 +1456,7 @@ class Config:
     # Explicit human-facing adapter policy. The default preserves the client
     # surfaces used by installations created before this policy existed.
     enabled_adapters: frozenset[str] = field(default_factory=lambda: DEFAULT_CLIENT_ADAPTERS)
+    initial_workshop_provisioning: str | None = None
 
     # Telegram transport mode: set telegram_webhook_url to use webhook mode,
     # leave as None to fall back to long-polling. The secret is only needed
@@ -2480,13 +2488,12 @@ def _load_user_configs(
     Reads via `_read_users_yaml`, which routes `/etc/kai/users.yaml`
     through the sudo-cat shim and any other path (XDG single-user,
     `KAI_USERS_YAML` override) through a direct `Path.read_text`.
-    users.yaml is mandatory: any failure raises SystemExit with a
-    message naming the resolved path. There is no None return path
-    and no fallback to ALLOWED_USER_IDS at runtime. The fail-closed
-    shape is load-bearing for the daemon's auth contract: a
-    malformed or unreadable users file must not silently degrade to
-    env-only auth, because the wizard and the runtime would then
-    disagree about whose value wins.
+    When this loader is called, users.yaml is required and any failure
+    raises SystemExit with a message naming the resolved path. The
+    caller skips it only when Telegram is disabled and no users file
+    exists. A present malformed or unreadable file still fails closed;
+    it must not silently degrade to env-only auth because the wizard
+    and runtime would then disagree about whose value wins.
 
     Failure cases (each raises SystemExit):
         - File absent: error names the path and points at `make config`.
@@ -2609,6 +2616,13 @@ def _load_user_configs(
         os_user = entry.get("os_user")
         if os_user is not None:
             os_user = str(os_user).strip() or None
+
+        raw_runtime_profile_id = entry.get("runtime_profile_id")
+        runtime_profile_id: str | None = None
+        if raw_runtime_profile_id is not None:
+            runtime_profile_id = str(raw_runtime_profile_id).strip()
+            if re.fullmatch(r"rtp_[0-9a-f]{32}", runtime_profile_id) is None:
+                raise SystemExit(f"users.yaml: user '{name}' has an invalid runtime_profile_id")
 
         # Validate home_workspace. Warn but don't skip the user if
         # the directory doesn't exist - it may be on an unmounted drive
@@ -3023,6 +3037,7 @@ def _load_user_configs(
             role=role,
             github=github,
             os_user=os_user,
+            runtime_profile_id=runtime_profile_id,
             home_workspace=home_workspace,
             model=model,
             timeout=user_timeout,
@@ -3092,6 +3107,17 @@ def load_config() -> Config:
         enabled_adapters = parse_enabled_adapters(os.environ.get("KAI_ENABLED_ADAPTERS"))
     except ValueError as exc:
         raise SystemExit(f"KAI_ENABLED_ADAPTERS {exc}") from None
+    initial_workshop_provisioning = os.environ.get("KAI_WORKSHOP_BOOTSTRAP", "").strip() or None
+    if initial_workshop_provisioning is not None:
+        from kai.workshop.initial_provisioning import (
+            WorkshopInitialProvisioningError,
+            parse_initial_provisioning,
+        )
+
+        try:
+            parse_initial_provisioning(initial_workshop_provisioning)
+        except WorkshopInitialProvisioningError as exc:
+            raise SystemExit(str(exc)) from None
 
     # Telegram credentials are adapter configuration, not host credentials.
     # Keeping a token in protected storage while the adapter is disabled must
@@ -3547,12 +3573,12 @@ def load_config() -> Config:
     # explicit override for tests and ad-hoc development; the operator
     # path is always one of the two resolved defaults.
     users_yaml_path = _resolve_users_yaml_path(bool(protected_env))
-    if telegram_enabled or protected_env:
+    if telegram_enabled:
         user_configs = _load_user_configs(default_backend, default_provider, users_yaml_path)
     else:
-        # Direct development can omit Telegram identities when the adapter is
-        # disabled. Protected installs retain their existing, real identity
-        # mappings during this installed qualification slice.
+        # Telegram identity policy is optional when that adapter is disabled.
+        # A present malformed file still fails closed, regardless of deployment
+        # mode; an absent file leaves canonical Workshop identity untouched.
         raw_users = _read_users_yaml(users_yaml_path)
         if raw_users is None:
             user_configs = {}
@@ -3789,6 +3815,7 @@ def load_config() -> Config:
         telegram_webhook_secret=telegram_webhook_secret,
         allowed_user_ids=allowed_ids,
         enabled_adapters=enabled_adapters,
+        initial_workshop_provisioning=initial_workshop_provisioning,
         default_model=default_model,
         default_models=default_models,
         default_timeout=default_timeout,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -21,6 +21,7 @@ The install.conf file bridges the two steps: config writes it, apply reads it.
 It's a JSON file with a version field for forward compatibility.
 """
 
+import asyncio
 import grp
 import hashlib
 import http.client
@@ -88,6 +89,13 @@ from kai.workshop.diagnostics import (
     workshop_transition_tooling_status,
 )
 from kai.workshop.domain import RuntimeProfileId, WorkshopId
+from kai.workshop.human_provisioning import provisioned_human_ids
+from kai.workshop.initial_provisioning import (
+    WORKSHOP_BOOTSTRAP_ENV,
+    WorkshopInitialProvisioning,
+    WorkshopInitialProvisioningError,
+    parse_initial_provisioning,
+)
 from kai.workshop.runtime_profiles import (
     WorkshopRuntimeProfileError,
     WorkshopRuntimeProfileRegistry,
@@ -830,6 +838,82 @@ def _xdg_users_yaml_path() -> Path:
     return base / "kai" / "users.yaml"
 
 
+def _xdg_runtime_profiles_path() -> Path:
+    """Return the operator-owned runtime policy path for single-user mode."""
+    explicit = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(explicit).expanduser() if explicit else Path.home() / ".config"
+    return base / "kai" / "runtime-profiles.yaml"
+
+
+def _build_fresh_runtime_profile_policy(
+    plan: WorkshopInitialProvisioning,
+    *,
+    display_name: str,
+    os_user: str,
+    env: dict[str, str],
+) -> str:
+    """Render one canonical runtime profile without any transport identity."""
+    backend = str(env.get("DEFAULT_BACKEND") or "").strip().lower()
+    if backend not in VALID_BACKENDS:
+        raise ValueError("Fresh Workshop runtime policy requires a valid default backend")
+    provider = get_effective_provider(
+        backend,
+        str(env.get("DEFAULT_PROVIDER") or "").strip().lower(),
+    )
+    model = canonicalize_model_for_backend(
+        str(env.get("DEFAULT_MODEL") or "").strip() or get_default_model_for_backend(backend, provider),
+        backend,
+    )
+    timeout = _runtime_policy_default_timeout(env)
+    document = {
+        "version": 2,
+        "runtime_profiles": {
+            str(plan.runtime_profile_id): {
+                "display_name": display_name,
+                "os_user": os_user,
+                "backend": backend,
+                "provider": provider,
+                "model": model,
+                "timeout_seconds": timeout,
+                "allowed_services": [],
+                "home_workspace": None,
+                "workspace_base": None,
+                "allowed_workspaces": [],
+                "models": {},
+                "github_repos": [],
+                "pr_review": None,
+                "issue_triage": None,
+                "allowed_triage_projects": [],
+            }
+        },
+    }
+    return yaml.safe_dump(document, sort_keys=False, default_flow_style=False)
+
+
+async def _provision_single_user_workshop(
+    plan: WorkshopInitialProvisioning,
+    runtime_policy_content: str,
+    data_dir: Path,
+):
+    """Create the initial canonical records and return a one-time enrollment."""
+    from kai import sessions
+
+    runtime_profiles = WorkshopRuntimeProfileRegistry.from_yaml(runtime_policy_content)
+    await sessions.init_db(data_dir / "kai.db")
+    try:
+        await sessions.bootstrap_workshop_foundation((), workshop_id=plan.workshop_id)
+        provisioned = await sessions.reconcile_initial_workshop_human(
+            plan,
+            runtime_profiles,
+        )
+        return await sessions.issue_workshop_enrollment(
+            provisioned.principal_id,
+            provisioned.channel_id,
+        )
+    finally:
+        await sessions.close_db()
+
+
 def _read_users_yaml_text(path: Path) -> str | None:
     """Return the contents of a users.yaml file, falling back to sudo
     for root-owned protected copies.
@@ -1063,6 +1147,7 @@ def _build_migrated_runtime_profiles(
 
     profiles: dict[str, dict[str, object]] = {}
     seen: set[int] = set()
+    legacy_runtime_keys: dict[str, int] = {}
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -1110,7 +1195,17 @@ def _build_migrated_runtime_profiles(
                 raise ValueError
         except (TypeError, ValueError):
             timeout_seconds = defaults.timeout_seconds
-        profile_id = runtime_profile_id_for_config_id(runtime_config_id)
+        raw_profile_id = entry.get("runtime_profile_id")
+        if raw_profile_id is None:
+            profile_id = runtime_profile_id_for_config_id(runtime_config_id)
+            legacy_runtime_keys[str(profile_id)] = runtime_config_id
+        else:
+            try:
+                profile_id = RuntimeProfileId(str(raw_profile_id).strip())
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"users.yaml entry {runtime_config_id} has an invalid runtime_profile_id") from exc
+        if str(profile_id) in profiles:
+            raise ValueError(f"users.yaml maps multiple Telegram identities to runtime profile {profile_id}")
         profile: dict[str, object] = {
             "display_name": display_name,
             "backend": backend,
@@ -1155,20 +1250,18 @@ def _build_migrated_runtime_profiles(
         if raw_os_user is not None and str(raw_os_user).strip():
             profile["os_user"] = str(raw_os_user).strip()
         profiles[str(profile_id)] = profile
-    legacy_runtime_keys = {
-        str(runtime_profile_id_for_config_id(runtime_config_id)): runtime_config_id
-        for runtime_config_id in sorted(seen)
+    document: dict[str, object] = {
+        "version": 2,
+        "runtime_profiles": profiles,
     }
+    if legacy_runtime_keys:
+        document["legacy_runtime_archive"] = {
+            "version": 1,
+            "runtime_keys": legacy_runtime_keys,
+            "removal_gate": "canonical_runtime_state_v1",
+        }
     return yaml.safe_dump(
-        {
-            "version": 2,
-            "runtime_profiles": profiles,
-            "legacy_runtime_archive": {
-                "version": 1,
-                "runtime_keys": legacy_runtime_keys,
-                "removal_gate": "canonical_runtime_state_v1",
-            },
-        },
+        document,
         sort_keys=False,
         default_flow_style=False,
     )
@@ -1287,24 +1380,43 @@ def _upgrade_runtime_policy_content(
 def _runtime_policy_apply_plan(
     service_user: str,
     env: dict[str, str],
-    users_yaml_path: Path,
+    users_yaml_path: Path | None,
+    *,
+    staged_policy_path: Path | None = None,
 ) -> tuple[str, str, WorkshopRuntimeProfileRegistry]:
     """Validate existing policy or prepare the one-time migration before apply."""
     registry_entries = _backend_registry_entries(service_user, env, users_yaml_path)
     defaults = _runtime_policy_defaults(env, registry_entries)
-    migrated_content = _build_migrated_runtime_profiles(
-        users_yaml_path,
-        registry_entries=registry_entries,
-        defaults=defaults,
+    migrated_content = (
+        _build_migrated_runtime_profiles(
+            users_yaml_path,
+            registry_entries=registry_entries,
+            defaults=defaults,
+        )
+        if users_yaml_path is not None
+        else None
     )
-    if RUNTIME_PROFILES_YAML.is_file():
+    if staged_policy_path is not None:
+        try:
+            content = staged_policy_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ValueError(f"Could not read staged runtime policy {staged_policy_path}: {exc}") from exc
+        if RUNTIME_PROFILES_YAML.is_file():
+            raise ValueError("A fresh staged runtime policy cannot replace an existing protected policy")
+        action = "initialize"
+    elif RUNTIME_PROFILES_YAML.is_file():
         try:
             content = RUNTIME_PROFILES_YAML.read_text(encoding="utf-8")
         except OSError as exc:
             raise ValueError(f"Could not read protected runtime policy {RUNTIME_PROFILES_YAML}: {exc}") from exc
-        content, upgraded = _upgrade_runtime_policy_content(content, migrated_content, defaults)
+        if migrated_content is not None:
+            content, upgraded = _upgrade_runtime_policy_content(content, migrated_content, defaults)
+        else:
+            upgraded = False
         action = "upgrade" if upgraded else "preserve"
     else:
+        if migrated_content is None:
+            raise ValueError("No protected runtime policy or Telegram migration source is available")
         content = migrated_content
         action = "initialize"
     try:
@@ -1314,11 +1426,19 @@ def _runtime_policy_apply_plan(
         )
     except WorkshopRuntimeProfileError as exc:
         raise ValueError(f"Protected runtime policy is invalid: {exc}") from exc
-    missing = [
-        runtime_config_id
-        for runtime_config_id, _name, _os_user in _protected_user_assignments(users_yaml_path)
-        if not _runtime_policy_has_config_id(profiles, runtime_config_id)
-    ]
+    explicit_links = _protected_user_runtime_profile_ids(users_yaml_path) if users_yaml_path is not None else {}
+    missing = []
+    for runtime_config_id, _name, _os_user in (
+        _protected_user_assignments(users_yaml_path) if users_yaml_path is not None else ()
+    ):
+        explicit_profile_id = explicit_links.get(runtime_config_id)
+        if explicit_profile_id is not None:
+            try:
+                profiles.resolve(explicit_profile_id)
+            except WorkshopRuntimeProfileError:
+                missing.append(runtime_config_id)
+        elif not _runtime_policy_has_config_id(profiles, runtime_config_id):
+            missing.append(runtime_config_id)
     if missing:
         rendered = ", ".join(str(item) for item in missing)
         raise ValueError(
@@ -1373,6 +1493,38 @@ def _validate_protected_users_yaml(
         account_uid=(lambda name: pwd.getpwnam(name).pw_uid) if require_existing_accounts else None,
         service_uid=service_uid,
     )
+
+
+def _protected_user_runtime_profile_ids(
+    users_yaml_path: Path,
+) -> dict[int, RuntimeProfileId]:
+    """Return explicit canonical runtime links from protected Telegram policy."""
+    raw = _read_users_yaml_text(users_yaml_path)
+    if raw is None:
+        raise ValueError(f"Protected users.yaml is missing or unreadable: {users_yaml_path}")
+    try:
+        document = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Protected users.yaml is malformed: {users_yaml_path}: {exc}") from exc
+    entries = document.get("users") if isinstance(document, dict) else None
+    if not isinstance(entries, list):
+        raise ValueError(f"Protected users.yaml must contain a 'users' list: {users_yaml_path}")
+    result: dict[int, RuntimeProfileId] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or entry.get("runtime_profile_id") is None:
+            continue
+        try:
+            raw_id = entry.get("telegram_id")
+            if isinstance(raw_id, bool):
+                raise ValueError
+            telegram_id = int(raw_id)
+            if telegram_id <= 0:
+                raise ValueError
+            profile_id = RuntimeProfileId(str(entry["runtime_profile_id"]).strip())
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Protected users.yaml contains an invalid explicit runtime-profile link") from exc
+        result[telegram_id] = profile_id
+    return result
 
 
 def _entry_backend(entry: dict) -> object:
@@ -1496,6 +1648,10 @@ def _cmd_config() -> None:
 
     existing_env: dict = existing.get("env", {})
     had_legacy_webhook_secret = bool(str(existing_env.get("WEBHOOK_SECRET", "")).strip())
+    try:
+        existing_initial_plan = parse_initial_provisioning(existing_env.get(WORKSHOP_BOOTSTRAP_ENV))
+    except WorkshopInitialProvisioningError as exc:
+        raise SystemExit(f"install.conf {exc}") from exc
 
     # Auto-detect platform
     if sys.platform == "darwin":
@@ -1665,19 +1821,27 @@ def _cmd_config() -> None:
     else:
         users_yaml_path = _xdg_users_yaml_path()
     users_yaml_exists = users_yaml_path.exists()
-    if not telegram_enabled:
-        if deployment_mode == "single_user":
-            raise SystemExit(
-                "Workshop-only single-user bootstrap is not available yet. "
-                "Use a protected installation with existing canonical runtime policy, "
-                "or keep Telegram enabled for single-user setup."
-            )
-        if not users_yaml_exists or not RUNTIME_PROFILES_YAML.is_file():
-            raise SystemExit(
-                "Workshop-only mode currently requires an existing protected installation "
-                "with users.yaml and runtime-profiles.yaml. Start from the qualified hybrid "
-                "installation path before switching modes."
-            )
+    runtime_profiles_path = RUNTIME_PROFILES_YAML if deployment_mode == "protected" else _xdg_runtime_profiles_path()
+    runtime_policy_exists = runtime_profiles_path.is_file()
+    pending_runtime_policy = existing.get("runtime_profiles_staging_path")
+    fresh_workshop_bootstrap = bool(
+        workshop_enabled
+        and not telegram_enabled
+        and not runtime_policy_exists
+        and not pending_runtime_policy
+        and existing_initial_plan is None
+    )
+    if (
+        workshop_enabled
+        and not telegram_enabled
+        and not runtime_policy_exists
+        and not pending_runtime_policy
+        and not fresh_workshop_bootstrap
+    ):
+        raise SystemExit(
+            "Workshop-only mode has no runtime policy to assign to its canonical human. "
+            "Re-run make config to create a fresh policy."
+        )
     stray_note = (
         f"  Note: {stray_project_users_yaml} is no longer used. Move it to {users_yaml_path} or remove it."
         if stray_project_users_yaml.exists()
@@ -1716,6 +1880,41 @@ def _cmd_config() -> None:
     # the canonical file from a no-longer-current staging artifact.
     users_yaml_staging_path: str | None = None
     protected_yaml_staging_paths: dict[str, str] = {}
+    initial_plan = existing_initial_plan
+    runtime_profiles_staging_path: str | None = None
+
+    if fresh_workshop_bootstrap:
+        print("-- Initial Workshop admin --")
+        while True:
+            admin_name = _prompt(
+                "Admin display name",
+                os.environ.get("USER", "admin"),
+                required=True,
+            ).strip()
+            if _validate_display_name(admin_name):
+                break
+            print("  Name may only contain letters, numbers, spaces, hyphens, and underscores.")
+        if deployment_mode == "protected":
+            print("  Protected mode requires a distinct OS account for the agent runtime.")
+            while True:
+                admin_os_user = _prompt(
+                    "OS user for subprocess isolation",
+                    os.environ.get("USER", ""),
+                    required=True,
+                ).strip()
+                if not _validate_os_user(admin_os_user):
+                    print("  Username may only contain letters, numbers, dots, hyphens, and underscores.")
+                    continue
+                if admin_os_user == service_user:
+                    print(f"  Must differ from the Kai service account {service_user!r}.")
+                    continue
+                break
+        else:
+            admin_os_user = service_user
+        initial_plan = WorkshopInitialProvisioning.create(admin_name)
+        print("  The first human, direct channel, and runtime assignment will be canonical.")
+        print("  Telegram can be linked later without creating another human.")
+        print()
 
     # First-time install only: collect the admin identity and stage a
     # users.yaml. An existing canonical file is left untouched.
@@ -1793,6 +1992,9 @@ def _cmd_config() -> None:
             admin_name,
             os_user=admin_os_user,
             home_workspace=admin_home_workspace,
+            runtime_profile_id=(
+                str(existing_initial_plan.runtime_profile_id) if existing_initial_plan is not None else None
+            ),
         )
         if deployment_mode == "protected":
             users_yaml_path = _install_staging_path("users.yaml")
@@ -2888,6 +3090,31 @@ def _cmd_config() -> None:
         # mislead an operator after the flip.
         env.pop("MEMORY_DUPLICATE_THRESHOLD", None)
 
+    if initial_plan is not None:
+        env[WORKSHOP_BOOTSTRAP_ENV] = initial_plan.to_json()
+        if deployment_mode == "single_user" and not fresh_workshop_bootstrap:
+            env["KAI_RUNTIME_PROFILES_YAML"] = str(runtime_profiles_path)
+
+    if fresh_workshop_bootstrap:
+        assert initial_plan is not None
+        assert admin_os_user is not None
+        runtime_policy_content = _build_fresh_runtime_profile_policy(
+            initial_plan,
+            display_name=admin_name,
+            os_user=admin_os_user,
+            env=env,
+        )
+        if deployment_mode == "protected":
+            staged_policy = _install_staging_path("runtime-profiles.yaml")
+            staged_policy.write_text(runtime_policy_content, encoding="utf-8")
+            os.chmod(staged_policy, 0o600)
+            runtime_profiles_staging_path = str(staged_policy)
+        else:
+            runtime_profiles_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            runtime_profiles_path.write_text(runtime_policy_content, encoding="utf-8")
+            os.chmod(runtime_profiles_path, 0o600)
+            env["KAI_RUNTIME_PROFILES_YAML"] = str(runtime_profiles_path)
+
     # Build and write install.conf
     conf = {
         "version": _CONF_VERSION,
@@ -2915,6 +3142,9 @@ def _cmd_config() -> None:
         conf["users_yaml_staging_path"] = users_yaml_staging_path
     if protected_yaml_staging_paths:
         conf["protected_yaml_staging_paths"] = protected_yaml_staging_paths
+    if runtime_profiles_staging_path:
+        conf["runtime_profiles_staging_path"] = runtime_profiles_staging_path
+        conf["workshop_enrollment_pending"] = True
 
     INSTALL_CONF.write_text(json.dumps(conf, indent=2) + "\n")
     # Restrict permissions since the file contains secrets (bot token, webhook secret)
@@ -2934,7 +3164,24 @@ def _cmd_config() -> None:
         env_path.write_text(_generate_env_file(env))
         os.chmod(env_path, 0o600)
         print(f"Wrote runtime env to {env_path}")
-        print(f"users.yaml is at {users_yaml_path}")
+        if users_yaml_exists or telegram_enabled:
+            print(f"users.yaml is at {users_yaml_path}")
+        if fresh_workshop_bootstrap:
+            assert initial_plan is not None
+            issued = asyncio.run(
+                _provision_single_user_workshop(
+                    initial_plan,
+                    runtime_policy_content,
+                    Path(data_dir),
+                )
+            )
+            print()
+            print("Initial Workshop browser enrollment")
+            print(f"Enrollment: {issued.grant.grant_id}")
+            print(f"Channel: {issued.channel_id}")
+            print(f"Expires: {issued.grant.expires_at.isoformat()}")
+            print(f"Token: {issued.grant.token}")
+            print("The token is shown once; Kai stores only its hash.")
         print()
         print("Single-user mode does not require 'sudo make install'.")
         print("Start the daemon with: make run")
@@ -3240,6 +3487,7 @@ def _generate_users_yaml(
     name: str,
     os_user: str | None = None,
     home_workspace: str | None = None,
+    runtime_profile_id: str | None = None,
 ) -> str:
     """
     Generate a minimal users.yaml with a single admin entry.
@@ -3285,6 +3533,8 @@ def _generate_users_yaml(
     ]
     if os_user:
         lines.append(f"    os_user: {_yaml_scalar(os_user)}")
+    if runtime_profile_id:
+        lines.append(f"    runtime_profile_id: {_yaml_scalar(runtime_profile_id)}")
     if home_workspace:
         lines.append(f"    home_workspace: {_yaml_scalar(home_workspace)}")
     lines.append("")  # trailing newline
@@ -4950,10 +5200,16 @@ def _runtime_profile_principal_names(
 def _runtime_storage_targets(
     data_path: Path,
     runtime_profiles: WorkshopRuntimeProfileRegistry,
-    users_yaml_path: Path,
+    users_yaml_path: Path | None,
+    *,
+    initial_plan: WorkshopInitialProvisioning | None = None,
 ) -> tuple[_RuntimeStorageTarget, ...]:
     """Build profile-authoritative provisioning targets before disk mutation."""
-    compatibility_order = [chat_id for chat_id, _os_user in _collect_user_memory_owners(users_yaml_path)]
+    compatibility_order = (
+        [chat_id for chat_id, _os_user in _collect_user_memory_owners(users_yaml_path)]
+        if users_yaml_path is not None
+        else []
+    )
     compatibility_ids = set(compatibility_order)
     assignments_initialized, workshop_id, principal_names = _runtime_profile_principal_names(data_path)
     compatibility_principal_names = _canonical_principal_storage_names(data_path)
@@ -4993,11 +5249,18 @@ def _runtime_storage_targets(
                 f"Protected runtime profile {profile.profile_id} conflicts with its canonical compatibility owner"
             )
         if principal_name is None:
-            if runtime_config_id is None or runtime_config_id not in compatibility_ids:
+            if initial_plan is not None and profile.profile_id == initial_plan.runtime_profile_id:
+                principal_name = str(
+                    provisioned_human_ids(
+                        initial_plan.workshop_id,
+                        initial_plan.provisioning_key,
+                    )[0]
+                )
+            elif runtime_config_id is None or runtime_config_id not in compatibility_ids:
                 raise RuntimeError(
                     f"Protected runtime profile {profile.profile_id} must map to exactly one canonical human owner"
                 )
-            if compatibility_principal is not None:
+            elif compatibility_principal is not None:
                 principal_name = compatibility_principal
             elif assignments_initialized:
                 assert workshop_id is not None
@@ -6075,6 +6338,53 @@ def _apply_migrate(
                 print(f"  Created {user_tmp}")
 
 
+def _issue_installed_initial_enrollment(
+    plan: WorkshopInitialProvisioning,
+    *,
+    install_dir: str,
+    data_dir: str,
+    service_user: str,
+) -> str:
+    """Issue the staged first browser enrollment as the database owner."""
+    principal_id, channel_id = provisioned_human_ids(
+        plan.workshop_id,
+        plan.provisioning_key,
+    )
+    command = [
+        "sudo",
+        "-H",
+        "-u",
+        service_user,
+        "env",
+        f"KAI_DATA_DIR={data_dir}",
+        f"KAI_INSTALL_DIR={install_dir}",
+        f"{install_dir}/venv/bin/python",
+        "-m",
+        "kai",
+        "workshop",
+        "client-access",
+        "issue-enrollment",
+        "--principal-id",
+        str(principal_id),
+        "--channel-id",
+        str(channel_id),
+    ]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        raise RuntimeError(f"Could not issue initial Workshop browser enrollment: {detail}")
+    output = result.stdout.strip()
+    if "Token: kai_ws_enroll_v1." not in output:
+        raise RuntimeError("Initial Workshop enrollment command returned no one-time token")
+    return output
+
+
 def _cmd_apply() -> None:
     """
     Read install.conf and perform the installation. Requires root.
@@ -6179,6 +6489,16 @@ def _cmd_apply() -> None:
     # touching; the protected-mode gate ensures we never reach here
     # with that combination.
     users_yaml_staging_path = conf.get("users_yaml_staging_path", "") or None
+    runtime_profiles_staging_path = conf.get("runtime_profiles_staging_path", "") or None
+    if runtime_profiles_staging_path is not None:
+        if not isinstance(runtime_profiles_staging_path, str):
+            raise SystemExit("install.conf runtime_profiles_staging_path must be an absolute path string.")
+        if not Path(runtime_profiles_staging_path).is_absolute():
+            raise SystemExit("install.conf runtime_profiles_staging_path must be an absolute path.")
+    try:
+        initial_plan = parse_initial_provisioning(env.get(WORKSHOP_BOOTSTRAP_ENV))
+    except WorkshopInitialProvisioningError as exc:
+        raise SystemExit(f"install.conf {exc}") from exc
     raw_protected_yaml_staging_paths = conf.get("protected_yaml_staging_paths", {})
     if raw_protected_yaml_staging_paths is None:
         protected_yaml_staging_paths: dict[str, str] = {}
@@ -6219,20 +6539,25 @@ def _cmd_apply() -> None:
     # file wins on first install; otherwise the canonical protected copy stays
     # authoritative, matching _apply_secrets' copy/skip behavior.
     staged_users_yaml = Path(users_yaml_staging_path) if users_yaml_staging_path else None
-    effective_users_yaml = (
+    candidate_users_yaml = (
         staged_users_yaml if staged_users_yaml is not None and staged_users_yaml.is_file() else USERS_YAML
     )
-    try:
-        _validate_protected_users_yaml(
-            effective_users_yaml,
-            service_user,
-            require_existing_accounts=True,
-            service_uid=svc_uid,
-        )
-    except ValueError as exc:
-        raise SystemExit(
-            f"Protected user isolation preflight failed; no installation changes were made:\n{exc}"
-        ) from exc
+    telegram_enabled = "telegram" in parse_enabled_adapters(env.get("KAI_ENABLED_ADAPTERS"))
+    effective_users_yaml: Path | None = (
+        candidate_users_yaml if candidate_users_yaml.is_file() or telegram_enabled else None
+    )
+    if effective_users_yaml is not None:
+        try:
+            _validate_protected_users_yaml(
+                effective_users_yaml,
+                service_user,
+                require_existing_accounts=True,
+                service_uid=svc_uid,
+            )
+        except ValueError as exc:
+            raise SystemExit(
+                f"Protected user isolation preflight failed; no installation changes were made:\n{exc}"
+            ) from exc
 
     # Defensive validation: refuse to apply an install.conf whose
     # explicit DEFAULT_MODEL would fail load_config's startup check.
@@ -6303,6 +6628,9 @@ def _cmd_apply() -> None:
             service_user,
             env,
             effective_users_yaml,
+            staged_policy_path=(
+                Path(runtime_profiles_staging_path) if runtime_profiles_staging_path is not None else None
+            ),
         )
         runtime_policy.validate_protected_os_users(
             service_user,
@@ -6319,6 +6647,7 @@ def _cmd_apply() -> None:
             Path(data_dir),
             runtime_policy,
             effective_users_yaml,
+            initial_plan=initial_plan,
         )
     except (RuntimeError, ValueError) as exc:
         raise SystemExit(
@@ -6340,7 +6669,11 @@ def _cmd_apply() -> None:
     print()
 
     if dry_run:
-        expected_humans = len(_protected_user_assignments(effective_users_yaml))
+        expected_humans = (
+            len(_protected_user_assignments(effective_users_yaml))
+            if effective_users_yaml is not None
+            else int(initial_plan is not None)
+        )
         print(
             "[DRY RUN] "
             + workshop_bootstrap_status(
@@ -6535,6 +6868,13 @@ def _cmd_apply() -> None:
                 for path in protected_yaml_staging_paths.values():
                     Path(path).unlink(missing_ok=True)
                 _strip_install_conf_keys("protected_yaml_staging_paths")
+        if runtime_profiles_staging_path:
+            if dry_run:
+                print(f"[DRY RUN] Would unlink staging file: {runtime_profiles_staging_path}")
+                print("[DRY RUN] Would strip runtime_profiles_staging_path from install.conf")
+            else:
+                Path(runtime_profiles_staging_path).unlink(missing_ok=True)
+                _strip_install_conf_keys("runtime_profiles_staging_path")
     except Exception:
         print("\nInstallation failed. See error above.")
         print("The installation may be in a partial state.")
@@ -6584,6 +6924,29 @@ def _cmd_apply() -> None:
                 print("Manual recovery: sudo systemctl start kai")
             if apply_succeeded:
                 raise
+
+    if conf.get("workshop_enrollment_pending"):
+        if initial_plan is None:
+            raise SystemExit("install.conf requests an initial Workshop enrollment but has no bootstrap policy")
+        if dry_run:
+            print("[DRY RUN] Would issue one browser enrollment for the initial canonical Workshop admin")
+        else:
+            try:
+                enrollment_output = _issue_installed_initial_enrollment(
+                    initial_plan,
+                    install_dir=install_dir,
+                    data_dir=data_dir,
+                    service_user=service_user,
+                )
+            except (OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
+                raise SystemExit(
+                    "Kai was installed and started, but initial Workshop enrollment failed. "
+                    f"Re-run make install to retry: {exc}"
+                ) from exc
+            print()
+            print("Initial Workshop browser enrollment")
+            print(enrollment_output)
+            _strip_install_conf_keys("workshop_enrollment_pending")
 
     # -- Summary --
     print()
@@ -8692,10 +9055,13 @@ def _cmd_status() -> None:
 
     expected_humans: int | None = None
     if os.geteuid() == 0:
+        configured_humans = 0
         try:
-            expected_humans = len(_protected_user_assignments(USERS_YAML))
+            configured_humans = len(_protected_user_assignments(USERS_YAML))
         except ValueError:
             pass
+        initial_plan = _read_deployed_initial_provisioning(_DEPLOYED_ENV_FILE)
+        expected_humans = max(configured_humans, int(initial_plan is not None))
     print(
         workshop_bootstrap_status(
             Path(data_dir) / "kai.db",
@@ -9019,6 +9385,32 @@ def _read_deployed_memory_enabled(env_path: Path) -> bool | None:
         return False
     except (FileNotFoundError, OSError, UnicodeError, ProtectedConfigError):
         return None
+
+
+def _read_deployed_initial_provisioning(
+    env_path: Path,
+) -> WorkshopInitialProvisioning | None:
+    """Read only non-secret initial Workshop policy from deployed env."""
+    try:
+        validate_protected_file_metadata(env_path, max_mode=0o600, require_root_owner=True)
+        with env_path.open(encoding="utf-8") as env_file:
+            for line in env_file:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                key, separator, raw_value = stripped.partition("=")
+                if separator and key.strip() == WORKSHOP_BOOTSTRAP_ENV:
+                    value = raw_value.strip().strip("\"'")
+                    return parse_initial_provisioning(value)
+    except (
+        FileNotFoundError,
+        OSError,
+        UnicodeError,
+        ProtectedConfigError,
+        WorkshopInitialProvisioningError,
+    ):
+        return None
+    return None
 
 
 def _core_schedule_status(db_path: Path) -> str:

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -54,6 +54,8 @@ from kai.http_adapter import HttpAdapter, HttpIngressAdapter
 from kai.memory_backup import run_memory_backup
 from kai.workshop.bootstrap import BootstrapHuman, BootstrapNotificationChannel
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
+from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.initial_provisioning import parse_initial_provisioning
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 
 
@@ -107,6 +109,7 @@ def _workshop_bootstrap_humans(
             runtime_profile_id=runtime_profiles.profile_for_legacy_runtime_key(user.telegram_id).profile_id,
         )
         for user in sorted(config.user_configs.values(), key=lambda user: user.telegram_id)
+        if user.runtime_profile_id is None
     )
 
 
@@ -509,10 +512,37 @@ def _start() -> None:
         # principals but never create an inbound identity or alter live GitHub
         # routing through this migration.
         runtime_profiles = WorkshopRuntimeProfileRegistry.load(config)
+        initial_plan = parse_initial_provisioning(config.initial_workshop_provisioning)
         workshop_bootstrap = await sessions.bootstrap_workshop_foundation(
-            _workshop_bootstrap_humans(config, runtime_profiles),
-            notification_channels=await _workshop_bootstrap_notification_channels(config),
+            (_workshop_bootstrap_humans(config, runtime_profiles) if config.telegram_enabled else ()),
+            workshop_id=initial_plan.workshop_id if initial_plan is not None else None,
         )
+        if initial_plan is not None:
+            await sessions.reconcile_initial_workshop_human(
+                initial_plan,
+                runtime_profiles,
+            )
+        if config.telegram_enabled:
+            for user in sorted(
+                config.user_configs.values(),
+                key=lambda item: item.telegram_id,
+            ):
+                if user.runtime_profile_id is None:
+                    continue
+                await sessions.link_workshop_transport_profile(
+                    runtime_profiles,
+                    runtime_profile_id=RuntimeProfileId(user.runtime_profile_id),
+                    transport="telegram",
+                    external_subject=str(user.telegram_id),
+                    external_channel_id=str(user.telegram_id),
+                )
+            notification_channels = await _workshop_bootstrap_notification_channels(config)
+            if notification_channels:
+                await sessions.bootstrap_workshop_foundation(
+                    (),
+                    notification_channels=notification_channels,
+                    workshop_id=initial_plan.workshop_id if initial_plan is not None else None,
+                )
         logging.info(
             "Workshop bootstrap ready (humans=%d, channels=%d, new_events=%d, existing_events=%d)",
             workshop_bootstrap.human_count,

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -50,19 +50,31 @@ from kai.workshop.bootstrap import (
     BootstrapResult,
     bootstrap_default_workshop,
 )
+from kai.workshop.client_access import IssuedClientEnrollment, WorkshopClientAccess
 from kai.workshop.conversation_runs import (
     CanonicalConversationRunResolution,
     resolve_canonical_conversation_run,
 )
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
-from kai.workshop.domain import MessageId
+from kai.workshop.domain import (
+    ChannelId,
+    MessageId,
+    PrincipalId,
+    RuntimeProfileId,
+    WorkshopId,
+)
 from kai.workshop.execution_state import (
     WorkshopExecutionStateMigration,
     WorkshopExecutionStateNamespace,
     WorkshopExecutionStateRegistry,
     reconcile_legacy_execution_state,
 )
+from kai.workshop.human_provisioning import (
+    ProvisionedWorkshopHuman,
+    WorkshopHumanProvisioner,
+)
 from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.initial_provisioning import WorkshopInitialProvisioning
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_authority import (
     WorkshopMemoryAuthorityMigration,
@@ -91,9 +103,11 @@ from kai.workshop.streaming_preview import (
     TelegramStreamingPreviewBinding,
     bind_confirmed_telegram_streaming_preview,
 )
+from kai.workshop.transport_linking import WorkshopTransportLinker
 
 if TYPE_CHECKING:
     from kai.config import Config, WorkspaceConfig
+from kai.workshop.runtime_assignments import WorkshopRuntimeAssignmentService
 from kai.workshop.runtime_key_cutover import (
     WorkshopRuntimeKeyCutover,
     reconcile_workshop_runtime_key_cutover,
@@ -360,6 +374,7 @@ async def bootstrap_workshop_foundation(
     humans: tuple[BootstrapHuman, ...],
     *,
     notification_channels: tuple[BootstrapNotificationChannel, ...] = (),
+    workshop_id: WorkshopId | None = None,
 ) -> BootstrapResult:
     """Seed non-authoritative Workshop records on Kai's initialized DB."""
     if _workshop_event_lock is None:
@@ -370,6 +385,67 @@ async def bootstrap_workshop_foundation(
             store,
             humans,
             notification_channels=notification_channels,
+            workshop_id=workshop_id,
+        )
+
+
+async def reconcile_initial_workshop_human(
+    plan: WorkshopInitialProvisioning,
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
+) -> ProvisionedWorkshopHuman:
+    """Idempotently provision and assign the first transport-free human."""
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    runtime_profiles.resolve(plan.runtime_profile_id)
+    async with _workshop_event_lock:
+        store = WorkshopEventStore.from_initialized_connection(_get_db())
+        provisioned = await WorkshopHumanProvisioner(store).provision(
+            plan.provisioning_key,
+            plan.display_name,
+            plan.role,
+            workshop_id=plan.workshop_id,
+        )
+        await WorkshopRuntimeAssignmentService(store, runtime_profiles).assign(
+            provisioned.principal_id,
+            provisioned.channel_id,
+            plan.runtime_profile_id,
+        )
+        return provisioned
+
+
+async def link_workshop_transport_profile(
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
+    *,
+    runtime_profile_id: RuntimeProfileId,
+    transport: str,
+    external_subject: str,
+    external_channel_id: str,
+) -> None:
+    """Bind adapter routing to an already-assigned canonical runtime profile."""
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        store = WorkshopEventStore.from_initialized_connection(_get_db())
+        await WorkshopTransportLinker(store, runtime_profiles).link_runtime_profile(
+            runtime_profile_id,
+            transport=transport,
+            external_subject=external_subject,
+            external_channel_id=external_channel_id,
+        )
+
+
+async def issue_workshop_enrollment(
+    principal_id: PrincipalId,
+    channel_id: ChannelId,
+) -> IssuedClientEnrollment:
+    """Issue one enrollment for an initialized canonical human/channel."""
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        store = WorkshopEventStore.from_initialized_connection(_get_db())
+        return await WorkshopClientAccess(store).issue_enrollment(
+            principal_id,
+            channel_id,
         )
 
 

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -141,6 +141,7 @@ async def bootstrap_default_workshop(
     humans: Iterable[BootstrapHuman],
     *,
     notification_channels: Iterable[BootstrapNotificationChannel] = (),
+    workshop_id: WorkshopId | None = None,
 ) -> BootstrapResult:
     """Seed one Workshop and its configured humans without changing routing."""
     ordered_humans = sorted(humans, key=lambda human: (human.transport, human.external_subject))
@@ -150,6 +151,7 @@ async def bootstrap_default_workshop(
     )
     seen_identities: set[tuple[str, str]] = set()
     seen_channels: set[tuple[str, str]] = set()
+    existing_identity_principals: dict[tuple[str, str], PrincipalId] = {}
     for human in ordered_humans:
         identity = (human.transport, human.external_subject)
         channel = (human.transport, human.external_channel_id)
@@ -165,8 +167,17 @@ async def bootstrap_default_workshop(
             raise ValueError(f"Duplicate bootstrap external channel for transport {channel.transport!r}")
         seen_channels.add(identity)
         for subject in channel.member_external_subjects:
-            if (channel.transport, subject) not in seen_identities:
+            member_identity = (channel.transport, subject)
+            if member_identity in seen_identities:
+                continue
+            async with store.connection.execute(
+                "SELECT principal_id FROM external_identities WHERE provider = ? AND external_subject = ?",
+                member_identity,
+            ) as cursor:
+                identity_rows = list(await cursor.fetchall())
+            if len(identity_rows) != 1:
                 raise ValueError("Notification channel member must reference a configured external identity")
+            existing_identity_principals[member_identity] = PrincipalId(str(identity_rows[0][0]))
 
     created_events = 0
     existing_events = 0
@@ -174,7 +185,7 @@ async def bootstrap_default_workshop(
     workshop_key = _idempotency_key("workshop", "default")
     workshop_event = await store.event_by_idempotency_key(workshop_key)
     if workshop_event is None:
-        workshop_id = WorkshopId.new()
+        workshop_id = workshop_id or WorkshopId.new()
         result = await store.append(
             EventEnvelope.create(
                 event_type=WorkshopEventType.WORKSHOP_CREATED,
@@ -195,7 +206,10 @@ async def bootstrap_default_workshop(
         existing_events += 1
     if not isinstance(workshop_event.envelope.aggregate_id, WorkshopId):
         raise RuntimeError("Default Workshop bootstrap event has the wrong aggregate type")
-    workshop_id = workshop_event.envelope.aggregate_id
+    resolved_workshop_id = workshop_event.envelope.aggregate_id
+    if workshop_id is not None and resolved_workshop_id != workshop_id:
+        raise RuntimeError("Configured initial Workshop ID conflicts with existing canonical state")
+    workshop_id = resolved_workshop_id
 
     async def ensure(**kwargs) -> StoredEvent:
         nonlocal created_events, existing_events
@@ -384,11 +398,15 @@ async def bootstrap_default_workshop(
         )
         for subject in sorted(notification.member_external_subjects):
             human_token = _stable_token(notification.transport, subject)
-            principal_id = bootstrap_human_principal_id(
-                workshop_id,
-                notification.transport,
-                subject,
-            )
+            existing_principal = existing_identity_principals.get((notification.transport, subject))
+            if existing_principal is not None:
+                principal_id = existing_principal
+            else:
+                principal_id = bootstrap_human_principal_id(
+                    workshop_id,
+                    notification.transport,
+                    subject,
+                )
             membership_id = ChannelMembershipId.derived(
                 workshop_id,
                 f"notification-channel-membership:{channel_token}:human:{human_token}",

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -124,7 +124,7 @@ def _pending_status(expected_humans: int | None) -> str:
     return (
         "Workshop bootstrap: pending; service startup will seed "
         f"1 workshop, {expected_humans} human principal(s), "
-        f"{expected_humans} Telegram direct channel binding(s), and 1 Kai agent"
+        f"{expected_humans} direct channel(s), runtime assignment(s), and 1 Kai agent"
     )
 
 
@@ -173,12 +173,7 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
 
     expected_memberships = 2 * (human_count if expected_humans is None else expected_humans)
     expected_state_present = (
-        expected_humans is None
-        or (
-            human_count >= expected_humans
-            and telegram_binding_count >= expected_humans
-            and runtime_assignment_count >= expected_humans
-        )
+        expected_humans is None or (human_count >= expected_humans and runtime_assignment_count >= expected_humans)
     ) and channel_membership_count >= expected_memberships
     initialized = workshop_count >= 1 and agent_count >= 1 and projection_count == 1 and expected_state_present
     state = "initialized" if initialized else "pending"

--- a/src/kai/workshop/human_provisioning.py
+++ b/src/kai/workshop/human_provisioning.py
@@ -39,6 +39,19 @@ class ProvisionedWorkshopHuman:
 _PROVISIONING_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 
 
+def provisioned_human_ids(
+    workshop_id: WorkshopId,
+    provisioning_key: str,
+) -> tuple[PrincipalId, ChannelId]:
+    """Return the stable principal/direct-channel IDs for operator provisioning."""
+    normalized_key = _normalize_provisioning_key(provisioning_key)
+    stable_prefix = f"operator-human:{normalized_key}"
+    return (
+        PrincipalId.derived(workshop_id, stable_prefix),
+        ChannelId.derived(workshop_id, f"{stable_prefix}:direct-channel"),
+    )
+
+
 def _normalize_display_name(value: object) -> str:
     if not isinstance(value, str) or not value.strip() or len(value.strip()) > 200:
         raise WorkshopHumanProvisioningError("Display name must contain 1 through 200 characters")
@@ -86,14 +99,13 @@ class WorkshopHumanProvisioner:
             resolved_workshop_id = await self._resolve_workshop(workshop_id)
             agent_id, agent_principal_id = await self._resolve_kai_agent(resolved_workshop_id)
             stable_prefix = f"operator-human:{normalized_key}"
-            principal_id = PrincipalId.derived(resolved_workshop_id, stable_prefix)
+            principal_id, channel_id = provisioned_human_ids(
+                resolved_workshop_id,
+                normalized_key,
+            )
             membership_id = WorkshopMembershipId.derived(
                 resolved_workshop_id,
                 f"{stable_prefix}:workshop-membership",
-            )
-            channel_id = ChannelId.derived(
-                resolved_workshop_id,
-                f"{stable_prefix}:direct-channel",
             )
             human_channel_membership_id = ChannelMembershipId.derived(
                 resolved_workshop_id,

--- a/src/kai/workshop/initial_provisioning.py
+++ b/src/kai/workshop/initial_provisioning.py
@@ -1,0 +1,113 @@
+"""Operator policy for the first transport-independent Workshop human."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+from dataclasses import dataclass
+
+from kai.workshop.domain import RuntimeProfileId, WorkshopId
+
+WORKSHOP_BOOTSTRAP_ENV = "KAI_WORKSHOP_BOOTSTRAP"
+_PROVISIONING_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+
+
+class WorkshopInitialProvisioningError(RuntimeError):
+    """The protected initial-Workshop policy is missing or malformed."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopInitialProvisioning:
+    """Stable operator intent for one initial canonical Workshop admin."""
+
+    workshop_id: WorkshopId
+    provisioning_key: str
+    display_name: str
+    role: str
+    runtime_profile_id: RuntimeProfileId
+
+    def __post_init__(self) -> None:
+        if not _PROVISIONING_KEY_PATTERN.fullmatch(self.provisioning_key):
+            raise WorkshopInitialProvisioningError("Initial Workshop provisioning key must be a lowercase identifier")
+        if not self.display_name.strip() or len(self.display_name.strip()) > 200:
+            raise WorkshopInitialProvisioningError(
+                "Initial Workshop display name must contain 1 through 200 characters"
+            )
+        if self.role not in {"admin", "member"}:
+            raise WorkshopInitialProvisioningError("Initial Workshop role must be 'admin' or 'member'")
+
+    @classmethod
+    def create(cls, display_name: str) -> WorkshopInitialProvisioning:
+        workshop_id = WorkshopId.new()
+        provisioning_key = "initial-admin"
+        return cls(
+            workshop_id=workshop_id,
+            provisioning_key=provisioning_key,
+            display_name=display_name.strip(),
+            role="admin",
+            runtime_profile_id=RuntimeProfileId.derived(
+                workshop_id,
+                f"initial-runtime:{provisioning_key}",
+            ),
+        )
+
+    @classmethod
+    def from_json(cls, value: object) -> WorkshopInitialProvisioning:
+        if not isinstance(value, str) or not value.strip():
+            raise WorkshopInitialProvisioningError(f"{WORKSHOP_BOOTSTRAP_ENV} must contain a versioned policy")
+        encoded = value.strip()
+        if not encoded.startswith("v1."):
+            raise WorkshopInitialProvisioningError(f"{WORKSHOP_BOOTSTRAP_ENV} must contain a version 1 policy")
+        try:
+            padding = "=" * (-len(encoded[3:]) % 4)
+            document = json.loads(base64.urlsafe_b64decode(encoded[3:] + padding).decode("utf-8"))
+        except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise WorkshopInitialProvisioningError(f"{WORKSHOP_BOOTSTRAP_ENV} is not a valid encoded policy") from exc
+        if not isinstance(document, dict) or document.get("version") != 1:
+            raise WorkshopInitialProvisioningError(f"{WORKSHOP_BOOTSTRAP_ENV} must be a version 1 JSON object")
+        expected = {
+            "version",
+            "workshop_id",
+            "provisioning_key",
+            "display_name",
+            "role",
+            "runtime_profile_id",
+        }
+        if set(document) != expected:
+            raise WorkshopInitialProvisioningError(f"{WORKSHOP_BOOTSTRAP_ENV} contains missing or unsupported fields")
+        try:
+            return cls(
+                workshop_id=WorkshopId(str(document["workshop_id"])),
+                provisioning_key=str(document["provisioning_key"]),
+                display_name=str(document["display_name"]),
+                role=str(document["role"]),
+                runtime_profile_id=RuntimeProfileId(str(document["runtime_profile_id"])),
+            )
+        except (TypeError, ValueError) as exc:
+            raise WorkshopInitialProvisioningError(
+                f"{WORKSHOP_BOOTSTRAP_ENV} contains an invalid opaque identifier"
+            ) from exc
+
+    def to_json(self) -> str:
+        payload = json.dumps(
+            {
+                "version": 1,
+                "workshop_id": str(self.workshop_id),
+                "provisioning_key": self.provisioning_key,
+                "display_name": self.display_name.strip(),
+                "role": self.role,
+                "runtime_profile_id": str(self.runtime_profile_id),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return "v1." + base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+def parse_initial_provisioning(value: object) -> WorkshopInitialProvisioning | None:
+    """Parse an optional initial-provisioning policy."""
+    if value is None or value == "":
+        return None
+    return WorkshopInitialProvisioning.from_json(value)

--- a/src/kai/workshop/transport_linking.py
+++ b/src/kai/workshop/transport_linking.py
@@ -1,0 +1,206 @@
+"""Bind optional client identities to existing canonical Workshop humans."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from kai.workshop.domain import (
+    ChannelBindingId,
+    ChannelId,
+    EventEnvelope,
+    ExternalIdentityId,
+    PrincipalId,
+    RuntimeProfileId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+
+_TRANSPORT_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+class WorkshopTransportLinkError(RuntimeError):
+    """A transport identity cannot be linked without changing authority."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopTransportLink:
+    principal_id: PrincipalId
+    channel_id: ChannelId
+    transport: str
+    external_subject: str
+    external_channel_id: str
+    created_events: int
+
+
+def _token(*parts: str) -> str:
+    return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
+
+
+class WorkshopTransportLinker:
+    """Attach adapter routing to a pre-existing runtime-owned direct channel."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        runtime_profiles: WorkshopRuntimeProfileRegistry,
+    ) -> None:
+        self._store = store
+        self._runtime_profiles = runtime_profiles
+
+    async def link_runtime_profile(
+        self,
+        runtime_profile_id: RuntimeProfileId,
+        *,
+        transport: str,
+        external_subject: str,
+        external_channel_id: str,
+    ) -> WorkshopTransportLink:
+        self._runtime_profiles.resolve(runtime_profile_id)
+        if not _TRANSPORT_PATTERN.fullmatch(transport):
+            raise WorkshopTransportLinkError("Transport must be a lowercase identifier")
+        subject = external_subject.strip()
+        external_channel = external_channel_id.strip()
+        if not subject or not external_channel:
+            raise WorkshopTransportLinkError("External subject and channel must be non-empty")
+
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            workshop_id, principal_id, channel_id = await self._resolve_runtime_owner(runtime_profile_id)
+            await self._reject_conflicting_identity(transport, subject, principal_id)
+            await self._reject_conflicting_channel(transport, external_channel, channel_id)
+            stable = _token(transport, subject, external_channel)
+            identity_key = f"operator:transport-link:{stable}:identity"
+            channel_key = f"operator:transport-link:{stable}:channel"
+            prior_identity = await self._store.event_by_idempotency_key(identity_key)
+            prior_channel = await self._store.event_by_idempotency_key(channel_key)
+            if prior_identity is not None or prior_channel is not None:
+                if prior_identity is None or prior_channel is None:
+                    raise WorkshopTransportLinkError("Transport link has an incomplete canonical event pair")
+                await connection.commit()
+                return WorkshopTransportLink(
+                    principal_id,
+                    channel_id,
+                    transport,
+                    subject,
+                    external_channel,
+                    0,
+                )
+            identity_id = ExternalIdentityId.derived(
+                workshop_id,
+                f"transport-link:identity:{stable}",
+            )
+            binding_id = ChannelBindingId.derived(
+                workshop_id,
+                f"transport-link:channel:{stable}",
+            )
+            events = (
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.EXTERNAL_IDENTITY_BOUND,
+                    event_version=1,
+                    workshop_id=workshop_id,
+                    aggregate_type="external_identity",
+                    aggregate_id=identity_id,
+                    occurred_at=datetime.now(UTC),
+                    idempotency_key=identity_key,
+                    payload={
+                        "principal_id": principal_id,
+                        "provider": transport,
+                        "external_subject": subject,
+                    },
+                    metadata={"source": "adapter_policy"},
+                ),
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.TRANSPORT_CHANNEL_BOUND,
+                    event_version=1,
+                    workshop_id=workshop_id,
+                    aggregate_type="channel_binding",
+                    aggregate_id=binding_id,
+                    occurred_at=datetime.now(UTC),
+                    idempotency_key=channel_key,
+                    payload={
+                        "channel_id": channel_id,
+                        "transport": transport,
+                        "external_channel_id": external_channel,
+                    },
+                    metadata={"source": "adapter_policy"},
+                ),
+            )
+            inserted = 0
+            for event in events:
+                result = await self._store.append_in_transaction(event)
+                inserted += int(result.inserted)
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            await connection.commit()
+        except IdempotencyConflictError as exc:
+            await connection.rollback()
+            raise WorkshopTransportLinkError("Transport link conflicts with an existing canonical event") from exc
+        except Exception:
+            await connection.rollback()
+            raise
+        return WorkshopTransportLink(
+            principal_id,
+            channel_id,
+            transport,
+            subject,
+            external_channel,
+            inserted,
+        )
+
+    async def _resolve_runtime_owner(
+        self,
+        runtime_profile_id: RuntimeProfileId,
+    ) -> tuple[WorkshopId, PrincipalId, ChannelId]:
+        async with self._store.connection.execute(
+            "SELECT c.workshop_id, cm.principal_id, c.id "
+            "FROM channel_agent_runtime_assignments ra "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
+            "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+            "WHERE ra.runtime_profile_id = ?",
+            (runtime_profile_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if len(rows) != 1:
+            raise WorkshopTransportLinkError(
+                "Runtime profile must resolve to exactly one canonical human direct channel"
+            )
+        return (
+            WorkshopId(str(rows[0][0])),
+            PrincipalId(str(rows[0][1])),
+            ChannelId(str(rows[0][2])),
+        )
+
+    async def _reject_conflicting_identity(
+        self,
+        transport: str,
+        subject: str,
+        principal_id: PrincipalId,
+    ) -> None:
+        async with self._store.connection.execute(
+            "SELECT principal_id FROM external_identities WHERE provider = ? AND external_subject = ?",
+            (transport, subject),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if rows and {str(row[0]) for row in rows} != {str(principal_id)}:
+            raise WorkshopTransportLinkError("External identity is already bound to a different canonical principal")
+
+    async def _reject_conflicting_channel(
+        self,
+        transport: str,
+        external_channel_id: str,
+        channel_id: ChannelId,
+    ) -> None:
+        async with self._store.connection.execute(
+            "SELECT channel_id FROM channel_bindings WHERE transport = ? AND external_channel_id = ?",
+            (transport, external_channel_id),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if rows and {str(row[0]) for row in rows} != {str(channel_id)}:
+            raise WorkshopTransportLinkError("External channel is already bound to a different canonical channel")

--- a/templates/.env
+++ b/templates/.env
@@ -1,14 +1,23 @@
-# ── Required ──────────────────────────────────────────────────────
+# ── Client adapters and initial Workshop identity ────────────────
 
-# Bot token from @BotFather on Telegram
-TELEGRAM_BOT_TOKEN=your-token-from-botfather
+# Enabled client adapters: telegram,workshop; workshop; or telegram.
+# Workshop-only installs do not require Telegram configuration.
+#KAI_ENABLED_ADAPTERS=telegram,workshop
+
+# Bot token from @BotFather. Required only when Telegram is enabled.
+#TELEGRAM_BOT_TOKEN=your-token-from-botfather
 
 # Per-user authorization, per-user model selection, per-user OS
 # isolation, per-user GitHub routing, and per-user agent toggles all
-# live in users.yaml (mandatory). Run 'make config' to generate one;
+# live in users.yaml when Telegram is enabled. Run 'make config' to
+# generate one;
 # the wizard writes /etc/kai/users.yaml (protected install) or
 # ${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml (single-user
 # install).
+#
+# Fresh Workshop-only installs instead store an opaque, installer-managed
+# bootstrap policy. Do not construct or edit this value by hand.
+#KAI_WORKSHOP_BOOTSTRAP=v1.<installer-managed-value>
 
 # ── Agent Backend ─────────────────────────────────────────────────
 

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -1,5 +1,6 @@
-# Per-user configuration for Kai. users.yaml is mandatory; the
-# daemon fails closed at startup if it cannot find or parse it.
+# Telegram-user configuration for Kai. users.yaml is required when the
+# Telegram adapter is enabled and optional for Workshop-only deployments.
+# When present, the daemon fails closed if it cannot parse it.
 #
 # Canonical paths:
 #   protected installs (`make install`, which invokes sudo): /etc/kai/users.yaml
@@ -9,7 +10,7 @@
 # `make config` writes the correct location for the deployment mode
 # you select. KAI_USERS_YAML can override either for tests/dev.
 #
-# Required fields per user: telegram_id, name.
+# Required fields per Telegram user: telegram_id, name.
 # All other fields are optional. Omitted fields inherit installation
 # defaults from the backend/provider model registry, .env or /etc/kai/env,
 # and the hardcoded defaults documented in the templates/.env header.
@@ -21,6 +22,7 @@ users:
     role: admin              # "admin" or "user" (default: "user")
     github: alice             # GitHub username for webhook routing
     # os_user: alice          # OS user for subprocess isolation
+    # runtime_profile_id: rtp_...  # link Telegram to an existing canonical runtime
     # home_workspace: ~/projects/main  # per-user home workspace
 
     # External services this user's persistent agent may call through

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,7 @@ from kai.config import (
 # All env vars that load_config reads
 _CONFIG_ENV_VARS = [
     "KAI_ENABLED_ADAPTERS",
+    "KAI_WORKSHOP_BOOTSTRAP",
     "TELEGRAM_BOT_TOKEN",
     "TELEGRAM_WEBHOOK_URL",
     "TELEGRAM_WEBHOOK_SECRET",
@@ -332,6 +333,23 @@ class TestLoadConfigErrors:
         monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "")
 
         with pytest.raises(SystemExit, match="must enable at least one client adapter"):
+            load_config()
+
+    def test_rejects_invalid_initial_workshop_provisioning(self, monkeypatch):
+        monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "workshop")
+        monkeypatch.setenv("KAI_WORKSHOP_BOOTSTRAP", "v1.not-base64")
+
+        with pytest.raises(SystemExit, match="KAI_WORKSHOP_BOOTSTRAP"):
+            load_config()
+
+    def test_rejects_invalid_runtime_profile_link(self, monkeypatch):
+        _set_required(monkeypatch)
+        _patch_protected_users_yaml(
+            monkeypatch,
+            "users:\n  - telegram_id: 123\n    name: Daniel\n    role: admin\n    runtime_profile_id: not-a-profile\n",
+        )
+
+        with pytest.raises(SystemExit, match="invalid runtime_profile_id"):
             load_config()
 
     def test_rejects_workshop_lan_listener_when_workshop_is_disabled(self, monkeypatch):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -66,6 +66,7 @@ from kai.install import (
     _github_automation_status,
     _integration_route_status,
     _internal_api_authority_status,
+    _issue_installed_initial_enrollment,
     _log_security_status,
     _memory_scope_review_status,
     _migrate_identity_to_claude_md,
@@ -2426,43 +2427,98 @@ class TestCmdConfig:
         assert env["VOICE_ENABLED"] == "true"
         assert env["TTS_ENABLED"] == "true"
 
-    def test_fresh_protected_workshop_only_fails_before_writing_config(self, tmp_path, monkeypatch):
+    def test_enabling_telegram_links_users_yaml_to_existing_canonical_profile(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        plan = kai.install.WorkshopInitialProvisioning.create("Daniel")
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "deployment_mode": "protected",
+                    "env": {
+                        "KAI_ENABLED_ADAPTERS": "workshop",
+                        "KAI_WORKSHOP_BOOTSTRAP": plan.to_json(),
+                        "DEFAULT_BACKEND": "claude",
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._redirect_staging(monkeypatch, tmp_path)
+        kai.install.RUNTIME_PROFILES_YAML.write_text(
+            f"version: 2\nruntime_profiles:\n  {plan.runtime_profile_id}: {{}}\n"
+        )
+        inputs = iter(self._base_inputs(["false"], client_mode="hybrid"))
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+
+        _cmd_config()
+
+        generated = json.loads(conf_path.read_text())
+        users_path = Path(generated["users_yaml_staging_path"])
+        users = yaml.safe_load(users_path.read_text())["users"]
+        assert users[0]["telegram_id"] == 12345
+        assert users[0]["runtime_profile_id"] == str(plan.runtime_profile_id)
+        assert generated["env"]["KAI_WORKSHOP_BOOTSTRAP"] == plan.to_json()
+
+    def test_fresh_protected_workshop_only_stages_canonical_bootstrap(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         conf_path = tmp_path / "install.conf"
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._redirect_staging(monkeypatch, tmp_path)
-        inputs = iter(
-            [
-                "protected",
-                "workshop-only",
-                "/opt/kai",
-                "/var/lib/kai",
-                "kai",
-                "darwin",
-            ]
-        )
+        answers = self._base_inputs(["false"], client_mode="workshop-only")
+        answers[6:6] = ["Daniel", "testuser"]
+        inputs = iter(answers)
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
-        with pytest.raises(SystemExit, match="requires an existing protected installation"):
-            _cmd_config()
+        _cmd_config()
 
-        assert not conf_path.exists()
+        conf = json.loads(conf_path.read_text())
+        assert conf["env"]["KAI_ENABLED_ADAPTERS"] == "workshop"
+        assert conf["env"]["KAI_WORKSHOP_BOOTSTRAP"].startswith("v1.")
+        assert "TELEGRAM_BOT_TOKEN" not in conf["env"]
+        assert "users_yaml_staging_path" not in conf
+        assert conf["workshop_enrollment_pending"] is True
+        staged = Path(conf["runtime_profiles_staging_path"])
+        policy = yaml.safe_load(staged.read_text())
+        assert len(policy["runtime_profiles"]) == 1
+        profile = next(iter(policy["runtime_profiles"].values()))
+        assert profile["display_name"] == "Daniel"
+        assert profile["os_user"] == "testuser"
 
-    def test_single_user_workshop_only_fails_before_writing_config(self, tmp_path, monkeypatch):
+    def test_single_user_workshop_only_provisions_browser_enrollment(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
         monkeypatch.chdir(tmp_path)
         conf_path = tmp_path / "install.conf"
         monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
         self._redirect_staging(monkeypatch, tmp_path)
         monkeypatch.setattr("kai.install._read_protected_file", lambda _path: None)
-        inputs = iter(["single_user", "workshop-only"])
+        monkeypatch.setattr(
+            "kai.install._xdg_runtime_profiles_path",
+            lambda: tmp_path / "config" / "runtime-profiles.yaml",
+        )
+        answers = self._base_inputs(["false"], client_mode="workshop-only")
+        inputs = iter(["single_user", "workshop-only", "Daniel", *answers[6:]])
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
-        with pytest.raises(SystemExit, match="single-user bootstrap is not available"):
-            _cmd_config()
+        _cmd_config()
 
-        assert not conf_path.exists()
+        conf = json.loads(conf_path.read_text())
+        assert conf["env"]["KAI_ENABLED_ADAPTERS"] == "workshop"
+        assert conf["env"]["KAI_RUNTIME_PROFILES_YAML"].endswith("config/runtime-profiles.yaml")
+        assert (tmp_path / "kai.db").is_file()
+        assert "Token: kai_ws_enroll_v1." in capsys.readouterr().out
 
     def test_memory_disabled_omits_env_keys(self, tmp_path, monkeypatch):
         """MEMORY_ENABLED=false produces no MEMORY_* env entries."""
@@ -3320,6 +3376,43 @@ class TestCmdConfig:
 # ── Apply subcommand ─────────────────────────────────────────────────
 
 
+class TestInstalledInitialWorkshopEnrollment:
+    def test_issues_as_service_user_for_the_canonical_human(self, monkeypatch):
+        plan = kai.install.WorkshopInitialProvisioning.create("Daniel")
+        principal_id, channel_id = kai.install.provisioned_human_ids(
+            plan.workshop_id,
+            plan.provisioning_key,
+        )
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=(f"Enrollment: enr_123\nChannel: {channel_id}\nToken: kai_ws_enroll_v1.enr_123.secret\n"),
+            stderr="",
+        )
+        run = MagicMock(return_value=completed)
+        monkeypatch.setattr("kai.install.subprocess.run", run)
+
+        output = _issue_installed_initial_enrollment(
+            plan,
+            install_dir="/opt/kai",
+            data_dir="/var/lib/kai",
+            service_user="kai",
+        )
+
+        assert "Token: kai_ws_enroll_v1." in output
+        command = run.call_args.args[0]
+        assert command[:5] == ["sudo", "-H", "-u", "kai", "env"]
+        assert "KAI_DATA_DIR=/var/lib/kai" in command
+        assert "KAI_INSTALL_DIR=/opt/kai" in command
+        assert command[-4:] == [
+            "--principal-id",
+            str(principal_id),
+            "--channel-id",
+            str(channel_id),
+        ]
+        assert run.call_args.kwargs["timeout"] == 30
+
+
 class TestCmdApply:
     def test_exits_if_not_root(self, monkeypatch):
         """Apply exits with code 1 if not running as root."""
@@ -3386,6 +3479,66 @@ class TestCmdApply:
         assert not (tmp_path / "opt" / "kai").exists()
         # Secrets reminder should NOT appear during dry run
         assert "contains secrets" not in output
+
+    def test_fresh_workshop_only_dry_run_needs_no_telegram_identity(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        monkeypatch.setattr("os.geteuid", lambda: 0)
+        monkeypatch.setenv("DRY_RUN", "1")
+        plan = kai.install.WorkshopInitialProvisioning.create("Daniel")
+        staged_policy = tmp_path / "runtime-profiles.yaml"
+        staged_policy.write_text(
+            yaml.safe_dump(
+                {
+                    "version": 2,
+                    "runtime_profiles": {
+                        str(plan.runtime_profile_id): {
+                            "display_name": "Daniel",
+                            "os_user": "root",
+                            "backend": "claude",
+                            "provider": "anthropic",
+                            "model": "sonnet",
+                            "timeout_seconds": 120,
+                            "allowed_services": [],
+                            "allowed_workspaces": [],
+                        }
+                    },
+                },
+                sort_keys=False,
+            )
+        )
+        conf_path = tmp_path / "install.conf"
+        conf_path.write_text(
+            json.dumps(
+                {
+                    "deployment_mode": "protected",
+                    "install_dir": str(tmp_path / "opt" / "kai"),
+                    "data_dir": str(tmp_path / "var" / "lib" / "kai"),
+                    "service_user": "nobody",
+                    "platform": "darwin",
+                    "env": {
+                        "KAI_ENABLED_ADAPTERS": "workshop",
+                        "KAI_WORKSHOP_BOOTSTRAP": plan.to_json(),
+                        "DEFAULT_BACKEND": "claude",
+                    },
+                    "runtime_profiles_staging_path": str(staged_policy),
+                    "workshop_enrollment_pending": True,
+                }
+            )
+        )
+        monkeypatch.setattr("kai.install.INSTALL_CONF", conf_path)
+
+        _cmd_apply()
+
+        output = capsys.readouterr().out
+        assert "1 human principal(s)" in output
+        assert "direct channel(s), runtime assignment(s)" in output
+        assert "Would issue one browser enrollment" in output
+        assert "Telegram direct channel" not in output
+        assert not kai.install.USERS_YAML.exists()
 
     def test_dry_run_flag_reaches_every_apply_helper(self, tmp_path, monkeypatch):
         """The apply orchestrator passes True to every mutation boundary.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -85,6 +85,20 @@ class TestWorkshopBootstrapMapping:
         assert humans[0].runtime_profile_id == profile_id(101)
         assert "-999" not in repr(humans)
 
+    def test_explicit_runtime_profile_link_is_not_rebootstrapped_as_a_human(self):
+        config = SimpleNamespace(
+            user_configs={
+                101: UserConfig(
+                    telegram_id=101,
+                    name="Admin",
+                    role="admin",
+                    runtime_profile_id=str(profile_id(101)),
+                )
+            }
+        )
+
+        assert _workshop_bootstrap_humans(config, profile_registry(101)) == ()
+
     async def test_effective_negative_destinations_become_deduplicated_notification_channels(self):
         config = SimpleNamespace(
             user_configs={

--- a/tests/test_workshop_initial_provisioning.py
+++ b/tests/test_workshop_initial_provisioning.py
@@ -1,0 +1,151 @@
+"""Fresh transport-independent Workshop provisioning contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.bootstrap import bootstrap_default_workshop
+from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.human_provisioning import WorkshopHumanProvisioner
+from kai.workshop.initial_provisioning import (
+    WorkshopInitialProvisioning,
+    WorkshopInitialProvisioningError,
+    parse_initial_provisioning,
+)
+from kai.workshop.runtime_assignments import WorkshopRuntimeAssignmentService
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.store import WorkshopEventStore
+from kai.workshop.transport_linking import (
+    WorkshopTransportLinker,
+    WorkshopTransportLinkError,
+)
+
+
+def _profiles(profile_id: RuntimeProfileId) -> WorkshopRuntimeProfileRegistry:
+    return WorkshopRuntimeProfileRegistry.from_document(
+        {
+            "version": 2,
+            "runtime_profiles": {
+                str(profile_id): {
+                    "display_name": "Daniel runtime",
+                    "backend": "codex",
+                    "provider": "openai",
+                    "model": "gpt-5.5",
+                    "timeout_seconds": 120,
+                    "allowed_services": [],
+                    "allowed_workspaces": [],
+                }
+            },
+        },
+        backend_registry={"codex": {}},
+    )
+
+
+def test_initial_policy_round_trips_without_transport_identity() -> None:
+    plan = WorkshopInitialProvisioning.create("Daniel")
+
+    restored = parse_initial_provisioning(plan.to_json())
+
+    assert restored == plan
+    assert "telegram" not in plan.to_json().lower()
+    with pytest.raises(WorkshopInitialProvisioningError):
+        parse_initial_provisioning("v1.not-base64")
+
+
+class TestWorkshopTransportLinking:
+    async def _provision(self, path: Path):
+        plan = WorkshopInitialProvisioning.create("Daniel")
+        store = await WorkshopEventStore.open(path)
+        await bootstrap_default_workshop(store, (), workshop_id=plan.workshop_id)
+        human = await WorkshopHumanProvisioner(store).provision(
+            plan.provisioning_key,
+            plan.display_name,
+            plan.role,
+            workshop_id=plan.workshop_id,
+        )
+        profiles = _profiles(plan.runtime_profile_id)
+        assignment = await WorkshopRuntimeAssignmentService(store, profiles).assign(
+            human.principal_id,
+            human.channel_id,
+            plan.runtime_profile_id,
+        )
+        return store, plan, human, profiles, assignment
+
+    async def test_later_telegram_link_reuses_human_channel_and_assignment(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, plan, human, profiles, assignment = await self._provision(tmp_path / "kai.db")
+        try:
+            linker = WorkshopTransportLinker(store, profiles)
+            linked = await linker.link_runtime_profile(
+                plan.runtime_profile_id,
+                transport="telegram",
+                external_subject="2114582497",
+                external_channel_id="2114582497",
+            )
+            retried = await linker.link_runtime_profile(
+                plan.runtime_profile_id,
+                transport="telegram",
+                external_subject="2114582497",
+                external_channel_id="2114582497",
+            )
+
+            assert linked.principal_id == human.principal_id
+            assert linked.channel_id == human.channel_id
+            assert linked.created_events == 2
+            assert retried.created_events == 0
+            async with store.connection.execute("SELECT COUNT(*) FROM principals WHERE kind = 'human'") as cursor:
+                assert int((await cursor.fetchone())[0]) == 1
+            async with store.connection.execute(
+                "SELECT runtime_profile_id FROM channel_agent_runtime_assignments WHERE id = ?",
+                (assignment.assignment_id,),
+            ) as cursor:
+                assert str((await cursor.fetchone())[0]) == str(plan.runtime_profile_id)
+        finally:
+            await store.close()
+
+    async def test_transport_identity_cannot_be_rebound_to_another_human(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, plan, _human, profiles, _assignment = await self._provision(tmp_path / "kai.db")
+        try:
+            await WorkshopTransportLinker(store, profiles).link_runtime_profile(
+                plan.runtime_profile_id,
+                transport="telegram",
+                external_subject="2114582497",
+                external_channel_id="2114582497",
+            )
+            other_profile = RuntimeProfileId("rtp_99999999999999999999999999999999")
+            other_profiles = WorkshopRuntimeProfileRegistry(
+                (*profiles.profiles, _profiles(other_profile).resolve(other_profile))
+            )
+            other = await WorkshopHumanProvisioner(store).provision(
+                "other",
+                "Other",
+                "member",
+                workshop_id=plan.workshop_id,
+            )
+            await WorkshopRuntimeAssignmentService(store, other_profiles).assign(
+                other.principal_id,
+                other.channel_id,
+                other_profile,
+            )
+            with pytest.raises(
+                WorkshopTransportLinkError,
+                match="different canonical principal",
+            ):
+                await WorkshopTransportLinker(
+                    store,
+                    other_profiles,
+                ).link_runtime_profile(
+                    other_profile,
+                    transport="telegram",
+                    external_subject="2114582497",
+                    external_channel_id="999",
+                )
+        finally:
+            await store.close()


### PR DESCRIPTION
Closes #1112.

## Summary

- provision a first canonical Workshop admin, Kai direct channel, protected runtime profile, and runtime assignment without requiring Telegram identity or configuration
- support the same fresh Workshop-only lifecycle in protected and single-user deployments, including a one-time browser enrollment emitted only after canonical state is ready
- let Telegram be enabled later by linking its external identity and direct-chat binding to the existing canonical human, channel, and runtime profile
- preserve canonical state when Telegram is disabled again, and make configuration and install diagnostics accurate when `users.yaml` is absent
- document the fresh Workshop-only flow and the installer-managed bootstrap policy

## Safety and migration behavior

- the bootstrap policy contains opaque canonical identifiers and no transport identity
- protected runtime policy is staged and validated before installation changes begin
- enrollment is issued as the Kai service user after application readiness; only the token is shown, while Kai stores its hash
- transport linking is transactional, idempotent, and rejects attempts to rebind an identity or channel to another canonical owner
- a present malformed `users.yaml` still fails closed; it is optional only when Telegram is disabled

## Validation

- `make check`
- `make typecheck`
- consolidated config/install/bootstrap regression run: 1,106 passed
- full test suite with local test-server access: 6,039 passed
