### PR TITLE
feat: add Telegram preference document parity

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -87,6 +87,16 @@ from kai.workshop.notification_preferences import (
     NotificationPreferenceAuthority,
     WorkshopNotificationPreferenceService,
 )
+from kai.workshop.preferences import (
+    PreferenceAuthority,
+    WorkshopPreferenceAccessDenied,
+    WorkshopPreferenceConflict,
+    WorkshopPreferenceError,
+    WorkshopPreferenceRevisionNotFound,
+    WorkshopPreferenceService,
+    WorkshopPreferenceStorageError,
+    WorkshopPreferenceValidationError,
+)
 from kai.workshop.scheduled_jobs import WorkshopScheduledJobAuthority
 from kai.workshop.settings_workspaces import (
     SettingsWorkspaceAuthority,
@@ -353,6 +363,23 @@ def _canonical_notification_preference_authority(
         storage.principal_id,
         storage.runtime_profile_id,
     )
+
+
+def _canonical_preference_document_authority(
+    context: ContextTypes.DEFAULT_TYPE,
+    runtime_config_id: int,
+) -> tuple[WorkshopPreferenceService, PreferenceAuthority] | None:
+    """Resolve a Telegram binding to its principal-owned preference document."""
+    services = _get_core_services(context)
+    service = getattr(services, "preference_documents", None)
+    if service is None:
+        return None
+    try:
+        storage = services.principal_storage.for_runtime_config_id(runtime_config_id)
+        authority = service.authority_for_principal(storage.principal_id)
+    except (WorkshopStorageNamespaceError, WorkshopPreferenceAccessDenied):
+        return None
+    return service, authority
 
 
 # ── Basic command handlers ───────────────────────────────────────────
@@ -3484,6 +3511,150 @@ async def handle_notifications(
     )
 
 
+_PREFERENCE_HISTORY_CHOICES_KEY = "preference_history_choices"
+
+
+def _preference_set_content(text: str) -> str | None:
+    """Extract exact `/preferences set` content after one command separator."""
+    match = re.fullmatch(
+        r"/preferences(?:@[A-Za-z0-9_]+)?[ \t]+set(?:[ \t]|\r?\n)([\s\S]*)",
+        text,
+        flags=re.IGNORECASE,
+    )
+    return match.group(1) if match is not None else None
+
+
+async def _reply_preference_error(message: Message, exc: WorkshopPreferenceError) -> None:
+    """Render canonical preference failures without exposing private storage."""
+    if isinstance(exc, WorkshopPreferenceConflict):
+        await message.reply_text(
+            "Preferences changed since they were displayed. Run /preferences history and try again."
+        )
+    elif isinstance(exc, WorkshopPreferenceRevisionNotFound):
+        await message.reply_text("That preference revision is no longer available. Run /preferences history again.")
+    elif isinstance(exc, WorkshopPreferenceValidationError):
+        await message.reply_text(str(exc))
+    elif isinstance(exc, (WorkshopPreferenceAccessDenied, WorkshopPreferenceStorageError)):
+        await message.reply_text("Preferences are temporarily unavailable.")
+    else:
+        await message.reply_text("Preferences are temporarily unavailable.")
+
+
+@_require_auth
+async def handle_preferences(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    """View and revise the authenticated principal's canonical preference document."""
+    assert update.message is not None
+    canonical = _canonical_preference_document_authority(context, _chat_id(update))
+    if canonical is None:
+        await update.message.reply_text("Canonical preferences are unavailable.")
+        return
+    service, authority = canonical
+    args = context.args or []
+    subcommand = args[0].lower() if args else "show"
+
+    try:
+        if subcommand == "show":
+            if len(args) > 1:
+                await update.message.reply_text("Usage: /preferences [show|set|history|restore]")
+                return
+            document = await service.read(authority)
+            if not document.content:
+                await update.message.reply_text("Preferences are empty.")
+                return
+            await update.message.reply_text("Preferences:")
+            for chunk in chunk_text(document.content):
+                await update.message.reply_text(chunk)
+            return
+
+        if subcommand == "set":
+            content = _preference_set_content(update.message.text or "")
+            if content is None or not content:
+                await update.message.reply_text("Usage: /preferences set <text>")
+                return
+            current = await service.read(authority)
+            saved = await service.save(
+                authority,
+                expected_revision=current.revision,
+                content=content,
+            )
+            context.user_data.pop(_PREFERENCE_HISTORY_CHOICES_KEY, None)
+            await update.message.reply_text(f"Preferences saved ({saved.size_bytes} bytes).")
+            return
+
+        if subcommand == "history":
+            if len(args) > 1:
+                await update.message.reply_text("Usage: /preferences history")
+                return
+            current = await service.read(authority)
+            history = await service.history(authority)
+            if not history.revisions:
+                context.user_data.pop(_PREFERENCE_HISTORY_CHOICES_KEY, None)
+                await update.message.reply_text("No previous preference revisions are available.")
+                return
+            choices = tuple(item.revision for item in history.revisions)
+            context.user_data[_PREFERENCE_HISTORY_CHOICES_KEY] = (
+                str(authority.principal_id),
+                current.revision,
+                choices,
+            )
+            lines = ["Previous preference revisions:"]
+            lines.extend(
+                f"{index}. {item.updated_at} ({item.size_bytes} bytes)"
+                for index, item in enumerate(history.revisions, start=1)
+            )
+            lines.extend(["", "Use /preferences restore <number> to restore a displayed revision."])
+            await update.message.reply_text("\n".join(lines))
+            return
+
+        if subcommand == "restore":
+            if len(args) != 2:
+                await update.message.reply_text("Usage: /preferences restore <number>")
+                return
+            displayed = context.user_data.get(_PREFERENCE_HISTORY_CHOICES_KEY)
+            if (
+                not isinstance(displayed, tuple)
+                or len(displayed) != 3
+                or not isinstance(displayed[0], str)
+                or displayed[0] != str(authority.principal_id)
+                or not isinstance(displayed[1], str)
+                or not isinstance(displayed[2], tuple)
+                or not all(isinstance(item, str) for item in displayed[2])
+            ):
+                await update.message.reply_text("Run /preferences history before restoring a revision.")
+                return
+            try:
+                selected_index = int(args[1])
+            except ValueError:
+                selected_index = 0
+            _principal_id, expected_revision, choices = displayed
+            if selected_index < 1 or selected_index > len(choices):
+                await update.message.reply_text("Choose a revision number from /preferences history.")
+                return
+            target_revision = choices[selected_index - 1]
+            current_history = await service.history(authority)
+            if target_revision not in {item.revision for item in current_history.revisions}:
+                context.user_data.pop(_PREFERENCE_HISTORY_CHOICES_KEY, None)
+                await update.message.reply_text(
+                    "That preference revision is no longer available. Run /preferences history again."
+                )
+                return
+            restored = await service.restore(
+                authority,
+                target_revision=target_revision,
+                expected_revision=expected_revision,
+            )
+            context.user_data.pop(_PREFERENCE_HISTORY_CHOICES_KEY, None)
+            await update.message.reply_text(f"Preferences restored ({restored.size_bytes} bytes).")
+            return
+
+        await update.message.reply_text("Usage: /preferences [show|set|history|restore]")
+    except WorkshopPreferenceError as exc:
+        await _reply_preference_error(update.message, exc)
+
+
 async def _handle_github_toggle(
     update: Update,
     chat_id: int,
@@ -3960,6 +4131,10 @@ async def handle_help(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         "/memory search <q> - Semantic search over memories\n"
         "/memory stats - Counts and confidence distribution\n"
         "/memory help - /memory subcommand reference\n"
+        "/preferences - Show your preference document\n"
+        "/preferences set <text> - Replace your preference document\n"
+        "/preferences history - List previous preference revisions\n"
+        "/preferences restore <number> - Restore a displayed revision\n"
         "\n"
         "/voice - Toggle voice off / voice-only\n"
         "/voice only - Voice only (no text)\n"
@@ -4765,6 +4940,7 @@ def create_bot(
         ("webhooks", handle_webhooks),
         ("github", handle_github),
         ("notifications", handle_notifications),
+        ("preferences", handle_preferences),
         ("review", handle_review_command),
         ("memory", memory_command.handle_memory_command),
         ("stop", handle_stop),

--- a/src/kai/telegram_adapter.py
+++ b/src/kai/telegram_adapter.py
@@ -96,6 +96,7 @@ _TELEGRAM_COMMANDS = (
     BotCommand("workspaces", "List recent workspaces"),
     BotCommand("github", "Show GitHub settings"),
     BotCommand("notifications", "Route personal notifications"),
+    BotCommand("preferences", "View or edit your preferences"),
     BotCommand("voice", "Toggle voice or set voice name"),
     BotCommand("voices", "Choose a voice"),
     BotCommand("stats", "Show session info and cost"),

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -60,6 +60,7 @@ from kai.bot import (
     handle_new,
     handle_notifications,
     handle_photo,
+    handle_preferences,
     handle_review_command,
     handle_settings,
     handle_start,
@@ -108,6 +109,13 @@ from kai.workshop.execution_coordinator import (
     CanonicalExecutionDisposition,
 )
 from kai.workshop.inbound import InboundMessage
+from kai.workshop.preferences import (
+    PreferenceDocument,
+    PreferenceRevision,
+    PreferenceRevisionHistory,
+    WorkshopPreferenceConflict,
+    WorkshopPreferenceStorageError,
+)
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.settings_workspaces import (
     EffectiveValue,
@@ -1279,6 +1287,8 @@ class TestHandleHelp:
         assert "/github notify [number|reset]" in reply
         assert "/github notify [on|off]" not in reply
         assert "/notifications <github|generic> [number|reset]" in reply
+        assert "/preferences set <text>" in reply
+        assert "/preferences restore <number>" in reply
 
         # /memory browses facts and episodes; the tag-browse axis was
         # retired when the dashboard was redesigned as Facts/Episodes/
@@ -4832,6 +4842,208 @@ class TestHandleNotifications:
         assert "<github|generic>" in update.message.reply_text.call_args[0][0]
 
 
+# ── /preferences command ────────────────────────────────────────────
+
+
+class TestHandlePreferences:
+    @staticmethod
+    def _document(content: str = "# Preferences\n\nKeep answers concise.\n", revision: str = "pref_current"):
+        return PreferenceDocument(
+            content=content,
+            revision=revision,
+            updated_at="2026-08-27T10:00:00Z",
+            size_bytes=len(content.encode("utf-8")),
+        )
+
+    @classmethod
+    def _context(cls, args: list[str], *, content: str = "# Preferences\n\nKeep answers concise.\n"):
+        ctx = _make_context(config=_make_config(), args=args)
+        service = MagicMock()
+        service.authority_for_principal.return_value = SimpleNamespace(
+            principal_id=PrincipalId("prn_00000000000000000000000000003039")
+        )
+        service.read = AsyncMock(return_value=cls._document(content))
+        service.history = AsyncMock(return_value=PreferenceRevisionHistory(()))
+        ctx.application.core_services.preference_documents = service
+        return ctx, service
+
+    @pytest.mark.asyncio
+    async def test_show_uses_bound_principal_and_plain_telegram_chunks(self):
+        content = "x" * 5000
+        update = _make_update(text="/preferences")
+        ctx, service = self._context([], content=content)
+        bound_principal = ctx.application.core_services.principal_storage.for_runtime_config_id(12345).principal_id
+
+        await handle_preferences(update, ctx)
+
+        service.authority_for_principal.assert_called_once_with(bound_principal)
+        service.read.assert_awaited_once_with(service.authority_for_principal.return_value)
+        replies = [call.args[0] for call in update.message.reply_text.await_args_list]
+        assert replies[0] == "Preferences:"
+        assert "".join(replies[1:]) == content
+        assert all(len(reply) <= 4096 for reply in replies)
+        assert all(call.kwargs.get("parse_mode") is None for call in update.message.reply_text.await_args_list)
+
+    @pytest.mark.asyncio
+    async def test_set_preserves_multiline_content_and_uses_current_revision(self):
+        content = "First line\n  indented line\nLast line\n"
+        update = _make_update(text=f"/preferences set {content}")
+        ctx, service = self._context(["set", "First", "line"])
+        authority = service.authority_for_principal.return_value
+        service.save = AsyncMock(return_value=self._document(content, "pref_saved"))
+        ctx.user_data["preference_history_choices"] = (
+            str(authority.principal_id),
+            "old",
+            ("target",),
+        )
+
+        await handle_preferences(update, ctx)
+
+        service.save.assert_awaited_once_with(
+            authority,
+            expected_revision="pref_current",
+            content=content,
+        )
+        assert "preference_history_choices" not in ctx.user_data
+        assert update.message.reply_text.await_args.args[0] == "Preferences saved (37 bytes)."
+
+    @pytest.mark.asyncio
+    async def test_set_preserves_additional_leading_space_after_separator(self):
+        update = _make_update(text="/preferences set  keep this indent")
+        ctx, service = self._context(["set", "keep", "this", "indent"])
+        service.save = AsyncMock(return_value=self._document(" keep this indent", "pref_saved"))
+
+        await handle_preferences(update, ctx)
+
+        assert service.save.await_args.kwargs["content"] == " keep this indent"
+
+    @pytest.mark.asyncio
+    async def test_set_requires_content_without_mutation(self):
+        update = _make_update(text="/preferences set")
+        ctx, service = self._context(["set"])
+        service.save = AsyncMock()
+
+        await handle_preferences(update, ctx)
+
+        service.read.assert_not_awaited()
+        service.save.assert_not_awaited()
+        assert update.message.reply_text.await_args.args[0] == "Usage: /preferences set <text>"
+
+    @pytest.mark.asyncio
+    async def test_history_lists_numbered_private_choices_without_identifiers(self):
+        update = _make_update(text="/preferences history")
+        ctx, service = self._context(["history"])
+        service.history.return_value = PreferenceRevisionHistory(
+            (
+                PreferenceRevision("pref_private_one", "2026-08-26T10:00:00Z", 120),
+                PreferenceRevision("pref_private_two", "2026-08-25T09:00:00Z", 80),
+            )
+        )
+
+        await handle_preferences(update, ctx)
+
+        reply = update.message.reply_text.await_args.args[0]
+        assert "1. 2026-08-26T10:00:00Z (120 bytes)" in reply
+        assert "2. 2026-08-25T09:00:00Z (80 bytes)" in reply
+        assert "pref_private" not in reply
+        assert "PREFERENCES.md" not in reply
+        assert ctx.user_data["preference_history_choices"] == (
+            "prn_00000000000000000000000000003039",
+            "pref_current",
+            ("pref_private_one", "pref_private_two"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_restore_uses_displayed_choice_and_displayed_current_revision(self):
+        update = _make_update(text="/preferences restore 2")
+        ctx, service = self._context(["restore", "2"])
+        authority = service.authority_for_principal.return_value
+        ctx.user_data["preference_history_choices"] = (
+            str(authority.principal_id),
+            "pref_expected",
+            ("pref_private_one", "pref_private_two"),
+        )
+        service.history.return_value = PreferenceRevisionHistory(
+            (
+                PreferenceRevision("pref_private_one", "2026-08-26T10:00:00Z", 120),
+                PreferenceRevision("pref_private_two", "2026-08-25T09:00:00Z", 80),
+            )
+        )
+        service.restore = AsyncMock(return_value=self._document("Restored.\n", "pref_restored"))
+
+        await handle_preferences(update, ctx)
+
+        service.restore.assert_awaited_once_with(
+            authority,
+            target_revision="pref_private_two",
+            expected_revision="pref_expected",
+        )
+        assert "preference_history_choices" not in ctx.user_data
+        assert update.message.reply_text.await_args.args[0] == "Preferences restored (10 bytes)."
+
+    @pytest.mark.asyncio
+    async def test_restore_requires_server_displayed_choice(self):
+        update = _make_update(text="/preferences restore pref_forged")
+        ctx, service = self._context(["restore", "pref_forged"])
+        service.restore = AsyncMock()
+
+        await handle_preferences(update, ctx)
+
+        service.history.assert_not_awaited()
+        service.restore.assert_not_awaited()
+        assert update.message.reply_text.await_args.args[0] == ("Run /preferences history before restoring a revision.")
+
+    @pytest.mark.asyncio
+    async def test_restore_conflict_does_not_expose_revision(self):
+        update = _make_update(text="/preferences restore 1")
+        ctx, service = self._context(["restore", "1"])
+        authority = service.authority_for_principal.return_value
+        ctx.user_data["preference_history_choices"] = (
+            str(authority.principal_id),
+            "pref_expected",
+            ("pref_private",),
+        )
+        service.history.return_value = PreferenceRevisionHistory(
+            (PreferenceRevision("pref_private", "2026-08-26T10:00:00Z", 120),)
+        )
+        service.restore = AsyncMock(side_effect=WorkshopPreferenceConflict("pref_secret_current"))
+
+        await handle_preferences(update, ctx)
+
+        reply = update.message.reply_text.await_args.args[0]
+        assert "changed since" in reply
+        assert "pref_secret_current" not in reply
+
+    @pytest.mark.asyncio
+    async def test_restore_rejects_choices_bound_to_another_principal(self):
+        update = _make_update(text="/preferences restore 1")
+        ctx, service = self._context(["restore", "1"])
+        ctx.user_data["preference_history_choices"] = (
+            "prn_ffffffffffffffffffffffffffffffff",
+            "pref_expected",
+            ("pref_private",),
+        )
+        service.restore = AsyncMock()
+
+        await handle_preferences(update, ctx)
+
+        service.history.assert_not_awaited()
+        service.restore.assert_not_awaited()
+        assert update.message.reply_text.await_args.args[0] == ("Run /preferences history before restoring a revision.")
+
+    @pytest.mark.asyncio
+    async def test_storage_failure_is_safe(self):
+        update = _make_update(text="/preferences")
+        ctx, service = self._context([])
+        service.read.side_effect = WorkshopPreferenceStorageError("/private/path failed")
+
+        await handle_preferences(update, ctx)
+
+        reply = update.message.reply_text.await_args.args[0]
+        assert reply == "Preferences are temporarily unavailable."
+        assert "/private/path" not in reply
+
+
 # ── /model persistence ─────────────────────────────────────────────
 
 
@@ -4908,6 +5120,7 @@ EXPECTED_MENU_COMMANDS = {
     "models",
     "new",
     "notifications",
+    "preferences",
     "settings",
     "stats",
     "stop",


### PR DESCRIPTION
## Summary

- add a dedicated `/preferences` Telegram command over the canonical principal preference-document service
- support safe chunked viewing, exact multiline replacement, bounded numbered history, and revision-safe restoration
- bind displayed restore choices to the authenticated canonical principal without exposing revision IDs or filesystem paths
- add the command to Telegram help, the command menu, and the common sensitive-authentication boundary

## Security

- accepts no principal, runtime-profile, OS-user, path, or raw revision selector
- resolves authority exclusively from the authenticated Telegram binding
- uses the canonical current revision for replacement and the displayed current revision for conflict-safe restoration
- rejects missing, stale, unavailable, malformed, cross-principal, and forged restore choices without mutation

## Verification

- `make check`
- `make typecheck`
- `make client-check` (86 browser tests)
- `.venv/bin/python -m pytest tests/test_bot.py -q` (329 passed)
- `.venv/bin/python -m pytest -q` (6145 passed)

Closes #1152
