### PR TITLE
Add canonical Workshop principal preference authority

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -25,6 +25,7 @@ from kai.workshop.integration_notifications import WorkshopIntegrationNotificati
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
 from kai.workshop.post_run_effects import WorkshopPostRunEffectService
+from kai.workshop.preferences import WorkshopPreferenceService
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
 from kai.workshop.proactive_publication import (
     ProactivePublicationAuthority,
@@ -132,6 +133,7 @@ class KaiCoreServices:
     artifacts: WorkshopArtifactService
     settings_workspaces: WorkshopSettingsWorkspaceService
     memory_queries: WorkshopMemoryQueryService
+    preference_documents: WorkshopPreferenceService
     proactive_publication: WorkshopProactivePublicationService
     integration_notifications: WorkshopIntegrationNotificationService
     github_automation: WorkshopGitHubAutomationService
@@ -273,6 +275,10 @@ class KaiApplicationHost:
                 runtime_pool,
                 self._execution_state,
             )
+            preference_documents = WorkshopPreferenceService(
+                Path(self._config.session_db_path).parent,
+                self._principal_storage,
+            )
             proactive_publication = WorkshopProactivePublicationService(
                 client_store,
                 artifacts,
@@ -318,6 +324,7 @@ class KaiApplicationHost:
                 artifacts=artifacts,
                 settings_workspaces=settings_workspaces,
                 memory_queries=memory_queries,
+                preference_documents=preference_documents,
                 proactive_publication=proactive_publication,
                 integration_notifications=integration_notifications,
                 github_automation=github_automation,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -125,6 +125,7 @@ _DEPLOYED_ENV_FILE = Path("/etc/kai/env")
 # steered outside DATA_DIR/memory/<name>/MEMORY.md. memory_backup.py
 # hardcodes the same path; keep them in sync.
 PRINCIPAL_MEMORY_READER = Path("/etc/kai/read-principal-memory")
+PRINCIPAL_PREFERENCE_MANAGER = Path("/etc/kai/manage-principal-preferences")
 
 # Default installation paths
 _DEFAULT_INSTALL_DIR = "/opt/kai"
@@ -4070,6 +4071,53 @@ def _generate_principal_memory_reader(data_dir: str) -> str:
     """)
 
 
+def _generate_principal_preference_manager(
+    data_dir: str,
+    install_dir: str = "/opt/kai",
+) -> str:
+    """Generate the fixed root wrapper for canonical preference operations.
+
+    The service cannot traverse foreign OS users' mode-0700 preference
+    directories.  This wrapper executes only Kai's installed, root-owned
+    preference module with a fixed data root; the caller can select an opaque
+    principal and one of the module's bounded operations, but never a path or
+    Python entry point.
+    """
+    python = repr(str(Path(install_dir) / "venv" / "bin" / "python"))
+    fixed_data_dir = repr(str(Path(data_dir)))
+    return textwrap.dedent(f"""\
+        #!/usr/bin/python3
+        # Kai - manage one canonical per-principal PREFERENCES.md.
+        # Managed by 'python -m kai install apply'. Do not edit manually.
+        import os
+        import sys
+
+        PYTHON = {python}
+        DATA_DIR = {fixed_data_dir}
+
+
+        def main() -> int:
+            argv = [
+                PYTHON,
+                "-I",
+                "-m",
+                "kai.workshop.preferences",
+                "--helper",
+                DATA_DIR,
+                *sys.argv[1:],
+            ]
+            os.execve(
+                PYTHON,
+                argv,
+                {{"LANG": "C.UTF-8", "PATH": "/usr/bin:/bin"}},
+            )
+            return 1
+
+
+        sys.exit(main())
+    """)
+
+
 def _generate_sudoers(
     service_user: str,
     os_users: Iterable[str] = (),
@@ -4155,6 +4203,7 @@ def _generate_sudoers(
     # OS user, so single-user installs never carry the grant.
     if target_users:
         rules += f"{service_user} ALL=(root) NOPASSWD: {PRINCIPAL_MEMORY_READER} *\n"
+        rules += f"{service_user} ALL=(root) NOPASSWD: {PRINCIPAL_PREFERENCE_MANAGER} *\n"
 
     if target_users:
         # In protected installs, these arguments come from
@@ -6816,6 +6865,7 @@ def _cmd_apply() -> None:
             service_user,
             dry_run,
             data_dir=data_dir,
+            install_dir=install_dir,
             agent_backend=agent_backend,
             runtime_profiles=runtime_policy,
         )
@@ -8548,6 +8598,7 @@ def _apply_sudoers(
     dry_run: bool,
     users_yaml_path: str | Path | None = None,
     data_dir: str | None = None,
+    install_dir: str = "/opt/kai",
     claude_bin: str | None = None,
     codex_bin: str | None = None,
     opencode_bin: str | None = None,
@@ -8573,7 +8624,8 @@ def _apply_sudoers(
     checks. `agent_backend` and users.yaml retain compatibility coverage for
     the global/default runtime path.
 
-    `data_dir` additionally installs the principal-memory reader helper
+    `data_dir` additionally installs the principal-memory reader and preference
+    manager helpers
     when the deployment has foreign os_users (the only case where its
     sudoers rule is emitted); None (direct/dev callers) always skips
     the helper.
@@ -8677,6 +8729,7 @@ def _apply_sudoers(
     if dry_run:
         if install_reader:
             print(f"[DRY RUN] Would write: {PRINCIPAL_MEMORY_READER} (mode 0755)")
+            print(f"[DRY RUN] Would write: {PRINCIPAL_PREFERENCE_MANAGER} (mode 0755)")
         print(f"[DRY RUN] Would write: {sudoers_path} (mode 0440)")
         print("[DRY RUN] Would validate with visudo -cf")
         return
@@ -8698,6 +8751,24 @@ def _apply_sudoers(
         os.chmod(PRINCIPAL_MEMORY_READER, 0o755)
         os.chown(PRINCIPAL_MEMORY_READER, 0, 0)
         print(f"  Wrote {PRINCIPAL_MEMORY_READER}")
+
+        fd, tmp_name = tempfile.mkstemp(prefix="kai-prefmanager-", suffix=".tmp")
+        try:
+            os.write(
+                fd,
+                _generate_principal_preference_manager(
+                    data_dir,
+                    install_dir,
+                ).encode(),
+            )
+            os.close(fd)
+            shutil.move(tmp_name, str(PRINCIPAL_PREFERENCE_MANAGER))
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        os.chmod(PRINCIPAL_PREFERENCE_MANAGER, 0o755)
+        os.chown(PRINCIPAL_PREFERENCE_MANAGER, 0, 0)
+        print(f"  Wrote {PRINCIPAL_PREFERENCE_MANAGER}")
 
     # Write to a secure temp file first, validate, then move into place.
     # Uses mkstemp (random name, restrictive permissions) instead of a

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -87,6 +87,7 @@ from kai.workshop.integration_notifications import (
     WorkshopIntegrationNotificationService,
 )
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
+from kai.workshop.preferences import WorkshopPreferenceService
 from kai.workshop.proactive_publication import (
     ProactivePublicationAuthority,
     ProactivePublicationResult,
@@ -1782,6 +1783,7 @@ async def _register_workshop_client_api(
     artifact_service: WorkshopArtifactService | None = None,
     settings_workspaces: WorkshopSettingsWorkspaceService | None = None,
     memory_queries: WorkshopMemoryQueryService | None = None,
+    preference_documents: WorkshopPreferenceService | None = None,
 ) -> Callable[[web.Application], None]:
     """Register the client API against the core-owned canonical store.
 
@@ -1816,6 +1818,7 @@ async def _register_workshop_client_api(
             artifact_service=artifact_service,
             settings_workspaces=settings_workspaces,
             memory_queries=memory_queries,
+            preference_documents=preference_documents,
         )
         if command_submitter is not None:
             register_workshop_command_routes(
@@ -1893,6 +1896,7 @@ async def start(
             artifact_service=core_services.artifacts,
             settings_workspaces=core_services.settings_workspaces,
             memory_queries=core_services.memory_queries,
+            preference_documents=core_services.preference_documents,
         )
 
     _runner = web.AppRunner(

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -64,6 +64,19 @@ from kai.workshop.memory_queries import (
     WorkshopMemoryResponseTooLarge,
     WorkshopMemoryValidationError,
 )
+from kai.workshop.preferences import (
+    MAX_PREFERENCE_BYTES,
+    PreferenceAuthority,
+    PreferenceDocument,
+    PreferenceRevisionHistory,
+    WorkshopPreferenceAccessDenied,
+    WorkshopPreferenceConflict,
+    WorkshopPreferenceError,
+    WorkshopPreferenceRevisionNotFound,
+    WorkshopPreferenceService,
+    WorkshopPreferenceStorageError,
+    WorkshopPreferenceValidationError,
+)
 from kai.workshop.run_lifecycle import DurableRun, RunNotFoundError, RunStatus
 from kai.workshop.run_previews import RunPreview, WorkshopRunPreviewRegistry
 from kai.workshop.settings_workspaces import (
@@ -96,6 +109,11 @@ _RUN_CANCELLATION_PATH = "/v1/channels/{channel_id}/runs/{run_id}/cancel"
 _RUNTIME_SETTINGS_PATH = "/v1/channels/{channel_id}/settings"
 _ACTIVE_WORKSPACE_PATH = "/v1/channels/{channel_id}/workspace"
 _WORKSPACE_CONFIG_PATH = "/v1/channels/{channel_id}/workspace-config"
+_PREFERENCES_PATH = "/v1/preferences"
+_PREFERENCE_REVISIONS_PATH = "/v1/preferences/revisions"
+_PREFERENCE_RESTORE_PATH = "/v1/preferences/revisions/{preference_revision}/restore"
+_MAX_PREFERENCE_UPDATE_BODY_BYTES = MAX_PREFERENCE_BYTES * 6 + 1024
+_MAX_PREFERENCE_RESTORE_BODY_BYTES = 512
 _MEMORY_STATS_PATH = "/v1/memory/stats"
 _MEMORY_RECORDS_PATH = "/v1/memory/records"
 _MEMORY_SEARCH_PATH = "/v1/memory/search"
@@ -115,6 +133,8 @@ _SETTINGS_REQUEST_FIELDS = frozenset({"model", "timeout_seconds", "reset"})
 _WORKSPACE_REQUEST_FIELDS = frozenset({"path"})
 _WORKSPACE_CONFIG_REQUEST_FIELDS = frozenset({"field", "value", "path"})
 _WORKSPACE_CONFIG_RESET_FIELDS = frozenset({"reset", "path"})
+_PREFERENCE_UPDATE_FIELDS = frozenset({"content", "revision"})
+_PREFERENCE_RESTORE_FIELDS = frozenset({"revision"})
 _DECIMAL_INTEGER = re.compile(r"^[0-9]+$")
 _CLIENT_MESSAGE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _EVENT_BATCH_SIZE = 100
@@ -183,6 +203,35 @@ def _serialize_settings_workspace(
                 "home": option.home,
             }
             for option in snapshot.workspaces
+        ],
+    }
+
+
+def _serialize_preference_document(document: PreferenceDocument) -> dict[str, object]:
+    return {
+        "version": 1,
+        "document": {
+            "content": document.content,
+            "revision": document.revision,
+            "updated_at": document.updated_at,
+            "size_bytes": document.size_bytes,
+            "max_bytes": document.max_bytes,
+            "editable": document.editable,
+        },
+    }
+
+
+def _serialize_preference_history(history: PreferenceRevisionHistory) -> dict[str, object]:
+    return {
+        "version": 1,
+        "limit": history.limit,
+        "revisions": [
+            {
+                "revision": item.revision,
+                "updated_at": item.updated_at,
+                "size_bytes": item.size_bytes,
+            }
+            for item in history.revisions
         ],
     }
 
@@ -780,6 +829,208 @@ async def _authenticate_settings_authority(
             message="Access denied",
         )
     return authority, None
+
+
+async def _authenticate_preference_authority(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopPreferenceService,
+) -> tuple[PreferenceAuthority | None, web.Response | None]:
+    principal_id = await authenticator.authenticate(request)
+    if not isinstance(principal_id, PrincipalId):
+        response = _error_response(
+            status=401,
+            code="authentication_required",
+            message="Authentication required",
+        )
+        response.headers["WWW-Authenticate"] = "Bearer"
+        return None, response
+    try:
+        return service.authority_for_principal(principal_id), None
+    except WorkshopPreferenceAccessDenied:
+        return None, _error_response(
+            status=403,
+            code="access_denied",
+            message="Access denied",
+        )
+
+
+def _preference_error_response(exc: WorkshopPreferenceError) -> web.Response:
+    if isinstance(exc, WorkshopPreferenceConflict):
+        return _json_response(
+            {
+                "error": {
+                    "code": "revision_conflict",
+                    "message": str(exc),
+                    "current_revision": exc.current_revision,
+                }
+            },
+            status=409,
+        )
+    if isinstance(exc, WorkshopPreferenceRevisionNotFound):
+        return _error_response(status=404, code="not_found", message="Preference revision was not found")
+    if isinstance(exc, WorkshopPreferenceValidationError):
+        return _error_response(status=400, code="invalid_request", message=str(exc))
+    if isinstance(exc, WorkshopPreferenceAccessDenied):
+        return _error_response(status=403, code="access_denied", message="Access denied")
+    if isinstance(exc, WorkshopPreferenceStorageError):
+        return _error_response(
+            status=503,
+            code="preferences_unavailable",
+            message="Preferences are temporarily unavailable",
+        )
+    return _error_response(
+        status=503, code="preferences_unavailable", message="Preferences are temporarily unavailable"
+    )
+
+
+async def _preference_json_object(
+    request: web.Request,
+    *,
+    max_bytes: int,
+) -> dict[str, object]:
+    if request.content_type != "application/json":
+        raise WorkshopPreferenceValidationError("Content-Type must be application/json")
+    if request.content_length is not None and request.content_length > max_bytes:
+        raise WorkshopPreferenceValidationError("Preference request is too large")
+    raw = await request.content.read(max_bytes + 1)
+    if len(raw) > max_bytes:
+        raise WorkshopPreferenceValidationError("Preference request is too large")
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise WorkshopPreferenceValidationError("Invalid JSON request") from exc
+    if not isinstance(payload, dict):
+        raise WorkshopPreferenceValidationError("Invalid preference request")
+    return payload
+
+
+async def _handle_preference_document(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopPreferenceService,
+) -> web.Response:
+    authority, error = await _authenticate_preference_authority(
+        request,
+        authenticator=authenticator,
+        service=service,
+    )
+    if error is not None:
+        return error
+    assert authority is not None
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid preference request")
+    try:
+        document = await service.read(authority)
+    except WorkshopPreferenceError as exc:
+        return _preference_error_response(exc)
+    return _json_response(_serialize_preference_document(document), status=200)
+
+
+async def _handle_preference_update(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopPreferenceService,
+) -> web.Response:
+    authority, error = await _authenticate_preference_authority(
+        request,
+        authenticator=authenticator,
+        service=service,
+    )
+    if error is not None:
+        return error
+    assert authority is not None
+    if request.query:
+        return _error_response(status=400, code="invalid_request", message="Invalid preference request")
+    try:
+        payload = await _preference_json_object(
+            request,
+            max_bytes=_MAX_PREFERENCE_UPDATE_BODY_BYTES,
+        )
+    except WorkshopPreferenceValidationError as exc:
+        return _preference_error_response(exc)
+    if set(payload) != _PREFERENCE_UPDATE_FIELDS:
+        return _error_response(status=400, code="invalid_request", message="Invalid preference request")
+    content = payload.get("content")
+    revision = payload.get("revision")
+    if not isinstance(content, str) or not isinstance(revision, str):
+        return _error_response(status=400, code="invalid_request", message="Invalid preference request")
+    try:
+        document = await service.save(
+            authority,
+            expected_revision=revision,
+            content=content,
+        )
+    except WorkshopPreferenceError as exc:
+        return _preference_error_response(exc)
+    return _json_response(_serialize_preference_document(document), status=200)
+
+
+async def _handle_preference_history(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopPreferenceService,
+) -> web.Response:
+    authority, error = await _authenticate_preference_authority(
+        request,
+        authenticator=authenticator,
+        service=service,
+    )
+    if error is not None:
+        return error
+    assert authority is not None
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid preference history request")
+    try:
+        history = await service.history(authority)
+    except WorkshopPreferenceError as exc:
+        return _preference_error_response(exc)
+    return _json_response(_serialize_preference_history(history), status=200)
+
+
+async def _handle_preference_restore(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopPreferenceService,
+) -> web.Response:
+    authority, error = await _authenticate_preference_authority(
+        request,
+        authenticator=authenticator,
+        service=service,
+    )
+    if error is not None:
+        return error
+    assert authority is not None
+    if request.query:
+        return _error_response(status=400, code="invalid_request", message="Invalid preference restore request")
+    try:
+        payload = await _preference_json_object(
+            request,
+            max_bytes=_MAX_PREFERENCE_RESTORE_BODY_BYTES,
+        )
+    except WorkshopPreferenceValidationError as exc:
+        return _preference_error_response(exc)
+    if set(payload) != _PREFERENCE_RESTORE_FIELDS:
+        return _error_response(status=400, code="invalid_request", message="Invalid preference restore request")
+    revision = payload.get("revision")
+    if not isinstance(revision, str):
+        return _error_response(status=400, code="invalid_request", message="Invalid preference restore request")
+    try:
+        document = await service.restore(
+            authority,
+            target_revision=request.match_info["preference_revision"],
+            expected_revision=revision,
+        )
+    except (KeyError, WorkshopPreferenceError) as exc:
+        if isinstance(exc, KeyError):
+            return _error_response(status=400, code="invalid_request", message="Invalid preference restore request")
+        return _preference_error_response(exc)
+    return _json_response(_serialize_preference_document(document), status=200)
 
 
 async def _handle_runtime_settings(
@@ -2202,6 +2453,7 @@ def register_workshop_read_routes(
     artifact_service: WorkshopArtifactService | None = None,
     settings_workspaces: WorkshopSettingsWorkspaceService | None = None,
     memory_queries: WorkshopMemoryQueryService | None = None,
+    preference_documents: WorkshopPreferenceService | None = None,
 ) -> None:
     """Register authenticated Workshop client routes on an application."""
     if event_poll_interval <= 0 or event_heartbeat_interval <= 0 or event_authentication_recheck_interval <= 0:
@@ -2248,6 +2500,44 @@ def register_workshop_read_routes(
     app.router.add_get(_CLIENT_NAVIGATION_PATH, handle_client_navigation)
     app.router.add_get(_TIMELINE_PATH, handle_channel_timeline)
     app.router.add_get(_TIMELINE_EVENTS_PATH, handle_channel_event_stream)
+    if preference_documents is not None:
+
+        async def handle_preference_document(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_preference_document(
+                    request,
+                    authenticator=authenticator,
+                    service=preference_documents,
+                )
+
+        async def handle_preference_update(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_preference_update(
+                    request,
+                    authenticator=authenticator,
+                    service=preference_documents,
+                )
+
+        async def handle_preference_history(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_preference_history(
+                    request,
+                    authenticator=authenticator,
+                    service=preference_documents,
+                )
+
+        async def handle_preference_restore(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_preference_restore(
+                    request,
+                    authenticator=authenticator,
+                    service=preference_documents,
+                )
+
+        app.router.add_get(_PREFERENCES_PATH, handle_preference_document)
+        app.router.add_put(_PREFERENCES_PATH, handle_preference_update)
+        app.router.add_get(_PREFERENCE_REVISIONS_PATH, handle_preference_history)
+        app.router.add_post(_PREFERENCE_RESTORE_PATH, handle_preference_restore)
     if artifact_service is not None:
 
         async def handle_artifact_content(request: web.Request) -> web.StreamResponse:

--- a/src/kai/workshop/preferences.py
+++ b/src/kai/workshop/preferences.py
@@ -1,0 +1,696 @@
+"""Canonical principal-owned preference document authority."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import secrets
+import stat
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from kai.workshop.domain import PrincipalId
+from kai.workshop.storage_namespaces import (
+    WorkshopPrincipalStorageNamespace,
+    WorkshopPrincipalStorageRegistry,
+    WorkshopStorageNamespaceError,
+)
+
+MAX_PREFERENCE_BYTES = 32 * 1024
+MAX_PREFERENCE_REVISIONS = 20
+PREFERENCE_MANAGER = Path("/etc/kai/manage-principal-preferences")
+_PREFERENCE_FILE = "PREFERENCES.md"
+_HISTORY_ROOT = "preference-revisions"
+_PRINCIPAL_PATTERN = re.compile(r"^prn_[0-9a-f]{32}$")
+_REVISION_PATTERN = re.compile(r"^pref_v1_([0-9a-f]{32})_([0-9a-f]{32})$")
+_MISSING_REVISION = f"pref_v1_{hashlib.sha256(b'').hexdigest()[:32]}_{'0' * 32}"
+_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_DIRECTORY = getattr(os, "O_DIRECTORY", 0)
+_NONBLOCK = getattr(os, "O_NONBLOCK", 0)
+
+
+class WorkshopPreferenceError(RuntimeError):
+    """Base failure for canonical preference operations."""
+
+
+class WorkshopPreferenceAccessDenied(WorkshopPreferenceError):
+    """The authenticated principal has no preference authority."""
+
+
+class WorkshopPreferenceValidationError(WorkshopPreferenceError):
+    """Preference content or a revision identifier is invalid."""
+
+
+class WorkshopPreferenceConflict(WorkshopPreferenceError):
+    """The expected preference revision is no longer current."""
+
+    def __init__(self, current_revision: str) -> None:
+        super().__init__("Preferences changed since they were opened")
+        self.current_revision = current_revision
+
+
+class WorkshopPreferenceRevisionNotFound(WorkshopPreferenceError):
+    """A private preference revision does not exist."""
+
+
+class WorkshopPreferenceStorageError(WorkshopPreferenceError):
+    """Private preference storage failed closed."""
+
+
+@dataclass(frozen=True, slots=True)
+class PreferenceAuthority:
+    principal_id: PrincipalId
+    namespace: WorkshopPrincipalStorageNamespace
+
+
+@dataclass(frozen=True, slots=True)
+class PreferenceDocument:
+    content: str
+    revision: str
+    updated_at: str | None
+    size_bytes: int
+    max_bytes: int = MAX_PREFERENCE_BYTES
+    editable: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class PreferenceRevision:
+    revision: str
+    updated_at: str
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class PreferenceRevisionHistory:
+    revisions: tuple[PreferenceRevision, ...]
+    limit: int = MAX_PREFERENCE_REVISIONS
+
+
+@dataclass(frozen=True, slots=True)
+class _OpenedDocument:
+    content: bytes
+    info: os.stat_result | None
+
+
+def _timestamp(info: os.stat_result) -> str:
+    return datetime.fromtimestamp(info.st_mtime, tz=UTC).isoformat().replace("+00:00", "Z")
+
+
+def _revision(content: bytes, info: os.stat_result | None) -> str:
+    if info is None:
+        return _MISSING_REVISION
+    content_hash = hashlib.sha256(content).hexdigest()[:32]
+    state = f"{info.st_dev}:{info.st_ino}:{info.st_mtime_ns}:{info.st_size}".encode("ascii")
+    state_hash = hashlib.sha256(state).hexdigest()[:32]
+    return f"pref_v1_{content_hash}_{state_hash}"
+
+
+def _normalize_content(content: str) -> tuple[str, bytes]:
+    if not isinstance(content, str):
+        raise WorkshopPreferenceValidationError("Preference content must be text")
+    normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+    if "\x00" in normalized:
+        raise WorkshopPreferenceValidationError("Preference content contains an invalid character")
+    try:
+        encoded = normalized.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise WorkshopPreferenceValidationError("Preference content is not valid UTF-8") from exc
+    if len(encoded) > MAX_PREFERENCE_BYTES:
+        raise WorkshopPreferenceValidationError(f"Preference content exceeds the {MAX_PREFERENCE_BYTES}-byte limit")
+    return normalized, encoded
+
+
+def _validate_revision(value: str) -> str:
+    if not isinstance(value, str) or _REVISION_PATTERN.fullmatch(value) is None:
+        raise WorkshopPreferenceValidationError("Preference revision is invalid")
+    return value
+
+
+def _validate_principal(value: str) -> str:
+    if _PRINCIPAL_PATTERN.fullmatch(value) is None:
+        raise WorkshopPreferenceAccessDenied("Preference authority is invalid")
+    return value
+
+
+def _read_fd(fd: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = MAX_PREFERENCE_BYTES + 1
+    while remaining > 0:
+        chunk = os.read(fd, min(remaining, 64 * 1024))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    content = b"".join(chunks)
+    if len(content) > MAX_PREFERENCE_BYTES:
+        raise WorkshopPreferenceValidationError("Stored preference document exceeds the size limit")
+    try:
+        content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise WorkshopPreferenceValidationError("Stored preference document is not valid UTF-8") from exc
+    return content
+
+
+def _validate_private_directory(info: os.stat_result, *, owner_uid: int | None = None) -> None:
+    if not stat.S_ISDIR(info.st_mode) or info.st_uid == 0 or info.st_mode & 0o077:
+        raise WorkshopPreferenceStorageError("Preference directory is not a private user directory")
+    if owner_uid is not None and info.st_uid != owner_uid:
+        raise WorkshopPreferenceStorageError("Preference directory ownership changed")
+
+
+def _validate_private_file(info: os.stat_result, *, owner_uid: int) -> None:
+    if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1 or info.st_uid != owner_uid or info.st_mode & 0o077:
+        raise WorkshopPreferenceStorageError("Preference document is not a private regular file")
+
+
+class _FilesystemPreferenceStore:
+    """Fd-anchored preference operations used directly and by the root helper."""
+
+    def __init__(self, data_dir: Path) -> None:
+        self._data_dir = data_dir
+
+    def _open_data_root(self) -> tuple[int, os.stat_result]:
+        data_fd = os.open(self._data_dir, os.O_RDONLY | _DIRECTORY | _NOFOLLOW)
+        data_info = os.fstat(data_fd)
+        if not stat.S_ISDIR(data_info.st_mode) or data_info.st_uid == 0 or data_info.st_mode & 0o022:
+            os.close(data_fd)
+            raise WorkshopPreferenceStorageError("Data directory ownership or mode is invalid")
+        return data_fd, data_info
+
+    def _open_principal(self, principal: str) -> tuple[int, os.stat_result]:
+        _validate_principal(principal)
+        data_fd, data_info = self._open_data_root()
+        try:
+            root_fd = os.open(
+                "preferences",
+                os.O_RDONLY | _DIRECTORY | _NOFOLLOW,
+                dir_fd=data_fd,
+            )
+        finally:
+            os.close(data_fd)
+        root_info = os.fstat(root_fd)
+        if not stat.S_ISDIR(root_info.st_mode) or root_info.st_uid != data_info.st_uid or root_info.st_mode & 0o022:
+            os.close(root_fd)
+            raise WorkshopPreferenceStorageError("Preference root is not a protected directory")
+        try:
+            principal_fd = os.open(
+                principal,
+                os.O_RDONLY | _DIRECTORY | _NOFOLLOW,
+                dir_fd=root_fd,
+            )
+        finally:
+            os.close(root_fd)
+        info = os.fstat(principal_fd)
+        try:
+            _validate_private_directory(info)
+        except BaseException:
+            os.close(principal_fd)
+            raise
+        return principal_fd, info
+
+    def _read_current(self, principal_fd: int, owner_uid: int) -> _OpenedDocument:
+        try:
+            fd = os.open(
+                _PREFERENCE_FILE,
+                os.O_RDONLY | _NOFOLLOW | _NONBLOCK,
+                dir_fd=principal_fd,
+            )
+        except FileNotFoundError:
+            return _OpenedDocument(b"", None)
+        try:
+            info = os.fstat(fd)
+            _validate_private_file(info, owner_uid=owner_uid)
+            return _OpenedDocument(_read_fd(fd), info)
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _document(opened: _OpenedDocument) -> PreferenceDocument:
+        return PreferenceDocument(
+            content=opened.content.decode("utf-8"),
+            revision=_revision(opened.content, opened.info),
+            updated_at=_timestamp(opened.info) if opened.info is not None else None,
+            size_bytes=len(opened.content),
+        )
+
+    def snapshot(self, principal: str) -> PreferenceDocument:
+        principal_fd, principal_info = self._open_principal(principal)
+        try:
+            return self._document(self._read_current(principal_fd, principal_info.st_uid))
+        finally:
+            os.close(principal_fd)
+
+    def _open_history(self, principal: str, *, create: bool) -> tuple[int, os.stat_result]:
+        data_fd, data_info = self._open_data_root()
+        try:
+            if create:
+                try:
+                    os.mkdir(_HISTORY_ROOT, 0o700, dir_fd=data_fd)
+                    os.chown(_HISTORY_ROOT, data_info.st_uid, data_info.st_gid, dir_fd=data_fd)
+                except FileExistsError:
+                    pass
+            history_root_fd = os.open(
+                _HISTORY_ROOT,
+                os.O_RDONLY | _DIRECTORY | _NOFOLLOW,
+                dir_fd=data_fd,
+            )
+        finally:
+            os.close(data_fd)
+        history_root_info = os.fstat(history_root_fd)
+        try:
+            _validate_private_directory(history_root_info, owner_uid=data_info.st_uid)
+            if create:
+                try:
+                    os.mkdir(principal, 0o700, dir_fd=history_root_fd)
+                    os.chown(principal, data_info.st_uid, data_info.st_gid, dir_fd=history_root_fd)
+                except FileExistsError:
+                    pass
+            principal_fd = os.open(
+                principal,
+                os.O_RDONLY | _DIRECTORY | _NOFOLLOW,
+                dir_fd=history_root_fd,
+            )
+        finally:
+            os.close(history_root_fd)
+        principal_info = os.fstat(principal_fd)
+        try:
+            _validate_private_directory(principal_info, owner_uid=data_info.st_uid)
+        except BaseException:
+            os.close(principal_fd)
+            raise
+        return principal_fd, principal_info
+
+    @staticmethod
+    def _atomic_write(
+        directory_fd: int,
+        name: str,
+        content: bytes,
+        *,
+        owner_uid: int,
+        owner_gid: int,
+    ) -> None:
+        temporary = f".{name}.{secrets.token_hex(12)}.tmp"
+        fd = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | _NOFOLLOW,
+            0o600,
+            dir_fd=directory_fd,
+        )
+        try:
+            offset = 0
+            while offset < len(content):
+                offset += os.write(fd, content[offset:])
+            os.fchmod(fd, 0o600)
+            os.fchown(fd, owner_uid, owner_gid)
+            os.fsync(fd)
+        except BaseException:
+            os.close(fd)
+            try:
+                os.unlink(temporary, dir_fd=directory_fd)
+            except OSError:
+                pass
+            raise
+        else:
+            os.close(fd)
+        try:
+            os.replace(temporary, name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+            os.fsync(directory_fd)
+        except BaseException:
+            try:
+                os.unlink(temporary, dir_fd=directory_fd)
+            except OSError:
+                pass
+            raise
+
+    def _archive(
+        self,
+        principal: str,
+        opened: _OpenedDocument,
+    ) -> None:
+        if opened.info is None:
+            return
+        revision = _revision(opened.content, opened.info)
+        history_fd, history_info = self._open_history(principal, create=True)
+        try:
+            try:
+                existing_fd = os.open(
+                    revision,
+                    os.O_RDONLY | _NOFOLLOW | _NONBLOCK,
+                    dir_fd=history_fd,
+                )
+            except FileNotFoundError:
+                self._atomic_write(
+                    history_fd,
+                    revision,
+                    opened.content,
+                    owner_uid=history_info.st_uid,
+                    owner_gid=history_info.st_gid,
+                )
+                os.utime(
+                    revision,
+                    ns=(opened.info.st_mtime_ns, opened.info.st_mtime_ns),
+                    dir_fd=history_fd,
+                    follow_symlinks=False,
+                )
+            else:
+                try:
+                    info = os.fstat(existing_fd)
+                    _validate_private_file(info, owner_uid=history_info.st_uid)
+                    if _read_fd(existing_fd) != opened.content:
+                        raise WorkshopPreferenceStorageError("Preference revision content is inconsistent")
+                finally:
+                    os.close(existing_fd)
+            self._prune_history(history_fd, history_info.st_uid)
+        finally:
+            os.close(history_fd)
+
+    @staticmethod
+    def _prune_history(history_fd: int, owner_uid: int) -> None:
+        entries: list[tuple[int, str]] = []
+        for name in os.listdir(history_fd):
+            if _REVISION_PATTERN.fullmatch(name) is None:
+                raise WorkshopPreferenceStorageError("Preference revision directory contains an invalid entry")
+            info = os.stat(name, dir_fd=history_fd, follow_symlinks=False)
+            _validate_private_file(info, owner_uid=owner_uid)
+            entries.append((info.st_mtime_ns, name))
+        entries.sort(reverse=True)
+        for _mtime, name in entries[MAX_PREFERENCE_REVISIONS:]:
+            os.unlink(name, dir_fd=history_fd)
+
+    def write(self, principal: str, expected_revision: str, content: str) -> PreferenceDocument:
+        expected = _validate_revision(expected_revision)
+        _normalized, encoded = _normalize_content(content)
+        principal_fd, principal_info = self._open_principal(principal)
+        try:
+            opened = self._read_current(principal_fd, principal_info.st_uid)
+            current_revision = _revision(opened.content, opened.info)
+            if current_revision != expected:
+                raise WorkshopPreferenceConflict(current_revision)
+            self._archive(principal, opened)
+            # Re-read immediately before replacement so a concurrent direct
+            # editor is detected before the atomic name swap.
+            rechecked = self._read_current(principal_fd, principal_info.st_uid)
+            rechecked_revision = _revision(rechecked.content, rechecked.info)
+            if rechecked_revision != expected:
+                raise WorkshopPreferenceConflict(rechecked_revision)
+            self._atomic_write(
+                principal_fd,
+                _PREFERENCE_FILE,
+                encoded,
+                owner_uid=principal_info.st_uid,
+                owner_gid=principal_info.st_gid,
+            )
+            return self._document(self._read_current(principal_fd, principal_info.st_uid))
+        finally:
+            os.close(principal_fd)
+
+    def history(self, principal: str) -> PreferenceRevisionHistory:
+        _validate_principal(principal)
+        try:
+            history_fd, history_info = self._open_history(principal, create=False)
+        except FileNotFoundError:
+            return PreferenceRevisionHistory(())
+        try:
+            revisions: list[PreferenceRevision] = []
+            for name in os.listdir(history_fd):
+                match = _REVISION_PATTERN.fullmatch(name)
+                if match is None:
+                    raise WorkshopPreferenceStorageError("Preference revision directory contains an invalid entry")
+                fd = os.open(name, os.O_RDONLY | _NOFOLLOW | _NONBLOCK, dir_fd=history_fd)
+                try:
+                    info = os.fstat(fd)
+                    _validate_private_file(info, owner_uid=history_info.st_uid)
+                    content = _read_fd(fd)
+                finally:
+                    os.close(fd)
+                if hashlib.sha256(content).hexdigest()[:32] != match.group(1):
+                    raise WorkshopPreferenceStorageError("Preference revision content is inconsistent")
+                revisions.append(PreferenceRevision(name, _timestamp(info), len(content)))
+            revisions.sort(key=lambda item: item.updated_at, reverse=True)
+            return PreferenceRevisionHistory(tuple(revisions))
+        finally:
+            os.close(history_fd)
+
+    def restore(
+        self,
+        principal: str,
+        target_revision: str,
+        expected_revision: str,
+    ) -> PreferenceDocument:
+        target = _validate_revision(target_revision)
+        try:
+            history_fd, history_info = self._open_history(principal, create=False)
+        except FileNotFoundError as exc:
+            raise WorkshopPreferenceRevisionNotFound("Preference revision was not found") from exc
+        try:
+            try:
+                fd = os.open(target, os.O_RDONLY | _NOFOLLOW | _NONBLOCK, dir_fd=history_fd)
+            except FileNotFoundError as exc:
+                raise WorkshopPreferenceRevisionNotFound("Preference revision was not found") from exc
+            try:
+                info = os.fstat(fd)
+                _validate_private_file(info, owner_uid=history_info.st_uid)
+                content = _read_fd(fd)
+            finally:
+                os.close(fd)
+            match = _REVISION_PATTERN.fullmatch(target)
+            assert match is not None
+            if hashlib.sha256(content).hexdigest()[:32] != match.group(1):
+                raise WorkshopPreferenceStorageError("Preference revision content is inconsistent")
+        finally:
+            os.close(history_fd)
+        return self.write(principal, expected_revision, content.decode("utf-8"))
+
+
+class WorkshopPreferenceService:
+    """Principal-scoped preference authority above local or privileged storage."""
+
+    def __init__(
+        self,
+        data_dir: Path,
+        principal_storage: WorkshopPrincipalStorageRegistry,
+        *,
+        privileged_helper: Path = PREFERENCE_MANAGER,
+    ) -> None:
+        self._data_dir = data_dir
+        self._principal_storage = principal_storage
+        self._local = _FilesystemPreferenceStore(data_dir)
+        self._privileged_helper = privileged_helper
+        self._locks: dict[PrincipalId, asyncio.Lock] = {}
+
+    def authority_for_principal(self, principal_id: str | PrincipalId) -> PreferenceAuthority:
+        try:
+            namespace = self._principal_storage.for_principal(principal_id)
+        except WorkshopStorageNamespaceError as exc:
+            raise WorkshopPreferenceAccessDenied("Principal has no preference authority") from exc
+        return PreferenceAuthority(namespace.principal_id, namespace)
+
+    def _validate_authority(self, authority: PreferenceAuthority) -> str:
+        try:
+            namespace = self._principal_storage.for_principal(authority.principal_id)
+        except WorkshopStorageNamespaceError as exc:
+            raise WorkshopPreferenceAccessDenied("Preference authority changed") from exc
+        if namespace.principal_id != authority.namespace.principal_id:
+            raise WorkshopPreferenceAccessDenied("Preference authority changed")
+        return _validate_principal(str(namespace.principal_id))
+
+    def _lock(self, principal_id: PrincipalId) -> asyncio.Lock:
+        return self._locks.setdefault(principal_id, asyncio.Lock())
+
+    async def read(self, authority: PreferenceAuthority) -> PreferenceDocument:
+        principal = self._validate_authority(authority)
+        return await self._operation("snapshot", principal)
+
+    async def save(
+        self,
+        authority: PreferenceAuthority,
+        *,
+        expected_revision: str,
+        content: str,
+    ) -> PreferenceDocument:
+        principal = self._validate_authority(authority)
+        _normalize_content(content)
+        _validate_revision(expected_revision)
+        async with self._lock(authority.principal_id):
+            return await self._operation(
+                "write",
+                principal,
+                expected_revision,
+                input_text=content,
+            )
+
+    async def history(self, authority: PreferenceAuthority) -> PreferenceRevisionHistory:
+        principal = self._validate_authority(authority)
+        return await self._operation("history", principal)
+
+    async def restore(
+        self,
+        authority: PreferenceAuthority,
+        *,
+        target_revision: str,
+        expected_revision: str,
+    ) -> PreferenceDocument:
+        principal = self._validate_authority(authority)
+        _validate_revision(target_revision)
+        _validate_revision(expected_revision)
+        async with self._lock(authority.principal_id):
+            return await self._operation(
+                "restore",
+                principal,
+                target_revision,
+                expected_revision,
+            )
+
+    async def _operation(
+        self,
+        operation: Literal["snapshot", "write", "history", "restore"],
+        principal: str,
+        *arguments: str,
+        input_text: str | None = None,
+    ) -> Any:
+        local_method = getattr(self._local, operation)
+        try:
+            return await asyncio.to_thread(
+                local_method, principal, *arguments, **({"content": input_text} if operation == "write" else {})
+            )
+        except PermissionError:
+            return await self._privileged_operation(
+                operation,
+                principal,
+                *arguments,
+                input_text=input_text,
+            )
+        except WorkshopPreferenceError:
+            raise
+        except OSError as exc:
+            raise WorkshopPreferenceStorageError("Preference storage is unavailable") from exc
+
+    async def _privileged_operation(
+        self,
+        operation: str,
+        principal: str,
+        *arguments: str,
+        input_text: str | None,
+    ) -> Any:
+        try:
+            helper_info = self._privileged_helper.lstat()
+        except OSError as exc:
+            raise WorkshopPreferenceStorageError("Preference storage is unavailable") from exc
+        if (
+            not stat.S_ISREG(helper_info.st_mode)
+            or helper_info.st_uid != 0
+            or helper_info.st_mode & 0o022
+            or not helper_info.st_mode & 0o111
+        ):
+            raise WorkshopPreferenceStorageError("Preference storage is unavailable")
+        process = await asyncio.create_subprocess_exec(
+            "sudo",
+            "-n",
+            str(self._privileged_helper),
+            operation,
+            principal,
+            *arguments,
+            stdin=asyncio.subprocess.PIPE if input_text is not None else asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        output, _ = await process.communicate(input_text.encode("utf-8") if input_text is not None else None)
+        try:
+            payload = json.loads(output)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise WorkshopPreferenceStorageError("Preference storage is unavailable") from exc
+        if process.returncode != 0:
+            self._raise_helper_error(payload)
+        return _decode_helper_result(operation, payload)
+
+    @staticmethod
+    def _raise_helper_error(payload: object) -> None:
+        if not isinstance(payload, dict):
+            raise WorkshopPreferenceStorageError("Preference storage is unavailable")
+        code = payload.get("error")
+        if code == "conflict" and isinstance(payload.get("current_revision"), str):
+            raise WorkshopPreferenceConflict(str(payload["current_revision"]))
+        if code == "not_found":
+            raise WorkshopPreferenceRevisionNotFound("Preference revision was not found")
+        if code == "validation":
+            raise WorkshopPreferenceValidationError("Preference request is invalid")
+        if code == "access_denied":
+            raise WorkshopPreferenceAccessDenied("Preference access denied")
+        raise WorkshopPreferenceStorageError("Preference storage is unavailable")
+
+
+def _decode_helper_result(operation: str, payload: object) -> Any:
+    if not isinstance(payload, dict):
+        raise WorkshopPreferenceStorageError("Preference storage returned an invalid response")
+    try:
+        if operation in {"snapshot", "write", "restore"}:
+            return PreferenceDocument(**payload)
+        if operation == "history":
+            raw_revisions = payload["revisions"]
+            if not isinstance(raw_revisions, list):
+                raise TypeError
+            return PreferenceRevisionHistory(
+                tuple(PreferenceRevision(**item) for item in raw_revisions),
+                int(payload["limit"]),
+            )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise WorkshopPreferenceStorageError("Preference storage returned an invalid response") from exc
+    raise WorkshopPreferenceStorageError("Preference storage returned an invalid response")
+
+
+def _helper_error(error: str, **details: object) -> int:
+    sys.stdout.write(json.dumps({"error": error, **details}, separators=(",", ":")))
+    return 1
+
+
+def _helper_main(arguments: list[str]) -> int:
+    if len(arguments) < 3 or arguments[0] != "--helper":
+        return _helper_error("validation")
+    data_dir = Path(arguments[1])
+    operation = arguments[2]
+    operation_arguments = arguments[3:]
+    store = _FilesystemPreferenceStore(data_dir)
+    try:
+        if operation == "snapshot" and len(operation_arguments) == 1:
+            result: object = store.snapshot(operation_arguments[0])
+        elif operation == "write" and len(operation_arguments) == 2:
+            raw = sys.stdin.buffer.read(MAX_PREFERENCE_BYTES + 1)
+            if len(raw) > MAX_PREFERENCE_BYTES:
+                raise WorkshopPreferenceValidationError("Preference content is too large")
+            try:
+                content = raw.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise WorkshopPreferenceValidationError("Preference content is not UTF-8") from exc
+            result = store.write(operation_arguments[0], operation_arguments[1], content)
+        elif operation == "history" and len(operation_arguments) == 1:
+            result = store.history(operation_arguments[0])
+        elif operation == "restore" and len(operation_arguments) == 3:
+            result = store.restore(
+                operation_arguments[0],
+                operation_arguments[1],
+                operation_arguments[2],
+            )
+        else:
+            raise WorkshopPreferenceValidationError("Preference operation is invalid")
+    except WorkshopPreferenceConflict as exc:
+        return _helper_error("conflict", current_revision=exc.current_revision)
+    except WorkshopPreferenceRevisionNotFound:
+        return _helper_error("not_found")
+    except WorkshopPreferenceValidationError:
+        return _helper_error("validation")
+    except WorkshopPreferenceAccessDenied:
+        return _helper_error("access_denied")
+    except (WorkshopPreferenceStorageError, OSError):
+        return _helper_error("storage")
+    sys.stdout.write(json.dumps(asdict(result), separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_helper_main(sys.argv[1:]))

--- a/src/kai/workshop/storage_namespaces.py
+++ b/src/kai/workshop/storage_namespaces.py
@@ -166,6 +166,7 @@ class WorkshopPrincipalStorageRegistry:
     ) -> None:
         by_profile: dict[RuntimeProfileId, WorkshopPrincipalStorageNamespace] = {}
         by_config_id: dict[int, WorkshopPrincipalStorageNamespace] = {}
+        by_principal: dict[PrincipalId, WorkshopPrincipalStorageNamespace] = {}
         for namespace in namespaces:
             if not isinstance(namespace, WorkshopPrincipalStorageNamespace):
                 raise TypeError("namespaces must contain WorkshopPrincipalStorageNamespace values")
@@ -174,12 +175,14 @@ class WorkshopPrincipalStorageRegistry:
             if namespace._legacy_runtime_key is not None and namespace._legacy_runtime_key in by_config_id:
                 raise WorkshopStorageNamespaceError("Duplicate archived runtime storage key")
             by_profile[namespace.runtime_profile_id] = namespace
+            by_principal.setdefault(namespace.principal_id, namespace)
             if namespace._legacy_runtime_key is not None:
                 by_config_id[namespace._legacy_runtime_key] = namespace
         if not by_profile:
             raise WorkshopStorageNamespaceError("At least one principal storage namespace is required")
         self._by_profile = by_profile
         self._by_config_id = by_config_id
+        self._by_principal = by_principal
 
     @classmethod
     async def from_store(
@@ -249,6 +252,20 @@ class WorkshopPrincipalStorageRegistry:
         namespace = self._by_profile.get(normalized)
         if namespace is None:
             raise WorkshopStorageNamespaceError("Runtime profile has no canonical principal storage namespace")
+        return namespace
+
+    def for_principal(
+        self,
+        principal_id: str | PrincipalId,
+    ) -> WorkshopPrincipalStorageNamespace:
+        """Resolve one human principal to its canonical private storage."""
+        try:
+            normalized = principal_id if isinstance(principal_id, PrincipalId) else PrincipalId(principal_id)
+        except (TypeError, ValueError) as exc:
+            raise WorkshopStorageNamespaceError("Principal ID is invalid") from exc
+        namespace = self._by_principal.get(normalized)
+        if namespace is None:
+            raise WorkshopStorageNamespaceError("Principal has no canonical storage namespace")
         return namespace
 
     def for_runtime_config_id(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -60,6 +60,7 @@ from kai.install import (
     _generate_launchd_plist,
     _generate_launcher_script,
     _generate_principal_memory_reader,
+    _generate_principal_preference_manager,
     _generate_sudoers,
     _generate_systemd_unit,
     _generate_users_yaml,
@@ -430,6 +431,36 @@ class TestGenerateSudoers:
         assert rule not in _generate_sudoers("kai", ["kai"])
         cat_path = shutil.which("cat") or "/bin/cat"
         assert f"{cat_path} /var/lib" not in _generate_sudoers("kai", ["daniel"])
+
+    def test_principal_preference_manager_rule_requires_foreign_users(self):
+        rule = "kai ALL=(root) NOPASSWD: /etc/kai/manage-principal-preferences *"
+        assert rule in _generate_sudoers("kai", ["daniel"])
+        assert rule not in _generate_sudoers("kai")
+        assert rule not in _generate_sudoers("kai", ["kai"])
+
+
+class TestGeneratePrincipalPreferenceManager:
+    def test_wrapper_pins_interpreter_module_and_data_root(self):
+        script = _generate_principal_preference_manager(
+            "/var/lib/kai",
+            "/opt/kai",
+        )
+        assert script.startswith("#!/usr/bin/python3\n")
+        assert "PYTHON = '/opt/kai/venv/bin/python'" in script
+        assert "DATA_DIR = '/var/lib/kai'" in script
+        assert '"kai.workshop.preferences"' in script
+        assert '"--helper"' in script
+        assert "os.execve(" in script
+        assert "environ" not in script
+        compile(script, "<preference-manager>", "exec")
+
+    def test_paths_are_baked_in_as_literals(self):
+        script = _generate_principal_preference_manager(
+            "/srv/o'dd-data",
+            "/srv/o'dd-install",
+        )
+        assert repr("/srv/o'dd-data") in script
+        assert repr("/srv/o'dd-install/venv/bin/python") in script
 
 
 class TestGeneratePrincipalMemoryReader:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -670,6 +670,7 @@ class TestNotificationChatIdMutations:
             artifacts=MagicMock(),
             settings_workspaces=MagicMock(),
             memory_queries=MagicMock(),
+            preference_documents=MagicMock(),
             github_automation=MagicMock(),
         )
         core_host = MagicMock()
@@ -738,6 +739,7 @@ class TestNotificationChatIdMutations:
             artifacts=MagicMock(),
             settings_workspaces=MagicMock(),
             memory_queries=MagicMock(),
+            preference_documents=MagicMock(),
             github_automation=MagicMock(),
         )
         fake_runner = MagicMock()
@@ -807,6 +809,7 @@ class TestNotificationChatIdMutations:
             artifacts=MagicMock(),
             settings_workspaces=MagicMock(),
             memory_queries=MagicMock(),
+            preference_documents=MagicMock(),
             github_automation=MagicMock(),
         )
         core_host = MagicMock()
@@ -867,6 +870,9 @@ class TestNotificationChatIdMutations:
                 "/v1/channels/{channel_id}/settings",
                 "/v1/channels/{channel_id}/workspace",
                 "/v1/channels/{channel_id}/workspace-config",
+                "/v1/preferences",
+                "/v1/preferences/revisions",
+                "/v1/preferences/revisions/{preference_revision}/restore",
                 "/v1/memory/stats",
                 "/v1/memory/records",
                 "/v1/memory/search",

--- a/tests/test_workshop_preferences.py
+++ b/tests/test_workshop_preferences.py
@@ -1,0 +1,620 @@
+"""Canonical Workshop preference authority and API security tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kai.backend import (
+    ApiContext,
+    PrincipalStorageNamespaceResolver,
+    build_session_context,
+    configure_principal_storage_namespaces,
+)
+from kai.workshop.client_api import register_workshop_read_routes
+from kai.workshop.domain import PrincipalId, RuntimeProfileId
+from kai.workshop.preferences import (
+    MAX_PREFERENCE_BYTES,
+    MAX_PREFERENCE_REVISIONS,
+    WorkshopPreferenceAccessDenied,
+    WorkshopPreferenceConflict,
+    WorkshopPreferenceRevisionNotFound,
+    WorkshopPreferenceService,
+    WorkshopPreferenceStorageError,
+    WorkshopPreferenceValidationError,
+    _OpenedDocument,
+)
+from kai.workshop.storage_namespaces import (
+    WorkshopPrincipalStorageNamespace,
+    WorkshopPrincipalStorageRegistry,
+)
+from kai.workshop.store import WorkshopEventStore
+
+
+@dataclass(frozen=True)
+class _PreferenceFixture:
+    data_dir: Path
+    alice: PrincipalId
+    bob: PrincipalId
+    registry: WorkshopPrincipalStorageRegistry
+    service: WorkshopPreferenceService
+
+
+@pytest.fixture
+def preferences(tmp_path: Path) -> _PreferenceFixture:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    preferences_root = data_dir / "preferences"
+    preferences_root.mkdir(mode=0o711)
+    os.chmod(preferences_root, 0o711)
+    alice = PrincipalId.new()
+    bob = PrincipalId.new()
+    namespaces = (
+        WorkshopPrincipalStorageNamespace(alice, RuntimeProfileId.new(), 101),
+        WorkshopPrincipalStorageNamespace(bob, RuntimeProfileId.new(), 202),
+    )
+    for principal, content in ((alice, "# Preferences\n\nAlice original.\n"), (bob, "Bob private.\n")):
+        directory = preferences_root / str(principal)
+        directory.mkdir(mode=0o700)
+        os.chmod(directory, 0o700)
+        document = directory / "PREFERENCES.md"
+        document.write_text(content)
+        os.chmod(document, 0o600)
+    registry = WorkshopPrincipalStorageRegistry(namespaces)
+    return _PreferenceFixture(
+        data_dir,
+        alice,
+        bob,
+        registry,
+        WorkshopPreferenceService(
+            data_dir,
+            registry,
+            privileged_helper=tmp_path / "missing-preference-helper",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_save_is_revision_checked_atomic_private_and_recoverable(
+    preferences: _PreferenceFixture,
+) -> None:
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    original = await preferences.service.read(authority)
+
+    saved = await preferences.service.save(
+        authority,
+        expected_revision=original.revision,
+        content="# Preferences\r\n\r\nAlice updated.\r\n",
+    )
+
+    path = preferences.data_dir / "preferences" / str(preferences.alice) / "PREFERENCES.md"
+    assert saved.content == "# Preferences\n\nAlice updated.\n"
+    assert saved.revision != original.revision
+    assert path.read_text() == saved.content
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert not list(path.parent.glob(".*.tmp"))
+
+    history = await preferences.service.history(authority)
+    assert history.limit == MAX_PREFERENCE_REVISIONS
+    assert [item.revision for item in history.revisions] == [original.revision]
+
+    restored = await preferences.service.restore(
+        authority,
+        target_revision=original.revision,
+        expected_revision=saved.revision,
+    )
+    assert restored.content == original.content
+    assert restored.revision not in {original.revision, saved.revision}
+
+
+@pytest.mark.asyncio
+async def test_stale_save_and_restore_fail_without_mutation(preferences: _PreferenceFixture) -> None:
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    original = await preferences.service.read(authority)
+    current = await preferences.service.save(
+        authority,
+        expected_revision=original.revision,
+        content="Current preferences.\n",
+    )
+
+    with pytest.raises(WorkshopPreferenceConflict) as save_conflict:
+        await preferences.service.save(
+            authority,
+            expected_revision=original.revision,
+            content="Stale overwrite.\n",
+        )
+    assert save_conflict.value.current_revision == current.revision
+
+    with pytest.raises(WorkshopPreferenceConflict) as restore_conflict:
+        await preferences.service.restore(
+            authority,
+            target_revision=original.revision,
+            expected_revision=original.revision,
+        )
+    assert restore_conflict.value.current_revision == current.revision
+    assert (await preferences.service.read(authority)).content == "Current preferences.\n"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saves_from_one_revision_allow_exactly_one_writer(
+    preferences: _PreferenceFixture,
+) -> None:
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    original = await preferences.service.read(authority)
+
+    results = await asyncio.gather(
+        preferences.service.save(
+            authority,
+            expected_revision=original.revision,
+            content="First concurrent edit.\n",
+        ),
+        preferences.service.save(
+            authority,
+            expected_revision=original.revision,
+            content="Second concurrent edit.\n",
+        ),
+        return_exceptions=True,
+    )
+
+    assert sum(not isinstance(result, BaseException) for result in results) == 1
+    assert sum(isinstance(result, WorkshopPreferenceConflict) for result in results) == 1
+    current = await preferences.service.read(authority)
+    assert current.content in {"First concurrent edit.\n", "Second concurrent edit.\n"}
+
+
+@pytest.mark.asyncio
+async def test_atomic_replace_failure_preserves_current_document(
+    preferences: _PreferenceFixture,
+) -> None:
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    original = await preferences.service.read(authority)
+    real_replace = os.replace
+
+    def fail_current_replace(
+        src: str,
+        dst: str,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+    ) -> None:
+        if dst == "PREFERENCES.md":
+            raise OSError("injected replace failure")
+        real_replace(
+            src,
+            dst,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+        )
+
+    with (
+        patch("kai.workshop.preferences.os.replace", side_effect=fail_current_replace),
+        pytest.raises(WorkshopPreferenceStorageError),
+    ):
+        await preferences.service.save(
+            authority,
+            expected_revision=original.revision,
+            content="Must not become current.\n",
+        )
+
+    current = await preferences.service.read(authority)
+    assert current.content == original.content
+    assert current.revision == original.revision
+    directory = preferences.data_dir / "preferences" / str(preferences.alice)
+    assert not list(directory.glob(".*.tmp"))
+
+
+@pytest.mark.asyncio
+async def test_direct_editor_race_is_detected_before_atomic_replace(
+    preferences: _PreferenceFixture,
+) -> None:
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    original = await preferences.service.read(authority)
+    path = preferences.data_dir / "preferences" / str(preferences.alice) / "PREFERENCES.md"
+    real_read = preferences.service._local._read_current
+    read_count = 0
+
+    def race_before_recheck(principal_fd: int, owner_uid: int) -> _OpenedDocument:
+        nonlocal read_count
+        read_count += 1
+        if read_count == 2:
+            path.write_text("External direct edit.\n")
+            os.chmod(path, 0o600)
+        return real_read(principal_fd, owner_uid)
+
+    with (
+        patch.object(
+            preferences.service._local,
+            "_read_current",
+            side_effect=race_before_recheck,
+        ),
+        pytest.raises(WorkshopPreferenceConflict),
+    ):
+        await preferences.service.save(
+            authority,
+            expected_revision=original.revision,
+            content="Stale Workshop edit.\n",
+        )
+
+    assert path.read_text() == "External direct edit.\n"
+
+
+@pytest.mark.asyncio
+async def test_missing_document_has_stable_bootstrap_revision(preferences: _PreferenceFixture) -> None:
+    path = preferences.data_dir / "preferences" / str(preferences.alice) / "PREFERENCES.md"
+    path.unlink()
+    authority = preferences.service.authority_for_principal(preferences.alice)
+
+    missing = await preferences.service.read(authority)
+    assert missing.content == ""
+    assert missing.updated_at is None
+    created = await preferences.service.save(
+        authority,
+        expected_revision=missing.revision,
+        content="# Preferences\n",
+    )
+    assert created.content == "# Preferences\n"
+    assert created.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_validation_and_unknown_revisions_fail_closed(preferences: _PreferenceFixture) -> None:
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    current = await preferences.service.read(authority)
+
+    with pytest.raises(WorkshopPreferenceValidationError):
+        await preferences.service.save(
+            authority,
+            expected_revision=current.revision,
+            content="x" * (MAX_PREFERENCE_BYTES + 1),
+        )
+    with pytest.raises(WorkshopPreferenceValidationError):
+        await preferences.service.save(
+            authority,
+            expected_revision=current.revision,
+            content="invalid\x00content",
+        )
+    with pytest.raises(WorkshopPreferenceRevisionNotFound):
+        await preferences.service.restore(
+            authority,
+            target_revision="pref_v1_" + "1" * 32 + "_" + "2" * 32,
+            expected_revision=current.revision,
+        )
+    assert (await preferences.service.read(authority)).revision == current.revision
+
+
+@pytest.mark.asyncio
+async def test_principal_authority_and_documents_are_isolated(preferences: _PreferenceFixture) -> None:
+    alice = preferences.service.authority_for_principal(preferences.alice)
+    bob = preferences.service.authority_for_principal(preferences.bob)
+    alice_document = await preferences.service.read(alice)
+    bob_document = await preferences.service.read(bob)
+    assert "Alice" in alice_document.content
+    assert "Bob" in bob_document.content
+
+    with pytest.raises(WorkshopPreferenceAccessDenied):
+        preferences.service.authority_for_principal(PrincipalId.new())
+
+
+@pytest.mark.asyncio
+async def test_untrusted_privileged_helper_is_never_executed(
+    preferences: _PreferenceFixture,
+    tmp_path: Path,
+) -> None:
+    helper = tmp_path / "helper"
+    helper.write_text("#!/bin/sh\nexit 0\n")
+    os.chmod(helper, 0o755)
+    service = WorkshopPreferenceService(
+        preferences.data_dir,
+        preferences.registry,
+        privileged_helper=helper,
+    )
+    authority = service.authority_for_principal(preferences.alice)
+    with (
+        patch.object(service._local, "snapshot", side_effect=PermissionError),
+        patch("asyncio.create_subprocess_exec") as spawn,
+        pytest.raises(WorkshopPreferenceStorageError),
+    ):
+        await service.read(authority)
+    spawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attack", ["symlink", "hardlink"])
+async def test_unsafe_preference_files_are_refused(
+    preferences: _PreferenceFixture,
+    tmp_path: Path,
+    attack: str,
+) -> None:
+    path = preferences.data_dir / "preferences" / str(preferences.alice) / "PREFERENCES.md"
+    path.unlink()
+    target = tmp_path / "outside-secret"
+    target.write_text("outside")
+    os.chmod(target, 0o600)
+    if attack == "symlink":
+        path.symlink_to(target)
+    else:
+        os.link(target, path)
+
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    with pytest.raises(WorkshopPreferenceStorageError):
+        await preferences.service.read(authority)
+    assert target.read_text() == "outside"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "attack",
+    ["data_writable", "root_symlink", "principal_symlink", "writable_root"],
+)
+async def test_unsafe_preference_directories_are_refused(
+    preferences: _PreferenceFixture,
+    tmp_path: Path,
+    attack: str,
+) -> None:
+    preferences_root = preferences.data_dir / "preferences"
+    principal_directory = preferences_root / str(preferences.alice)
+    if attack == "data_writable":
+        os.chmod(preferences.data_dir, 0o733)
+    elif attack == "root_symlink":
+        moved_root = tmp_path / "moved-preferences"
+        preferences_root.rename(moved_root)
+        preferences_root.symlink_to(moved_root, target_is_directory=True)
+    elif attack == "principal_symlink":
+        moved_principal = tmp_path / "moved-principal"
+        principal_directory.rename(moved_principal)
+        principal_directory.symlink_to(moved_principal, target_is_directory=True)
+    else:
+        os.chmod(preferences_root, 0o733)
+
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    with pytest.raises(WorkshopPreferenceStorageError):
+        await preferences.service.read(authority)
+
+
+@pytest.mark.asyncio
+async def test_history_is_private_bounded_and_tamper_checked(preferences: _PreferenceFixture) -> None:
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    current = await preferences.service.read(authority)
+    for index in range(MAX_PREFERENCE_REVISIONS + 3):
+        current = await preferences.service.save(
+            authority,
+            expected_revision=current.revision,
+            content=f"Preference revision {index}.\n",
+        )
+
+    history = await preferences.service.history(authority)
+    assert len(history.revisions) == MAX_PREFERENCE_REVISIONS
+    history_dir = preferences.data_dir / "preference-revisions" / str(preferences.alice)
+    assert stat.S_IMODE(history_dir.stat().st_mode) == 0o700
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o600 for path in history_dir.iterdir())
+
+    newest = history_dir / history.revisions[0].revision
+    newest.write_text("tampered")
+    with pytest.raises(WorkshopPreferenceStorageError):
+        await preferences.service.history(authority)
+
+
+@pytest.mark.asyncio
+async def test_saved_preferences_are_the_exact_next_session_context(
+    preferences: _PreferenceFixture,
+    tmp_path: Path,
+) -> None:
+    authority = preferences.service.authority_for_principal(preferences.alice)
+    current = await preferences.service.read(authority)
+    saved = await preferences.service.save(
+        authority,
+        expected_revision=current.revision,
+        content="Use Celsius.\nAvoid decorative headings.\n",
+    )
+    configure_principal_storage_namespaces(cast(PrincipalStorageNamespaceResolver, preferences.registry))
+    try:
+        with patch("kai.backend.get_recent_history", return_value=""):
+            context = build_session_context(
+                workspace=tmp_path,
+                home_workspace=tmp_path,
+                api=ApiContext(webhook_port=8080, webhook_secret=""),
+                workspace_config=None,
+                chat_id=101,
+                data_dir=preferences.data_dir,
+                memory_enabled=True,
+            )
+    finally:
+        configure_principal_storage_namespaces(None)
+    assert saved.content.strip() in context
+
+
+def test_fixed_helper_protocol_returns_no_paths(preferences: _PreferenceFixture) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kai.workshop.preferences",
+            "--helper",
+            str(preferences.data_dir),
+            "snapshot",
+            str(preferences.alice),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["content"].startswith("# Preferences")
+    assert str(preferences.data_dir) not in result.stdout
+
+
+@pytest.mark.parametrize("principal", ["101", "../preferences", "prn_not_hex"])
+def test_fixed_helper_rejects_noncanonical_principal_names(
+    preferences: _PreferenceFixture,
+    principal: str,
+) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kai.workshop.preferences",
+            "--helper",
+            str(preferences.data_dir),
+            "snapshot",
+            principal,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert json.loads(result.stdout) == {"error": "access_denied"}
+    assert str(preferences.data_dir) not in result.stdout
+
+
+class _BearerAuthenticator:
+    def __init__(self, principals: dict[str, PrincipalId]) -> None:
+        self._principals = principals
+
+    async def authenticate(self, request: web.Request) -> PrincipalId | None:
+        header = request.headers.get("Authorization", "")
+        scheme, _, token = header.partition(" ")
+        return self._principals.get(token) if scheme == "Bearer" else None
+
+    async def authenticate_token(self, token: str) -> PrincipalId | None:
+        return self._principals.get(token)
+
+
+async def _preference_client(
+    preferences: _PreferenceFixture,
+) -> tuple[TestClient, WorkshopEventStore]:
+    store = await WorkshopEventStore.open(preferences.data_dir / "kai.db")
+    app = web.Application()
+    register_workshop_read_routes(
+        app,
+        store=store,
+        authenticator=_BearerAuthenticator({"alice-token": preferences.alice, "bob-token": preferences.bob}),
+        request_lock=__import__("asyncio").Lock(),
+        preference_documents=preferences.service,
+    )
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client, store
+
+
+@pytest.mark.asyncio
+async def test_preference_api_is_authenticated_revision_checked_and_principal_scoped(
+    preferences: _PreferenceFixture,
+) -> None:
+    client, store = await _preference_client(preferences)
+    try:
+        unauthorized = await client.get("/v1/preferences")
+        alice_response = await client.get(
+            "/v1/preferences",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        bob_response = await client.get(
+            "/v1/preferences",
+            headers={"Authorization": "Bearer bob-token"},
+        )
+        assert unauthorized.status == 401
+        assert unauthorized.headers["WWW-Authenticate"] == "Bearer"
+        assert (await alice_response.json())["document"]["content"].startswith("# Preferences")
+        assert (await bob_response.json())["document"]["content"] == "Bob private.\n"
+
+        alice_payload = await alice_response.json()
+        updated = await client.put(
+            "/v1/preferences",
+            headers={"Authorization": "Bearer alice-token"},
+            json={
+                "content": "Alice API update.\n",
+                "revision": alice_payload["document"]["revision"],
+            },
+        )
+        assert updated.status == 200
+        updated_payload = await updated.json()
+        stale = await client.put(
+            "/v1/preferences",
+            headers={"Authorization": "Bearer alice-token"},
+            json={
+                "content": "Stale.\n",
+                "revision": alice_payload["document"]["revision"],
+            },
+        )
+        assert stale.status == 409
+        assert (await stale.json())["error"]["current_revision"] == updated_payload["document"]["revision"]
+
+        history = await client.get(
+            "/v1/preferences/revisions",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        history_payload = await history.json()
+        assert history.status == 200
+        assert len(history_payload["revisions"]) == 1
+        restored = await client.post(
+            f"/v1/preferences/revisions/{history_payload['revisions'][0]['revision']}/restore",
+            headers={"Authorization": "Bearer alice-token"},
+            json={"revision": updated_payload["document"]["revision"]},
+        )
+        assert restored.status == 200
+        assert (await restored.json())["document"]["content"].startswith("# Preferences")
+    finally:
+        await client.close()
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_preference_api_rejects_untyped_requests_without_mutation(
+    preferences: _PreferenceFixture,
+) -> None:
+    client, store = await _preference_client(preferences)
+    try:
+        before = await client.get(
+            "/v1/preferences",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        revision = (await before.json())["document"]["revision"]
+        foreign_selector = await client.put(
+            "/v1/preferences",
+            headers={"Authorization": "Bearer alice-token"},
+            json={
+                "content": "Attack.\n",
+                "revision": revision,
+                "principal_id": str(preferences.bob),
+            },
+        )
+        wrong_content_type = await client.put(
+            "/v1/preferences",
+            headers={
+                "Authorization": "Bearer alice-token",
+                "Content-Type": "text/plain",
+            },
+            data="Attack",
+        )
+        oversized = await client.put(
+            "/v1/preferences",
+            headers={"Authorization": "Bearer alice-token"},
+            json={
+                "content": "x" * (MAX_PREFERENCE_BYTES + 1),
+                "revision": revision,
+            },
+        )
+        assert foreign_selector.status == 400
+        assert wrong_content_type.status == 400
+        assert oversized.status == 400
+        after = await client.get(
+            "/v1/preferences",
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        assert (await after.json())["document"]["revision"] == revision
+    finally:
+        await client.close()
+        await store.close()


### PR DESCRIPTION
## Summary

- add a canonical principal-scoped authority for reading, updating, and restoring the exact `PREFERENCES.md` used by agent sessions
- expose authenticated Workshop preference document and revision-history APIs with optimistic concurrency, bounded payloads, and no caller-selected identity or filesystem path
- preserve private OS-user ownership through an installed, root-owned, fixed-operation helper when the Kai service cannot traverse a protected principal directory
- retain bounded private revision history and restore older content as a new atomic current revision
- reject unsafe roots, directories, symlinks, hardlinks, malformed UTF-8, oversized content, stale writes, and cross-principal access

## Validation

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest tests/ -q` (`6063 passed`)
- focused preference/application/webhook/installer integration suite (`1054 passed`)

The installed dry-run command was also attempted, but this environment cannot answer the host's sudo password prompt. Installer generation and sudoers behavior are covered by the test suite.

Closes #1131
