### PR TITLE
test: enforce final Telegram adapter boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests
         run: make BIN= test
 
-  workshop-base:
+  core-workshop:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -66,5 +66,45 @@ jobs:
           python -m pip install --upgrade \
             --constraint requirements/constraints.txt -e '.[dev,totp]'
 
-      - name: Prove the Telegram-free import and runtime boundary
-        run: python -m pytest tests/test_telegram_optional_boundary.py -v
+      - name: Prove the Telegram-free architecture and runtime boundary
+        run: |
+          python -m pytest -v \
+            tests/test_adapter_architecture.py \
+            tests/test_telegram_optional_boundary.py \
+            tests/test_application_host.py \
+            tests/test_workshop_initial_provisioning.py \
+            tests/test_workshop_delivery_planning.py \
+            tests/test_install.py::TestCmdConfig::test_fresh_protected_workshop_only_stages_canonical_bootstrap \
+            tests/test_install.py::TestCmdConfig::test_single_user_workshop_only_provisions_browser_enrollment \
+            tests/test_install.py::TestApplyVenv::test_workshop_only_install_omits_telegram_extra \
+            tests/test_workshop_conversation_commands.py::TestAtomicClientConversationCommandAcceptance::test_disabled_telegram_adapter_does_not_enqueue_for_retained_binding \
+            tests/test_workshop_private_text_execution.py::test_owner_accepts_executes_and_atomically_enqueues_terminal_reply \
+            tests/test_workshop_terminal_transactions.py::TestAtomicTerminalTransactions::test_post_run_worker_ingests_one_non_telegram_success_exactly_once \
+            tests/test_workshop_scheduler.py::test_workshop_only_reminder_fires_canonically_without_delivery \
+            tests/test_workshop_scheduler.py::test_workshop_only_agent_job_uses_canonical_execution \
+            tests/test_workshop_scheduler.py::test_disabled_telegram_adapter_does_not_enqueue_retained_reminder_binding \
+            tests/test_workshop_github_notifications.py::TestWorkshopIntegrationNotificationService::test_route_records_without_resolving_any_transport_binding
+
+  telegram-adapter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install Telegram adapter dependencies
+        run: |
+          python -m pip install --upgrade \
+            --constraint requirements/constraints.txt pip setuptools
+          python -m pip install --upgrade \
+            --constraint requirements/constraints.txt -e '.[dev,telegram,totp]'
+
+      - name: Prove the optional Telegram adapter
+        run: |
+          python -m pytest -v \
+            tests/test_telegram_adapter.py \
+            tests/test_workshop_telegram_delivery.py \
+            tests/test_workshop_telegram_delivery_runtime.py

--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ Most AI coding tools are either interactive terminals or hosted chat surfaces. K
 | Repo-aware coding | Runs an agent inside local workspaces with shell, filesystem, git, and web access. |
 | Workspaces | Switches between projects by name and keeps per-workspace settings. |
 | Memory | Maintains identity, durable user memory, semantic recall, and searchable conversation history. |
-| Scheduling | Runs reminders, recurring jobs, and condition monitors from Telegram or HTTP. |
+| Scheduling | Runs canonical reminders, recurring jobs, and condition monitors from any authorized client or internal API caller. |
 | GitHub automation | Reviews PRs, triages issues, routes notifications, and reacts to webhook events. |
-| File exchange | Accepts files from Telegram, exposes their local paths to the agent, and can send files back. |
+| File exchange | Accepts artifacts through Workshop or a capable client adapter, exposes authorized local paths to the agent, and publishes results. |
 | Voice | Supports local voice transcription and optional text-to-speech responses. |
 | Multi-user operation | Isolates canonical principals, runtime profiles, workspaces, files, history, jobs, settings, and OS accounts. |
 
 ## How It Works
 
 ```text
-Workshop browser --\
-                    -> Kai service -> per-user agent backend
-Telegram (optional)-/                    -> local workspace, shell, git, files, web, services
+Workshop browser -----\
+Optional adapters -----+-> Kai core -> per-user agent backend
+Webhooks/internal API -/                  -> local workspace, shell, git, files, web, services
 ```
 
 Kai has two layers. The outer Python service owns client adapters, HTTP, scheduling, authentication, persistence, webhooks, file exchange, and per-user routing. The inner agent backend does the thinking and acting inside a local workspace. Backend subprocesses are created lazily per user and evicted after an idle timeout, so resource use follows active users rather than registered users.
