### PR TITLE
fix: preserve Workshop appearance preferences

### DIFF
--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 37
+WORKSHOP_SCHEMA_VERSION = 38
 
 
 @dataclass(frozen=True, slots=True)
@@ -1814,6 +1814,36 @@ _PRINCIPAL_APPEARANCE_PREFERENCES_SCHEMA = SchemaMigration(
     ),
 )
 
+_DURABLE_PRINCIPAL_APPEARANCE_PREFERENCES_SCHEMA = SchemaMigration(
+    version=38,
+    name="isolate_principal_appearance_preferences_from_projection_rebuilds",
+    statements=(
+        """
+        CREATE TABLE principal_appearance_preferences_v38 (
+            -- principal_id is deliberately not a foreign key. Principals are
+            -- replayed collaboration projections, while appearance choices
+            -- are mutable principal state that must survive projection reset.
+            principal_id TEXT PRIMARY KEY,
+            theme_id TEXT NOT NULL CHECK (length(trim(theme_id)) > 0),
+            created_at TEXT NOT NULL DEFAULT (
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            ),
+            updated_at TEXT NOT NULL DEFAULT (
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+        )
+        """,
+        """
+        INSERT INTO principal_appearance_preferences_v38 (
+            principal_id, theme_id, created_at, updated_at
+        ) SELECT principal_id, theme_id, created_at, updated_at
+          FROM principal_appearance_preferences
+        """,
+        "DROP TABLE principal_appearance_preferences",
+        "ALTER TABLE principal_appearance_preferences_v38 RENAME TO principal_appearance_preferences",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1852,6 +1882,7 @@ _MIGRATIONS = (
     _PRINCIPAL_NOTIFICATION_PREFERENCES_SCHEMA,
     _CLIENT_BINDING_VOICE_PREFERENCES_SCHEMA,
     _PRINCIPAL_APPEARANCE_PREFERENCES_SCHEMA,
+    _DURABLE_PRINCIPAL_APPEARANCE_PREFERENCES_SCHEMA,
 )
 
 

--- a/tests/test_workshop_appearance_preferences.py
+++ b/tests/test_workshop_appearance_preferences.py
@@ -38,6 +38,55 @@ async def _seed(path: Path) -> tuple[WorkshopEventStore, str, str]:
 
 
 @pytest.mark.asyncio
+async def test_version_thirty_seven_preferences_upgrade_without_data_loss(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kai.workshop import schema
+
+    path = tmp_path / "kai.db"
+    principal_id = "prn_00000000000000000000000000000001"
+    with monkeypatch.context() as migration_context:
+        migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 37)
+        migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:37])
+        version_thirty_seven = await WorkshopEventStore.open(path)
+        await version_thirty_seven.connection.execute(
+            "INSERT INTO principals (id, kind, display_name, created_at) "
+            "VALUES (?, 'human', 'Daniel', '2026-08-27T12:00:00Z')",
+            (principal_id,),
+        )
+        await version_thirty_seven.connection.execute(
+            "INSERT INTO principal_appearance_preferences "
+            "(principal_id, theme_id, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            (
+                principal_id,
+                "github-dark-dimmed",
+                "2026-08-27T12:01:00Z",
+                "2026-08-27T12:02:00Z",
+            ),
+        )
+        await version_thirty_seven.connection.commit()
+        await version_thirty_seven.close()
+
+    upgraded = await WorkshopEventStore.open(path)
+    try:
+        assert await upgraded.schema_version() == 38
+        async with upgraded.connection.execute(
+            "SELECT principal_id, theme_id, created_at, updated_at FROM principal_appearance_preferences"
+        ) as cursor:
+            assert tuple(await cursor.fetchone()) == (
+                principal_id,
+                "github-dark-dimmed",
+                "2026-08-27T12:01:00Z",
+                "2026-08-27T12:02:00Z",
+            )
+        async with upgraded.connection.execute("PRAGMA foreign_key_list(principal_appearance_preferences)") as cursor:
+            assert await cursor.fetchall() == []
+    finally:
+        await upgraded.close()
+
+
+@pytest.mark.asyncio
 async def test_defaults_are_principal_scoped_and_survive_restart(tmp_path: Path) -> None:
     path = tmp_path / "kai.db"
     store, daniel_id, scott_id = await _seed(path)
@@ -113,12 +162,22 @@ async def test_non_default_light_and_dark_themes_are_isolated_and_survive_restar
     assert len(WORKSHOP_APPEARANCE_THEMES) == 11
     await store.close()
 
-    reopened = await WorkshopAppearancePreferenceService.open(path)
+    # Application startup bootstraps canonical conversations by deleting and
+    # replaying the collaboration projection. Appearance state must survive
+    # that full lifecycle, not merely a database close/reopen.
+    restarted_store, restarted_daniel_id, restarted_scott_id = await _seed(path)
+    assert restarted_daniel_id == daniel_id
+    assert restarted_scott_id == scott_id
+    reopened = WorkshopAppearancePreferenceService(restarted_store.connection)
     try:
         assert (await reopened.inspect(reopened.authority_for_principal(daniel_id))).theme_id == "github-light-default"
         assert (await reopened.inspect(reopened.authority_for_principal(scott_id))).theme_id == "catppuccin-mocha"
+        assert workshop_appearance_preference_status(path) == (
+            "Workshop appearance preferences: active; principals=2, explicit=2, "
+            "defaulted=0, invalid=0; authority=canonical"
+        )
     finally:
-        await reopened.close()
+        await restarted_store.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -92,7 +92,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",
@@ -129,7 +129,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             async with upgraded.connection.execute(
                 "SELECT field, value FROM channel_agent_execution_settings"
             ) as cursor:

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -208,7 +208,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 37
+        assert await workshop_store.schema_version() == 38
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -223,7 +223,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 37
+        assert await second.schema_version() == 38
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -255,7 +255,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -283,7 +283,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -338,6 +338,7 @@ class TestWorkshopSchema:
                     35,
                     36,
                     37,
+                    38,
                 ]
         finally:
             await upgraded.close()
@@ -360,7 +361,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -401,7 +402,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -454,7 +455,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -498,7 +499,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -542,7 +543,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -586,7 +587,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -690,7 +691,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -817,7 +818,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -521,7 +521,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -411,7 +411,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -524,7 +524,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -382,7 +382,7 @@ class TestAtomicTerminalTransactions:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 37
+            assert await upgraded.schema_version() == 38
             assert await _post_run_effect_count(upgraded) == 1
             async with upgraded.connection.execute(
                 "SELECT status, source_message_id, result_message_id FROM workshop_post_run_effects WHERE run_id = ?",


### PR DESCRIPTION
## Summary

- preserve principal-scoped Workshop appearance choices across startup projection rebuilds
- migrate existing appearance rows without data loss while removing the unsafe cascading foreign key
- cover the full bootstrap/replay lifecycle and the version 37 to 38 upgrade path

## Root cause

`principal_appearance_preferences.principal_id` referenced the replayable `principals` projection with `ON DELETE CASCADE`. Startup deliberately deletes and replays that projection, so saved theme rows were deleted before principals were reconstructed.

## Validation

- `make check`
- `make typecheck`
- `make client-check` (95 tests)
- `.venv/bin/python -m pytest` (6,155 tests)
