### PR TITLE
Add Telegram notification preference parity

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -82,6 +82,8 @@ from kai.workshop.github_settings import (
 )
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.notification_preferences import (
+    GENERIC_INTEGRATION_CLASS,
+    GITHUB_INTEGRATION_CLASS,
     NotificationPreferenceAuthority,
     WorkshopNotificationPreferenceService,
 )
@@ -3339,18 +3341,19 @@ async def _show_github(
     await update.message.reply_text("\n".join(lines))
 
 
-async def _handle_github_notify(
+async def _handle_notification_destination(
     update: Update,
-    chat_id: int,
     args: list[str],
     *,
+    integration_class: str,
+    command: str,
     canonical: tuple[
         WorkshopNotificationPreferenceService,
         NotificationPreferenceAuthority,
     ]
     | None = None,
 ) -> None:
-    """Select a canonical GitHub notification destination by displayed number."""
+    """Select one canonical integration destination by displayed number."""
     assert update.message is not None
 
     if canonical is None:
@@ -3359,22 +3362,23 @@ async def _handle_github_notify(
 
     service, authority = canonical
     snapshot = await service.inspect(authority)
-    github_preference = next(item for item in snapshot.preferences if item.integration_class == "github")
-    github_destinations = [item for item in snapshot.destinations if "github" in item.supported_classes]
+    preference = next(item for item in snapshot.preferences if item.integration_class == integration_class)
+    destinations = [item for item in snapshot.destinations if integration_class in item.supported_classes]
+    notification_label = (
+        "GitHub notification" if integration_class == GITHUB_INTEGRATION_CLASS else "Generic webhook notification"
+    )
     if not args:
         lines = [
-            f"GitHub notifications: {github_preference.destination_name} ({github_preference.source})",
+            f"{notification_label}s: {preference.destination_name} ({preference.source})",
             "",
             "Available destinations:",
         ]
-        lines.extend(
-            f"{index}. {item.display_name} ({item.kind})" for index, item in enumerate(github_destinations, start=1)
-        )
+        lines.extend(f"{index}. {item.display_name} ({item.kind})" for index, item in enumerate(destinations, start=1))
         lines.extend(
             [
                 "",
-                "Use /github notify <number> to select a destination.",
-                "Use /github notify reset to restore protected policy.",
+                f"Use {command} <number> to select a destination.",
+                f"Use {command} reset to restore protected policy.",
             ]
         )
         await update.message.reply_text("\n".join(lines))
@@ -3385,32 +3389,99 @@ async def _handle_github_notify(
     if value == "reset":
         changed = await service.reset(
             authority,
-            "github",
+            integration_class,
             expected_revision=snapshot.revision,
         )
-        preference = next(item for item in changed.preferences if item.integration_class == "github")
+        preference = next(item for item in changed.preferences if item.integration_class == integration_class)
         await update.message.reply_text(
-            f"GitHub notification destination reset to {preference.destination_name} ({preference.source})."
+            f"{notification_label} destination reset to {preference.destination_name} ({preference.source})."
         )
         return
 
     try:
         selected_index = int(value)
     except ValueError:
-        await update.message.reply_text("Destination must be a number from /github notify, or reset.")
+        await update.message.reply_text(f"Destination must be a number from {command}, or reset.")
         return
-    if selected_index < 1 or selected_index > len(github_destinations):
-        await update.message.reply_text("Destination must be a number from /github notify, or reset.")
+    if selected_index < 1 or selected_index > len(destinations):
+        await update.message.reply_text(f"Destination must be a number from {command}, or reset.")
         return
-    selected = github_destinations[selected_index - 1]
+    selected = destinations[selected_index - 1]
     changed = await service.select(
         authority,
-        "github",
+        integration_class,
         selected.choice_id,
         expected_revision=snapshot.revision,
     )
-    preference = next(item for item in changed.preferences if item.integration_class == "github")
-    await update.message.reply_text(f"GitHub notifications will go to {preference.destination_name}.")
+    preference = next(item for item in changed.preferences if item.integration_class == integration_class)
+    await update.message.reply_text(f"{notification_label}s will go to {preference.destination_name}.")
+
+
+async def _handle_github_notify(
+    update: Update,
+    args: list[str],
+    *,
+    canonical: tuple[
+        WorkshopNotificationPreferenceService,
+        NotificationPreferenceAuthority,
+    ]
+    | None = None,
+) -> None:
+    """Keep `/github notify` as the GitHub-specific compatibility surface."""
+    await _handle_notification_destination(
+        update,
+        args,
+        integration_class=GITHUB_INTEGRATION_CLASS,
+        command="/github notify",
+        canonical=canonical,
+    )
+
+
+@_require_auth
+async def handle_notifications(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    """Show or change canonical personal integration destinations."""
+    assert update.message is not None
+    canonical = _canonical_notification_preference_authority(
+        context,
+        _chat_id(update),
+    )
+    if canonical is None:
+        await update.message.reply_text("Canonical notification destinations are unavailable.")
+        return
+
+    args = context.args or []
+    if not args:
+        service, authority = canonical
+        snapshot = await service.inspect(authority)
+        lines = ["Notification delivery:"]
+        lines.extend(f"{item.display_name}: {item.destination_name} ({item.source})" for item in snapshot.preferences)
+        lines.extend(
+            [
+                "",
+                "Use /notifications github to view GitHub destinations.",
+                "Use /notifications generic to view generic-webhook destinations.",
+            ]
+        )
+        await update.message.reply_text("\n".join(lines))
+        return
+
+    integration_class = args[0].strip().lower()
+    if integration_class not in {
+        GITHUB_INTEGRATION_CLASS,
+        GENERIC_INTEGRATION_CLASS,
+    }:
+        await update.message.reply_text("Usage: /notifications <github|generic> [number|reset]")
+        return
+    await _handle_notification_destination(
+        update,
+        args[1:],
+        integration_class=integration_class,
+        command=f"/notifications {integration_class}",
+        canonical=canonical,
+    )
 
 
 async def _handle_github_toggle(
@@ -3470,7 +3541,6 @@ async def handle_github(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     if subcommand == "notify":
         await _handle_github_notify(
             update,
-            chat_id,
             args[1:],
             canonical=notification_preferences,
         )
@@ -3881,6 +3951,8 @@ async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         "/github token [<token>] - Manage access token\n"
         "/github add <repo> - Watch a repo\n"
         "/github remove <repo> - Unwatch a repo\n"
+        "/notifications - Show personal notification destinations\n"
+        "/notifications <github|generic> [number|reset] - Route notifications\n"
         "/review <pr-number> - Review a PR on the inferred repo\n"
         "/review <owner/repo> <pr-number> - Review an explicit PR\n"
         "\n"
@@ -4692,6 +4764,7 @@ def create_bot(
         ("voices", handle_voices),
         ("webhooks", handle_webhooks),
         ("github", handle_github),
+        ("notifications", handle_notifications),
         ("review", handle_review_command),
         ("memory", memory_command.handle_memory_command),
         ("stop", handle_stop),

--- a/src/kai/telegram_adapter.py
+++ b/src/kai/telegram_adapter.py
@@ -95,6 +95,7 @@ _TELEGRAM_COMMANDS = (
     BotCommand("workspace", "Switch working directory"),
     BotCommand("workspaces", "List recent workspaces"),
     BotCommand("github", "Show GitHub settings"),
+    BotCommand("notifications", "Route personal notifications"),
     BotCommand("voice", "Toggle voice or set voice name"),
     BotCommand("voices", "Choose a voice"),
     BotCommand("stats", "Show session info and cost"),

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -58,6 +58,7 @@ from kai.bot import (
     handle_model_callback,
     handle_models,
     handle_new,
+    handle_notifications,
     handle_photo,
     handle_review_command,
     handle_settings,
@@ -1277,6 +1278,7 @@ class TestHandleHelp:
         # routing notifications.
         assert "/github notify [number|reset]" in reply
         assert "/github notify [on|off]" not in reply
+        assert "/notifications <github|generic> [number|reset]" in reply
 
         # /memory browses facts and episodes; the tag-browse axis was
         # retired when the dashboard was redesigned as Facts/Episodes/
@@ -4695,6 +4697,141 @@ class TestHandleGitHub:
         assert "unknown subcommand" in reply.lower()
 
 
+# ── /notifications command ──────────────────────────────────────────
+
+
+class TestHandleNotifications:
+    @staticmethod
+    def _snapshot():
+        return SimpleNamespace(
+            revision="revision-1",
+            preferences=(
+                SimpleNamespace(
+                    integration_class="github",
+                    display_name="GitHub",
+                    destination_name="Notifications",
+                    source="protected policy",
+                ),
+                SimpleNamespace(
+                    integration_class="generic",
+                    display_name="Generic webhooks",
+                    destination_name="Home",
+                    source="protected policy",
+                ),
+            ),
+            destinations=(
+                SimpleNamespace(
+                    choice_id="ndst_home",
+                    display_name="Home",
+                    kind="direct",
+                    supported_classes=("github", "generic"),
+                ),
+                SimpleNamespace(
+                    choice_id="ndst_notifications",
+                    display_name="Notifications",
+                    kind="notification",
+                    supported_classes=("github",),
+                ),
+            ),
+        )
+
+    @staticmethod
+    def _context(args: list[str]):
+        ctx = _make_context(config=_make_config(), args=args)
+        service = MagicMock()
+        service.authority_for_principal_profile.return_value = object()
+        service.inspect = AsyncMock(return_value=TestHandleNotifications._snapshot())
+        ctx.application.core_services.notification_preferences = service
+        return ctx, service
+
+    @pytest.mark.asyncio
+    async def test_reports_both_effective_destinations(self):
+        update = _make_update(text="/notifications")
+        ctx, _service = self._context([])
+
+        await handle_notifications(update, ctx)
+
+        reply = update.message.reply_text.call_args[0][0]
+        assert "GitHub: Notifications (protected policy)" in reply
+        assert "Generic webhooks: Home (protected policy)" in reply
+        assert "ndst_" not in reply
+        assert "telegram" not in reply.lower()
+
+    @pytest.mark.asyncio
+    async def test_lists_only_generic_authorized_destinations(self):
+        update = _make_update(text="/notifications generic")
+        ctx, _service = self._context(["generic"])
+
+        await handle_notifications(update, ctx)
+
+        reply = update.message.reply_text.call_args[0][0]
+        assert "1. Home (direct)" in reply
+        assert "Notifications (notification)" not in reply
+        assert "/notifications generic <number>" in reply
+
+    @pytest.mark.asyncio
+    async def test_selects_generic_destination_through_canonical_service(self):
+        update = _make_update(text="/notifications generic 1")
+        ctx, service = self._context(["generic", "1"])
+        authority = service.authority_for_principal_profile.return_value
+        service.select = AsyncMock(
+            return_value=SimpleNamespace(
+                preferences=(
+                    SimpleNamespace(
+                        integration_class="generic",
+                        destination_name="Home",
+                    ),
+                ),
+            )
+        )
+
+        await handle_notifications(update, ctx)
+
+        service.select.assert_awaited_once_with(
+            authority,
+            "generic",
+            "ndst_home",
+            expected_revision="revision-1",
+        )
+        assert "Generic webhook notifications will go to Home" in (update.message.reply_text.call_args[0][0])
+
+    @pytest.mark.asyncio
+    async def test_resets_generic_destination_through_canonical_service(self):
+        update = _make_update(text="/notifications generic reset")
+        ctx, service = self._context(["generic", "reset"])
+        authority = service.authority_for_principal_profile.return_value
+        service.reset = AsyncMock(
+            return_value=SimpleNamespace(
+                preferences=(
+                    SimpleNamespace(
+                        integration_class="generic",
+                        destination_name="Home",
+                        source="protected policy",
+                    ),
+                ),
+            )
+        )
+
+        await handle_notifications(update, ctx)
+
+        service.reset.assert_awaited_once_with(
+            authority,
+            "generic",
+            expected_revision="revision-1",
+        )
+        assert "reset to Home (protected policy)" in (update.message.reply_text.call_args[0][0])
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_integration_class_without_inspection(self):
+        update = _make_update(text="/notifications telegram 1")
+        ctx, service = self._context(["telegram", "1"])
+
+        await handle_notifications(update, ctx)
+
+        service.inspect.assert_not_awaited()
+        assert "<github|generic>" in update.message.reply_text.call_args[0][0]
+
+
 # ── /model persistence ─────────────────────────────────────────────
 
 
@@ -4770,6 +4907,7 @@ EXPECTED_MENU_COMMANDS = {
     "model",
     "models",
     "new",
+    "notifications",
     "settings",
     "stats",
     "stop",


### PR DESCRIPTION
## Summary

- add a general `/notifications` Telegram command that reports both GitHub and generic-webhook delivery preferences
- support canonical, revision-checked selection and reset using only displayed numeric choices
- retain `/github notify` as a compatible GitHub-specific entry point over the same helper and authority
- register the command in Telegram help, the command menu, and sensitive-authentication coverage

## Verification

- `make check`
- `make typecheck`
- `make client-check` (86 tests)
- `.venv/bin/python -m pytest tests -q --tb=short` (6135 passed)

Closes #1151
