### PR TITLE
Prepare Kai v2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,146 @@
 
 This file records the notable operator-facing changes in each Kai release.
 
+## [2.1.0] - 2026-08-26
+
+Kai 2.1 introduces Kai Workshop as a first-class browser client and establishes
+the qualified boundary between Kai's canonical core and its optional client
+adapters. Telegram remains fully supported, but no longer supplies Kai's
+application lifecycle, identity, runtime, transcript, scheduling, memory,
+integration, or publication authority.
+
+### Highlights
+
+- A LAN-accessible React Workshop client with secure enrollment, revocable
+  sessions, canonical conversation history, live updates, Markdown rendering,
+  resilient scrolling, run activity, cancellation, and a detailed agent trace
+  inspector.
+- Durable canonical principals, channels, agents, runtime profiles, messages,
+  runs, attempts, artifacts, deliveries, schedules, and post-run effects.
+- Browser-native uploads and authorized previews for images, documents, and
+  audio, plus transport-neutral artifact access for agents.
+- Canonical settings and workspace controls, notification feeds, GitHub review
+  and issue-triage automation, generic-webhook routing, and a read-only semantic
+  memory explorer.
+- Workshop-only, Telegram-only, and hybrid application composition. Telegram
+  is now installed through the optional `telegram` dependency extra and is
+  supervised as an adapter rather than as the application host.
+
+### Canonical runtime and state
+
+- Root-owned runtime profiles select the backend, provider, OS execution user,
+  model and timeout policy, service grants, and workspace policy independently
+  of Telegram configuration.
+- Backend processes and persistent execution state are addressed by canonical
+  runtime-profile and conversation identities. Compatibility execution reads,
+  rollback dual writes, and Telegram-shaped runtime keys are retired.
+- Canonical messages are the live transcript and cold-start context authority.
+  Legacy JSONL records remain classified archives and are not read or written
+  by protected execution.
+- The core-owned scheduler creates canonical work and survives restart without
+  depending on Telegram's job queue.
+- Internal agent APIs resolve a scoped canonical execution context from their
+  credentials and reject caller-supplied identity selectors.
+- GitHub automation, generic integrations, proactive messages, and ordinary
+  replies publish canonically and reach enabled transports through durable,
+  adapter-pluggable delivery plans and outbox workers.
+- Common post-run effects, including semantic-memory ingestion, are owned by a
+  durable canonical worker rather than by a client handler.
+
+### Workshop client
+
+- Browser enrollment uses one-time, hashed enrollment credentials and produces
+  revocable device sessions without requiring a Telegram identity.
+- Conversation submission, streaming progress, finalization, cancellation,
+  restart recovery, and provider-session continuity use the same durable run
+  lifecycle across clients.
+- The conversation pane supports recent-history windows, jump-to-latest,
+  Markdown, uploads, previews, direct-message identification, collapsible and
+  resizable navigation, and an Atom One Dark-inspired interface.
+- The run inspector exposes backend-neutral tool, command, file, diff, and
+  progress traces without granting the browser direct backend authority.
+- The memory explorer provides principal-scoped statistics, filtering, search,
+  provenance, and source inspection. Editing and management remain planned
+  follow-up work rather than part of this release.
+
+### Telegram adapter boundary
+
+- Telegram private text and media enter the canonical command, artifact, run,
+  transcript, post-run, and delivery boundaries used by other clients.
+- Telegram-specific update parsing, authentication, external identity and
+  binding, Markdown, keyboards, media download, streaming previews, Bot API
+  delivery, retries, webhook/polling lifecycle, and diagnostics remain adapter
+  responsibilities.
+- Disabling Telegram prevents dormant bindings from planning Telegram
+  deliveries and does not require dormant Telegram human configuration to be
+  parsed.
+- Core and Workshop CI runs without the Telegram extra and blocks Telegram SDK
+  imports. A separate adapter job installs and verifies Telegram behavior.
+- Retained Telegram bindings, delivery records, migrations, and archives are
+  compatibility or audit data, not core runtime authority.
+
+These boundaries are complete against the automated architecture gates and
+installed qualifications recorded under epic #917. They are not a claim that
+future adapter development can never uncover another coupling; any such
+finding should be treated as a boundary regression.
+
+### Memory, security, and operations
+
+- Semantic memory now carries canonical principal, channel, agent,
+  runtime-profile, project, and source provenance where applicable.
+- Legacy-default memory scopes fail closed, recalled memory is explicitly
+  treated as untrusted data, vector-store and telemetry permissions are
+  private, and nightly snapshots cover the semantic-memory corpus.
+- Memory embeddings load from the local cache without startup requests to
+  Hugging Face, and extraction plus vector-store work drains cleanly during
+  shutdown.
+- Per-principal uploads, history, managed homes, preferences, and memory use
+  canonical namespaces with protected ownership and modes.
+- Launchd generations are serialized, Workshop streams and semantic memory
+  close during graceful shutdown, and installation reports its readiness wait
+  instead of appearing to stall.
+- Dependency constraints are audited and enforced in CI.
+
+### Upgrade from 2.0.0
+
+For an existing protected installation:
+
+1. Update the working tree to the 2.1.0 release.
+2. Optionally preview the installation with `make DRY_RUN=1 install`.
+3. Run `make install`. The installer performs idempotent canonical-state and
+   storage migrations, preserves legacy data as non-authoritative archives,
+   and waits for full application readiness.
+4. Run `make install-status`. Confirm that the canonical runtime, transcript,
+   memory, operational, delivery, internal-API, post-run, and transition
+   diagnostics are active or clean as applicable.
+5. Verify a Workshop conversation and every enabled client adapter. For a
+   hybrid installation, verify both Workshop and Telegram.
+
+Re-run `make config` only when changing client-adapter mode, listener settings,
+secrets, or other operator configuration. Existing configured backend accounts
+remain sufficient; Kai does not require accounts for unused backends.
+
+### Qualification and known boundaries
+
+- Automated common-contract coverage exercises Claude, Codex, Goose, OpenCode,
+  and Pi without invoking provider models. Installed live qualification covers
+  the runtime profiles that are configured and authenticated on the host.
+- Workshop-only and restored-hybrid installed qualifications passed, including
+  execution, cancellation, restart recovery, canonical history, scoped memory,
+  artifacts, scheduling, integrations, and Telegram delivery.
+- The final corrective boundary change passed separate core/Workshop and
+  Telegram-adapter CI jobs, the full Python suite, lint, formatting, strict
+  typing, and dependency audit.
+- Unreviewed legacy-default semantic memories remain quarantined and
+  fail-closed until explicitly classified. This does not weaken canonical
+  memory authority.
+- Historical numeric directories and JSONL data may remain as documented
+  archives. Protected runtime reads and writes do not use them.
+- The local-process protected runtime remains a trusted-host compatibility
+  mode. Isolated workers remain the intended stronger multi-user boundary.
+
+**Full comparison:** [v2.0.0...v2.1.0]
+
 ## [2.0.0] - 2026-08-11
 
 Kai 2.0 is the stable Telegram-first, multi-backend release. It replaces the
