### PR TITLE
Fix runtime-policy timeout ceilings

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -624,19 +624,22 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         except ValueError:
             await update.message.reply_text("Timeout must be a positive integer (seconds).")
             return
-        # Cap at 600s (10 minutes). The timeout is the runaway guard
-        # for a stuck subprocess; this cap prevents a single stuck
-        # request from holding the per-chat lock indefinitely.
-        if timeout > 600:
-            await update.message.reply_text("Timeout cannot exceed 600 seconds.")
-            return
         authority = _canonical_settings_authority(context, chat_id)
         if authority is not None:
-            await _get_core_services(context).settings_workspaces.set_timeout(
-                authority,
-                timeout,
-            )
+            try:
+                await _get_core_services(context).settings_workspaces.set_timeout(
+                    authority,
+                    timeout,
+                )
+            except WorkshopSettingsWorkspaceValidationError as exc:
+                await update.message.reply_text(str(exc))
+                return
             await update.message.reply_text(f"Default timeout set to {timeout}s.")
+            return
+        # Compatibility-only users retain the historical ceiling. Canonical
+        # runtimes derive this bound from their protected runtime profile.
+        if timeout > 600:
+            await update.message.reply_text("Timeout cannot exceed 600 seconds.")
             return
         await sessions.set_user_setting(chat_id, "timeout", str(timeout))
         # Apply to running instance if one exists. Don't use pool.get()

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -97,6 +97,7 @@ from kai.workshop.initial_provisioning import (
     parse_initial_provisioning,
 )
 from kai.workshop.runtime_profiles import (
+    DEFAULT_MAXIMUM_TIMEOUT_SECONDS,
     WorkshopRuntimeProfileError,
     WorkshopRuntimeProfileRegistry,
     legacy_runtime_key_for_v1_profile_id,
@@ -876,6 +877,7 @@ def _build_fresh_runtime_profile_policy(
                 "provider": provider,
                 "model": model,
                 "timeout_seconds": timeout,
+                "maximum_timeout_seconds": max(DEFAULT_MAXIMUM_TIMEOUT_SECONDS, timeout),
                 "allowed_services": [],
                 "home_workspace": None,
                 "workspace_base": None,
@@ -1213,6 +1215,7 @@ def _build_migrated_runtime_profiles(
             "provider": provider,
             "model": model,
             "timeout_seconds": timeout_seconds,
+            "maximum_timeout_seconds": max(DEFAULT_MAXIMUM_TIMEOUT_SECONDS, timeout_seconds),
             "allowed_services": _migrated_service_scopes(entry),
             "home_workspace": _migrated_workspace_directory(
                 entry.get("home_workspace"),
@@ -1346,6 +1349,15 @@ def _upgrade_runtime_policy_content(
         if "timeout_seconds" not in profile:
             profile["timeout_seconds"] = (
                 expected["timeout_seconds"] if isinstance(expected, dict) else defaults.timeout_seconds
+            )
+            changed = True
+        if "maximum_timeout_seconds" not in profile:
+            timeout_seconds = profile.get("timeout_seconds", defaults.timeout_seconds)
+            if not isinstance(timeout_seconds, int) or isinstance(timeout_seconds, bool):
+                continue
+            profile["maximum_timeout_seconds"] = max(
+                DEFAULT_MAXIMUM_TIMEOUT_SECONDS,
+                timeout_seconds,
             )
             changed = True
         if "allowed_services" not in profile:

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -36,6 +36,7 @@ RUNTIME_PROFILES_YAML_ENV = "KAI_RUNTIME_PROFILES_YAML"
 INSTALL_DIR_ENV = "KAI_INSTALL_DIR"
 _OS_USER_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 RUNTIME_KEY_ARCHIVE_REMOVAL_GATE = "canonical_runtime_state_v1"
+DEFAULT_MAXIMUM_TIMEOUT_SECONDS = 600
 
 
 class WorkshopRuntimeProfileError(RuntimeError):
@@ -62,12 +63,23 @@ class ProtectedRuntimeProfile:
     home_workspace: Path | None
     workspace_base: Path | None
     allowed_workspaces: tuple[Path, ...]
+    maximum_timeout_seconds: int = 0
     allowed_models: tuple[str, ...] | None = None
     role_models: tuple[tuple[str, str], ...] = ()
     github_repos: tuple[str, ...] = ()
     pr_review: bool | None = None
     issue_triage: bool | None = None
     allowed_triage_projects: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        maximum_timeout = self.maximum_timeout_seconds
+        if maximum_timeout == 0:
+            maximum_timeout = max(DEFAULT_MAXIMUM_TIMEOUT_SECONDS, self.timeout_seconds)
+        if isinstance(maximum_timeout, bool) or maximum_timeout < self.timeout_seconds:
+            raise WorkshopRuntimeProfileError(
+                "maximum_timeout_seconds must be an integer greater than or equal to timeout_seconds"
+            )
+        object.__setattr__(self, "maximum_timeout_seconds", maximum_timeout)
 
 
 def _compatibility_model(
@@ -277,6 +289,7 @@ class WorkshopRuntimeProfileRegistry:
                 raise WorkshopRuntimeProfileError("Configured-user key does not match its protected user record")
             backend, provider = get_user_backend_and_provider(user, config)
             profile_id = runtime_profile_id_for_config_id(runtime_config_id)
+            timeout_seconds = user.timeout if user.timeout is not None else config.default_timeout
             profiles.append(
                 ProtectedRuntimeProfile(
                     profile_id=profile_id,
@@ -285,11 +298,15 @@ class WorkshopRuntimeProfileRegistry:
                     backend=backend,
                     provider=provider,
                     model=_compatibility_model(user, config, backend=backend, provider=provider),
-                    timeout_seconds=user.timeout if user.timeout is not None else config.default_timeout,
+                    timeout_seconds=timeout_seconds,
                     allowed_services=tuple(user.allowed_services),
                     home_workspace=user.home_workspace,
                     workspace_base=user.workspace_base,
                     allowed_workspaces=tuple(user.allowed_workspaces),
+                    maximum_timeout_seconds=max(
+                        DEFAULT_MAXIMUM_TIMEOUT_SECONDS,
+                        timeout_seconds,
+                    ),
                     role_models=tuple(sorted((user.models or {}).items())),
                     github_repos=tuple(user.github_repos),
                     pr_review=user.pr_review,
@@ -370,6 +387,19 @@ class WorkshopRuntimeProfileRegistry:
             if isinstance(raw_timeout, bool) or not isinstance(raw_timeout, int) or raw_timeout <= 0:
                 raise WorkshopRuntimeProfileError(
                     f"Runtime profile {profile_id}: timeout_seconds must be a positive integer"
+                )
+            raw_maximum_timeout = raw_profile.get(
+                "maximum_timeout_seconds",
+                max(DEFAULT_MAXIMUM_TIMEOUT_SECONDS, raw_timeout),
+            )
+            if (
+                isinstance(raw_maximum_timeout, bool)
+                or not isinstance(raw_maximum_timeout, int)
+                or raw_maximum_timeout < raw_timeout
+            ):
+                raise WorkshopRuntimeProfileError(
+                    f"Runtime profile {profile_id}: maximum_timeout_seconds must be an integer "
+                    "greater than or equal to timeout_seconds"
                 )
             raw_os_user = raw_profile.get("os_user")
             os_user = None if raw_os_user is None else str(raw_os_user).strip() or None
@@ -454,6 +484,7 @@ class WorkshopRuntimeProfileRegistry:
                         raw_profile.get("allowed_workspaces"),
                         profile_id=profile_id,
                     ),
+                    maximum_timeout_seconds=raw_maximum_timeout,
                     allowed_models=allowed_models,
                     role_models=tuple(sorted(role_models)),
                     github_repos=tuple(sorted({item.strip().lower() for item in raw_github_repos})),

--- a/src/kai/workshop/settings_workspaces.py
+++ b/src/kai/workshop/settings_workspaces.py
@@ -46,7 +46,6 @@ class WorkshopSettingsWorkspaceConsistencyError(WorkshopSettingsWorkspaceError):
 
 
 MIN_SELF_SERVICE_TIMEOUT_SECONDS = 1
-MAX_SELF_SERVICE_TIMEOUT_SECONDS = 600
 MAX_SELF_SERVICE_PROMPT_CHARACTERS = 32_000
 
 
@@ -266,7 +265,10 @@ class WorkshopSettingsWorkspaceService:
             model_options=model_options,
             workspaces=tuple(workspace_options),
             revision=revision,
-            capabilities=self._capabilities(model_options),
+            capabilities=self._capabilities(
+                model_options,
+                maximum_timeout_seconds=profile.maximum_timeout_seconds,
+            ),
             mutation=mutation,
         )
 
@@ -305,10 +307,11 @@ class WorkshopSettingsWorkspaceService:
     ) -> SettingsWorkspaceSnapshot:
         if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, int):
             raise WorkshopSettingsWorkspaceValidationError("Timeout must be a whole number of seconds")
-        if not MIN_SELF_SERVICE_TIMEOUT_SECONDS <= timeout_seconds <= MAX_SELF_SERVICE_TIMEOUT_SECONDS:
+        profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
+        maximum_timeout = profile.maximum_timeout_seconds
+        if not MIN_SELF_SERVICE_TIMEOUT_SECONDS <= timeout_seconds <= maximum_timeout:
             raise WorkshopSettingsWorkspaceValidationError(
-                f"Timeout must be between {MIN_SELF_SERVICE_TIMEOUT_SECONDS} "
-                f"and {MAX_SELF_SERVICE_TIMEOUT_SECONDS} seconds"
+                f"Timeout must be between {MIN_SELF_SERVICE_TIMEOUT_SECONDS} and {maximum_timeout} seconds"
             )
         async with self._lock(authority):
             return await self._mutate_runtime_settings_locked(
@@ -472,7 +475,8 @@ class WorkshopSettingsWorkspaceService:
                     profile.backend,
                     profile.provider,
                     allowed_models=profile.allowed_models,
-                )
+                ),
+                maximum_timeout_seconds=profile.maximum_timeout_seconds,
             ),
             mutation=mutation,
         )
@@ -503,10 +507,10 @@ class WorkshopSettingsWorkspaceService:
                 parsed_timeout = int(value)
             except ValueError as exc:
                 raise WorkshopSettingsWorkspaceValidationError("Timeout must be a whole number of seconds") from exc
-            if not MIN_SELF_SERVICE_TIMEOUT_SECONDS <= parsed_timeout <= MAX_SELF_SERVICE_TIMEOUT_SECONDS:
+            if not MIN_SELF_SERVICE_TIMEOUT_SECONDS <= parsed_timeout <= profile.maximum_timeout_seconds:
                 raise WorkshopSettingsWorkspaceValidationError(
                     f"Timeout must be between {MIN_SELF_SERVICE_TIMEOUT_SECONDS} "
-                    f"and {MAX_SELF_SERVICE_TIMEOUT_SECONDS} seconds"
+                    f"and {profile.maximum_timeout_seconds} seconds"
                 )
             value = str(parsed_timeout)
         elif field == "env":
@@ -1033,6 +1037,8 @@ class WorkshopSettingsWorkspaceService:
     @staticmethod
     def _capabilities(
         model_options: tuple[ModelOption, ...] | None,
+        *,
+        maximum_timeout_seconds: int,
     ) -> tuple[EditableCapability, ...]:
         return (
             EditableCapability(
@@ -1048,7 +1054,7 @@ class WorkshopSettingsWorkspaceService:
                 value_type="integer_seconds",
                 resettable=True,
                 minimum=MIN_SELF_SERVICE_TIMEOUT_SECONDS,
-                maximum=MAX_SELF_SERVICE_TIMEOUT_SECONDS,
+                maximum=maximum_timeout_seconds,
             ),
             EditableCapability(
                 field="workspace",
@@ -1061,6 +1067,8 @@ class WorkshopSettingsWorkspaceService:
     @staticmethod
     def _workspace_capabilities(
         model_options: dict[str, str] | None,
+        *,
+        maximum_timeout_seconds: int,
     ) -> tuple[EditableCapability, ...]:
         return (
             EditableCapability(
@@ -1076,7 +1084,7 @@ class WorkshopSettingsWorkspaceService:
                 "integer_seconds",
                 True,
                 minimum=MIN_SELF_SERVICE_TIMEOUT_SECONDS,
-                maximum=MAX_SELF_SERVICE_TIMEOUT_SECONDS,
+                maximum=maximum_timeout_seconds,
             ),
             EditableCapability(
                 "prompt",
@@ -1140,7 +1148,7 @@ class WorkshopSettingsWorkspaceService:
                 parsed_timeout = int(raw_timeout)
             except (TypeError, ValueError):
                 continue
-            if MIN_SELF_SERVICE_TIMEOUT_SECONDS <= parsed_timeout <= MAX_SELF_SERVICE_TIMEOUT_SECONDS:
+            if MIN_SELF_SERVICE_TIMEOUT_SECONDS <= parsed_timeout <= profile.maximum_timeout_seconds:
                 timeout = EffectiveValue(
                     parsed_timeout,
                     source,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3875,6 +3875,21 @@ class TestHandleSettings:
         reply = update.message.reply_text.call_args[0][0]
         assert "300s" in reply
 
+    @pytest.mark.asyncio
+    async def test_protected_timeout_uses_canonical_policy_above_compatibility_cap(self):
+        update = _make_update(text="/settings timeout 1800")
+        ctx = _make_context(args=["timeout", "1800"])
+        authority = SimpleNamespace(runtime_profile_id=profile_id(12345))
+        service = MagicMock()
+        service.authority_for_principal_profile.return_value = authority
+        service.set_timeout = AsyncMock()
+        ctx.application.core_services.settings_workspaces = service
+
+        await handle_settings(update, ctx)
+
+        service.set_timeout.assert_awaited_once_with(authority, 1800)
+        assert "1800s" in update.message.reply_text.call_args[0][0]
+
     # ── 7. Reject zero timeout ─────────────────────────────────────
 
     @pytest.mark.asyncio

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9780,6 +9780,7 @@ class TestIndependentRuntimePolicy:
             "provider": "openai",
             "model": "gpt-5.5",
             "timeout_seconds": 120,
+            "maximum_timeout_seconds": 600,
             "allowed_services": ["perplexity"],
             "home_workspace": None,
             "workspace_base": None,
@@ -9795,6 +9796,7 @@ class TestIndependentRuntimePolicy:
         assert document["runtime_profiles"][scott_id]["provider"] == "anthropic"
         assert document["runtime_profiles"][scott_id]["model"] == "sonnet"
         assert document["runtime_profiles"][scott_id]["timeout_seconds"] == 120
+        assert document["runtime_profiles"][scott_id]["maximum_timeout_seconds"] == 600
         assert document["runtime_profiles"][scott_id]["allowed_services"] == []
         assert document["runtime_profiles"][scott_id]["home_workspace"] is None
         assert document["runtime_profiles"][scott_id]["workspace_base"] is None
@@ -10003,6 +10005,7 @@ backends:
         assert document["runtime_profiles"][profile_id]["display_name"] == "Operator display name"
         assert document["runtime_profiles"][profile_id]["model"] == "gpt-5.6-sol"
         assert document["runtime_profiles"][profile_id]["timeout_seconds"] == 345
+        assert document["runtime_profiles"][profile_id]["maximum_timeout_seconds"] == 600
         assert document["runtime_profiles"][profile_id]["allowed_services"] == ["perplexity"]
         assert profiles.legacy_runtime_key(profile_id) == 101
 

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -751,6 +751,34 @@ runtime_profiles:
 
     assert profile.model == "gpt-5.5"
     assert profile.timeout_seconds == 999
+    assert profile.maximum_timeout_seconds == 999
+
+
+def test_loaded_policy_rejects_timeout_default_above_protected_ceiling(tmp_path, monkeypatch):
+    profile_id = runtime_profile_id_for_config_id(101)
+    policy = tmp_path / "runtime-profiles.yaml"
+    policy.write_text(
+        f"""version: 2
+runtime_profiles:
+  {profile_id}:
+    display_name: Daniel
+    os_user: daniel
+    backend: codex
+    provider: openai
+    model: gpt-5.5
+    timeout_seconds: 1800
+    maximum_timeout_seconds: 600
+    allowed_services: []
+    allowed_workspaces: []
+"""
+    )
+    monkeypatch.setattr(
+        "kai.workshop.runtime_profiles.load_backend_registry",
+        lambda: {"codex": {}, "claude": {}},
+    )
+
+    with pytest.raises(WorkshopRuntimeProfileError, match="maximum_timeout_seconds"):
+        WorkshopRuntimeProfileRegistry.load(_config(), path=policy)
 
 
 def test_loaded_policy_owns_service_scopes_independently_of_users_yaml(tmp_path, monkeypatch):

--- a/tests/test_workshop_settings_workspaces.py
+++ b/tests/test_workshop_settings_workspaces.py
@@ -38,6 +38,7 @@ class _RuntimePool:
             provider="openai",
             model="gpt-5.6-sol",
             timeout_seconds=120,
+            maximum_timeout_seconds=600,
             allowed_models=None,
         )
 
@@ -461,6 +462,43 @@ async def test_capability_catalog_and_model_validation_share_protected_policy(
         )
     assert replace_calls == []
     assert pool.events == []
+
+
+async def test_timeout_capability_and_validation_follow_protected_runtime_policy(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    service, pool, authority, _, _ = _service(tmp_path)
+    pool.profile.timeout_seconds = 1800
+    pool.profile.maximum_timeout_seconds = 1800
+    execution, _, replace_calls, _ = _canonical_state(monkeypatch)
+
+    initial = await service.inspect(authority)
+
+    assert initial.timeout_seconds == EffectiveValue(1800, "runtime policy", 1800)
+    assert initial.capabilities[1].maximum == 1800
+    workspace = await service.workspace_config(authority)
+    assert workspace.capabilities[1].maximum == 1800
+
+    changed = await service.set_timeout(
+        authority,
+        1200,
+        expected_revision=initial.revision,
+    )
+    assert changed.timeout_seconds == EffectiveValue(1200, "runtime override", 1800)
+    assert execution == {"timeout": "1200"}
+
+    reset = await service.reset_settings(
+        authority,
+        "timeout",
+        expected_revision=changed.revision,
+    )
+    assert reset.timeout_seconds == EffectiveValue(1800, "runtime policy", 1800)
+    assert execution == {}
+
+    with pytest.raises(WorkshopSettingsWorkspaceValidationError, match="1800"):
+        await service.set_timeout(authority, 1801)
+    assert len(replace_calls) == 2
 
 
 async def test_stale_revision_fails_before_persistent_or_live_mutation(


### PR DESCRIPTION
## Summary

- derive runtime and workspace timeout capabilities and validation from each protected runtime profile instead of a hard-coded 600-second ceiling
- add an explicit protected `maximum_timeout_seconds` policy field and safely enrich older profiles with at least their configured default timeout
- keep compatibility-only Telegram users on the historical 600-second ceiling while routing canonical Telegram settings through the protected policy service
- cover the installed 1800-second default, reset-to-policy behavior, invalid ceilings, installer enrichment, and Telegram compatibility

## Installed regression

After #1135, `/settings reset timeout` correctly restored the protected default of 1800 seconds, but the capability catalog and mutation validator still reported a maximum of 600 seconds. That contradicted #1132's requirement that timeout bounds come from canonical runtime policy.

## Validation

- `make check`
- `make typecheck`
- focused service, runtime-policy, Telegram, and installer tests (1,048 passed)
- `.venv/bin/python -m pytest tests/ -q` (6,076 passed)

Closes #1132
