### PR TITLE
Complete Telegram adapter boundary corrections

### DIFF
--- a/home/docs/specs/telegram-adapter-boundary.md
+++ b/home/docs/specs/telegram-adapter-boundary.md
@@ -7,7 +7,8 @@ post-run effects, remember, schedule, publish proactive output, route
 integrations, and settle deliveries without the Telegram extra installed or a
 Telegram adapter enabled. Adding a transport may contribute only identity and
 channel bindings, ingress translation, capabilities, presentation, and a
-delivery worker. It must not require a core feature branch.
+delivery worker. Composition and configuration must register that adapter, but
+core feature services must not change for the new transport.
 
 CI enforces this rule in two dependency environments:
 
@@ -19,9 +20,12 @@ CI enforces this rule in two dependency environments:
   lifecycle and delivery behavior separately.
 
 The static architecture test additionally rejects Telegram SDK imports outside
-the adapter implementation and imports of Telegram implementation modules from
-core or feature services. `kai.main` is the sole composition root and loads the
-adapter dynamically only when it is enabled.
+the adapter implementation, imports of Telegram implementation modules from
+core or feature services, Telegram-named identity or cancellation APIs in core
+services, Telegram state in the shared HTTP host, and adapter presentation
+types re-exported from the Workshop package. `kai.main` is the sole composition
+root and loads the adapter dynamically only when it is enabled. Dormant adapter
+configuration is not parsed and cannot veto Workshop-only startup.
 
 ## Remaining Telegram references
 
@@ -33,9 +37,9 @@ over core behavior.
 | `telegram_adapter`, `bot`, `telegram_context`, `telegram_http`, `memory_command`, `telegram_utils` | Telegram lifecycle, update authentication, command and media presentation, ingress, formatting, and SDK calls | Optional adapter implementation; statically forbidden as a core dependency |
 | `workshop/telegram_delivery*` | Convert canonical outbox work into Telegram API calls and record adapter outcomes | Optional delivery adapter/worker; core owns the outbox and settlement contract |
 | `telegram_contract` | SDK-free capability declaration used during composition and contract testing | Metadata only; importing it cannot import or contact Telegram |
-| `workshop/streaming_preview` and corresponding session facade | Persist and validate Telegram preview/edit state used by the adapter | Presentation state only; never transcript, run, or delivery authority |
+| `workshop/streaming_preview` and corresponding session facade | Persist and validate Telegram preview/edit state used by the adapter | Presentation state only; imported explicitly by adapter paths and not re-exported from the Workshop package |
 | Telegram update queue and preview tables in `sessions`/schema | Durable adapter ingress and retained adapter presentation state | Used only through Telegram adapter paths; not canonical identity or execution keys |
-| Telegram identities and channel bindings in Workshop schema, bootstrap, linking, diagnostics, and operator commands | Map one optional external transport to canonical principals and channels; preserve installed migrations | Bindings are data, not owner/runtime keys; disabling the adapter makes them ineligible for delivery |
+| Telegram identities and channel bindings in Workshop schema, bootstrap, linking, diagnostics, and operator commands | Map one optional external transport to canonical principals and channels; preserve installed migrations | Generic core resolvers consume provider/transport values; bindings are data, not owner/runtime keys, and disabling the adapter makes them ineligible for delivery |
 | installer/configuration/status references | Install the optional extra, token, webhook mode, allowlist, and adapter policy | Deployment composition and truthful diagnostics only |
 | historical JSONL, numeric-directory, migration, and archive references | Preserve owner-gated historical evidence and migration receipts | Explicitly non-authoritative and never a fallback for protected execution |
 | Telegram-focused tests and documentation | Verify the optional adapter and record prior migration decisions | Separate from the Telegram-free core gate |

--- a/src/kai/__init__.py
+++ b/src/kai/__init__.py
@@ -1,3 +1,3 @@
-"""Kai — Telegram gateway to AI coding-agent backends."""
+"""Kai — multi-client personal AI and agent-workshop runtime."""
 
 __version__ = "2.0.0"

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -1144,9 +1144,10 @@ async def handle_stop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     chat_id = _chat_id(update)
     execution = _get_core_services(context).private_text_execution
     if execution is not None and chat_id == _user_id(update):