@@ -114,3 +254,5 @@ release.
 
 [2.0.0]: https://github.com/dcellison/kai/releases/tag/v2.0.0
 [v1.4.0...v2.0.0]: https://github.com/dcellison/kai/compare/v1.4.0...v2.0.0
+[2.1.0]: https://github.com/dcellison/kai/releases/tag/v2.1.0
+[v2.0.0...v2.1.0]: https://github.com/dcellison/kai/compare/v2.0.0...v2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kai"
-version = "2.0.0"
+version = "2.1.0"
 description = "Personal AI assistant with pluggable clients and coding-agent backends"
 license = "Apache-2.0"
 requires-python = ">=3.13"

--- a/src/kai/__init__.py
+++ b/src/kai/__init__.py
@@ -1,3 +1,3 @@
 """Kai — multi-client personal AI and agent-workshop runtime."""
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"


### PR DESCRIPTION
## Summary

- bump Kai's package and runtime version from 2.0.0 to 2.1.0
- add operator-facing release notes for Kai Workshop, canonical runtime and
  state authority, and the qualified Telegram adapter boundary
- document the 2.0.0 upgrade path, installed qualification scope, retained
  archives, quarantined legacy memory scopes, and trusted-host runtime boundary

This PR is release metadata only and intentionally changes no runtime behavior.

## Qualification

- `make test` — 6,025 passed
- `make check` — clean
- `make typecheck` — 0 errors
- `make client-check` — 54 tests passed; generated assets current
- `make check-install-constraints` — base and Telegram dependency sets resolve
  as Kai 2.1.0
- `make audit-deps` — no known vulnerabilities

## Release boundary

The changelog describes Telegram independence as complete against the current
automated architecture gates and installed qualifications, not as proof that
future adapter work can never uncover another coupling. Any such finding is a
boundary regression to address explicitly.