@@ -153,7 +153,7 @@ For full installation details, see [Getting Started](https://github.com/dcelliso
 
 Kai has real local authority, so the security model is part of the product rather than an afterthought.
 
-- **Telegram allowlist:** Only configured Telegram user IDs can interact with the bot.
+- **Optional Telegram allowlist:** When the Telegram adapter is enabled, only configured Telegram user IDs can interact with it.
 - **Optional TOTP gate:** Time-based one-time passwords can protect the chat surface after idle timeout.
 - **Local execution:** Kai runs on your machine. Conversations do not pass through a Kai-hosted relay.
 - **Path confinement:** File exchange is constrained to allowed workspace and file-storage paths.
@@ -185,15 +185,15 @@ See [TOTP Authentication](https://github.com/dcellison/kai/wiki/TOTP-Authenticat
 
 ## Common Workflows
 
-- Send a normal Telegram message to have Kai work in the current workspace.
-- Use `/workspace <name>` or `/workspaces` to move between projects.
-- Use `/models` or `/model <name>` to change the active model.
-- Use `/memory`, `/memory search <query>`, and `/memory stats` to inspect durable memory.
+- Send a message in Workshop or an enabled conversational adapter to have Kai work in the current workspace.
+- Use Workshop settings or adapter commands such as `/workspace` to move between projects.
+- Use Workshop settings or adapter commands such as `/model` to change the active model.
+- Use the Workshop memory editor or adapter memory commands to inspect durable memory.
 - Ask Kai to remind you later, run a recurring check, or monitor a condition.
 - Subscribe a GitHub repo so pushes, PRs, issues, comments, and reviews can reach Kai.
 - Enable PR review or issue triage per user when you want background GitHub automation.
-- Send files directly in Telegram so the agent can inspect or transform them locally.
-- Use `/help` in Telegram for the current command reference.
+- Attach files in Workshop or a capable adapter so the agent can inspect or transform them locally.
+- Use each client surface's own help and controls; Telegram commands are adapter presentation, not core APIs.
 
 ## Documentation
 

--- a/home/docs/specs/telegram-adapter-boundary.md
+++ b/home/docs/specs/telegram-adapter-boundary.md
@@ -1,0 +1,59 @@
+# Telegram adapter boundary
+
+## Completion rule
+
+Kai core and Workshop must install, import, start, execute agents, commit
+post-run effects, remember, schedule, publish proactive output, route
+integrations, and settle deliveries without the Telegram extra installed or a
+Telegram adapter enabled. Adding a transport may contribute only identity and
+channel bindings, ingress translation, capabilities, presentation, and a
+delivery worker. It must not require a core feature branch.
+
+CI enforces this rule in two dependency environments:
+
+- `core-workshop` installs the base package without `python-telegram-bot`,
+  rejects any attempted Telegram SDK import, and exercises the core lifecycle,
+  fresh provisioning, command execution, post-run memory, scheduling,
+  integration routing, proactive publication, and transport-neutral delivery;
+- `telegram-adapter` installs the `telegram` extra and exercises Telegram
+  lifecycle and delivery behavior separately.
+
+The static architecture test additionally rejects Telegram SDK imports outside
+the adapter implementation and imports of Telegram implementation modules from
+core or feature services. `kai.main` is the sole composition root and loads the
+adapter dynamically only when it is enabled.
+
+## Remaining Telegram references
+
+The following references are intentional and do not grant Telegram authority
+over core behavior.
+
+| Location or category | Reason retained | Boundary |
+|---|---|---|
+| `telegram_adapter`, `bot`, `telegram_context`, `telegram_http`, `memory_command`, `telegram_utils` | Telegram lifecycle, update authentication, command and media presentation, ingress, formatting, and SDK calls | Optional adapter implementation; statically forbidden as a core dependency |
+| `workshop/telegram_delivery*` | Convert canonical outbox work into Telegram API calls and record adapter outcomes | Optional delivery adapter/worker; core owns the outbox and settlement contract |
+| `telegram_contract` | SDK-free capability declaration used during composition and contract testing | Metadata only; importing it cannot import or contact Telegram |
+| `workshop/streaming_preview` and corresponding session facade | Persist and validate Telegram preview/edit state used by the adapter | Presentation state only; never transcript, run, or delivery authority |
+| Telegram update queue and preview tables in `sessions`/schema | Durable adapter ingress and retained adapter presentation state | Used only through Telegram adapter paths; not canonical identity or execution keys |
+| Telegram identities and channel bindings in Workshop schema, bootstrap, linking, diagnostics, and operator commands | Map one optional external transport to canonical principals and channels; preserve installed migrations | Bindings are data, not owner/runtime keys; disabling the adapter makes them ineligible for delivery |
+| installer/configuration/status references | Install the optional extra, token, webhook mode, allowlist, and adapter policy | Deployment composition and truthful diagnostics only |
+| historical JSONL, numeric-directory, migration, and archive references | Preserve owner-gated historical evidence and migration receipts | Explicitly non-authoritative and never a fallback for protected execution |
+| Telegram-focused tests and documentation | Verify the optional adapter and record prior migration decisions | Separate from the Telegram-free core gate |
+
+Any new Telegram SDK import, core import of a Telegram implementation module,
+caller-supplied transport identity in a core API, direct Telegram send from a
+feature service, or Telegram-keyed runtime decision is a regression.
+
+## Qualification matrix
+
+Automated gates cover a base Workshop-only environment, the optional Telegram
+extra, a retained-but-disabled Telegram binding, independent multi-adapter
+fan-out outcomes, and a non-Telegram test adapter spanning ordinary replies,
+scheduling, proactive publication, integration routing, and post-run effects.
+
+Installed completion evidence is recorded against the backends actually
+configured on the qualification host. It must include Workshop-only and hybrid
+operation, restart continuity, canonical memory and scheduling, optional
+Telegram delivery when enabled, and healthy authoritative status. Supported
+but unconfigured backends do not block the adapter-boundary result; their
+backend-specific harness tests remain a separate compatibility obligation.

--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -2239,7 +2239,39 @@ the removed shadow recorders, crash flags, parity comparator, qualification
 module, and operator commands from returning.
 
 This completes the four source-retirement packages from the #917 completion
-audit. Closing the epic still requires its separate final installed matrix:
-Workshop-only and hybrid operation across Claude, Codex, Goose, OpenCode, and
-Pi, including ordinary execution, restart continuity, and unchanged optional
-Telegram delivery.
+audit. The final adapter-boundary gate and installed qualification are recorded
+in section 48. Earlier sections in this map are chronological records; claims
+such as "production-unused," "shadow," or "JSONL authority" describe their
+implementation date rather than the current system.
+
+## 48. Final Telegram adapter boundary
+
+**Implementation date:** 2026-08-26
+
+Telegram is an optional adapter, not a Kai core authority. The base package has
+no Telegram SDK dependency. CI installs it without the Telegram extra, blocks
+all Telegram SDK imports, and exercises Workshop startup, fresh canonical
+provisioning, command execution, post-run effects, scheduling, proactive
+publication, integration routing, and non-Telegram delivery. A separate CI
+lane installs the Telegram extra and tests its lifecycle and delivery workers.
+
+Static architecture gates prohibit Telegram SDK imports outside the adapter
+implementation and prohibit core or feature-service imports from those
+implementation modules. The composition root loads the adapter dynamically
+only when configured. Delivery capabilities live in an SDK-free adapter
+contract, so transport-neutral tests no longer import the Telegram runtime.
+
+The final reference classification is maintained in
+`home/docs/specs/telegram-adapter-boundary.md`. Remaining Telegram references
+are limited to adapter lifecycle, ingress, authentication, presentation,
+delivery, optional identity/channel binding, deployment configuration,
+retained non-authoritative archives, and adapter tests. Retained bindings are
+ineligible when Telegram is disabled, and multi-adapter delivery outcomes are
+independent.
+
+Installed qualification covers Workshop-only and hybrid operation using the
+backends configured on the qualification host, including ordinary execution,
+restart continuity, memory, scheduling, integration publication, and unchanged
+optional Telegram delivery. Supported backends for which the operator has no
+configured authenticated account are not falsely reported as active and do not
+block this architectural boundary.

--- a/src/kai/telegram_adapter.py
+++ b/src/kai/telegram_adapter.py
@@ -15,24 +15,14 @@ from kai.application_host import KaiCoreServices
 from kai.bot import create_bot
 from kai.config import Config
 from kai.telegram_context import KaiTelegramApplication
+from kai.telegram_contract import TELEGRAM_DELIVERY_CAPABILITIES as TELEGRAM_DELIVERY_CAPABILITIES
 from kai.telegram_http import TelegramWebhookIngress
-from kai.workshop.delivery_policy import DeliveryAdapterCapabilities
 from kai.workshop.telegram_delivery_runtime import (
     WorkshopTelegramConversationDeliveryService,
     WorkshopTelegramNotificationService,
 )
 
 log = logging.getLogger(__name__)
-
-TELEGRAM_DELIVERY_CAPABILITIES = DeliveryAdapterCapabilities(
-    transport="telegram",
-    final_text=True,
-    preview_streaming=True,
-    message_editing=True,
-    replies=True,
-    threads=True,
-    attachments=True,
-)
 
 
 class TelegramAdapterState(StrEnum):

--- a/src/kai/telegram_contract.py
+++ b/src/kai/telegram_contract.py
@@ -1,0 +1,13 @@
+"""SDK-free capability declaration for the optional Telegram adapter."""
+
+from kai.workshop.delivery_policy import DeliveryAdapterCapabilities
+
+TELEGRAM_DELIVERY_CAPABILITIES = DeliveryAdapterCapabilities(
+    transport="telegram",
+    final_text=True,
+    preview_streaming=True,
+    message_editing=True,
+    replies=True,
+    threads=True,
+    attachments=True,
+)

--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -197,8 +197,8 @@ async def record_outbound_message_with_delivery(
 ) -> OutboundDeliveryResult:
     """Atomically create one canonical reply and eligible adapter deliveries.
 
-    This service is deliberately production-unused. It accepts no transport or
-    destination identity from its caller and does not send or register a worker.
+    The service accepts no transport or destination identity from its caller;
+    enabled adapter capabilities and canonical bindings determine delivery.
     """
     connection = store.connection
     try:

--- a/src/kai/workshop/run_execution_authority.py
+++ b/src/kai/workshop/run_execution_authority.py
@@ -1,4 +1,4 @@
-"""Production-unused fenced execution authority for durable Workshop runs."""
+"""Fenced execution authority for durable Workshop runs."""
 
 from __future__ import annotations
 

--- a/src/kai/workshop/run_lifecycle.py
+++ b/src/kai/workshop/run_lifecycle.py
@@ -1,4 +1,4 @@
-"""Production-unused durable lifecycle for canonical Workshop runs."""
+"""Durable lifecycle for canonical Workshop runs."""
 
 from __future__ import annotations
 

--- a/src/kai/workshop/terminal_transactions.py
+++ b/src/kai/workshop/terminal_transactions.py
@@ -1,4 +1,4 @@
-"""Atomic, production-unused terminal transactions for Workshop runs."""
+"""Atomic terminal transactions for Workshop runs."""
 
 from __future__ import annotations
 

--- a/tests/test_adapter_architecture.py
+++ b/tests/test_adapter_architecture.py
@@ -1,0 +1,82 @@
+"""Static dependency gates for optional client adapters."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = PROJECT_ROOT / "src" / "kai"
+
+_TELEGRAM_SDK_ADAPTERS = frozenset(
+    {
+        "kai.bot",
+        "kai.memory_command",
+        "kai.telegram_adapter",
+        "kai.telegram_context",
+        "kai.telegram_http",
+        "kai.workshop.telegram_delivery",
+        "kai.workshop.telegram_delivery_runtime",
+    }
+)
+_TELEGRAM_IMPLEMENTATION_MODULES = _TELEGRAM_SDK_ADAPTERS | {
+    "kai.telegram_utils",
+}
+
+
+def _module_name(path: Path) -> str:
+    relative = path.relative_to(SOURCE_ROOT.parent).with_suffix("")
+    return ".".join(relative.parts)
+
+
+def _imports(path: Path) -> tuple[str, ...]:
+    module = _module_name(path)
+    package = module if path.name == "__init__.py" else module.rpartition(".")[0]
+    tree = ast.parse(path.read_text(), filename=str(path))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            source = node.module or ""
+            if node.level:
+                source = importlib.util.resolve_name(f"{'.' * node.level}{source}", package)
+            if source:
+                imported.append(source)
+            imported.extend(f"{source}.{alias.name}" for alias in node.names if source and alias.name != "*")
+    return tuple(imported)
+
+
+def _is_module_or_child(imported: str, modules: frozenset[str]) -> bool:
+    return any(imported == module or imported.startswith(f"{module}.") for module in modules)
+
+
+def test_only_telegram_adapter_modules_import_the_optional_sdk() -> None:
+    violations: list[str] = []
+    for path in SOURCE_ROOT.rglob("*.py"):
+        module = _module_name(path)
+        for imported in _imports(path):
+            if (imported == "telegram" or imported.startswith("telegram.")) and module not in _TELEGRAM_SDK_ADAPTERS:
+                violations.append(f"{module} imports {imported}")
+    assert violations == []
+
+
+def test_core_and_feature_services_do_not_import_telegram_implementation() -> None:
+    violations: list[str] = []
+    for path in SOURCE_ROOT.rglob("*.py"):
+        module = _module_name(path)
+        if module in _TELEGRAM_IMPLEMENTATION_MODULES:
+            continue
+        for imported in _imports(path):
+            if _is_module_or_child(imported, _TELEGRAM_IMPLEMENTATION_MODULES):
+                violations.append(f"{module} imports {imported}")
+    assert violations == []
+
+
+def test_composition_root_loads_telegram_adapter_only_when_enabled() -> None:
+    main_source = (SOURCE_ROOT / "main.py").read_text()
+
+    assert 'import_module("kai.telegram_adapter")' in main_source
+    assert "from kai.telegram_adapter" not in main_source
+    assert "import kai.telegram_adapter" not in main_source

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -1,4 +1,4 @@
-"""Security contracts for production-unused Workshop client enrollment."""
+"""Security contracts for Workshop client enrollment."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_client_sessions.py
+++ b/tests/test_workshop_client_sessions.py
@@ -1,4 +1,4 @@
-"""Security contracts for production-unused Workshop human-client sessions."""
+"""Security contracts for Workshop human-client sessions."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -1,4 +1,4 @@
-"""Contracts for production-unused atomic Workshop command acceptance."""
+"""Contracts for atomic Workshop command acceptance."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_delivery_outbox.py
+++ b/tests/test_workshop_delivery_outbox.py
@@ -1,4 +1,4 @@
-"""Contracts for the production-unused Workshop delivery outbox foundation."""
+"""Contracts for the Workshop delivery outbox."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -1,4 +1,4 @@
-"""End-to-end contracts for the production-unused Workshop coordinator."""
+"""End-to-end contracts for the Workshop execution coordinator."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -1,4 +1,4 @@
-"""Contract tests for the production-unused Kai Workshop foundation."""
+"""Contract tests for the Kai Workshop foundation."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -1,4 +1,4 @@
-"""Contracts for production-unused fenced Workshop run execution authority."""
+"""Contracts for fenced Workshop run execution authority."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -1,4 +1,4 @@
-"""Contracts for the production-unused durable Workshop run lifecycle."""
+"""Contracts for the durable Workshop run lifecycle."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -1,4 +1,4 @@
-"""Atomic, production-unused Workshop streaming-finalization contracts."""
+"""Atomic Workshop streaming-finalization contracts."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -1,4 +1,4 @@
-"""Contracts for durable, production-unused Telegram streaming previews."""
+"""Contracts for durable Telegram adapter streaming previews."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_telegram_delivery.py
+++ b/tests/test_workshop_telegram_delivery.py
@@ -1,4 +1,4 @@
-"""Contracts for the production-unused Workshop Telegram outbox worker."""
+"""Contracts for the Workshop Telegram outbox worker."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_telegram_streaming_finalization.py
+++ b/tests/test_workshop_telegram_streaming_finalization.py
@@ -1,4 +1,4 @@
-"""Production-unused Telegram execution contracts for streaming finalization."""
+"""Telegram adapter execution contracts for streaming finalization."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -1,4 +1,4 @@
-"""Atomic terminal transaction contracts for production-unused Workshop runs."""
+"""Atomic terminal transaction contracts for Workshop runs."""
 
 from __future__ import annotations
 

--- a/tests/test_workshop_timeline.py
+++ b/tests/test_workshop_timeline.py
@@ -1,4 +1,4 @@
-"""Contracts for the production-unused canonical Workshop timeline reader."""
+"""Contracts for the canonical Workshop timeline reader."""
 
 from __future__ import annotations
 

--- a/tests/workshop_delivery.py
+++ b/tests/workshop_delivery.py
@@ -1,6 +1,6 @@
 """Shared delivery-policy fixtures for Workshop contract tests."""
 
-from kai.telegram_adapter import TELEGRAM_DELIVERY_CAPABILITIES
+from kai.telegram_contract import TELEGRAM_DELIVERY_CAPABILITIES
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 
 TELEGRAM_DELIVERY_POLICY = WorkshopDeliveryBindingPolicy(


### PR DESCRIPTION
## Summary

- enforce a static boundary that keeps the optional Telegram SDK and adapter implementation out of Kai core and Workshop feature services
- split CI into a real Telegram-free core/Workshop lane and a separately installed Telegram-adapter lane
- exercise fresh Workshop-only provisioning, retained disabled bindings, independent multi-adapter outcomes, backend execution, post-run memory, scheduling, proactive publication, integration routing, and delivery
- move Telegram delivery capabilities into an SDK-free adapter contract so transport-neutral tests never import the Telegram runtime
- replace stale current-state claims and record a durable classification of every legitimate remaining Telegram reference

## Verification

- `make check`
- `make typecheck`
- `make check-install-constraints`
- clean Python 3.13 environment with `.[dev,totp]`, confirmed `telegram` absent: 30 boundary tests passed
- Telegram adapter qualification: 49 tests passed
- full suite: 6,043 tests passed

Closes #1113