-        disposition = await execution.request_cancellation(
-            telegram_user_id=_user_id(update),
-            telegram_chat_id=chat_id,
+        disposition = await execution.request_transport_cancellation(
+            transport="telegram",
+            sender_subject=str(_user_id(update)),
+            channel_subject=str(chat_id),
         )
         if disposition == CanonicalCancellationDisposition.REQUESTED:
             await update.message.reply_text("Stopping...")
@@ -3044,43 +3045,10 @@ async def _show_github(update: Update, chat_id: int, config: Config) -> None:
     await update.message.reply_text("\n".join(lines))
 
 
-async def _is_notify_chat_used(
-    notify_chat_id: int,
-    exclude_user: int,
-    config: Config,
-) -> bool:
-    """
-    Check if any user other than exclude_user still uses this chat_id
-    as their GitHub notification destination.
-
-    Checks users.yaml (via config) and the database. Returns True if
-    at least one other source references this chat_id.
-
-    Note: this does a linear scan of all users with one DB query per
-    user. Fine for a personal assistant with a handful of users.
-    """
-    for uid, uc in config.user_configs.items():
-        if uid == exclude_user:
-            continue
-        # Check the users.yaml entry for this user
-        if uc.github_notify_chat_id == notify_chat_id:
-            return True
-        # Check DB override for this user
-        val = await sessions.get_setting(f"github_notify_chat:{uid}")
-        if val:
-            try:
-                if int(val) == notify_chat_id:
-                    return True
-            except ValueError:
-                continue
-    return False
-
-
 async def _handle_github_notify(
     update: Update,
     chat_id: int,
     args: list[str],
-    config: Config,
 ) -> None:
     """Handle /github notify <chat_id|reset> - set or clear notification destination."""
     assert update.message is not None
@@ -3092,26 +3060,7 @@ async def _handle_github_notify(
     value = args[0].lower()
 
     if value == "reset":
-        # Read the current notify chat_id before deleting it, so we can
-        # remove it from the live notification-destination registry.
-        old_val = await sessions.get_setting(f"github_notify_chat:{chat_id}")
         await sessions.delete_setting(f"github_notify_chat:{chat_id}")
-        if old_val:
-            try:
-                old_chat_id = int(old_val)
-            except ValueError:
-                old_chat_id = None
-            # Never remove the user's own chat_id from the legacy registry.
-            # The registry is no longer an authorization source, but keeping
-            # this guard preserves its outbound-destination semantics.
-            if old_chat_id is not None and old_chat_id != chat_id:
-                still_used = await _is_notify_chat_used(
-                    old_chat_id,
-                    exclude_user=chat_id,
-                    config=config,
-                )
-                if not still_used:
-                    webhook.remove_notification_chat_id(old_chat_id)
         await update.message.reply_text("Notification destination reset to this chat.")
         return
 
@@ -3122,29 +3071,7 @@ async def _handle_github_notify(
         await update.message.reply_text("Chat ID must be an integer.")
         return
 
-    # If there is an existing notify destination that differs from the
-    # new one, clean it up from the live registry before overwriting.
-    # Without this, the old chat_id would linger until restart.
-    old_val = await sessions.get_setting(f"github_notify_chat:{chat_id}")
-    if old_val:
-        try:
-            old_notify = int(old_val)
-        except ValueError:
-            old_notify = None
-        if old_notify is not None and old_notify != notify_id and old_notify != chat_id:
-            still_used = await _is_notify_chat_used(
-                old_notify,
-                exclude_user=chat_id,
-                config=config,
-            )
-            if not still_used:
-                webhook.remove_notification_chat_id(old_notify)
-
     await sessions.set_setting(f"github_notify_chat:{chat_id}", str(notify_id))
-
-    # Keep the live outbound-destination registry synchronized. This does not
-    # expand Telegram inbound authorization.
-    webhook.add_notification_chat_id(notify_id)
 
     await update.message.reply_text(f"GitHub notifications will go to chat {notify_id}.")
 
@@ -3187,7 +3114,7 @@ async def handle_github(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         return
 
     if subcommand == "notify":
-        await _handle_github_notify(update, chat_id, args[1:], config)
+        await _handle_github_notify(update, chat_id, args[1:])
         return
 
     if subcommand == "reviews":

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -3562,9 +3562,10 @@ def load_config() -> Config:
     memory_projects = _load_memory_project_configs()
 
     # Telegram identity and compatibility configuration. users.yaml is
-    # mandatory while Telegram is enabled; a missing file is permitted in a
-    # Workshop-only runtime, while a present malformed file always fails
-    # closed. The legacy ALLOWED_USER_IDS authorization fallback is gone.
+    # mandatory only while the Telegram adapter is enabled. A disabled
+    # adapter cannot veto an otherwise valid Workshop-only deployment merely
+    # because its dormant configuration is stale, unreadable, or malformed.
+    # The legacy ALLOWED_USER_IDS authorization fallback is gone.
     #
     # The path resolves based on whether `/etc/kai/env` had readable
     # content at the top of this load_config call (protected install)
@@ -3576,14 +3577,7 @@ def load_config() -> Config:
     if telegram_enabled:
         user_configs = _load_user_configs(default_backend, default_provider, users_yaml_path)
     else:
-        # Telegram identity policy is optional when that adapter is disabled.
-        # A present malformed file still fails closed, regardless of deployment
-        # mode; an absent file leaves canonical Workshop identity untouched.
-        raw_users = _read_users_yaml(users_yaml_path)
-        if raw_users is None:
-            user_configs = {}
-        else:
-            user_configs = _load_user_configs(default_backend, default_provider, users_yaml_path)
+        user_configs = {}
     if protected_env and user_configs:
         # A protected install gives the outer service account narrowly
         # scoped sudo access to root-owned Kai configuration.  A persistent

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -46,7 +46,6 @@ import hmac
 import json
 import logging
 import os
-import re
 import uuid
 from collections.abc import Callable, Iterable
 from dataclasses import asdict
@@ -124,20 +123,12 @@ log = logging.getLogger(__name__)
 # which cannot express `T | None` at runtime); the variable
 # annotation carries the type narrowing the call sites rely on.
 
-ALLOWED_USER_IDS_KEY: web.AppKey[set[int]] = web.AppKey("allowed_user_ids", set)
 ALLOWED_WORKSPACES_KEY: web.AppKey[list[str]] = web.AppKey("allowed_workspaces", list)
-CHAT_ID_KEY: web.AppKey[int] = web.AppKey("chat_id", int)
 CONFIG_KEY: web.AppKey[Config] = web.AppKey("config", Config)
 CORE_HOST_KEY: web.AppKey[KaiApplicationHost] = web.AppKey("core_host", KaiApplicationHost)
 GENERIC_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("generic_webhook_secret", str)
 GITHUB_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("github_webhook_secret", str)
 INTERNAL_API_AUTH_KEY: web.AppKey[InternalAPIAuth] = web.AppKey("internal_api_auth", InternalAPIAuth)
-NOTIFICATION_CHAT_IDS_KEY: web.AppKey[set[int]] = web.AppKey("notification_chat_ids", set)
-# Compatibility-only app keys retained for older API fixtures. The shared HTTP
-# host neither populates nor reads these; Telegram owns its concrete state.
-TELEGRAM_APP_KEY: web.AppKey[object] = web.AppKey("telegram_app", object)
-TELEGRAM_BOT_KEY: web.AppKey[object] = web.AppKey("telegram_bot", object)
-TELEGRAM_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("telegram_webhook_secret", str)
 WORKSPACE_BASE_KEY: web.AppKey[str | None] = web.AppKey("workspace_base")
 WORKSHOP_PRINCIPAL_STORAGE_KEY: web.AppKey[WorkshopPrincipalStorageRegistry] = web.AppKey(
     "workshop_principal_storage", WorkshopPrincipalStorageRegistry
@@ -199,27 +190,6 @@ async def _resolve_local_repo(repo_full_name: str, app: web.Application) -> str 
             return str(path)
 
     return None
-
-
-def _strip_markdown(text: str) -> str:
-    """
-    Remove markdown syntax so text reads cleanly as plain Telegram text.
-
-    Used as a fallback when Telegram's Markdown parser rejects a message
-    (e.g., unbalanced backticks or brackets). Converts links to "text (url)"
-    format and strips bold, italic, and code markers.
-
-    Args:
-        text: Markdown-formatted string.
-
-    Returns:
-        The same text with markdown syntax removed.
-    """
-    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", text)  # [text](url) → text (url)
-    text = text.replace("**", "").replace("__", "")  # bold
-    text = text.replace("`", "")  # inline code
-    text = re.sub(r"(?<!\w)_(\S.*?\S)_(?!\w)", r"\1", text)  # _italic_ but not snake_case
-    return text
 
 
 def _require_generic_webhook_secret(handler):
@@ -1898,14 +1868,7 @@ async def start(
         raise RuntimeError("Subprocess pool did not provide an internal API credential store")
     _app[INTERNAL_API_AUTH_KEY] = internal_api_auth
 
-    # Keep notification destinations separate from Config.allowed_user_ids,
-    # which is the immutable-at-runtime source for Telegram inbound auth. The
-    # API no longer consults this set for identity; credentials resolve their
-    # principal server-side.
-    _app[ALLOWED_USER_IDS_KEY] = set(config.allowed_user_ids)
-    _app[NOTIFICATION_CHAT_IDS_KEY] = set()
-
-    # Retain the loaded application configuration for compatibility APIs.
+    # Retain loaded configuration for transport-neutral service policy.
     _app[CONFIG_KEY] = config
 
     # Workspace policy lets canonical review work resolve a local checkout for
@@ -1914,25 +1877,6 @@ async def start(
     _app[WORKSPACE_BASE_KEY] = str(config.workspace_base) if config.workspace_base else None
     _app[ALLOWED_WORKSPACES_KEY] = [str(p) for p in config.allowed_workspaces]
 
-    # Maintain the legacy live notification-destination registry from both
-    # users.yaml and DB. This set is intentionally detached from Config's
-    # inbound Telegram principals and is not consulted by internal API auth.
-    for uc in config.user_configs.values():
-        if uc.github_notify_chat_id is not None:
-            _app[NOTIFICATION_CHAT_IDS_KEY].add(uc.github_notify_chat_id)
-    # Also add any DB-stored notify chat IDs (set via /github notify).
-    # webhook.start() is already async so the await is fine.
-    for uid in config.user_configs:
-        val = await sessions.get_setting(f"github_notify_chat:{uid}")
-        if val:
-            try:
-                _app[NOTIFICATION_CHAT_IDS_KEY].add(int(val))
-            except ValueError:
-                log.warning(
-                    "Invalid github_notify_chat for user %s in DB: %s (ignoring)",
-                    uid,
-                    val,
-                )
     _register_routes(_app, config)
     for register_routes in route_registrars:
         register_routes(_app)
@@ -2011,41 +1955,3 @@ def is_running() -> bool:
 def is_workshop_lan_running() -> bool:
     """True if the dedicated Workshop LAN listener is currently running."""
     return _workshop_lan_runner is not None
-
-
-def add_notification_chat_id(chat_id: int) -> None:
-    """
-    Add a chat_id to the live notification-destination registry.
-
-    Called by bot.py when /github notify sets a new notification
-    destination. This registry never grants Telegram or internal API
-    authority; those identities come from users.yaml and API credentials.
-    """
-    if _app is not None:
-        notification_chat_ids = _app.get(NOTIFICATION_CHAT_IDS_KEY)
-        if notification_chat_ids is not None:
-            notification_chat_ids.add(chat_id)
-
-
-def remove_notification_chat_id(chat_id: int) -> None:
-    """
-    Remove a chat_id from the live notification registry, but only
-    if it does not belong to an actual authorized user.
-
-    Called by bot.py when /github notify reset clears a notification
-    destination. A user's own telegram_id must never be removed.
-
-    Config.allowed_user_ids is deliberately a different set object so
-    notification changes cannot mutate inbound Telegram authorization.
-    user_configs remains the immutable source for the preservation guard.
-    """
-    if _app is not None:
-        notification_chat_ids = _app.get(NOTIFICATION_CHAT_IDS_KEY)
-        if notification_chat_ids is None:
-            return
-        # Never remove a chat_id that belongs to an actual user.
-        # user_configs keys are telegram_ids of real users.
-        config = _app.get(CONFIG_KEY)
-        if config and chat_id in config.user_configs:
-            return
-        notification_chat_ids.discard(chat_id)

--- a/src/kai/workshop/__init__.py
+++ b/src/kai/workshop/__init__.py
@@ -89,14 +89,6 @@ from kai.workshop.store import (
     StoredEvent,
     WorkshopEventStore,
 )
-from kai.workshop.streaming_preview import (
-    ConfirmedTelegramStreamingPreview,
-    StreamingPreviewBindingError,
-    StreamingPreviewConflictError,
-    StreamingPreviewTargetError,
-    TelegramStreamingPreviewBinding,
-    bind_confirmed_telegram_streaming_preview,
-)
 from kai.workshop.timeline import (
     ChannelTimelineAuthorizer,
     TimelineAccessDeniedError,
@@ -131,7 +123,6 @@ __all__ = [
     "ChannelTimelineAuthorizer",
     "ClientDeviceUnavailableError",
     "ClientSessionId",
-    "ConfirmedTelegramStreamingPreview",
     "DeliveryAttemptId",
     "DeliveryClaim",
     "DeliveryExecutionContract",
@@ -171,10 +162,6 @@ __all__ = [
     "RedeemedWorkshopClient",
     "StaleDeliveryLeaseError",
     "StoredEvent",
-    "StreamingPreviewBindingError",
-    "StreamingPreviewConflictError",
-    "StreamingPreviewTargetError",
-    "TelegramStreamingPreviewBinding",
     "TimelineAccessDeniedError",
     "TimelineCursorError",
     "TimelineMessage",
@@ -194,7 +181,6 @@ __all__ = [
     "WorkshopEventType",
     "WorkshopId",
     "WorkshopMembershipId",
-    "bind_confirmed_telegram_streaming_preview",
     "read_channel_timeline",
     "read_channel_timeline_updates",
     "record_inbound_artifact",

--- a/src/kai/workshop/client_access.py
+++ b/src/kai/workshop/client_access.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 from kai.workshop.client_sessions import (
@@ -30,14 +31,15 @@ class EnrollableWorkshopHuman:
     direct_channels: tuple[ChannelId, ...]
 
 
-def _telegram_subject(telegram_user_id: int) -> str:
-    if (
-        not isinstance(telegram_user_id, int)
-        or isinstance(telegram_user_id, bool)
-        or not 1 <= telegram_user_id <= 2**63 - 1
-    ):
-        raise WorkshopClientAccessError("Telegram user ID must be a positive signed 64-bit integer")
-    return str(telegram_user_id)
+_EXTERNAL_IDENTITY_KIND = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+
+
+def _external_identity_value(kind: str, value: str) -> str:
+    if not isinstance(kind, str) or _EXTERNAL_IDENTITY_KIND.fullmatch(kind) is None:
+        raise WorkshopClientAccessError("External identity kind is invalid")
+    if not isinstance(value, str) or not value or len(value) > 512:
+        raise WorkshopClientAccessError("External identity value is invalid")
+    return value
 
 
 class WorkshopClientAccess:
@@ -88,24 +90,33 @@ class WorkshopClientAccess:
         if not available:
             raise WorkshopClientAccessError("Canonical human does not own that direct channel in an active Workshop")
 
-    async def _resolve_direct_human(self, telegram_user_id: int) -> tuple[PrincipalId, ChannelId]:
-        subject = _telegram_subject(telegram_user_id)
+    async def resolve_external_direct_human(
+        self,
+        *,
+        provider: str,
+        external_subject: str,
+        transport: str,
+        external_channel_id: str,
+    ) -> tuple[PrincipalId, ChannelId]:
+        """Resolve one adapter identity and channel to a canonical direct human."""
+        subject = _external_identity_value(provider, external_subject)
+        channel_subject = _external_identity_value(transport, external_channel_id)
         async with self._store.connection.execute(
             "SELECT ei.principal_id, c.id FROM external_identities ei "
             "JOIN principals p ON p.id = ei.principal_id AND p.kind = 'human' "
             "JOIN channel_memberships cm ON cm.principal_id = p.id AND cm.role = 'owner' "
             "JOIN channels c ON c.id = cm.channel_id AND c.kind = 'direct' "
             "JOIN workshop_memberships wm ON wm.workshop_id = c.workshop_id AND wm.principal_id = p.id "
-            "JOIN channel_bindings cb ON cb.channel_id = c.id AND cb.transport = 'telegram' "
-            "AND cb.external_channel_id = ei.external_subject "
-            "WHERE ei.provider = 'telegram' AND ei.external_subject = ?",
-            (subject,),
+            "JOIN channel_bindings cb ON cb.channel_id = c.id AND cb.transport = ? "
+            "AND cb.external_channel_id = ? "
+            "WHERE ei.provider = ? AND ei.external_subject = ?",
+            (transport, channel_subject, provider, subject),
         ) as cursor:
             rows = list(await cursor.fetchall())
         if len(rows) != 1:
             raise WorkshopClientAccessError(
-                "Telegram user does not resolve to exactly one canonical human and direct channel; restart Kai "
-                "after configuring the user"
+                "External identity does not resolve to exactly one canonical human and direct channel; restart "
+                "Kai after configuring the adapter binding"
             )
         return PrincipalId(str(rows[0][0])), ChannelId(str(rows[0][1]))
 
@@ -118,17 +129,9 @@ class WorkshopClientAccess:
         grant = await self._enrollment.issue_grant(principal_id)
         return IssuedClientEnrollment(grant, channel_id)
 
-    async def issue_enrollment_for_telegram(self, telegram_user_id: int) -> IssuedClientEnrollment:
-        principal_id, channel_id = await self._resolve_direct_human(telegram_user_id)
-        return await self.issue_enrollment(principal_id, channel_id)
-
     async def revoke_device(self, principal_id: PrincipalId, device_id: DeviceId) -> None:
         if not await self._sessions.revoke_device(principal_id, device_id):
             raise WorkshopClientAccessError("Client device is unavailable for that canonical human")
-
-    async def revoke_device_for_telegram(self, telegram_user_id: int, device_id: DeviceId) -> None:
-        principal_id, _ = await self._resolve_direct_human(telegram_user_id)
-        await self.revoke_device(principal_id, device_id)
 
     async def revoke_enrollment(
         self,
@@ -137,11 +140,3 @@ class WorkshopClientAccess:
     ) -> None:
         if not await self._enrollment.revoke_grant(principal_id, grant_id):
             raise WorkshopClientAccessError("Enrollment grant is unavailable for that canonical human")
-
-    async def revoke_enrollment_for_telegram(
-        self,
-        telegram_user_id: int,
-        grant_id: EnrollmentGrantId,
-    ) -> None:
-        principal_id, _ = await self._resolve_direct_human(telegram_user_id)
-        await self.revoke_enrollment(principal_id, grant_id)

--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -218,14 +218,15 @@ class WorkshopPrivateTextExecutionService:
             raise RuntimeError("Workshop private-text execution service is closed")
         return await self._coordinator.request_cancellation(run_id)
 
-    async def request_cancellation(
+    async def request_transport_cancellation(
         self,
         *,
-        telegram_user_id: int,
-        telegram_chat_id: int,
+        transport: str,
+        sender_subject: str,
+        channel_subject: str,
     ) -> CanonicalCancellationDisposition:
-        """Resolve transport identity to a canonical run before cancellation."""
-        if telegram_user_id <= 0 or telegram_chat_id <= 0 or telegram_user_id != telegram_chat_id:
+        """Resolve an authenticated adapter identity to a canonical run."""
+        if not transport or not sender_subject or not channel_subject:
             return CanonicalCancellationDisposition.NOT_ACTIVE
         async with (
             self._database_lock,
@@ -233,12 +234,12 @@ class WorkshopPrivateTextExecutionService:
                 "SELECT r.id FROM runs r "
                 "JOIN channels c ON c.id = r.channel_id AND c.kind = 'direct' "
                 "JOIN external_identities ei ON ei.principal_id = r.requested_by_principal_id "
-                "AND ei.provider = 'telegram' AND ei.external_subject = ? "
+                "AND ei.provider = ? AND ei.external_subject = ? "
                 "JOIN channel_bindings cb ON cb.channel_id = r.channel_id "
-                "AND cb.transport = 'telegram' AND cb.external_channel_id = ? "
+                "AND cb.transport = ? AND cb.external_channel_id = ? "
                 "WHERE r.status IN ('accepted', 'started') "
                 "ORDER BY r.accepted_at DESC, r.id",
-                (str(telegram_user_id), str(telegram_chat_id)),
+                (transport, sender_subject, transport, channel_subject),
             ) as cursor,
         ):
             rows = list(await cursor.fetchall())

--- a/src/kai/workshop/storage_namespaces.py
+++ b/src/kai/workshop/storage_namespaces.py
@@ -33,13 +33,7 @@ class WorkshopChannelHistoryNamespace:
 
 
 class WorkshopChannelHistoryRegistry:
-    """Resolve compatibility chat keys to canonical channel histories.
-
-    Telegram chat IDs remain adapter inputs while the compatibility runtime is
-    being retired. They are never used as new directory names once this
-    registry is configured. Runtime configuration IDs are also accepted as
-    aliases for direct-channel execution initiated by a non-Telegram client.
-    """
+    """Resolve archived runtime keys to canonical channel histories."""
 
     def __init__(
         self,
@@ -81,27 +75,7 @@ class WorkshopChannelHistoryRegistry:
         store: WorkshopEventStore,
         runtime_profiles: WorkshopRuntimeProfileRegistry,
     ) -> WorkshopChannelHistoryRegistry:
-        """Resolve transport bindings and protected runtimes to channels."""
-        async with store.connection.execute(
-            "SELECT c.id, cb.external_channel_id "
-            "FROM channels c JOIN channel_bindings cb ON cb.channel_id = c.id "
-            "WHERE cb.transport = 'telegram' ORDER BY c.id"
-        ) as cursor:
-            binding_rows = list(await cursor.fetchall())
-
-        namespaces: list[WorkshopChannelHistoryNamespace] = []
-        for row in binding_rows:
-            try:
-                channel_id = ChannelId(str(row[0]))
-                legacy_chat_id = int(str(row[1]))
-            except (TypeError, ValueError) as exc:
-                raise WorkshopStorageNamespaceError(
-                    "Telegram channel history binding contains an invalid identifier"
-                ) from exc
-            if legacy_chat_id == 0:
-                raise WorkshopStorageNamespaceError("Telegram channel history binding cannot use chat ID zero")
-            namespaces.append(WorkshopChannelHistoryNamespace(channel_id, legacy_chat_id))
-
+        """Resolve protected runtime assignments to canonical channels."""
         async with store.connection.execute(
             "SELECT runtime_profile_id, channel_id FROM channel_agent_runtime_assignments ORDER BY runtime_profile_id"
         ) as cursor:
@@ -120,7 +94,8 @@ class WorkshopChannelHistoryRegistry:
             channel_by_profile[profile_id] = channel_id
 
         runtime_aliases: dict[int, ChannelId] = {}
-        namespace_channels = {namespace.channel_id for namespace in namespaces}
+        namespaces: list[WorkshopChannelHistoryNamespace] = []
+        namespace_channels: set[ChannelId] = set()
         for profile in runtime_profiles.profiles:
             channel_id = channel_by_profile.get(profile.profile_id)
             if channel_id is None:

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -155,6 +155,12 @@ def _channel_id(value: str) -> ChannelId:
         raise WorkshopClientAccessError("Invalid channel ID") from exc
 
 
+def _telegram_subject(value: int) -> str:
+    if isinstance(value, bool) or not isinstance(value, int) or not 1 <= value <= 2**63 - 1:
+        raise WorkshopClientAccessError("Telegram user ID must be a positive signed 64-bit integer")
+    return str(value)
+
+
 def _transcript_channel_id(value: str) -> ChannelId:
     try:
         return ChannelId(value)
@@ -290,7 +296,14 @@ async def _run(args: argparse.Namespace) -> int:
                 else:
                     if args.channel_id is not None:
                         raise WorkshopClientAccessError("--channel-id cannot be used with --telegram-user-id")
-                    issued = await access.issue_enrollment_for_telegram(args.telegram_user_id)
+                    subject = _telegram_subject(args.telegram_user_id)
+                    principal_id, channel_id = await access.resolve_external_direct_human(
+                        provider="telegram",
+                        external_subject=subject,
+                        transport="telegram",
+                        external_channel_id=subject,
+                    )
+                    issued = await access.issue_enrollment(principal_id, channel_id)
                 print(f"Enrollment: {issued.grant.grant_id}")
                 print(f"Channel: {issued.channel_id}")
                 print(f"Expires: {issued.grant.expires_at.isoformat()}")
@@ -302,7 +315,14 @@ async def _run(args: argparse.Namespace) -> int:
                 if args.principal_id is not None:
                     await access.revoke_device(_principal_id(args.principal_id), device_id)
                 else:
-                    await access.revoke_device_for_telegram(args.telegram_user_id, device_id)
+                    subject = _telegram_subject(args.telegram_user_id)
+                    principal_id, _ = await access.resolve_external_direct_human(
+                        provider="telegram",
+                        external_subject=subject,
+                        transport="telegram",
+                        external_channel_id=subject,
+                    )
+                    await access.revoke_device(principal_id, device_id)
                 print(f"Device: {device_id}")
                 print("Status: revoked (all device sessions revoked)")
                 return 0
@@ -310,7 +330,14 @@ async def _run(args: argparse.Namespace) -> int:
             if args.principal_id is not None:
                 await access.revoke_enrollment(_principal_id(args.principal_id), grant_id)
             else:
-                await access.revoke_enrollment_for_telegram(args.telegram_user_id, grant_id)
+                subject = _telegram_subject(args.telegram_user_id)
+                principal_id, _ = await access.resolve_external_direct_human(
+                    provider="telegram",
+                    external_subject=subject,
+                    transport="telegram",
+                    external_channel_id=subject,
+                )
+                await access.revoke_enrollment(principal_id, grant_id)
             print(f"Enrollment: {grant_id}")
             print("Status: revoked")
             return 0

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -2,11 +2,11 @@
 
 ## About This File
 
-This file is the bootstrap template for Kai's backend-neutral identity. The installer copies it to `<DATA_DIR>/home/<chat_id>/AGENTS.md` for every user in `users.yaml` at install time; `backend.ensure_user_home` lazily seeds it for users added later in development mode. Claude receives a thin `.claude/CLAUDE.md` import adapter; all managed identity content remains here. Edit the per-user `AGENTS.md` to add operator-personal content; the tracked template ships universal content only. Once customized, you can delete this "About This File" section from the per-user copy.
+This file is the bootstrap template for Kai's backend-neutral identity. The installer copies it to `<DATA_DIR>/home/<principal_id>/AGENTS.md` for each canonical Workshop human with an assigned runtime; `backend.ensure_user_home` lazily seeds it for profiles added later in development mode. Claude receives a thin `.claude/CLAUDE.md` import adapter; all managed identity content remains here. Edit the per-principal `AGENTS.md` to add operator-personal content; the tracked template ships universal content only. Once customized, you can delete this "About This File" section from the per-principal copy.
 
 ## Who You Are
 
-You're Kai, a personal AI assistant accessed via Telegram. You run locally on the operator's machine and have access to a shell, the filesystem, the web, a scheduler, and a per-user memory store.
+You're Kai, a personal AI assistant available through configured clients such as Workshop and Telegram. You run locally on the operator's machine and have access to a shell, the filesystem, the web, a scheduler, and a per-principal memory store.
 
 ## Hard Rules
 
@@ -86,7 +86,7 @@ When searching the web:
 
 ## Chat History
 
-All past conversations are logged as JSONL, one file per day (e.g., `2026-02-10.jsonl`). The history directory path is injected into your session context - look for `[Recent conversations (search /path/to/history/)]` (when recent history is available) or `[Chat history is stored in /path/to/history/]` (when no recent history exists). Each line is a JSON object with fields: `ts` (ISO timestamp), `dir` (`user` or `assistant`), `chat_id`, `text`, and optional `media`. When asked about past conversations, search these files with grep or jq.
+Canonical conversation history is stored in Workshop's SQLite timeline. A derived, recoverable `canonical-transcript.ndjson` export is injected into your session context for searching; look for `[Recent conversations (search /path/to/history/)]` or `[Chat history is stored in /path/to/history/]`. Each line identifies the canonical channel, message, author principal, body, timestamp, and event position. When asked about past conversations, search that export with grep or jq. Date-named JSONL files, if present, are legacy archives and are not authoritative for newer conversations.
 
 ## Scheduling Jobs
 
@@ -193,7 +193,7 @@ You have a per-user vector store that holds extracted facts about the user (pref
 
 This is distinct from your `MEMORY.md` file, which holds operator notes and project state. In enabled mode, MEMORY.md is not injected; the vector store is the active fact surface, populated automatically by the extractor and on demand via the API.
 
-There is deliberately no delete endpoint in this API. When the user asks to remove memories, point them at the `/memory` Telegram command (per-fact review and forget) or at the operator; do not attempt deletion through this API or retry variations hoping for one.
+There is deliberately no delete endpoint in this agent API. When the user asks to remove memories, direct them to the Workshop memory editor, an adapter's memory controls, or the operator; do not attempt deletion through this API or retry variations hoping for one.
 
 ### When to store a fact via the API
 

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -14,7 +14,7 @@
 #   5. Restart Kai.
 #
 # Kai injects authentication from the server-side env at call time — API keys never
-# enter the selected agent's context. See <DATA_DIR>/home/<chat_id>/AGENTS.md for usage docs.
+# enter the selected agent's context. See <DATA_DIR>/home/<principal_id>/AGENTS.md for usage docs.
 #
 # Auth types:
 #   bearer  — Authorization: Bearer $KEY

--- a/tests/test_adapter_architecture.py
+++ b/tests/test_adapter_architecture.py
@@ -80,3 +80,30 @@ def test_composition_root_loads_telegram_adapter_only_when_enabled() -> None:
     assert 'import_module("kai.telegram_adapter")' in main_source
     assert "from kai.telegram_adapter" not in main_source
     assert "import kai.telegram_adapter" not in main_source
+
+
+def test_core_identity_and_cancellation_services_are_transport_generic() -> None:
+    for relative in (
+        "workshop/client_access.py",
+        "workshop/private_text_execution.py",
+        "workshop/storage_namespaces.py",
+    ):
+        source = (SOURCE_ROOT / relative).read_text()
+        assert "telegram" not in source.lower(), relative
+
+
+def test_shared_http_host_exports_no_telegram_application_state() -> None:
+    source = (SOURCE_ROOT / "webhook.py").read_text()
+
+    assert "TELEGRAM_APP_KEY" not in source
+    assert "TELEGRAM_BOT_KEY" not in source
+    assert "TELEGRAM_WEBHOOK_SECRET_KEY" not in source
+    assert "NOTIFICATION_CHAT_IDS_KEY" not in source
+    assert "CHAT_ID_KEY" not in source
+
+
+def test_workshop_package_does_not_export_adapter_preview_types() -> None:
+    source = (SOURCE_ROOT / "workshop" / "__init__.py").read_text()
+
+    assert "streaming_preview" not in source
+    assert "TelegramStreamingPreview" not in source

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -31,7 +31,6 @@ from kai.bot import (
     _handle_workspace_config,
     _handle_workspace_deny,
     _is_authorized,
-    _is_notify_chat_used,
     _models_keyboard,
     _reply_safe,
     _require_auth,
@@ -1261,12 +1260,16 @@ class TestHandleStop:
         update = _make_update(chat_id=1, user_id=1)
         ctx = _make_context(claude=pool, config=_make_config(allowed_user_ids={1}))
         execution = MagicMock()
-        execution.request_cancellation = AsyncMock(return_value=CanonicalCancellationDisposition.REQUESTED)
+        execution.request_transport_cancellation = AsyncMock(return_value=CanonicalCancellationDisposition.REQUESTED)
         ctx.application.core_services.private_text_execution = execution
 
         await handle_stop(update, ctx)
 
-        execution.request_cancellation.assert_awaited_once_with(telegram_user_id=1, telegram_chat_id=1)
+        execution.request_transport_cancellation.assert_awaited_once_with(
+            transport="telegram",
+            sender_subject="1",
+            channel_subject="1",
+        )
         pool.force_kill.assert_not_called()
         assert update.message.reply_text.await_args.args[0] == "Stopping..."
 
@@ -4206,7 +4209,7 @@ class TestHandleGitHub:
 
     @pytest.mark.asyncio
     async def test_notify_set(self):
-        """/github notify 123456 sets notification chat and updates live set."""
+        """/github notify 123456 persists the adapter-owned destination."""
         update = _make_update(text="/github notify 123456")
         config = _make_config()
         ctx = _make_context(config=config, args=["notify", "123456"])
@@ -4218,14 +4221,10 @@ class TestHandleGitHub:
         # No existing notify setting (fresh set)
         mock_sessions.get_setting = AsyncMock(return_value=None)
 
-        with (
-            patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
-        ):
+        with patch("kai.bot.sessions", mock_sessions):
             await handle_github(update, ctx)
 
         mock_sessions.set_setting.assert_called_once_with("github_notify_chat:12345", "123456")
-        mock_add.assert_called_once_with(123456)
         reply = update.message.reply_text.call_args[0][0]
         assert "123456" in reply
         # Fix removes the restart requirement
@@ -4353,230 +4352,6 @@ class TestHandleGitHub:
 
         reply = update.message.reply_text.call_args[0][0]
         assert "unknown subcommand" in reply.lower()
-
-    # ── 11. /github notify - live notification destination updates ────────
-
-    @pytest.mark.asyncio
-    async def test_notify_set_updates_notification_destinations(self):
-        """/github notify -100999 adds the group to notification destinations immediately."""
-        update = _make_update(text="/github notify -100999")
-        config = _make_config()
-        ctx = _make_context(config=config, args=["notify", "-100999"])
-        mock_sessions = AsyncMock()
-        mock_sessions.set_setting = AsyncMock()
-        # No existing notify setting (fresh set)
-        mock_sessions.get_setting = AsyncMock(return_value=None)
-
-        with (
-            patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
-        ):
-            await handle_github(update, ctx)
-
-        mock_sessions.set_setting.assert_called_once_with("github_notify_chat:12345", "-100999")
-        mock_add.assert_called_once_with(-100999)
-        reply = update.message.reply_text.call_args[0][0]
-        assert "restart" not in reply.lower()
-
-    @pytest.mark.asyncio
-    async def test_notify_set_overwrite_cleans_up_old(self):
-        """Overwriting a notify destination removes the old outbound destination.
-
-        Without this cleanup, the old chat_id would linger in the live
-        outbound notification registry until restart.
-        """
-        update = _make_update(text="/github notify -100888")
-        config = _make_config()
-        ctx = _make_context(config=config, args=["notify", "-100888"])
-        mock_sessions = AsyncMock()
-        mock_sessions.set_setting = AsyncMock()
-        # Existing notify setting points to a different group chat
-        mock_sessions.get_setting = AsyncMock(return_value="-100999")
-
-        with (
-            patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
-            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
-            patch("kai.bot._is_notify_chat_used", new_callable=AsyncMock, return_value=False),
-        ):
-            await handle_github(update, ctx)
-
-        # Old destination removed, new one added
-        mock_remove.assert_called_once_with(-100999)
-        mock_add.assert_called_once_with(-100888)
-
-    @pytest.mark.asyncio
-    async def test_notify_set_overwrite_skips_cleanup_when_shared(self):
-        """Overwriting a notify destination keeps the old chat_id if another user uses it."""
-        update = _make_update(text="/github notify -100888")
-        config = _make_config()
-        ctx = _make_context(config=config, args=["notify", "-100888"])
-        mock_sessions = AsyncMock()
-        mock_sessions.set_setting = AsyncMock()
-        mock_sessions.get_setting = AsyncMock(return_value="-100999")
-
-        with (
-            patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
-            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
-            # Another user still uses the old chat_id
-            patch("kai.bot._is_notify_chat_used", new_callable=AsyncMock, return_value=True),
-        ):
-            await handle_github(update, ctx)
-
-        # Old destination kept (still used), new one added
-        mock_remove.assert_not_called()
-        mock_add.assert_called_once_with(-100888)
-
-    @pytest.mark.asyncio
-    async def test_notify_set_overwrite_same_value_no_cleanup(self):
-        """Setting the same notify destination again does not trigger cleanup."""
-        update = _make_update(text="/github notify -100999")
-        config = _make_config()
-        ctx = _make_context(config=config, args=["notify", "-100999"])
-        mock_sessions = AsyncMock()
-        mock_sessions.set_setting = AsyncMock()
-        # Same value already stored
-        mock_sessions.get_setting = AsyncMock(return_value="-100999")
-
-        with (
-            patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.add_notification_chat_id") as mock_add,
-            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
-        ):
-            await handle_github(update, ctx)
-
-        # No removal needed (same value), just re-add (idempotent)
-        mock_remove.assert_not_called()
-        mock_add.assert_called_once_with(-100999)
-
-    @pytest.mark.asyncio
-    async def test_notify_reset_removes_from_notification_destinations(self):
-        """/github notify reset removes the old outbound notification destination."""
-        update = _make_update(text="/github notify reset")
-        config = _make_config()
-        ctx = _make_context(config=config, args=["notify", "reset"])
-        mock_sessions = AsyncMock()
-        # Simulate an existing notify setting pointing to a group chat
-        mock_sessions.get_setting = AsyncMock(return_value="-100999")
-        mock_sessions.delete_setting = AsyncMock()
-
-        with (
-            patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
-            patch("kai.bot._is_notify_chat_used", new_callable=AsyncMock, return_value=False),
-        ):
-            await handle_github(update, ctx)
-
-        mock_sessions.delete_setting.assert_called_once_with("github_notify_chat:12345")
-        mock_remove.assert_called_once_with(-100999)
-
-    @pytest.mark.asyncio
-    async def test_notify_reset_skips_removal_when_shared(self):
-        """/github notify reset does NOT remove a chat_id still used by another user."""
-        update = _make_update(text="/github notify reset")
-        config = _make_config()
-        ctx = _make_context(config=config, args=["notify", "reset"])
-        mock_sessions = AsyncMock()
-        mock_sessions.get_setting = AsyncMock(return_value="-100999")
-        mock_sessions.delete_setting = AsyncMock()
-
-        with (
-            patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
-            # Another user still uses this chat_id
-            patch("kai.bot._is_notify_chat_used", new_callable=AsyncMock, return_value=True),
-        ):
-            await handle_github(update, ctx)
-
-        mock_sessions.delete_setting.assert_called_once()
-        mock_remove.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_notify_reset_self_id_skips_removal(self):
-        """/github notify reset does NOT remove the user's own chat_id.
-
-        This guard keeps the user's own authorized chat out of outbound
-        notification cleanup.
-        """
-        update = _make_update(text="/github notify reset")
-        config = _make_config()
-        ctx = _make_context(config=config, args=["notify", "reset"])
-        mock_sessions = AsyncMock()
-        # The user previously set their own telegram_id (12345) as the target
-        mock_sessions.get_setting = AsyncMock(return_value="12345")
-        mock_sessions.delete_setting = AsyncMock()
-
-        with (
-            patch("kai.bot.sessions", mock_sessions),
-            patch("kai.bot.webhook.remove_notification_chat_id") as mock_remove,
-        ):
-            await handle_github(update, ctx)
-
-        mock_sessions.delete_setting.assert_called_once()
-        # The self-ID guard fires before _is_notify_chat_used is even called
-        mock_remove.assert_not_called()
-
-
-# ── _is_notify_chat_used ──────────────────────────────────────────
-
-
-class TestIsNotifyChatUsed:
-    """Tests for _is_notify_chat_used helper.
-
-    Verifies detection of shared notify chat_ids across users.yaml,
-    database settings, and the global env var fallback.
-    """
-
-    @pytest.mark.asyncio
-    async def test_yaml_match(self):
-        """Returns True when another user in users.yaml uses the chat_id."""
-        from kai.config import UserConfig
-
-        user_a = UserConfig(telegram_id=111, name="alice")
-        user_b = UserConfig(telegram_id=222, name="bob", github_notify_chat_id=-100999)
-        config = _make_config(user_configs={111: user_a, 222: user_b})
-
-        mock_sessions = AsyncMock()
-        mock_sessions.get_setting = AsyncMock(return_value=None)
-
-        with patch("kai.bot.sessions", mock_sessions):
-            result = await _is_notify_chat_used(-100999, exclude_user=111, config=config)
-        assert result is True
-
-    @pytest.mark.asyncio
-    async def test_db_match(self):
-        """Returns True when another user's DB setting uses the chat_id."""
-        from kai.config import UserConfig
-
-        user_a = UserConfig(telegram_id=111, name="alice")
-        user_b = UserConfig(telegram_id=222, name="bob")
-        config = _make_config(user_configs={111: user_a, 222: user_b})
-
-        mock_sessions = AsyncMock()
-        # User B has the notify target in the DB
-        mock_sessions.get_setting = AsyncMock(
-            side_effect=lambda key: "-100999" if key == "github_notify_chat:222" else None
-        )
-
-        with patch("kai.bot.sessions", mock_sessions):
-            result = await _is_notify_chat_used(-100999, exclude_user=111, config=config)
-        assert result is True
-
-    @pytest.mark.asyncio
-    async def test_no_match(self):
-        """Returns False when no other source references the chat_id."""
-        from kai.config import UserConfig
-
-        user_a = UserConfig(telegram_id=111, name="alice")
-        config = _make_config(user_configs={111: user_a})
-
-        mock_sessions = AsyncMock()
-        mock_sessions.get_setting = AsyncMock(return_value=None)
-
-        with patch("kai.bot.sessions", mock_sessions):
-            result = await _is_notify_chat_used(-100999, exclude_user=111, config=config)
-        assert result is False
 
 
 # ── /model persistence ─────────────────────────────────────────────

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -265,12 +265,11 @@ class TestLoadConfigDefaults:
         assert config.telegram_webhook_url is None
         assert config.telegram_webhook_secret is None
 
-    def test_workshop_only_rejects_a_present_malformed_users_file(self, monkeypatch):
+    def test_workshop_only_ignores_a_present_malformed_users_file(self, monkeypatch):
         monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "workshop")
         _patch_protected_users_yaml(monkeypatch, "users: invalid\n")
 
-        with pytest.raises(SystemExit, match=r"users\.yaml"):
-            load_config()
+        assert load_config().user_configs == {}
 
     def test_telegram_only_does_not_enable_workshop(self, monkeypatch):
         _set_required(monkeypatch)
@@ -916,7 +915,7 @@ class TestDualModeLoading:
 
 
 class TestProtectedUserIsolation:
-    def test_workshop_only_protected_install_rejects_unreadable_users_yaml(self, monkeypatch):
+    def test_workshop_only_protected_install_ignores_unreadable_users_yaml(self, monkeypatch):
         monkeypatch.setenv("KAI_ENABLED_ADAPTERS", "workshop")
 
         def protected_reader(path):
@@ -930,8 +929,7 @@ class TestProtectedUserIsolation:
             lambda path, **kwargs: path == "/etc/kai/users.yaml",
         )
 
-        with pytest.raises(SystemExit, match=r"users\.yaml"):
-            load_config()
+        assert load_config().user_configs == {}
 
     def test_protected_install_requires_os_user(self, monkeypatch):
         monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "fake-token")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -14,15 +14,10 @@ from kai.config import UserConfig
 from kai.internal_api_auth import InternalAPIAuth
 from kai.telegram_http import TelegramWebhookIngress
 from kai.webhook import (
-    ALLOWED_USER_IDS_KEY,
     ALLOWED_WORKSPACES_KEY,
-    CHAT_ID_KEY,
     CONFIG_KEY,
     GITHUB_WEBHOOK_SECRET_KEY,
     INTERNAL_API_AUTH_KEY,
-    NOTIFICATION_CHAT_IDS_KEY,
-    TELEGRAM_APP_KEY,
-    TELEGRAM_BOT_KEY,
     WORKSPACE_BASE_KEY,
     _fmt_issue_comment,
     _fmt_issues,
@@ -31,10 +26,7 @@ from kai.webhook import (
     _fmt_push,
     _handle_github,
     _resolve_local_repo,
-    _strip_markdown,
     _verify_github_signature,
-    add_notification_chat_id,
-    remove_notification_chat_id,
 )
 from kai.workshop.domain import AgentId, ChannelId, PrincipalId
 from kai.workshop.integration_notifications import WorkshopIntegrationNotificationService
@@ -46,6 +38,12 @@ from kai.workshop.storage_namespaces import (
 )
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id
+
+# Telegram-specific fixtures own these values; the shared HTTP host does not.
+ALLOWED_USER_IDS_KEY: web.AppKey[set[int]] = web.AppKey("test_allowed_user_ids", set)
+CHAT_ID_KEY: web.AppKey[int] = web.AppKey("test_chat_id", int)
+TELEGRAM_APP_KEY: web.AppKey[object] = web.AppKey("test_telegram_app", object)
+TELEGRAM_BOT_KEY: web.AppKey[object] = web.AppKey("test_telegram_bot", object)
 
 
 def _internal_api_auth() -> InternalAPIAuth:
@@ -88,31 +86,6 @@ class TestVerifyGithubSignature:
         body = b"body"
         digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
         assert _verify_github_signature(secret, body, digest) is False
-
-
-# ── _strip_markdown ──────────────────────────────────────────────────
-
-
-class TestStripMarkdown:
-    def test_converts_links(self):
-        assert _strip_markdown("[click](https://example.com)") == "click (https://example.com)"
-
-    def test_removes_bold(self):
-        assert _strip_markdown("**bold text**") == "bold text"
-
-    def test_removes_backticks(self):
-        assert _strip_markdown("`inline code`") == "inline code"
-
-    def test_removes_italic_preserves_snake_case(self):
-        result = _strip_markdown("_italic_ and snake_case")
-        assert result == "italic and snake_case"
-
-    def test_combined(self):
-        text = "**Push** to `main` by [alice](https://github.com/alice)"
-        result = _strip_markdown(text)
-        assert "**" not in result
-        assert "`" not in result
-        assert "alice (https://github.com/alice)" in result
 
 
 # ── _fmt_push ────────────────────────────────────────────────────────
@@ -724,8 +697,7 @@ class TestNotificationChatIdMutations:
                     integration_notifications=integration_notifications,
                 )
 
-            assert wh._app[ALLOWED_USER_IDS_KEY] == {111}
-            assert wh._app[NOTIFICATION_CHAT_IDS_KEY] == {-100111, -100222}
+            assert ALLOWED_USER_IDS_KEY not in wh._app
         finally:
             await wh.stop()
             wh._app = old_app
@@ -910,121 +882,3 @@ class TestNotificationChatIdMutations:
         finally:
             await wh.stop()
             await core_store.close()
-
-    def test_add_notification_chat_id(self):
-        """add_notification_chat_id adds a chat_id to the outbound registry."""
-        import kai.webhook as wh
-
-        app = web.Application()
-        app[ALLOWED_USER_IDS_KEY] = {100}
-        app[NOTIFICATION_CHAT_IDS_KEY] = set()
-        old_app = wh._app
-        wh._app = app
-        try:
-            add_notification_chat_id(999)
-            assert app[NOTIFICATION_CHAT_IDS_KEY] == {999}
-            assert app[ALLOWED_USER_IDS_KEY] == {100}
-        finally:
-            wh._app = old_app
-
-    def test_add_notification_chat_id_idempotent(self):
-        """Adding the same chat_id twice does not duplicate it."""
-        import kai.webhook as wh
-
-        app = web.Application()
-        app[ALLOWED_USER_IDS_KEY] = {100}
-        app[NOTIFICATION_CHAT_IDS_KEY] = set()
-        old_app = wh._app
-        wh._app = app
-        try:
-            add_notification_chat_id(999)
-            add_notification_chat_id(999)
-            # Sets don't have duplicates; just verify it's present
-            assert app[NOTIFICATION_CHAT_IDS_KEY] == {999}
-            assert app[ALLOWED_USER_IDS_KEY] == {100}
-        finally:
-            wh._app = old_app
-
-    def test_add_does_not_mutate_inbound_principals(self):
-        """Adding an outbound destination cannot authorize a Telegram user."""
-        import kai.webhook as wh
-
-        inbound_principals = {100}
-        app = web.Application()
-        app[ALLOWED_USER_IDS_KEY] = set(inbound_principals)
-        app[NOTIFICATION_CHAT_IDS_KEY] = set()
-        old_app = wh._app
-        wh._app = app
-        try:
-            add_notification_chat_id(999)
-            assert app[ALLOWED_USER_IDS_KEY] == {100}
-            assert app[NOTIFICATION_CHAT_IDS_KEY] == {999}
-            assert inbound_principals == {100}
-        finally:
-            wh._app = old_app
-
-    def test_add_notification_chat_id_no_app(self):
-        """add_notification_chat_id is a no-op when _app is None (polling mode)."""
-        import kai.webhook as wh
-
-        old_app = wh._app
-        wh._app = None
-        try:
-            # Should not raise
-            add_notification_chat_id(999)
-        finally:
-            wh._app = old_app
-
-    def test_remove_notification_chat_id_group(self):
-        """remove_notification_chat_id removes a group chat_id from the outbound registry."""
-        import kai.webhook as wh
-
-        app = web.Application()
-        app[ALLOWED_USER_IDS_KEY] = {100}
-        app[NOTIFICATION_CHAT_IDS_KEY] = {-100123}
-        # No config needed for this case - group IDs are never in user_configs
-        mock_config = MagicMock()
-        mock_config.user_configs = {}
-        app[CONFIG_KEY] = mock_config
-        old_app = wh._app
-        wh._app = app
-        try:
-            remove_notification_chat_id(-100123)
-            assert -100123 not in app[NOTIFICATION_CHAT_IDS_KEY]
-            assert app[ALLOWED_USER_IDS_KEY] == {100}
-        finally:
-            wh._app = old_app
-
-    def test_remove_notification_chat_id_preserves_users(self):
-        """remove_notification_chat_id does NOT remove a real user's telegram_id."""
-        import kai.webhook as wh
-
-        user = UserConfig(telegram_id=12345, name="alice")
-        mock_config = MagicMock()
-        mock_config.user_configs = {12345: user}
-
-        app = web.Application()
-        app[ALLOWED_USER_IDS_KEY] = {12345}
-        app[NOTIFICATION_CHAT_IDS_KEY] = {12345, -100999}
-        app[CONFIG_KEY] = mock_config
-        old_app = wh._app
-        wh._app = app
-        try:
-            remove_notification_chat_id(12345)
-            # 12345 is a real user - must NOT be removed
-            assert 12345 in app[ALLOWED_USER_IDS_KEY]
-            assert 12345 in app[NOTIFICATION_CHAT_IDS_KEY]
-        finally:
-            wh._app = old_app
-
-    def test_remove_notification_chat_id_no_app(self):
-        """remove_notification_chat_id is a no-op when _app is None (polling mode)."""
-        import kai.webhook as wh
-
-        old_app = wh._app
-        wh._app = None
-        try:
-            # Should not raise
-            remove_notification_chat_id(-100123)
-        finally:
-            wh._app = old_app

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -18,16 +18,11 @@ from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, Interna
 from kai.services import ServiceResponse
 from kai.telegram_http import TelegramWebhookIngress
 from kai.webhook import (
-    ALLOWED_USER_IDS_KEY,
-    CHAT_ID_KEY,
     CONFIG_KEY,
     CORE_HOST_KEY,
     GENERIC_WEBHOOK_SECRET_KEY,
     GITHUB_WEBHOOK_SECRET_KEY,
     INTERNAL_API_AUTH_KEY,
-    TELEGRAM_APP_KEY,
-    TELEGRAM_BOT_KEY,
-    TELEGRAM_WEBHOOK_SECRET_KEY,
     WORKSHOP_GITHUB_AUTOMATION_KEY,
     WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY,
     WORKSHOP_PRINCIPAL_STORAGE_KEY,
@@ -55,6 +50,14 @@ from kai.workshop.storage_namespaces import (
     WorkshopPrincipalStorageRegistry,
 )
 from tests.workshop_profiles import profile_id
+
+# Adapter fixtures own their state. The shared HTTP host deliberately exports
+# no Telegram application or identity keys.
+ALLOWED_USER_IDS_KEY: web.AppKey[set[int]] = web.AppKey("test_allowed_user_ids", set)
+CHAT_ID_KEY: web.AppKey[int] = web.AppKey("test_chat_id", int)
+TELEGRAM_APP_KEY: web.AppKey[object] = web.AppKey("test_telegram_app", object)
+TELEGRAM_BOT_KEY: web.AppKey[object] = web.AppKey("test_telegram_bot", object)
+TELEGRAM_WEBHOOK_SECRET_KEY: web.AppKey[str] = web.AppKey("test_telegram_secret", str)
 
 
 def _make_internal_api_auth() -> InternalAPIAuth:

--- a/tests/test_webhook_github_canonical.py
+++ b/tests/test_webhook_github_canonical.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from aiohttp.test_utils import TestClient, TestServer
 
 from kai.webhook import (
-    TELEGRAM_BOT_KEY,
     WORKSHOP_GITHUB_AUTOMATION_KEY,
     WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY,
 )
@@ -70,7 +69,6 @@ async def test_reviewable_delivery_enqueues_durable_canonical_work():
     assert automation.enqueue.call_args.kwargs["delivery_id"] == "delivery-1"
     assert automation.enqueue.call_args.kwargs["local_repo_path"] == "/resolved/kai"
     notifications.record_for_channel.assert_not_awaited()
-    app[TELEGRAM_BOT_KEY].send_message.assert_not_awaited()
 
 
 async def test_issue_triage_delivery_enqueues_durable_canonical_work():
@@ -93,12 +91,10 @@ async def test_unprivileged_subscription_cannot_trigger_mutation_and_gets_notifi
     automation.enqueue.assert_not_awaited()
     notifications.record_for_channel.assert_awaited_once()
     assert notifications.record_for_channel.call_args.args[1] == route.notification_channel_id
-    app[TELEGRAM_BOT_KEY].send_message.assert_not_awaited()
 
 
 async def test_standard_delivery_records_canonical_notification_without_telegram():
     app, _automation, notifications = _canonical_app(_route())
-    del app[TELEGRAM_BOT_KEY]
     async with TestClient(TestServer(app)) as client:
         response = await _post(client, _make_pr_payload("closed"), "pull_request")
 

--- a/tests/test_workshop_client_access.py
+++ b/tests/test_workshop_client_access.py
@@ -111,22 +111,64 @@ class TestWorkshopClientAccess:
         finally:
             await store.close()
 
-    async def test_unknown_telegram_identity_cannot_receive_a_grant(self, tmp_path: Path):
+    async def test_unknown_external_identity_cannot_receive_a_grant(self, tmp_path: Path):
         store = await _store(tmp_path / "kai.db")
         try:
             with pytest.raises(WorkshopClientAccessError, match="exactly one canonical human"):
-                await WorkshopClientAccess(store).issue_enrollment_for_telegram(999)
+                await WorkshopClientAccess(store).resolve_external_direct_human(
+                    provider="example",
+                    external_subject="unknown",
+                    transport="example",
+                    external_channel_id="unknown",
+                )
             async with store.connection.execute("SELECT COUNT(*) FROM workshop_client_enrollment_grants") as cursor:
                 assert (await cursor.fetchone())[0] == 0
         finally:
             await store.close()
 
-    @pytest.mark.parametrize("telegram_user_id", [0, -1, True, 2**63])
-    async def test_invalid_telegram_identity_is_bounded(self, tmp_path: Path, telegram_user_id):
+    @pytest.mark.parametrize(
+        ("provider", "subject"),
+        [("Telegram", "101"), ("bad provider", "101"), ("telegram", ""), ("telegram", "x" * 513)],
+    )
+    async def test_invalid_external_identity_is_bounded(self, tmp_path: Path, provider: str, subject: str):
         store = await _store(tmp_path / "kai.db")
         try:
-            with pytest.raises(WorkshopClientAccessError, match="positive signed 64-bit"):
-                await WorkshopClientAccess(store).issue_enrollment_for_telegram(telegram_user_id)
+            with pytest.raises(WorkshopClientAccessError, match="External identity"):
+                await WorkshopClientAccess(store).resolve_external_direct_human(
+                    provider=provider,
+                    external_subject=subject,
+                    transport="telegram",
+                    external_channel_id="101",
+                )
+        finally:
+            await store.close()
+
+    async def test_non_telegram_external_identity_resolves_canonically(self, tmp_path: Path):
+        store = await _store(tmp_path / "kai.db")
+        try:
+            principal_id, channel_id = await _canonical_access_ids(store)
+            await store.connection.execute(
+                "INSERT INTO external_identities "
+                "(id, principal_id, provider, external_subject, created_at) "
+                "VALUES (?, ?, 'example', 'alice', '2026-01-01T00:00:00Z')",
+                ("xid_" + "a" * 32, principal_id),
+            )
+            await store.connection.execute(
+                "INSERT INTO channel_bindings "
+                "(id, channel_id, transport, external_channel_id, created_at) "
+                "VALUES (?, ?, 'example', 'dm-alice', '2026-01-01T00:00:00Z')",
+                ("cbd_" + "b" * 32, channel_id),
+            )
+            await store.connection.commit()
+
+            resolved = await WorkshopClientAccess(store).resolve_external_direct_human(
+                provider="example",
+                external_subject="alice",
+                transport="example",
+                external_channel_id="dm-alice",
+            )
+
+            assert resolved == (principal_id, channel_id)
         finally:
             await store.close()
 

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -170,7 +170,11 @@ async def test_owner_routes_stop_to_exact_active_runtime_and_terminal_cancellati
         while not runtime.validated:
             await asyncio.sleep(0)
 
-        cancellation = await service.request_cancellation(telegram_user_id=101, telegram_chat_id=101)
+        cancellation = await service.request_transport_cancellation(
+            transport="telegram",
+            sender_subject="101",
+            channel_subject="101",
+        )
         result = await execution
 
         assert cancellation == CanonicalCancellationDisposition.REQUESTED

--- a/tests/test_workshop_storage_namespaces.py
+++ b/tests/test_workshop_storage_namespaces.py
@@ -154,17 +154,22 @@ class TestWorkshopPrincipalStorageRegistry:
 
 
 class TestWorkshopChannelHistoryRegistry:
-    async def test_resolves_transport_and_runtime_keys_to_canonical_channel(
+    async def test_resolves_archived_runtime_keys_to_canonical_channel(
         self,
         tmp_path: Path,
     ):
         store = await _store(tmp_path / "kai.db")
         try:
+            expected_channel = await _channel_for_telegram_subject(store, "101")
+            await store.connection.execute(
+                "UPDATE channel_bindings SET external_channel_id = 'dormant-invalid-value' WHERE channel_id = ?",
+                (expected_channel,),
+            )
+            await store.connection.commit()
             registry = await WorkshopChannelHistoryRegistry.from_store(
                 store,
                 profile_registry(101, 202),
             )
-            expected_channel = await _channel_for_telegram_subject(store, "101")
             namespace = registry.for_compatibility_chat_id(101)
 
             assert namespace.channel_id == expected_channel


### PR DESCRIPTION
## Summary

- make disabled Telegram configuration entirely dormant so malformed or unreadable `users.yaml` cannot block Workshop-only startup
- replace Telegram-specific enrollment and cancellation APIs in core Workshop services with generic external-identity and transport bindings
- derive canonical history namespaces from runtime assignments instead of Telegram channel bindings
- remove dead Telegram application keys, notification registries, and formatting helpers from the shared HTTP host
- stop re-exporting Telegram preview state from the transport-independent Workshop package
- correct the installed agent template to describe canonical principals, transcripts, and multi-client memory controls
- add architecture and behavior gates that prevent these dependencies from returning

## Verification

- `make check`
- `make typecheck`
- focused adapter-boundary regression suite: 978 passed
- `make test`: 6025 passed

Refs #917
