### PR TITLE
feat: add canonical model discovery inventory

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import pwd
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import Protocol
 
 from kai import sessions
+from kai.backend_registry import (
+    BackendRegistryEntry,
+    BackendRegistryError,
+    load_backend_registry,
+    resolve_backend_command,
+)
 from kai.config import Config
 from kai.pool import SubprocessPool
 from kai.workshop.appearance_preferences import WorkshopAppearancePreferenceService
@@ -30,6 +38,7 @@ from kai.workshop.github_settings import WorkshopGitHubSettingsService
 from kai.workshop.integration_notifications import WorkshopIntegrationNotificationService
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
+from kai.workshop.model_discovery_inventory import WorkshopModelDiscoveryInventoryService
 from kai.workshop.notification_preferences import WorkshopNotificationPreferenceService
 from kai.workshop.post_run_effects import WorkshopPostRunEffectService
 from kai.workshop.preferences import WorkshopPreferenceService
@@ -76,6 +85,34 @@ class KaiApplicationAdapter(Protocol):
     async def wait(self) -> None: ...
 
     async def stop(self) -> None: ...
+
+
+def _model_discovery_backend_registry(
+    registered_backend_ids: frozenset[str],
+) -> dict[str, BackendRegistryEntry]:
+    """Resolve installed commands without invoking them.
+
+    Protected installations always return their authoritative registry.  A
+    direct development run may instead resolve its already-registered
+    backends through the same environment/PATH compatibility used by the
+    subprocess pool.
+    """
+    registry = load_backend_registry()
+    if registry:
+        return registry
+    resolved: dict[str, BackendRegistryEntry] = {}
+    for backend in sorted(registered_backend_ids):
+        try:
+            command = resolve_backend_command(backend)
+        except (BackendRegistryError, ValueError):
+            continue
+        resolved[backend] = BackendRegistryEntry(
+            id=backend,
+            driver=backend,
+            runtime="local_process",
+            command=command,
+        )
+    return resolved
 
 
 @dataclass(frozen=True, slots=True)
@@ -128,6 +165,7 @@ class KaiCoreServices:
     subprocess_pool: SubprocessPool
     runtime_profiles: WorkshopRuntimeProfileRegistry
     runtime_pool: WorkshopRuntimePool
+    model_discovery_inventory: WorkshopModelDiscoveryInventoryService
     conversation_runs: WorkshopConversationRunService
     private_text_execution: WorkshopPrivateTextExecutionService
     client_commands: WorkshopClientCommandExecutor
@@ -239,6 +277,14 @@ class KaiApplicationHost:
             )
             runtime_pool = WorkshopRuntimePool(subprocess_pool, self._runtime_profiles)
             await subprocess_pool.hydrate_backend_selections()
+            model_discovery_inventory = WorkshopModelDiscoveryInventoryService(
+                config=self._config,
+                runtime_profiles=self._runtime_profiles,
+                execution_state=self._execution_state,
+                backend_registry=_model_discovery_backend_registry(self._registered_backend_ids),
+                selected_backend=lambda profile_id: runtime_pool.get_backend_provider(profile_id),
+                service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
+            )
             runtime_state = WorkshopRuntimeStateWriter(
                 self._config,
                 runtime_pool,
@@ -346,6 +392,7 @@ class KaiApplicationHost:
                 subprocess_pool=subprocess_pool,
                 runtime_profiles=self._runtime_profiles,
                 runtime_pool=runtime_pool,
+                model_discovery_inventory=model_discovery_inventory,
                 conversation_runs=conversation_runs,
                 private_text_execution=private_execution,
                 client_commands=client_commands,

--- a/src/kai/workshop/model_discovery_inventory.py
+++ b/src/kai/workshop/model_discovery_inventory.py
@@ -1,0 +1,460 @@
+"""Canonical runtime inventory for backend model discovery.
+
+The inventory is deliberately read-only.  It describes which discovery lanes
+exist and which non-secret inputs make their caches distinct; later discovery
+workers own provider calls and durable catalogue refreshes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from kai.backend_registry import BackendRegistryEntry
+from kai.config import PROVIDER_KEY_VARS, Config
+from kai.workshop.domain import PrincipalId, RuntimeAssignmentId, RuntimeProfileId
+from kai.workshop.execution_state import (
+    WorkshopExecutionStateNamespace,
+    WorkshopExecutionStateRegistry,
+)
+from kai.workshop.runtime_profiles import (
+    ProtectedRuntimeBackend,
+    ProtectedRuntimeProfile,
+    WorkshopRuntimeProfileRegistry,
+)
+
+_CACHE_KEY_DOMAIN = b"kai-workshop-model-discovery-cache:v1\0"
+_IDENTITY_DOMAIN = b"kai-workshop-model-discovery-identity:v1\0"
+
+
+class ModelDiscoveryInventoryError(RuntimeError):
+    """Canonical model-discovery inventory cannot be resolved safely."""
+
+
+class ModelDiscoverySelectionStatus(StrEnum):
+    """Relationship between an authorized option and the current selection."""
+
+    SELECTED = "selected"
+    SELECTABLE = "selectable"
+    UNAVAILABLE = "unavailable"
+    MISCONFIGURED = "misconfigured"
+
+
+class ModelDiscoveryReadiness(StrEnum):
+    """Whether a discovery lane can be used without probing its backend."""
+
+    READY = "ready"
+    UNVERIFIED = "unverified"
+    UNAVAILABLE = "unavailable"
+    MISCONFIGURED = "misconfigured"
+
+
+class ModelDiscoveryAuthMode(StrEnum):
+    """Non-secret authentication class used by one backend/provider lane."""
+
+    API_KEY = "api_key"
+    SUBSCRIPTION = "subscription"
+    BACKEND_MANAGED = "backend_managed"
+    LOCAL = "local"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryAuthContext:
+    """Sanitized authentication inputs relevant to catalogue discovery."""
+
+    mode: ModelDiscoveryAuthMode
+    source: str
+    configured: bool | None
+    fingerprint: str
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryExecutableIdentity:
+    """Installed executable identity without executing the backend."""
+
+    configured_path: str | None
+    resolved_path: str | None
+    fingerprint: str
+    readiness: ModelDiscoveryReadiness
+    diagnostic: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryCacheInputs:
+    """Stable, non-secret inputs that invalidate one discovery cache lane."""
+
+    version: int
+    principal_id: PrincipalId
+    runtime_profile_id: RuntimeProfileId
+    backend: str
+    provider: str
+    os_user: str
+    executable_fingerprint: str
+    auth_fingerprint: str
+    default_model: str
+    allowed_models: tuple[str, ...] | None
+    role_models: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryBackendInventory:
+    """One operator-authorized backend/provider discovery lane."""
+
+    option_id: str
+    backend: str
+    provider: str
+    selected: bool
+    status: ModelDiscoverySelectionStatus
+    readiness: ModelDiscoveryReadiness
+    effective_os_user: str
+    executable: ModelDiscoveryExecutableIdentity
+    auth: ModelDiscoveryAuthContext
+    default_model: str
+    allowed_models: tuple[str, ...] | None
+    role_models: tuple[tuple[str, str], ...]
+    cache_inputs: ModelDiscoveryCacheInputs
+    cache_key: str
+    diagnostic: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryProfileInventory:
+    """Canonical owner and discovery lanes for one protected runtime profile."""
+
+    principal_id: PrincipalId
+    channel_id: str
+    agent_id: str
+    runtime_profile_id: RuntimeProfileId
+    runtime_assignment_id: RuntimeAssignmentId
+    display_name: str
+    selected_option_id: str
+    backends: tuple[ModelDiscoveryBackendInventory, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryOperatorDiagnostics:
+    """Sanitized aggregate diagnostics suitable for installed status output."""
+
+    profiles: int
+    options: int
+    selected: int
+    selectable: int
+    unavailable: int
+    misconfigured: int
+
+
+SelectedBackendResolver = Callable[[RuntimeProfileId], tuple[str, str]]
+
+
+class WorkshopModelDiscoveryInventoryService:
+    """Resolve model-discovery inventory from canonical protected authorities."""
+
+    def __init__(
+        self,
+        *,
+        config: Config,
+        runtime_profiles: WorkshopRuntimeProfileRegistry,
+        execution_state: WorkshopExecutionStateRegistry,
+        backend_registry: Mapping[str, BackendRegistryEntry],
+        selected_backend: SelectedBackendResolver,
+        service_os_user: str,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        if not service_os_user.strip():
+            raise ModelDiscoveryInventoryError("Kai service OS user is required")
+        self._config = config
+        self._runtime_profiles = runtime_profiles
+        self._execution_state = execution_state
+        self._backend_registry = dict(backend_registry)
+        self._selected_backend = selected_backend
+        self._service_os_user = service_os_user.strip()
+        self._environment = os.environ if environment is None else environment
+
+    @property
+    def inventories(self) -> tuple[ModelDiscoveryProfileInventory, ...]:
+        """Return a fresh snapshot so canonical selection changes are visible."""
+        return tuple(self._inventory(profile) for profile in self._runtime_profiles.profiles)
+
+    def for_principal(
+        self,
+        principal_id: str | PrincipalId,
+    ) -> tuple[ModelDiscoveryProfileInventory, ...]:
+        """Return only the caller principal's discovery inventory."""
+        try:
+            canonical_id = principal_id if isinstance(principal_id, PrincipalId) else PrincipalId(principal_id)
+        except (TypeError, ValueError):
+            return ()
+        return tuple(item for item in self.inventories if item.principal_id == canonical_id)
+
+    @property
+    def operator_diagnostics(self) -> ModelDiscoveryOperatorDiagnostics:
+        """Return aggregate, credential-free readiness counts."""
+        inventories = self.inventories
+        options = tuple(option for inventory in inventories for option in inventory.backends)
+        counts = {status: 0 for status in ModelDiscoverySelectionStatus}
+        for option in options:
+            counts[option.status] += 1
+        return ModelDiscoveryOperatorDiagnostics(
+            profiles=len(inventories),
+            options=len(options),
+            selected=counts[ModelDiscoverySelectionStatus.SELECTED],
+            selectable=counts[ModelDiscoverySelectionStatus.SELECTABLE],
+            unavailable=counts[ModelDiscoverySelectionStatus.UNAVAILABLE],
+            misconfigured=counts[ModelDiscoverySelectionStatus.MISCONFIGURED],
+        )
+
+    def _inventory(self, profile: ProtectedRuntimeProfile) -> ModelDiscoveryProfileInventory:
+        namespace = self._execution_state.resolve_profile(profile.profile_id)
+        backend, provider = self._selected_backend(profile.profile_id)
+        selected_option_id = f"{backend}:{provider}"
+        if selected_option_id not in {option.option_id for option in profile.backend_options}:
+            raise ModelDiscoveryInventoryError(
+                f"Runtime profile {profile.profile_id} selected an option outside protected policy"
+            )
+        effective_os_user = profile.os_user or self._service_os_user
+        backends = tuple(
+            self._backend_inventory(
+                profile,
+                namespace,
+                option,
+                effective_os_user=effective_os_user,
+                selected=option.option_id == selected_option_id,
+            )
+            for option in sorted(profile.backend_options, key=lambda item: item.option_id)
+        )
+        return ModelDiscoveryProfileInventory(
+            principal_id=namespace.principal_id,
+            channel_id=str(namespace.channel_id),
+            agent_id=str(namespace.agent_id),
+            runtime_profile_id=profile.profile_id,
+            runtime_assignment_id=RuntimeAssignmentId.derived(
+                namespace.channel_id,
+                f"runtime-profile:{namespace.agent_id}",
+            ),
+            display_name=profile.display_name,
+            selected_option_id=selected_option_id,
+            backends=backends,
+        )
+
+    def _backend_inventory(
+        self,
+        profile: ProtectedRuntimeProfile,
+        namespace: WorkshopExecutionStateNamespace,
+        option: ProtectedRuntimeBackend,
+        *,
+        effective_os_user: str,
+        selected: bool,
+    ) -> ModelDiscoveryBackendInventory:
+        executable = _executable_identity(option.backend, self._backend_registry.get(option.backend))
+        auth = _auth_context(
+            option.backend,
+            option.provider,
+            effective_os_user,
+            codex_auth_mode=self._config.codex_auth_mode,
+            environment=self._environment,
+        )
+        readiness, diagnostic = _combined_readiness(executable, auth)
+        if selected:
+            status = ModelDiscoverySelectionStatus.SELECTED
+        elif readiness == ModelDiscoveryReadiness.MISCONFIGURED:
+            status = ModelDiscoverySelectionStatus.MISCONFIGURED
+        elif readiness == ModelDiscoveryReadiness.UNAVAILABLE:
+            status = ModelDiscoverySelectionStatus.UNAVAILABLE
+        else:
+            status = ModelDiscoverySelectionStatus.SELECTABLE
+        cache_inputs = ModelDiscoveryCacheInputs(
+            version=1,
+            principal_id=namespace.principal_id,
+            runtime_profile_id=profile.profile_id,
+            backend=option.backend,
+            provider=option.provider,
+            os_user=effective_os_user,
+            executable_fingerprint=executable.fingerprint,
+            auth_fingerprint=auth.fingerprint,
+            default_model=option.model,
+            allowed_models=option.allowed_models,
+            role_models=option.role_models,
+        )
+        return ModelDiscoveryBackendInventory(
+            option_id=option.option_id,
+            backend=option.backend,
+            provider=option.provider,
+            selected=selected,
+            status=status,
+            readiness=readiness,
+            effective_os_user=effective_os_user,
+            executable=executable,
+            auth=auth,
+            default_model=option.model,
+            allowed_models=option.allowed_models,
+            role_models=option.role_models,
+            cache_inputs=cache_inputs,
+            cache_key=_fingerprint(
+                _CACHE_KEY_DOMAIN,
+                {
+                    "version": cache_inputs.version,
+                    "principal_id": str(cache_inputs.principal_id),
+                    "runtime_profile_id": str(cache_inputs.runtime_profile_id),
+                    "backend": cache_inputs.backend,
+                    "provider": cache_inputs.provider,
+                    "os_user": cache_inputs.os_user,
+                    "executable": cache_inputs.executable_fingerprint,
+                    "auth": cache_inputs.auth_fingerprint,
+                    "default_model": cache_inputs.default_model,
+                    "allowed_models": cache_inputs.allowed_models,
+                    "role_models": cache_inputs.role_models,
+                },
+            ),
+            diagnostic=diagnostic,
+        )
+
+
+def _auth_context(
+    backend: str,
+    provider: str,
+    os_user: str,
+    *,
+    codex_auth_mode: str,
+    environment: Mapping[str, str],
+) -> ModelDiscoveryAuthContext:
+    key_var = PROVIDER_KEY_VARS.get(provider)
+    key_configured = bool(key_var and environment.get(key_var, "").strip())
+    if provider == "ollama":
+        mode = ModelDiscoveryAuthMode.LOCAL
+        source = "local provider"
+        configured: bool | None = True
+    elif backend == "codex":
+        mode = ModelDiscoveryAuthMode.API_KEY if codex_auth_mode == "api_key" else ModelDiscoveryAuthMode.SUBSCRIPTION
+        source = key_var or "backend login"
+        configured = key_configured if mode == ModelDiscoveryAuthMode.API_KEY else None
+    elif backend == "claude":
+        mode = ModelDiscoveryAuthMode.API_KEY if key_configured else ModelDiscoveryAuthMode.SUBSCRIPTION
+        source = key_var if key_configured and key_var is not None else "backend login"
+        configured = True if key_configured else None
+    elif backend == "pi" and provider in {"openai-codex", "github-copilot"}:
+        mode = ModelDiscoveryAuthMode.SUBSCRIPTION
+        source = "backend login"
+        configured = None
+    elif key_configured:
+        mode = ModelDiscoveryAuthMode.API_KEY
+        source = key_var or "environment credential"
+        configured = True
+    else:
+        mode = ModelDiscoveryAuthMode.BACKEND_MANAGED
+        source = "backend configuration"
+        configured = None
+    fingerprint = _fingerprint(
+        _IDENTITY_DOMAIN,
+        {
+            "kind": "auth",
+            "backend": backend,
+            "provider": provider,
+            "os_user": os_user,
+            "mode": mode.value,
+            "source": source,
+            "configured": configured,
+        },
+    )
+    return ModelDiscoveryAuthContext(mode, source, configured, fingerprint)
+
+
+def _executable_identity(
+    backend: str,
+    entry: BackendRegistryEntry | None,
+) -> ModelDiscoveryExecutableIdentity:
+    if entry is None:
+        return ModelDiscoveryExecutableIdentity(
+            configured_path=None,
+            resolved_path=None,
+            fingerprint=_fingerprint(
+                _IDENTITY_DOMAIN,
+                {"kind": "executable", "backend": backend, "state": "missing_registry_entry"},
+            ),
+            readiness=ModelDiscoveryReadiness.MISCONFIGURED,
+            diagnostic="Backend has no installed registry entry",
+        )
+    configured = Path(entry.command)
+    if (
+        entry.id != backend
+        or entry.driver != backend
+        or entry.runtime != "local_process"
+        or not configured.is_absolute()
+    ):
+        return ModelDiscoveryExecutableIdentity(
+            configured_path=entry.command,
+            resolved_path=None,
+            fingerprint=_fingerprint(
+                _IDENTITY_DOMAIN,
+                {"kind": "executable", "backend": backend, "state": "invalid_registry_entry"},
+            ),
+            readiness=ModelDiscoveryReadiness.MISCONFIGURED,
+            diagnostic="Backend registry entry is invalid",
+        )
+    try:
+        resolved = configured.resolve(strict=True)
+        metadata = resolved.stat()
+    except OSError:
+        return ModelDiscoveryExecutableIdentity(
+            configured_path=str(configured),
+            resolved_path=None,
+            fingerprint=_fingerprint(
+                _IDENTITY_DOMAIN,
+                {"kind": "executable", "backend": backend, "path": str(configured), "state": "unavailable"},
+            ),
+            readiness=ModelDiscoveryReadiness.UNAVAILABLE,
+            diagnostic="Backend executable is unavailable",
+        )
+    if not resolved.is_file() or not os.access(resolved, os.X_OK):
+        readiness = ModelDiscoveryReadiness.UNAVAILABLE
+        diagnostic = "Backend command is not an executable file"
+    elif metadata.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        readiness = ModelDiscoveryReadiness.MISCONFIGURED
+        diagnostic = "Backend executable has unsafe write permissions"
+    else:
+        readiness = ModelDiscoveryReadiness.READY
+        diagnostic = None
+    fingerprint = _fingerprint(
+        _IDENTITY_DOMAIN,
+        {
+            "kind": "executable",
+            "backend": backend,
+            "configured": str(configured),
+            "resolved": str(resolved),
+            "device": metadata.st_dev,
+            "inode": metadata.st_ino,
+            "size": metadata.st_size,
+            "mtime_ns": metadata.st_mtime_ns,
+            "mode": stat.S_IMODE(metadata.st_mode),
+        },
+    )
+    return ModelDiscoveryExecutableIdentity(
+        configured_path=str(configured),
+        resolved_path=str(resolved),
+        fingerprint=fingerprint,
+        readiness=readiness,
+        diagnostic=diagnostic,
+    )
+
+
+def _combined_readiness(
+    executable: ModelDiscoveryExecutableIdentity,
+    auth: ModelDiscoveryAuthContext,
+) -> tuple[ModelDiscoveryReadiness, str | None]:
+    if executable.readiness != ModelDiscoveryReadiness.READY:
+        return executable.readiness, executable.diagnostic
+    if auth.mode == ModelDiscoveryAuthMode.API_KEY and auth.configured is not True:
+        return ModelDiscoveryReadiness.UNAVAILABLE, "Required environment credential is not configured"
+    if auth.configured is None:
+        return ModelDiscoveryReadiness.UNVERIFIED, "Backend-managed authentication is not probed at startup"
+    return ModelDiscoveryReadiness.READY, None
+
+
+def _fingerprint(domain: bytes, value: object) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(domain + payload).hexdigest()

--- a/tests/test_workshop_model_discovery_inventory.py
+++ b/tests/test_workshop_model_discovery_inventory.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kai.backend_registry import BackendRegistryEntry
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeAssignmentId, RuntimeProfileId
+from kai.workshop.execution_state import (
+    WorkshopExecutionStateNamespace,
+    WorkshopExecutionStateRegistry,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryAuthMode,
+    ModelDiscoveryInventoryError,
+    ModelDiscoveryReadiness,
+    ModelDiscoverySelectionStatus,
+    WorkshopModelDiscoveryInventoryService,
+)
+from kai.workshop.runtime_profiles import (
+    ProtectedRuntimeBackend,
+    ProtectedRuntimeProfile,
+    WorkshopRuntimeProfileRegistry,
+)
+
+
+def _id(identifier_type, value: int):
+    return identifier_type(f"{identifier_type.prefix}_{value:032x}")
+
+
+def _executable(path: Path) -> Path:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o700)
+    return path
+
+
+def _options() -> tuple[ProtectedRuntimeBackend, ...]:
+    return (
+        ProtectedRuntimeBackend("claude", "anthropic", "claude-default"),
+        ProtectedRuntimeBackend("codex", "openai", "codex-default", ("codex-default",)),
+        ProtectedRuntimeBackend("opencode", "openrouter", "opencode-default"),
+        ProtectedRuntimeBackend("goose", "ollama", "goose-default"),
+        ProtectedRuntimeBackend(
+            "pi",
+            "openai-codex",
+            "pi-default",
+            role_models=(("fast", "pi-fast"),),
+        ),
+    )
+
+
+def _profile(value: int, *, os_user: str | None = "daniel") -> ProtectedRuntimeProfile:
+    return ProtectedRuntimeProfile(
+        profile_id=_id(RuntimeProfileId, value),
+        display_name=f"Profile {value}",
+        os_user=os_user,
+        backend="claude",
+        provider="anthropic",
+        model="claude-default",
+        timeout_seconds=300,
+        allowed_services=(),
+        home_workspace=None,
+        workspace_base=None,
+        allowed_workspaces=(),
+        backend_options=_options(),
+    )
+
+
+def _namespace(value: int, principal: int | None = None) -> WorkshopExecutionStateNamespace:
+    return WorkshopExecutionStateNamespace(
+        principal_id=_id(PrincipalId, principal or value),
+        channel_id=_id(ChannelId, value),
+        agent_id=_id(AgentId, value),
+        runtime_profile_id=_id(RuntimeProfileId, value),
+        legacy_runtime_key=None,
+    )
+
+
+def _registry(tmp_path: Path) -> dict[str, BackendRegistryEntry]:
+    return {
+        backend: BackendRegistryEntry(
+            id=backend,
+            driver=backend,
+            runtime="local_process",
+            command=str(_executable(tmp_path / backend)),
+        )
+        for backend in ("claude", "codex", "opencode", "goose", "pi")
+    }
+
+
+def _service(
+    tmp_path: Path,
+    *,
+    profiles: tuple[ProtectedRuntimeProfile, ...] | None = None,
+    namespaces: tuple[WorkshopExecutionStateNamespace, ...] | None = None,
+    selected: dict[RuntimeProfileId, tuple[str, str]] | None = None,
+    environment: dict[str, str] | None = None,
+    backend_registry: dict[str, BackendRegistryEntry] | None = None,
+    codex_auth_mode: str = "subscription",
+) -> WorkshopModelDiscoveryInventoryService:
+    checked_profiles = profiles or (_profile(1),)
+    checked_namespaces = namespaces or (_namespace(1),)
+    selected_options = selected or {
+        profile.profile_id: (profile.backend, profile.provider) for profile in checked_profiles
+    }
+    return WorkshopModelDiscoveryInventoryService(
+        config=SimpleNamespace(codex_auth_mode=codex_auth_mode),  # type: ignore[arg-type]
+        runtime_profiles=WorkshopRuntimeProfileRegistry(checked_profiles),
+        execution_state=WorkshopExecutionStateRegistry(checked_namespaces),
+        backend_registry=backend_registry if backend_registry is not None else _registry(tmp_path),
+        selected_backend=lambda profile_id: selected_options[profile_id],
+        service_os_user="kai",
+        environment=environment or {},
+    )
+
+
+def test_inventory_resolves_all_five_backends_from_canonical_authorities(tmp_path: Path) -> None:
+    service = _service(
+        tmp_path,
+        environment={"OPENROUTER_API_KEY": "opencode-secret"},
+    )
+
+    inventory = service.inventories[0]
+
+    assert inventory.principal_id == _id(PrincipalId, 1)
+    assert inventory.runtime_profile_id == _id(RuntimeProfileId, 1)
+    assert inventory.runtime_assignment_id == RuntimeAssignmentId.derived(
+        _id(ChannelId, 1),
+        f"runtime-profile:{_id(AgentId, 1)}",
+    )
+    assert inventory.selected_option_id == "claude:anthropic"
+    assert [option.option_id for option in inventory.backends] == [
+        "claude:anthropic",
+        "codex:openai",
+        "goose:ollama",
+        "opencode:openrouter",
+        "pi:openai-codex",
+    ]
+    by_backend = {option.backend: option for option in inventory.backends}
+    assert by_backend["claude"].status == ModelDiscoverySelectionStatus.SELECTED
+    assert by_backend["claude"].auth.mode == ModelDiscoveryAuthMode.SUBSCRIPTION
+    assert by_backend["codex"].auth.mode == ModelDiscoveryAuthMode.SUBSCRIPTION
+    assert by_backend["opencode"].auth.mode == ModelDiscoveryAuthMode.API_KEY
+    assert by_backend["opencode"].readiness == ModelDiscoveryReadiness.READY
+    assert by_backend["goose"].auth.mode == ModelDiscoveryAuthMode.LOCAL
+    assert by_backend["pi"].auth.mode == ModelDiscoveryAuthMode.SUBSCRIPTION
+    assert by_backend["pi"].role_models == (("fast", "pi-fast"),)
+    assert by_backend["pi"].cache_inputs.principal_id == _id(PrincipalId, 1)
+    assert by_backend["pi"].cache_inputs.backend == "pi"
+    assert by_backend["pi"].cache_inputs.provider == "openai-codex"
+    assert service.operator_diagnostics.profiles == 1
+    assert service.operator_diagnostics.options == 5
+    assert service.operator_diagnostics.selected == 1
+    assert "opencode-secret" not in repr(inventory)
+
+
+def test_inventory_isolates_principals_and_supports_multiple_profiles(tmp_path: Path) -> None:
+    profiles = (_profile(1), _profile(2), _profile(3))
+    namespaces = (_namespace(1, 10), _namespace(2, 10), _namespace(3, 20))
+    service = _service(tmp_path, profiles=profiles, namespaces=namespaces)
+
+    first = service.for_principal(_id(PrincipalId, 10))
+
+    assert [item.runtime_profile_id for item in first] == [
+        _id(RuntimeProfileId, 1),
+        _id(RuntimeProfileId, 2),
+    ]
+    assert service.for_principal(_id(PrincipalId, 20))[0].runtime_profile_id == _id(RuntimeProfileId, 3)
+    assert service.for_principal("not-a-principal") == ()
+
+
+def test_cache_key_tracks_lane_inputs_but_not_current_selection(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+    profile = _profile(1)
+    default = _service(tmp_path, backend_registry=registry)
+    switched = _service(
+        tmp_path,
+        backend_registry=registry,
+        selected={profile.profile_id: ("opencode", "openrouter")},
+    )
+
+    default_keys = {option.option_id: option.cache_key for option in default.inventories[0].backends}
+    switched_keys = {option.option_id: option.cache_key for option in switched.inventories[0].backends}
+
+    assert default_keys == switched_keys
+    assert switched.inventories[0].selected_option_id == "opencode:openrouter"
+
+    opencode_path = Path(registry["opencode"].command)
+    opencode_path.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    modified_keys = {
+        option.option_id: option.cache_key
+        for option in _service(tmp_path, backend_registry=registry).inventories[0].backends
+    }
+    assert modified_keys["opencode:openrouter"] != default_keys["opencode:openrouter"]
+    for option_id in default_keys.keys() - {"opencode:openrouter"}:
+        assert modified_keys[option_id] == default_keys[option_id]
+
+
+def test_cache_key_tracks_auth_mode_without_containing_secret(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+    subscription = _service(tmp_path, backend_registry=registry)
+    api_key = _service(
+        tmp_path,
+        backend_registry=registry,
+        codex_auth_mode="api_key",
+        environment={"OPENAI_API_KEY": "do-not-leak"},
+    )
+    subscription_codex = next(option for option in subscription.inventories[0].backends if option.backend == "codex")
+    api_key_codex = next(option for option in api_key.inventories[0].backends if option.backend == "codex")
+
+    assert subscription_codex.cache_key != api_key_codex.cache_key
+    assert api_key_codex.auth.configured is True
+    assert "do-not-leak" not in repr(api_key_codex)
+    assert "do-not-leak" not in api_key_codex.cache_key
+
+
+def test_inventory_classifies_missing_and_unsafe_executables(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+    del registry["pi"]
+    unsafe = Path(registry["goose"].command)
+    unsafe.chmod(0o722)
+    unavailable = Path(registry["opencode"].command)
+    unavailable.unlink()
+
+    inventory = _service(tmp_path, backend_registry=registry).inventories[0]
+    by_backend = {option.backend: option for option in inventory.backends}
+
+    assert by_backend["pi"].status == ModelDiscoverySelectionStatus.MISCONFIGURED
+    assert by_backend["pi"].diagnostic == "Backend has no installed registry entry"
+    assert by_backend["goose"].status == ModelDiscoverySelectionStatus.MISCONFIGURED
+    assert by_backend["opencode"].status == ModelDiscoverySelectionStatus.UNAVAILABLE
+
+
+def test_selected_but_unavailable_is_identified_as_selected(tmp_path: Path) -> None:
+    registry = _registry(tmp_path)
+    Path(registry["claude"].command).unlink()
+
+    selected = _service(tmp_path, backend_registry=registry).inventories[0].backends[0]
+
+    assert selected.backend == "claude"
+    assert selected.selected is True
+    assert selected.status == ModelDiscoverySelectionStatus.SELECTED
+    assert selected.readiness == ModelDiscoveryReadiness.UNAVAILABLE
+
+
+def test_api_key_auth_without_key_is_unavailable(tmp_path: Path) -> None:
+    service = _service(tmp_path, codex_auth_mode="api_key")
+    codex = next(option for option in service.inventories[0].backends if option.backend == "codex")
+
+    assert codex.auth.mode == ModelDiscoveryAuthMode.API_KEY
+    assert codex.auth.configured is False
+    assert codex.readiness == ModelDiscoveryReadiness.UNAVAILABLE
+    assert codex.status == ModelDiscoverySelectionStatus.UNAVAILABLE
+    assert codex.diagnostic == "Required environment credential is not configured"
+
+
+def test_inventory_rejects_selection_outside_protected_policy(tmp_path: Path) -> None:
+    profile = _profile(1)
+    service = _service(
+        tmp_path,
+        selected={profile.profile_id: ("goose", "openrouter")},
+    )
+
+    with pytest.raises(ModelDiscoveryInventoryError, match="outside protected policy"):
+        _ = service.inventories


### PR DESCRIPTION
## Summary

- add a transport-neutral core inventory that maps canonical principals, runtime assignments, and protected backend grants into model-discovery lanes
- classify selected, selectable, unavailable, and misconfigured lanes across Claude, Codex, OpenCode, Goose, and Pi without invoking their executables
- derive non-secret executable and authentication identities plus deterministic per-lane cache keys and explicit invalidation inputs
- expose principal-scoped inventory and sanitized aggregate operator diagnostics through Kai core services
- retain protected backend-registry authority while supporting the existing executable-resolution path for direct development runs

## Safety

- no Telegram identity or `users.yaml` authority is used
- no backend CLI, provider API, or external model is invoked
- credentials are reduced to configured/unconfigured state and opaque fingerprints; secret values are never stored in inventory or cache inputs
- current model selections and active sessions are read only and are never changed

## Verification

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q tests/test_workshop_model_discovery_inventory.py tests/test_application_host.py` (16 passed)
- `.venv/bin/python -m pytest -q` (6172 passed)

Closes #729
