### PR TITLE
feat: add durable model catalogue coordinator

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -17,7 +17,7 @@ from kai.backend_registry import (
     load_backend_registry,
     resolve_backend_command,
 )
-from kai.config import Config
+from kai.config import Config, models_for_backend_policy
 from kai.pool import SubprocessPool
 from kai.workshop.appearance_preferences import WorkshopAppearancePreferenceService
 from kai.workshop.artifacts import WorkshopArtifactService
@@ -38,6 +38,7 @@ from kai.workshop.github_settings import WorkshopGitHubSettingsService
 from kai.workshop.integration_notifications import WorkshopIntegrationNotificationService
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
+from kai.workshop.model_catalogue import WorkshopModelCatalogueService
 from kai.workshop.model_discovery_inventory import WorkshopModelDiscoveryInventoryService
 from kai.workshop.notification_preferences import WorkshopNotificationPreferenceService
 from kai.workshop.post_run_effects import WorkshopPostRunEffectService
@@ -166,6 +167,7 @@ class KaiCoreServices:
     runtime_profiles: WorkshopRuntimeProfileRegistry
     runtime_pool: WorkshopRuntimePool
     model_discovery_inventory: WorkshopModelDiscoveryInventoryService
+    model_catalogue: WorkshopModelCatalogueService
     conversation_runs: WorkshopConversationRunService
     private_text_execution: WorkshopPrivateTextExecutionService
     client_commands: WorkshopClientCommandExecutor
@@ -267,6 +269,7 @@ class KaiApplicationHost:
         notification_preferences: WorkshopNotificationPreferenceService | None = None
         client_preferences: WorkshopClientPreferenceService | None = None
         appearance_preferences: WorkshopAppearancePreferenceService | None = None
+        model_catalogue: WorkshopModelCatalogueService | None = None
         try:
             delivery_policy = self._delivery_policy
             subprocess_pool = SubprocessPool(
@@ -300,6 +303,16 @@ class KaiApplicationHost:
             # with the active authority epoch. Resume or create that durable,
             # transport-neutral authority before either recovery owner starts.
             client_store = await WorkshopEventStore.open(Path(self._config.session_db_path))
+            model_catalogue = await WorkshopModelCatalogueService.open(
+                Path(self._config.session_db_path),
+                model_discovery_inventory,
+                selected_model=lambda profile_id: runtime_pool.get_effective_model(profile_id),
+                curated_models=lambda lane: models_for_backend_policy(
+                    lane.backend,
+                    lane.provider,
+                    allowed_models=lane.allowed_models,
+                ),
+            )
             delivery_authority_epoch = (await WorkshopConversationDeliveryAuthority(client_store).activate()).epoch
             private_execution = await WorkshopPrivateTextExecutionService.open_and_start(
                 Path(self._config.session_db_path),
@@ -393,6 +406,7 @@ class KaiApplicationHost:
                 runtime_profiles=self._runtime_profiles,
                 runtime_pool=runtime_pool,
                 model_discovery_inventory=model_discovery_inventory,
+                model_catalogue=model_catalogue,
                 conversation_runs=conversation_runs,
                 private_text_execution=private_execution,
                 client_commands=client_commands,
@@ -434,6 +448,8 @@ class KaiApplicationHost:
                 await client_preferences.close()
             if appearance_preferences is not None:
                 await appearance_preferences.close()
+            if model_catalogue is not None:
+                await model_catalogue.close()
             if client_commands is not None:
                 await client_commands.stop()
             if post_run_effects is not None:
@@ -500,6 +516,7 @@ class KaiApplicationHost:
             services.notification_preferences.close,
             services.client_preferences.close,
             services.appearance_preferences.close,
+            services.model_catalogue.close,
             services.client_commands.stop,
             services.post_run_effects.stop,
             services.client_store.close,

--- a/src/kai/workshop/model_catalogue.py
+++ b/src/kai/workshop/model_catalogue.py
@@ -1,0 +1,997 @@
+"""Durable, canonical model catalogue and refresh coordination."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Protocol
+
+import aiosqlite
+
+from kai.workshop.domain import PrincipalId, RuntimeProfileId
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryBackendInventory,
+    WorkshopModelDiscoveryInventoryService,
+)
+from kai.workshop.store import WorkshopEventStore
+
+_SOURCE_PATTERN = re.compile(r"^[a-z][a-z0-9_.-]{0,127}$")
+_DEFAULT_TTL_SECONDS = 86_400
+_MAX_TTL_SECONDS = 604_800
+
+
+class ModelCatalogueError(RuntimeError):
+    """Base failure for canonical model-catalogue operations."""
+
+
+class ModelCatalogueAccessDenied(ModelCatalogueError):
+    """The caller does not own the requested catalogue lane."""
+
+
+class ModelCatalogueValidationError(ModelCatalogueError):
+    """Discovery or operator catalogue content is malformed."""
+
+
+class ModelDiscoveryUnsupported(ModelCatalogueError):
+    """A backend/auth context does not support model enumeration."""
+
+
+class ModelCatalogueEntryStatus(StrEnum):
+    AVAILABLE = "available"
+    NOT_ADVERTISED = "not_advertised"
+    UNAVAILABLE = "unavailable"
+    UNKNOWN = "unknown"
+
+
+class ModelCatalogueRefreshStatus(StrEnum):
+    REFRESHING = "refreshing"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    UNSUPPORTED = "unsupported"
+    MALFORMED = "malformed"
+    TIMED_OUT = "timed_out"
+    INVALIDATED = "invalidated"
+    SUPERSEDED = "superseded"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryCandidate:
+    """One normalized candidate returned by a metadata-only adapter."""
+
+    model_id: str
+    display_label: str
+    capabilities: Mapping[str, object] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ModelDiscoveryBatch:
+    """One complete, authoritative observation for a discovery lane."""
+
+    source: str
+    models: tuple[ModelDiscoveryCandidate, ...]
+    ttl_seconds: int = _DEFAULT_TTL_SECONDS
+
+
+class ModelDiscoveryAdapter(Protocol):
+    """Metadata-only backend discovery contract; generation is forbidden."""
+
+    async def discover(self, lane: ModelDiscoveryBackendInventory) -> ModelDiscoveryBatch: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCatalogueAuthority:
+    principal_id: PrincipalId
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCatalogueOperatorAuthority:
+    _token: object
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCatalogueProvenance:
+    source: str
+    status: ModelCatalogueEntryStatus
+    display_label: str
+    capabilities: Mapping[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCatalogueEntry:
+    model_id: str
+    display_label: str
+    status: ModelCatalogueEntryStatus
+    selectable: bool
+    retained: bool
+    provenances: tuple[ModelCatalogueProvenance, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCatalogueRefreshState:
+    status: ModelCatalogueRefreshStatus
+    generation: int
+    last_attempt_at: datetime
+    last_successful_refresh_at: datetime | None
+    expires_at: datetime | None
+    error_code: str | None
+    error_detail: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCatalogueSnapshot:
+    principal_id: PrincipalId
+    runtime_profile_id: RuntimeProfileId
+    option_id: str
+    cache_key: str
+    entries: tuple[ModelCatalogueEntry, ...]
+    refresh: ModelCatalogueRefreshState | None
+    stale: bool
+    last_known_good: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCatalogueRefreshResult:
+    runtime_profile_id: RuntimeProfileId
+    option_id: str
+    cache_key: str
+    status: ModelCatalogueRefreshStatus
+    generation: int
+    discovered_models: int
+    preserved_last_known_good: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ModelCatalogueInvalidationResult:
+    invalidated: int
+
+
+SelectedModelResolver = Callable[[RuntimeProfileId], Awaitable[str]]
+CuratedModelResolver = Callable[[ModelDiscoveryBackendInventory], Mapping[str, str] | None]
+Clock = Callable[[], datetime]
+
+
+class WorkshopModelCatalogueService:
+    """Persist observations without owning or mutating runtime selection."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        inventory: WorkshopModelDiscoveryInventoryService,
+        *,
+        selected_model: SelectedModelResolver,
+        curated_models: CuratedModelResolver,
+        adapters: Mapping[str, ModelDiscoveryAdapter] | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        self._store = store
+        self._inventory = inventory
+        self._selected_model = selected_model
+        self._curated_models = curated_models
+        self._adapters = dict(adapters or {})
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self._locks: dict[tuple[RuntimeProfileId, str, str], asyncio.Lock] = {}
+        self._operator_token = object()
+        self._periodic_stop = asyncio.Event()
+        self._periodic_task: asyncio.Task[None] | None = None
+
+    @classmethod
+    async def open(
+        cls,
+        database_path: Path,
+        inventory: WorkshopModelDiscoveryInventoryService,
+        *,
+        selected_model: SelectedModelResolver,
+        curated_models: CuratedModelResolver,
+        adapters: Mapping[str, ModelDiscoveryAdapter] | None = None,
+        clock: Clock | None = None,
+    ) -> WorkshopModelCatalogueService:
+        service = cls(
+            await WorkshopEventStore.open(database_path),
+            inventory,
+            selected_model=selected_model,
+            curated_models=curated_models,
+            adapters=adapters,
+            clock=clock,
+        )
+        await service.synchronize_inventory()
+        return service
+
+    async def close(self) -> None:
+        await self.stop_periodic_refresh()
+        await self._store.close()
+
+    def authority_for_principal(self, principal_id: str | PrincipalId) -> ModelCatalogueAuthority:
+        try:
+            canonical = principal_id if isinstance(principal_id, PrincipalId) else PrincipalId(principal_id)
+        except (TypeError, ValueError) as exc:
+            raise ModelCatalogueAccessDenied("Model catalogue access denied") from exc
+        return ModelCatalogueAuthority(canonical)
+
+    def operator_authority(self) -> ModelCatalogueOperatorAuthority:
+        """Return the capability used only by trusted operator surfaces."""
+        return ModelCatalogueOperatorAuthority(self._operator_token)
+
+    def register_adapter(self, backend: str, adapter: ModelDiscoveryAdapter) -> None:
+        normalized = backend.strip().lower()
+        if not normalized:
+            raise ValueError("backend must be non-empty")
+        self._adapters[normalized] = adapter
+
+    async def inspect(
+        self,
+        authority: ModelCatalogueAuthority,
+        runtime_profile_id: str | RuntimeProfileId,
+        option_id: str,
+    ) -> ModelCatalogueSnapshot:
+        lane = self._principal_lane(authority, runtime_profile_id, option_id)
+        return await self._snapshot(lane)
+
+    async def refresh(
+        self,
+        authority: ModelCatalogueAuthority,
+        runtime_profile_id: str | RuntimeProfileId,
+        option_id: str,
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> ModelCatalogueRefreshResult:
+        lane = self._principal_lane(authority, runtime_profile_id, option_id)
+        return await self._refresh_lane(lane, timeout_seconds=timeout_seconds)
+
+    async def refresh_as_operator(
+        self,
+        authority: ModelCatalogueOperatorAuthority,
+        runtime_profile_id: str | RuntimeProfileId,
+        option_id: str,
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> ModelCatalogueRefreshResult:
+        self._require_operator(authority)
+        lane = self._operator_lane(runtime_profile_id, option_id)
+        return await self._refresh_lane(lane, timeout_seconds=timeout_seconds)
+
+    async def refresh_all(
+        self,
+        authority: ModelCatalogueOperatorAuthority,
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> tuple[ModelCatalogueRefreshResult, ...]:
+        self._require_operator(authority)
+        results: list[ModelCatalogueRefreshResult] = []
+        for profile in self._inventory.inventories:
+            for lane in profile.backends:
+                results.append(await self._refresh_lane(lane, timeout_seconds=timeout_seconds))
+        return tuple(results)
+
+    async def start_periodic_refresh(
+        self,
+        authority: ModelCatalogueOperatorAuthority,
+        *,
+        interval_seconds: float,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self._require_operator(authority)
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+        if self._periodic_task is not None:
+            raise RuntimeError("Periodic model refresh is already active")
+        self._periodic_stop.clear()
+        self._periodic_task = asyncio.create_task(
+            self._periodic_refresh_loop(
+                authority,
+                interval_seconds=interval_seconds,
+                timeout_seconds=timeout_seconds,
+            ),
+            name="kai-workshop-model-catalogue-refresh",
+        )
+
+    async def stop_periodic_refresh(self) -> None:
+        task = self._periodic_task
+        if task is None:
+            return
+        self._periodic_stop.set()
+        await task
+        self._periodic_task = None
+
+    async def synchronize_inventory(self) -> ModelCatalogueInvalidationResult:
+        """Invalidate cache contexts whose protected lane inputs changed."""
+        current = {
+            (str(profile.runtime_profile_id), lane.backend, lane.provider): lane.cache_key
+            for profile in self._inventory.inventories
+            for lane in profile.backends
+        }
+        now = _format_timestamp(self._now())
+        try:
+            await self._store.connection.execute("BEGIN IMMEDIATE")
+            async with self._store.connection.execute(
+                "SELECT cache_key, runtime_profile_id, backend, provider "
+                "FROM workshop_model_catalogue_refreshes WHERE active = 1"
+            ) as cursor:
+                rows = tuple(await cursor.fetchall())
+            invalidated = 0
+            for row in rows:
+                lane_key = (str(row[1]), str(row[2]), str(row[3]))
+                if current.get(lane_key) == str(row[0]):
+                    continue
+                cursor = await self._store.connection.execute(
+                    "UPDATE workshop_model_catalogue_refreshes SET "
+                    "active = 0, status = 'invalidated', updated_at = ? "
+                    "WHERE cache_key = ? AND active = 1",
+                    (now, str(row[0])),
+                )
+                invalidated += cursor.rowcount
+            await self._store.connection.commit()
+            return ModelCatalogueInvalidationResult(invalidated)
+        except Exception:
+            await self._store.connection.rollback()
+            raise
+
+    async def invalidate(
+        self,
+        authority: ModelCatalogueOperatorAuthority,
+        runtime_profile_id: str | RuntimeProfileId,
+        option_id: str,
+    ) -> ModelCatalogueInvalidationResult:
+        self._require_operator(authority)
+        lane = self._operator_lane(runtime_profile_id, option_id)
+        now = _format_timestamp(self._now())
+        cursor = await self._store.connection.execute(
+            "UPDATE workshop_model_catalogue_refreshes SET "
+            "active = 0, status = 'invalidated', updated_at = ? "
+            "WHERE cache_key = ? AND active = 1",
+            (now, lane.cache_key),
+        )
+        await self._store.connection.commit()
+        return ModelCatalogueInvalidationResult(cursor.rowcount)
+
+    async def upsert_operator_entry(
+        self,
+        authority: ModelCatalogueOperatorAuthority,
+        runtime_profile_id: str | RuntimeProfileId,
+        option_id: str,
+        *,
+        model_id: str,
+        display_label: str,
+        capabilities: Mapping[str, object] | None = None,
+    ) -> None:
+        self._require_operator(authority)
+        lane = self._operator_lane(runtime_profile_id, option_id)
+        model, label, encoded_capabilities = _normalize_model(
+            ModelDiscoveryCandidate(model_id, display_label, capabilities)
+        )
+        if not _policy_allows_model(model, lane.allowed_models):
+            raise ModelCatalogueValidationError("Operator model is outside protected runtime policy")
+        now = _format_timestamp(self._now())
+        await self._store.connection.execute(
+            "INSERT INTO workshop_model_catalogue_operator_entries ("
+            "runtime_profile_id, backend, provider, model_id, display_label, "
+            "capabilities_json, active, created_at, updated_at"
+            ") VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?) "
+            "ON CONFLICT(runtime_profile_id, backend, provider, model_id) DO UPDATE SET "
+            "display_label = excluded.display_label, "
+            "capabilities_json = excluded.capabilities_json, active = 1, "
+            "updated_at = excluded.updated_at",
+            (
+                lane.cache_inputs.runtime_profile_id,
+                lane.backend,
+                lane.provider,
+                model,
+                label,
+                encoded_capabilities,
+                now,
+                now,
+            ),
+        )
+        await self._store.connection.commit()
+
+    async def deactivate_operator_entry(
+        self,
+        authority: ModelCatalogueOperatorAuthority,
+        runtime_profile_id: str | RuntimeProfileId,
+        option_id: str,
+        *,
+        model_id: str,
+    ) -> bool:
+        self._require_operator(authority)
+        lane = self._operator_lane(runtime_profile_id, option_id)
+        model = _clean_text(model_id, "model_id", maximum=512)
+        cursor = await self._store.connection.execute(
+            "UPDATE workshop_model_catalogue_operator_entries SET active = 0, updated_at = ? "
+            "WHERE runtime_profile_id = ? AND backend = ? AND provider = ? "
+            "AND model_id = ? AND active = 1",
+            (
+                _format_timestamp(self._now()),
+                lane.cache_inputs.runtime_profile_id,
+                lane.backend,
+                lane.provider,
+                model,
+            ),
+        )
+        await self._store.connection.commit()
+        return cursor.rowcount == 1
+
+    async def _refresh_lane(
+        self,
+        initial_lane: ModelDiscoveryBackendInventory,
+        *,
+        timeout_seconds: float,
+    ) -> ModelCatalogueRefreshResult:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        lock = self._locks.setdefault(
+            (
+                initial_lane.cache_inputs.runtime_profile_id,
+                initial_lane.backend,
+                initial_lane.provider,
+            ),
+            asyncio.Lock(),
+        )
+        async with lock:
+            lane = self._operator_lane(
+                initial_lane.cache_inputs.runtime_profile_id,
+                initial_lane.option_id,
+            )
+            generation = await self._begin_refresh(lane)
+            adapter = self._adapters.get(lane.backend)
+            if adapter is None:
+                return await self._complete_failure(
+                    lane,
+                    generation,
+                    ModelCatalogueRefreshStatus.UNSUPPORTED,
+                    "enumeration_unsupported",
+                    "This backend has no model-discovery adapter",
+                )
+            try:
+                async with asyncio.timeout(timeout_seconds):
+                    batch = await adapter.discover(lane)
+                normalized = _normalize_batch(batch)
+            except TimeoutError:
+                return await self._complete_failure(
+                    lane,
+                    generation,
+                    ModelCatalogueRefreshStatus.TIMED_OUT,
+                    "discovery_timed_out",
+                    "Model discovery timed out",
+                )
+            except ModelDiscoveryUnsupported:
+                return await self._complete_failure(
+                    lane,
+                    generation,
+                    ModelCatalogueRefreshStatus.UNSUPPORTED,
+                    "enumeration_unsupported",
+                    "This backend context does not support model enumeration",
+                )
+            except ModelCatalogueValidationError:
+                return await self._complete_failure(
+                    lane,
+                    generation,
+                    ModelCatalogueRefreshStatus.MALFORMED,
+                    "malformed_discovery_result",
+                    "The discovery adapter returned malformed model metadata",
+                )
+            except Exception:
+                return await self._complete_failure(
+                    lane,
+                    generation,
+                    ModelCatalogueRefreshStatus.FAILED,
+                    "discovery_failed",
+                    "Model discovery failed",
+                )
+            current = self._operator_lane(
+                lane.cache_inputs.runtime_profile_id,
+                lane.option_id,
+            )
+            if current.cache_key != lane.cache_key:
+                await self._invalidate_generation(lane, generation)
+                return ModelCatalogueRefreshResult(
+                    lane.cache_inputs.runtime_profile_id,
+                    lane.option_id,
+                    lane.cache_key,
+                    ModelCatalogueRefreshStatus.SUPERSEDED,
+                    generation,
+                    0,
+                    await self._has_last_known_good(lane),
+                )
+            return await self._complete_success(lane, generation, normalized)
+
+    async def _begin_refresh(self, lane: ModelDiscoveryBackendInventory) -> int:
+        now = _format_timestamp(self._now())
+        try:
+            await self._store.connection.execute("BEGIN IMMEDIATE")
+            await self._store.connection.execute(
+                "UPDATE workshop_model_catalogue_refreshes SET "
+                "active = 0, status = 'invalidated', updated_at = ? "
+                "WHERE runtime_profile_id = ? AND backend = ? AND provider = ? "
+                "AND cache_key <> ? AND active = 1",
+                (
+                    now,
+                    lane.cache_inputs.runtime_profile_id,
+                    lane.backend,
+                    lane.provider,
+                    lane.cache_key,
+                ),
+            )
+            async with self._store.connection.execute(
+                "SELECT generation, created_at FROM workshop_model_catalogue_refreshes WHERE cache_key = ?",
+                (lane.cache_key,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            generation = int(row[0]) + 1 if row is not None else 1
+            created_at = str(row[1]) if row is not None else now
+            await self._store.connection.execute(
+                "INSERT INTO workshop_model_catalogue_refreshes ("
+                "cache_key, principal_id, runtime_profile_id, backend, provider, "
+                "auth_fingerprint, executable_fingerprint, status, generation, active, "
+                "refresh_started_at, last_attempt_at, created_at, updated_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, 'refreshing', ?, 1, ?, ?, ?, ?) "
+                "ON CONFLICT(cache_key) DO UPDATE SET "
+                "principal_id = excluded.principal_id, runtime_profile_id = excluded.runtime_profile_id, "
+                "backend = excluded.backend, provider = excluded.provider, "
+                "auth_fingerprint = excluded.auth_fingerprint, "
+                "executable_fingerprint = excluded.executable_fingerprint, "
+                "status = 'refreshing', generation = excluded.generation, active = 1, "
+                "last_error_code = NULL, last_error_detail = NULL, "
+                "refresh_started_at = excluded.refresh_started_at, "
+                "last_attempt_at = excluded.last_attempt_at, updated_at = excluded.updated_at",
+                (
+                    lane.cache_key,
+                    lane.cache_inputs.principal_id,
+                    lane.cache_inputs.runtime_profile_id,
+                    lane.backend,
+                    lane.provider,
+                    lane.auth.fingerprint,
+                    lane.executable.fingerprint,
+                    generation,
+                    now,
+                    now,
+                    created_at,
+                    now,
+                ),
+            )
+            await self._store.connection.commit()
+            return generation
+        except Exception:
+            await self._store.connection.rollback()
+            raise
+
+    async def _complete_success(
+        self,
+        lane: ModelDiscoveryBackendInventory,
+        generation: int,
+        batch: ModelDiscoveryBatch,
+    ) -> ModelCatalogueRefreshResult:
+        now_value = self._now()
+        now = _format_timestamp(now_value)
+        expires = _format_timestamp(now_value + timedelta(seconds=batch.ttl_seconds))
+        try:
+            await self._store.connection.execute("BEGIN IMMEDIATE")
+            if not await self._generation_is_current(lane.cache_key, generation):
+                await self._store.connection.rollback()
+                return ModelCatalogueRefreshResult(
+                    lane.cache_inputs.runtime_profile_id,
+                    lane.option_id,
+                    lane.cache_key,
+                    ModelCatalogueRefreshStatus.SUPERSEDED,
+                    generation,
+                    0,
+                    await self._has_last_known_good(lane),
+                )
+            await self._store.connection.execute(
+                "UPDATE workshop_model_catalogue_discovered_entries SET "
+                "status = 'not_advertised', last_successful_refresh_at = ?, expires_at = ? "
+                "WHERE cache_key = ?",
+                (now, expires, lane.cache_key),
+            )
+            for candidate in batch.models:
+                model, label, capabilities = _normalize_model(candidate)
+                await self._store.connection.execute(
+                    "INSERT INTO workshop_model_catalogue_discovered_entries ("
+                    "cache_key, model_id, display_label, discovery_source, capabilities_json, "
+                    "status, first_seen_at, last_seen_at, last_successful_refresh_at, expires_at"
+                    ") VALUES (?, ?, ?, ?, ?, 'available', ?, ?, ?, ?) "
+                    "ON CONFLICT(cache_key, model_id) DO UPDATE SET "
+                    "display_label = excluded.display_label, "
+                    "discovery_source = excluded.discovery_source, "
+                    "capabilities_json = excluded.capabilities_json, status = 'available', "
+                    "last_seen_at = excluded.last_seen_at, "
+                    "last_successful_refresh_at = excluded.last_successful_refresh_at, "
+                    "expires_at = excluded.expires_at",
+                    (
+                        lane.cache_key,
+                        model,
+                        label,
+                        batch.source,
+                        capabilities,
+                        now,
+                        now,
+                        now,
+                        expires,
+                    ),
+                )
+            cursor = await self._store.connection.execute(
+                "UPDATE workshop_model_catalogue_refreshes SET "
+                "status = 'succeeded', discovery_source = ?, last_error_code = NULL, "
+                "last_error_detail = NULL, last_successful_refresh_at = ?, expires_at = ?, "
+                "updated_at = ? WHERE cache_key = ? AND generation = ? AND active = 1",
+                (batch.source, now, expires, now, lane.cache_key, generation),
+            )
+            if cursor.rowcount != 1:
+                await self._store.connection.rollback()
+                return ModelCatalogueRefreshResult(
+                    lane.cache_inputs.runtime_profile_id,
+                    lane.option_id,
+                    lane.cache_key,
+                    ModelCatalogueRefreshStatus.SUPERSEDED,
+                    generation,
+                    0,
+                    await self._has_last_known_good(lane),
+                )
+            await self._store.connection.commit()
+        except Exception:
+            await self._store.connection.rollback()
+            raise
+        return ModelCatalogueRefreshResult(
+            lane.cache_inputs.runtime_profile_id,
+            lane.option_id,
+            lane.cache_key,
+            ModelCatalogueRefreshStatus.SUCCEEDED,
+            generation,
+            len(batch.models),
+            False,
+        )
+
+    async def _complete_failure(
+        self,
+        lane: ModelDiscoveryBackendInventory,
+        generation: int,
+        status: ModelCatalogueRefreshStatus,
+        error_code: str,
+        error_detail: str,
+    ) -> ModelCatalogueRefreshResult:
+        now = _format_timestamp(self._now())
+        cursor = await self._store.connection.execute(
+            "UPDATE workshop_model_catalogue_refreshes SET status = ?, "
+            "last_error_code = ?, last_error_detail = ?, updated_at = ? "
+            "WHERE cache_key = ? AND generation = ? AND active = 1",
+            (status.value, error_code, error_detail, now, lane.cache_key, generation),
+        )
+        await self._store.connection.commit()
+        effective_status = status if cursor.rowcount == 1 else ModelCatalogueRefreshStatus.SUPERSEDED
+        return ModelCatalogueRefreshResult(
+            lane.cache_inputs.runtime_profile_id,
+            lane.option_id,
+            lane.cache_key,
+            effective_status,
+            generation,
+            0,
+            await self._has_last_known_good(lane),
+        )
+
+    async def _snapshot(self, lane: ModelDiscoveryBackendInventory) -> ModelCatalogueSnapshot:
+        refresh = await self._refresh_state(lane.cache_key)
+        rows = await self._discovered_rows(lane.cache_key)
+        last_known_good = False
+        if not rows:
+            fallback_key = await self._last_known_good_cache_key(lane)
+            if fallback_key is not None and fallback_key != lane.cache_key:
+                rows = await self._discovered_rows(fallback_key)
+                last_known_good = bool(rows)
+        merged: dict[str, list[ModelCatalogueProvenance]] = {}
+        for row in rows:
+            provenance = ModelCatalogueProvenance(
+                source=f"discovered:{row['discovery_source']}",
+                status=ModelCatalogueEntryStatus(str(row["status"])),
+                display_label=str(row["display_label"]),
+                capabilities=_decode_capabilities(str(row["capabilities_json"])),
+            )
+            merged.setdefault(str(row["model_id"]), []).append(provenance)
+        async with self._store.connection.execute(
+            "SELECT model_id, display_label, capabilities_json, active "
+            "FROM workshop_model_catalogue_operator_entries "
+            "WHERE runtime_profile_id = ? AND backend = ? AND provider = ? "
+            "ORDER BY model_id",
+            (lane.cache_inputs.runtime_profile_id, lane.backend, lane.provider),
+        ) as cursor:
+            operator_rows = tuple(await cursor.fetchall())
+        for row in operator_rows:
+            provenance = ModelCatalogueProvenance(
+                source="operator",
+                status=(ModelCatalogueEntryStatus.AVAILABLE if bool(row[3]) else ModelCatalogueEntryStatus.UNAVAILABLE),
+                display_label=str(row[1]),
+                capabilities=_decode_capabilities(str(row[2])),
+            )
+            merged.setdefault(str(row[0]), []).append(provenance)
+        curated = self._curated_models(lane) or {}
+        for model_id, label in sorted(curated.items()):
+            model = _clean_text(model_id, "curated model id", maximum=512)
+            display = _clean_text(label, "curated display label", maximum=512)
+            merged.setdefault(model, []).append(
+                ModelCatalogueProvenance(
+                    source="curated",
+                    status=ModelCatalogueEntryStatus.AVAILABLE,
+                    display_label=display,
+                    capabilities={},
+                )
+            )
+        retained = {lane.default_model}
+        if lane.selected:
+            retained.add(await self._selected_model(lane.cache_inputs.runtime_profile_id))
+        for model_id in retained:
+            model = _clean_text(model_id, "retained model id", maximum=512)
+            if model not in merged:
+                merged[model] = [
+                    ModelCatalogueProvenance(
+                        source="retained_selection",
+                        status=ModelCatalogueEntryStatus.NOT_ADVERTISED,
+                        display_label=model,
+                        capabilities={},
+                    )
+                ]
+        entries = tuple(
+            _merge_entry(model_id, tuple(provenances), retained=model_id in retained, lane=lane)
+            for model_id, provenances in sorted(merged.items())
+        )
+        stale = last_known_good or refresh is None or refresh.status != ModelCatalogueRefreshStatus.SUCCEEDED
+        if refresh is not None and refresh.expires_at is not None and refresh.expires_at <= self._now():
+            stale = True
+        return ModelCatalogueSnapshot(
+            principal_id=lane.cache_inputs.principal_id,
+            runtime_profile_id=lane.cache_inputs.runtime_profile_id,
+            option_id=lane.option_id,
+            cache_key=lane.cache_key,
+            entries=entries,
+            refresh=refresh,
+            stale=stale,
+            last_known_good=last_known_good,
+        )
+
+    async def _refresh_state(self, cache_key: str) -> ModelCatalogueRefreshState | None:
+        async with self._store.connection.execute(
+            "SELECT status, generation, last_attempt_at, last_successful_refresh_at, "
+            "expires_at, last_error_code, last_error_detail "
+            "FROM workshop_model_catalogue_refreshes WHERE cache_key = ?",
+            (cache_key,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        return ModelCatalogueRefreshState(
+            ModelCatalogueRefreshStatus(str(row[0])),
+            int(row[1]),
+            _parse_timestamp(str(row[2])),
+            _parse_timestamp(str(row[3])) if row[3] is not None else None,
+            _parse_timestamp(str(row[4])) if row[4] is not None else None,
+            str(row[5]) if row[5] is not None else None,
+            str(row[6]) if row[6] is not None else None,
+        )
+
+    async def _discovered_rows(self, cache_key: str) -> tuple[aiosqlite.Row, ...]:
+        async with self._store.connection.execute(
+            "SELECT model_id, display_label, discovery_source, capabilities_json, status "
+            "FROM workshop_model_catalogue_discovered_entries "
+            "WHERE cache_key = ? ORDER BY model_id",
+            (cache_key,),
+        ) as cursor:
+            return tuple(await cursor.fetchall())
+
+    async def _last_known_good_cache_key(self, lane: ModelDiscoveryBackendInventory) -> str | None:
+        async with self._store.connection.execute(
+            "SELECT cache_key FROM workshop_model_catalogue_refreshes "
+            "WHERE runtime_profile_id = ? AND backend = ? AND provider = ? "
+            "AND last_successful_refresh_at IS NOT NULL "
+            "ORDER BY last_successful_refresh_at DESC, generation DESC LIMIT 1",
+            (lane.cache_inputs.runtime_profile_id, lane.backend, lane.provider),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return str(row[0]) if row is not None else None
+
+    async def _has_last_known_good(self, lane: ModelDiscoveryBackendInventory) -> bool:
+        return await self._last_known_good_cache_key(lane) is not None
+
+    async def _generation_is_current(self, cache_key: str, generation: int) -> bool:
+        async with self._store.connection.execute(
+            "SELECT 1 FROM workshop_model_catalogue_refreshes "
+            "WHERE cache_key = ? AND generation = ? AND active = 1 AND status = 'refreshing'",
+            (cache_key, generation),
+        ) as cursor:
+            return await cursor.fetchone() is not None
+
+    async def _invalidate_generation(self, lane: ModelDiscoveryBackendInventory, generation: int) -> None:
+        await self._store.connection.execute(
+            "UPDATE workshop_model_catalogue_refreshes SET "
+            "active = 0, status = 'invalidated', updated_at = ? "
+            "WHERE cache_key = ? AND generation = ? AND active = 1",
+            (_format_timestamp(self._now()), lane.cache_key, generation),
+        )
+        await self._store.connection.commit()
+
+    def _principal_lane(
+        self,
+        authority: ModelCatalogueAuthority,
+        runtime_profile_id: str | RuntimeProfileId,
+        option_id: str,
+    ) -> ModelDiscoveryBackendInventory:
+        try:
+            profile_id = (
+                runtime_profile_id
+                if isinstance(runtime_profile_id, RuntimeProfileId)
+                else RuntimeProfileId(runtime_profile_id)
+            )
+        except (TypeError, ValueError) as exc:
+            raise ModelCatalogueAccessDenied("Model catalogue access denied") from exc
+        profile = next(
+            (
+                item
+                for item in self._inventory.for_principal(authority.principal_id)
+                if item.runtime_profile_id == profile_id
+            ),
+            None,
+        )
+        if profile is None:
+            raise ModelCatalogueAccessDenied("Model catalogue access denied")
+        lane = next((item for item in profile.backends if item.option_id == option_id.strip().lower()), None)
+        if lane is None:
+            raise ModelCatalogueAccessDenied("Model catalogue access denied")
+        return lane
+
+    def _operator_lane(
+        self,
+        runtime_profile_id: str | RuntimeProfileId,
+        option_id: str,
+    ) -> ModelDiscoveryBackendInventory:
+        try:
+            profile_id = (
+                runtime_profile_id
+                if isinstance(runtime_profile_id, RuntimeProfileId)
+                else RuntimeProfileId(runtime_profile_id)
+            )
+        except (TypeError, ValueError) as exc:
+            raise ModelCatalogueAccessDenied("Model catalogue lane does not exist") from exc
+        for profile in self._inventory.inventories:
+            if profile.runtime_profile_id != profile_id:
+                continue
+            lane = next((item for item in profile.backends if item.option_id == option_id.strip().lower()), None)
+            if lane is not None:
+                return lane
+        raise ModelCatalogueAccessDenied("Model catalogue lane does not exist")
+
+    def _require_operator(self, authority: ModelCatalogueOperatorAuthority) -> None:
+        if authority._token is not self._operator_token:
+            raise ModelCatalogueAccessDenied("Model catalogue operator access denied")
+
+    async def _periodic_refresh_loop(
+        self,
+        authority: ModelCatalogueOperatorAuthority,
+        *,
+        interval_seconds: float,
+        timeout_seconds: float,
+    ) -> None:
+        while not self._periodic_stop.is_set():
+            try:
+                await asyncio.wait_for(self._periodic_stop.wait(), timeout=interval_seconds)
+            except TimeoutError:
+                await self.refresh_all(authority, timeout_seconds=timeout_seconds)
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        if value.tzinfo is None:
+            raise ModelCatalogueError("Model catalogue clock must return a timezone-aware datetime")
+        return value.astimezone(UTC)
+
+
+def _normalize_batch(batch: object) -> ModelDiscoveryBatch:
+    if not isinstance(batch, ModelDiscoveryBatch):
+        raise ModelCatalogueValidationError("Discovery result has the wrong type")
+    source = batch.source.strip().lower()
+    if not _SOURCE_PATTERN.fullmatch(source):
+        raise ModelCatalogueValidationError("Discovery source is invalid")
+    if isinstance(batch.ttl_seconds, bool) or not 1 <= batch.ttl_seconds <= _MAX_TTL_SECONDS:
+        raise ModelCatalogueValidationError("Discovery TTL is invalid")
+    seen: dict[str, tuple[str, str]] = {}
+    normalized: list[ModelDiscoveryCandidate] = []
+    for candidate in batch.models:
+        if not isinstance(candidate, ModelDiscoveryCandidate):
+            raise ModelCatalogueValidationError("Discovery candidates have the wrong type")
+        model, label, capabilities = _normalize_model(candidate)
+        prior = seen.get(model)
+        identity = (label, capabilities)
+        if prior is not None and prior != identity:
+            raise ModelCatalogueValidationError("Discovery contains conflicting duplicate models")
+        if prior is None:
+            seen[model] = identity
+            normalized.append(ModelDiscoveryCandidate(model, label, _decode_capabilities(capabilities)))
+    return ModelDiscoveryBatch(source, tuple(normalized), batch.ttl_seconds)
+
+
+def _normalize_model(candidate: ModelDiscoveryCandidate) -> tuple[str, str, str]:
+    model = _clean_text(candidate.model_id, "model_id", maximum=512)
+    label = _clean_text(candidate.display_label, "display_label", maximum=512)
+    capabilities = candidate.capabilities or {}
+    try:
+        encoded = json.dumps(capabilities, sort_keys=True, separators=(",", ":"), allow_nan=False)
+        decoded = json.loads(encoded)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ModelCatalogueValidationError("Model capabilities are not valid JSON metadata") from exc
+    if not isinstance(decoded, dict) or len(encoded) > 16_384:
+        raise ModelCatalogueValidationError("Model capabilities must be a bounded JSON object")
+    return model, label, encoded
+
+
+def _clean_text(value: object, field: str, *, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise ModelCatalogueValidationError(f"{field} must be text")
+    cleaned = value.strip()
+    if not cleaned or len(cleaned) > maximum or any(ord(character) < 32 for character in cleaned):
+        raise ModelCatalogueValidationError(f"{field} is invalid")
+    return cleaned
+
+
+def _decode_capabilities(value: str) -> Mapping[str, object]:
+    decoded = json.loads(value)
+    if not isinstance(decoded, dict):
+        raise ModelCatalogueError("Stored model capability metadata is invalid")
+    return decoded
+
+
+def _merge_entry(
+    model_id: str,
+    provenances: tuple[ModelCatalogueProvenance, ...],
+    *,
+    retained: bool,
+    lane: ModelDiscoveryBackendInventory,
+) -> ModelCatalogueEntry:
+    status_values = {item.status for item in provenances}
+    policy_allowed = _policy_allows_model(model_id, lane.allowed_models)
+    if not policy_allowed:
+        status = ModelCatalogueEntryStatus.UNAVAILABLE
+    elif ModelCatalogueEntryStatus.AVAILABLE in status_values:
+        status = ModelCatalogueEntryStatus.AVAILABLE
+    elif retained or ModelCatalogueEntryStatus.NOT_ADVERTISED in status_values:
+        status = ModelCatalogueEntryStatus.NOT_ADVERTISED
+    elif ModelCatalogueEntryStatus.UNAVAILABLE in status_values:
+        status = ModelCatalogueEntryStatus.UNAVAILABLE
+    else:
+        status = ModelCatalogueEntryStatus.UNKNOWN
+    preferred = sorted(
+        provenances,
+        key=lambda item: (
+            {"operator": 0, "discovered": 1, "curated": 2, "retained_selection": 3}.get(
+                item.source.partition(":")[0],
+                4,
+            ),
+            item.source,
+        ),
+    )[0]
+    return ModelCatalogueEntry(
+        model_id=model_id,
+        display_label=preferred.display_label,
+        status=status,
+        selectable=status == ModelCatalogueEntryStatus.AVAILABLE,
+        retained=retained,
+        provenances=tuple(sorted(provenances, key=lambda item: item.source)),
+    )
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _policy_allows_model(model_id: str, allowed_models: tuple[str, ...] | None) -> bool:
+    """Apply only the protected operator ceiling to observed catalogue IDs.
+
+    Static curated lists are deliberately not validators here: discovery must
+    be able to advertise a newly released model before Kai itself is updated.
+    """
+    if allowed_models is None:
+        return True
+    return any(fnmatchcase(model_id, pattern) for pattern in allowed_models)

--- a/src/kai/workshop/runtime_pool.py
+++ b/src/kai/workshop/runtime_pool.py
@@ -57,6 +57,11 @@ class WorkshopRuntimePool:
         profile_id = self._profiles.resolve(runtime_profile_id).profile_id
         return self._pool.get_model(profile_id)
 
+    async def get_effective_model(self, runtime_profile_id: str | RuntimeProfileId) -> str:
+        """Return canonical persisted selection without starting a backend."""
+        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
+        return await self._pool.get_effective_model(profile_id)
+
     def get_backend_provider(
         self,
         runtime_profile_id: str | RuntimeProfileId,

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 38
+WORKSHOP_SCHEMA_VERSION = 39
 
 
 @dataclass(frozen=True, slots=True)
@@ -1844,6 +1844,95 @@ _DURABLE_PRINCIPAL_APPEARANCE_PREFERENCES_SCHEMA = SchemaMigration(
     ),
 )
 
+_CANONICAL_MODEL_CATALOGUE_SCHEMA = SchemaMigration(
+    version=39,
+    name="canonical_model_catalogue",
+    statements=(
+        """
+        CREATE TABLE workshop_model_catalogue_refreshes (
+            cache_key TEXT PRIMARY KEY CHECK (length(cache_key) = 64),
+            principal_id TEXT NOT NULL CHECK (length(principal_id) BETWEEN 1 AND 128),
+            runtime_profile_id TEXT NOT NULL CHECK (
+                length(runtime_profile_id) BETWEEN 1 AND 128
+            ),
+            backend TEXT NOT NULL CHECK (length(trim(backend)) > 0),
+            provider TEXT NOT NULL CHECK (length(trim(provider)) > 0),
+            auth_fingerprint TEXT NOT NULL CHECK (length(auth_fingerprint) = 64),
+            executable_fingerprint TEXT NOT NULL CHECK (
+                length(executable_fingerprint) = 64
+            ),
+            status TEXT NOT NULL CHECK (
+                status IN (
+                    'refreshing', 'succeeded', 'failed', 'unsupported',
+                    'malformed', 'timed_out', 'invalidated'
+                )
+            ),
+            generation INTEGER NOT NULL CHECK (generation > 0),
+            active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+            discovery_source TEXT,
+            last_error_code TEXT,
+            last_error_detail TEXT,
+            refresh_started_at TEXT NOT NULL,
+            last_attempt_at TEXT NOT NULL,
+            last_successful_refresh_at TEXT,
+            expires_at TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """,
+        "CREATE UNIQUE INDEX workshop_model_catalogue_active_lane_idx "
+        "ON workshop_model_catalogue_refreshes (runtime_profile_id, backend, provider) "
+        "WHERE active = 1",
+        "CREATE INDEX workshop_model_catalogue_refresh_status_idx "
+        "ON workshop_model_catalogue_refreshes (status, active, updated_at)",
+        """
+        CREATE TABLE workshop_model_catalogue_discovered_entries (
+            cache_key TEXT NOT NULL REFERENCES workshop_model_catalogue_refreshes(cache_key)
+                ON DELETE CASCADE,
+            model_id TEXT NOT NULL CHECK (length(trim(model_id)) BETWEEN 1 AND 512),
+            display_label TEXT NOT NULL CHECK (
+                length(trim(display_label)) BETWEEN 1 AND 512
+            ),
+            discovery_source TEXT NOT NULL CHECK (
+                length(trim(discovery_source)) BETWEEN 1 AND 128
+            ),
+            capabilities_json TEXT NOT NULL DEFAULT '{}',
+            status TEXT NOT NULL CHECK (
+                status IN ('available', 'not_advertised', 'unavailable', 'unknown')
+            ),
+            first_seen_at TEXT NOT NULL,
+            last_seen_at TEXT NOT NULL,
+            last_successful_refresh_at TEXT NOT NULL,
+            expires_at TEXT,
+            PRIMARY KEY (cache_key, model_id)
+        )
+        """,
+        "CREATE INDEX workshop_model_catalogue_discovered_status_idx "
+        "ON workshop_model_catalogue_discovered_entries (cache_key, status, model_id)",
+        """
+        CREATE TABLE workshop_model_catalogue_operator_entries (
+            runtime_profile_id TEXT NOT NULL CHECK (
+                length(runtime_profile_id) BETWEEN 1 AND 128
+            ),
+            backend TEXT NOT NULL CHECK (length(trim(backend)) > 0),
+            provider TEXT NOT NULL CHECK (length(trim(provider)) > 0),
+            model_id TEXT NOT NULL CHECK (length(trim(model_id)) BETWEEN 1 AND 512),
+            display_label TEXT NOT NULL CHECK (
+                length(trim(display_label)) BETWEEN 1 AND 512
+            ),
+            capabilities_json TEXT NOT NULL DEFAULT '{}',
+            active INTEGER NOT NULL DEFAULT 1 CHECK (active IN (0, 1)),
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (runtime_profile_id, backend, provider, model_id)
+        )
+        """,
+        "CREATE INDEX workshop_model_catalogue_operator_active_idx "
+        "ON workshop_model_catalogue_operator_entries "
+        "(runtime_profile_id, backend, provider, active, model_id)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1883,6 +1972,7 @@ _MIGRATIONS = (
     _CLIENT_BINDING_VOICE_PREFERENCES_SCHEMA,
     _PRINCIPAL_APPEARANCE_PREFERENCES_SCHEMA,
     _DURABLE_PRINCIPAL_APPEARANCE_PREFERENCES_SCHEMA,
+    _CANONICAL_MODEL_CATALOGUE_SCHEMA,
 )
 
 

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -228,6 +228,20 @@ class _FakeAppearancePreferences:
         self.events.append("appearance-preferences:close")
 
 
+class _FakeModelCatalogue:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    @classmethod
+    async def open(cls, *_args, **_kwargs):
+        events = _FakeExecutionFactory.events
+        events.append("model-catalogue:open")
+        return cls(events)
+
+    async def close(self) -> None:
+        self.events.append("model-catalogue:close")
+
+
 class _FakeGitHubAutomation:
     def __init__(self, events: list[str]) -> None:
         self.events = events
@@ -314,6 +328,7 @@ def host_dependencies(monkeypatch):
         "WorkshopAppearancePreferenceService",
         _FakeAppearancePreferences,
     )
+    monkeypatch.setattr(host_module, "WorkshopModelCatalogueService", _FakeModelCatalogue)
     monkeypatch.setattr(host_module, "WorkshopGitHubAutomationService", _FakeGitHubAutomation)
     monkeypatch.setattr(
         host_module,
@@ -407,6 +422,7 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
     assert host_dependencies == [
         "pool:start",
         "store:open",
+        "model-catalogue:open",
         "authority:activate",
         "execution:start",
         "post-run-effects:start",
@@ -425,7 +441,7 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
 
     assert host.readiness.state == KaiApplicationState.STOPPED
     assert host.readiness.ready is False
-    assert host_dependencies[-16:] == [
+    assert host_dependencies[-17:] == [
         "execution:wait",
         "scheduler:wait",
         "github-automation:wait",
@@ -437,6 +453,7 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
         "notification-preferences:close",
         "client-preferences:close",
         "appearance-preferences:close",
+        "model-catalogue:close",
         "client:stop",
         "post-run-effects:stop",
         "store:close",

--- a/tests/test_workshop_appearance_preferences.py
+++ b/tests/test_workshop_appearance_preferences.py
@@ -70,7 +70,7 @@ async def test_version_thirty_seven_preferences_upgrade_without_data_loss(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 38
+        assert await upgraded.schema_version() == 39
         async with upgraded.connection.execute(
             "SELECT principal_id, theme_id, created_at, updated_at FROM principal_appearance_preferences"
         ) as cursor:

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -92,7 +92,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",
@@ -129,7 +129,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             async with upgraded.connection.execute(
                 "SELECT field, value FROM channel_agent_execution_settings"
             ) as cursor:

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -208,7 +208,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 38
+        assert await workshop_store.schema_version() == 39
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -223,7 +223,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 38
+        assert await second.schema_version() == 39
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -255,7 +255,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -283,7 +283,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -339,6 +339,7 @@ class TestWorkshopSchema:
                     36,
                     37,
                     38,
+                    39,
                 ]
         finally:
             await upgraded.close()
@@ -361,7 +362,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -402,7 +403,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -455,7 +456,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -499,7 +500,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -543,7 +544,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -587,7 +588,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -691,7 +692,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -818,7 +819,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -521,7 +521,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_model_catalogue.py
+++ b/tests/test_workshop_model_catalogue.py
@@ -1,0 +1,461 @@
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kai.backend_registry import BackendRegistryEntry
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
+from kai.workshop.execution_state import (
+    WorkshopExecutionStateNamespace,
+    WorkshopExecutionStateRegistry,
+)
+from kai.workshop.model_catalogue import (
+    ModelCatalogueAccessDenied,
+    ModelCatalogueEntryStatus,
+    ModelCatalogueOperatorAuthority,
+    ModelCatalogueRefreshStatus,
+    ModelCatalogueValidationError,
+    ModelDiscoveryBatch,
+    ModelDiscoveryCandidate,
+    ModelDiscoveryUnsupported,
+    WorkshopModelCatalogueService,
+)
+from kai.workshop.model_discovery_inventory import WorkshopModelDiscoveryInventoryService
+from kai.workshop.runtime_profiles import (
+    ProtectedRuntimeBackend,
+    ProtectedRuntimeProfile,
+    WorkshopRuntimeProfileRegistry,
+)
+
+
+def _id(identifier_type, value: int):
+    return identifier_type(f"{identifier_type.prefix}_{value:032x}")
+
+
+def _profile(value: int, *, allowed_models: tuple[str, ...] | None = None) -> ProtectedRuntimeProfile:
+    option = ProtectedRuntimeBackend(
+        "claude",
+        "anthropic",
+        "default-model",
+        allowed_models=allowed_models,
+    )
+    return ProtectedRuntimeProfile(
+        profile_id=_id(RuntimeProfileId, value),
+        display_name=f"Profile {value}",
+        os_user="daniel",
+        backend=option.backend,
+        provider=option.provider,
+        model=option.model,
+        timeout_seconds=300,
+        allowed_services=(),
+        home_workspace=None,
+        workspace_base=None,
+        allowed_workspaces=(),
+        allowed_models=allowed_models,
+        backend_options=(option,),
+    )
+
+
+def _namespace(value: int) -> WorkshopExecutionStateNamespace:
+    return WorkshopExecutionStateNamespace(
+        principal_id=_id(PrincipalId, value),
+        channel_id=_id(ChannelId, value),
+        agent_id=_id(AgentId, value),
+        runtime_profile_id=_id(RuntimeProfileId, value),
+        legacy_runtime_key=None,
+    )
+
+
+def _executable(path: Path) -> Path:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o700)
+    return path
+
+
+@dataclass
+class _Fixture:
+    database: Path
+    inventory: WorkshopModelDiscoveryInventoryService
+    selected_models: dict[RuntimeProfileId, str]
+    executable: Path
+
+    async def selected_model(self, profile_id: RuntimeProfileId) -> str:
+        return self.selected_models[profile_id]
+
+
+def _fixture(tmp_path: Path, *, count: int = 1, allowed_models: tuple[str, ...] | None = None) -> _Fixture:
+    profiles = tuple(_profile(value, allowed_models=allowed_models) for value in range(1, count + 1))
+    namespaces = tuple(_namespace(value) for value in range(1, count + 1))
+    executable = _executable(tmp_path / "claude")
+    inventory = WorkshopModelDiscoveryInventoryService(
+        config=SimpleNamespace(codex_auth_mode="subscription"),  # type: ignore[arg-type]
+        runtime_profiles=WorkshopRuntimeProfileRegistry(profiles),
+        execution_state=WorkshopExecutionStateRegistry(namespaces),
+        backend_registry={
+            "claude": BackendRegistryEntry(
+                id="claude",
+                driver="claude",
+                runtime="local_process",
+                command=str(executable),
+            )
+        },
+        selected_backend=lambda _profile_id: ("claude", "anthropic"),
+        service_os_user="kai",
+        environment={},
+    )
+    return _Fixture(
+        tmp_path / "kai.db",
+        inventory,
+        {profile.profile_id: "selected-model" for profile in profiles},
+        executable,
+    )
+
+
+class _QueueAdapter:
+    def __init__(self, results: list[object]) -> None:
+        self.results = results
+        self.calls = 0
+        self.active = 0
+        self.maximum_active = 0
+
+    async def discover(self, _lane) -> ModelDiscoveryBatch:
+        self.calls += 1
+        self.active += 1
+        self.maximum_active = max(self.maximum_active, self.active)
+        await asyncio.sleep(0.01)
+        try:
+            result = self.results.pop(0)
+            if isinstance(result, BaseException):
+                raise result
+            return result  # type: ignore[return-value]
+        finally:
+            self.active -= 1
+
+
+class _BlockingAdapter:
+    def __init__(self, batch: ModelDiscoveryBatch) -> None:
+        self.batch = batch
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def discover(self, _lane) -> ModelDiscoveryBatch:
+        self.started.set()
+        await self.release.wait()
+        return self.batch
+
+
+class _SleepingAdapter:
+    async def discover(self, _lane) -> ModelDiscoveryBatch:
+        await asyncio.sleep(60)
+        raise AssertionError("unreachable")
+
+
+def _batch(*models: str, source: str = "fixture") -> ModelDiscoveryBatch:
+    return ModelDiscoveryBatch(
+        source,
+        tuple(ModelDiscoveryCandidate(model, model.replace("-", " ").title(), {"tools": True}) for model in models),
+        ttl_seconds=3600,
+    )
+
+
+async def _open(
+    fixture: _Fixture,
+    *,
+    adapter=None,
+    curated: Mapping[str, str] | None = None,
+) -> WorkshopModelCatalogueService:
+    return await WorkshopModelCatalogueService.open(
+        fixture.database,
+        fixture.inventory,
+        selected_model=fixture.selected_model,
+        curated_models=lambda _lane: curated,
+        adapters={"claude": adapter} if adapter is not None else None,
+    )
+
+
+def _entry(snapshot, model_id: str):
+    return next(item for item in snapshot.entries if item.model_id == model_id)
+
+
+async def test_refresh_tracks_additions_removals_and_retained_models(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    adapter = _QueueAdapter([_batch("alpha", "selected-model"), _batch("beta")])
+    service = await _open(fixture, adapter=adapter, curated={"curated": "Curated Model"})
+    authority = service.authority_for_principal(_id(PrincipalId, 1))
+    try:
+        first = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        first_snapshot = await service.inspect(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        second = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        second_snapshot = await service.inspect(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+    finally:
+        await service.close()
+
+    assert first.status == ModelCatalogueRefreshStatus.SUCCEEDED
+    assert first.discovered_models == 2
+    assert _entry(first_snapshot, "alpha").status == ModelCatalogueEntryStatus.AVAILABLE
+    assert _entry(first_snapshot, "curated").status == ModelCatalogueEntryStatus.AVAILABLE
+    assert _entry(first_snapshot, "default-model").status == ModelCatalogueEntryStatus.NOT_ADVERTISED
+    assert second.status == ModelCatalogueRefreshStatus.SUCCEEDED
+    assert _entry(second_snapshot, "beta").status == ModelCatalogueEntryStatus.AVAILABLE
+    assert _entry(second_snapshot, "alpha").status == ModelCatalogueEntryStatus.NOT_ADVERTISED
+    retained = _entry(second_snapshot, "selected-model")
+    assert retained.retained is True
+    assert retained.status == ModelCatalogueEntryStatus.NOT_ADVERTISED
+    assert retained.selectable is False
+
+
+async def test_failures_preserve_last_known_good_and_sanitize_diagnostics(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    adapter = _QueueAdapter(
+        [
+            _batch("known-good"),
+            object(),
+            RuntimeError("secret-bearing raw response"),
+            ModelDiscoveryUnsupported(),
+        ]
+    )
+    service = await _open(fixture, adapter=adapter)
+    authority = service.authority_for_principal(_id(PrincipalId, 1))
+    try:
+        assert (
+            await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        ).status == ModelCatalogueRefreshStatus.SUCCEEDED
+        malformed = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        failed = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        unsupported = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        snapshot = await service.inspect(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+    finally:
+        await service.close()
+
+    assert malformed.status == ModelCatalogueRefreshStatus.MALFORMED
+    assert failed.status == ModelCatalogueRefreshStatus.FAILED
+    assert unsupported.status == ModelCatalogueRefreshStatus.UNSUPPORTED
+    assert all(result.preserved_last_known_good for result in (malformed, failed, unsupported))
+    assert _entry(snapshot, "known-good").status == ModelCatalogueEntryStatus.AVAILABLE
+    assert snapshot.stale is True
+    assert snapshot.refresh is not None
+    assert snapshot.refresh.error_detail == "This backend context does not support model enumeration"
+    assert "secret-bearing" not in repr(snapshot)
+    raw_database = fixture.database.read_bytes()
+    assert b"secret-bearing" not in raw_database
+
+
+async def test_timeout_and_missing_adapter_preserve_catalogue(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    service = await _open(fixture, adapter=_QueueAdapter([_batch("known-good")]))
+    authority = service.authority_for_principal(_id(PrincipalId, 1))
+    try:
+        await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        service.register_adapter("claude", _SleepingAdapter())
+        timed_out = await service.refresh(
+            authority,
+            _id(RuntimeProfileId, 1),
+            "claude:anthropic",
+            timeout_seconds=0.01,
+        )
+    finally:
+        await service.close()
+    unsupported_service = await _open(fixture)
+    unsupported_authority = unsupported_service.authority_for_principal(_id(PrincipalId, 1))
+    try:
+        unsupported = await unsupported_service.refresh(
+            unsupported_authority,
+            _id(RuntimeProfileId, 1),
+            "claude:anthropic",
+        )
+        snapshot = await unsupported_service.inspect(
+            unsupported_authority,
+            _id(RuntimeProfileId, 1),
+            "claude:anthropic",
+        )
+    finally:
+        await unsupported_service.close()
+
+    assert timed_out.status == ModelCatalogueRefreshStatus.TIMED_OUT
+    assert timed_out.preserved_last_known_good is True
+    assert unsupported.status == ModelCatalogueRefreshStatus.UNSUPPORTED
+    assert _entry(snapshot, "known-good").status == ModelCatalogueEntryStatus.AVAILABLE
+
+
+async def test_same_process_concurrent_refreshes_are_serialized(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    adapter = _QueueAdapter([_batch("first"), _batch("second")])
+    service = await _open(fixture, adapter=adapter)
+    authority = service.authority_for_principal(_id(PrincipalId, 1))
+    try:
+        results = await asyncio.gather(
+            service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic"),
+            service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic"),
+        )
+        snapshot = await service.inspect(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+    finally:
+        await service.close()
+
+    assert adapter.maximum_active == 1
+    assert [result.generation for result in results] == [1, 2]
+    assert _entry(snapshot, "second").status == ModelCatalogueEntryStatus.AVAILABLE
+    assert _entry(snapshot, "first").status == ModelCatalogueEntryStatus.NOT_ADVERTISED
+
+
+async def test_stale_cross_process_result_cannot_overwrite_newer_refresh(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    slow_adapter = _BlockingAdapter(_batch("stale"))
+    slow = await _open(fixture, adapter=slow_adapter)
+    fast = await _open(fixture, adapter=_QueueAdapter([_batch("fresh")]))
+    authority = slow.authority_for_principal(_id(PrincipalId, 1))
+    fast_authority = fast.authority_for_principal(_id(PrincipalId, 1))
+    try:
+        slow_task = asyncio.create_task(slow.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic"))
+        await slow_adapter.started.wait()
+        fast_result = await fast.refresh(
+            fast_authority,
+            _id(RuntimeProfileId, 1),
+            "claude:anthropic",
+        )
+        slow_adapter.release.set()
+        slow_result = await slow_task
+        snapshot = await fast.inspect(fast_authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+    finally:
+        await slow.close()
+        await fast.close()
+
+    assert fast_result.status == ModelCatalogueRefreshStatus.SUCCEEDED
+    assert slow_result.status == ModelCatalogueRefreshStatus.SUPERSEDED
+    assert _entry(snapshot, "fresh").status == ModelCatalogueEntryStatus.AVAILABLE
+    assert all(entry.model_id != "stale" for entry in snapshot.entries)
+
+
+async def test_inventory_change_invalidates_context_and_uses_stale_fallback(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    service = await _open(fixture, adapter=_QueueAdapter([_batch("last-good")]))
+    authority = service.authority_for_principal(_id(PrincipalId, 1))
+    try:
+        old = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        fixture.executable.write_text("#!/bin/sh\nexit 123\n", encoding="utf-8")
+        invalidation = await service.synchronize_inventory()
+        snapshot = await service.inspect(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+    finally:
+        await service.close()
+
+    assert invalidation.invalidated == 1
+    assert snapshot.cache_key != old.cache_key
+    assert snapshot.last_known_good is True
+    assert snapshot.stale is True
+    assert _entry(snapshot, "last-good").status == ModelCatalogueEntryStatus.AVAILABLE
+
+
+async def test_operator_entries_and_refreshes_never_mutate_runtime_settings(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    service = await _open(fixture, adapter=_QueueAdapter([_batch("discovered")]))
+    operator = service.operator_authority()
+    authority = service.authority_for_principal(_id(PrincipalId, 1))
+    connection = sqlite3.connect(fixture.database)
+    try:
+        connection.execute(
+            "INSERT INTO channel_agent_execution_settings "
+            "(channel_id, agent_id, runtime_profile_id, field, value) VALUES (?, ?, ?, 'model', ?)",
+            (_id(ChannelId, 1), _id(AgentId, 1), _id(RuntimeProfileId, 1), "selected-model"),
+        )
+        connection.commit()
+        before = connection.execute(
+            "SELECT channel_id, agent_id, runtime_profile_id, field, value, updated_at "
+            "FROM channel_agent_execution_settings"
+        ).fetchall()
+        await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        service.register_adapter("claude", _QueueAdapter([RuntimeError("failed refresh")]))
+        failed = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        await service.upsert_operator_entry(
+            operator,
+            _id(RuntimeProfileId, 1),
+            "claude:anthropic",
+            model_id="operator-model",
+            display_label="Operator Model",
+            capabilities={"vision": True},
+        )
+        active = await service.inspect(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        await service.upsert_operator_entry(
+            operator,
+            _id(RuntimeProfileId, 1),
+            "claude:anthropic",
+            model_id="operator-model",
+            display_label="Updated Operator Model",
+            capabilities={"vision": False},
+        )
+        updated = await service.inspect(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        assert await service.deactivate_operator_entry(
+            operator,
+            _id(RuntimeProfileId, 1),
+            "claude:anthropic",
+            model_id="operator-model",
+        )
+        inactive = await service.inspect(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        after = connection.execute(
+            "SELECT channel_id, agent_id, runtime_profile_id, field, value, updated_at "
+            "FROM channel_agent_execution_settings"
+        ).fetchall()
+    finally:
+        connection.close()
+        await service.close()
+
+    assert _entry(active, "operator-model").status == ModelCatalogueEntryStatus.AVAILABLE
+    assert _entry(updated, "operator-model").display_label == "Updated Operator Model"
+    assert _entry(inactive, "operator-model").status == ModelCatalogueEntryStatus.UNAVAILABLE
+    assert failed.status == ModelCatalogueRefreshStatus.FAILED
+    assert before == after
+
+
+async def test_operator_entry_respects_protected_model_ceiling(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path, allowed_models=("allowed", "default-model"))
+    service = await _open(fixture)
+    try:
+        with pytest.raises(ModelCatalogueValidationError, match="outside protected"):
+            await service.upsert_operator_entry(
+                service.operator_authority(),
+                _id(RuntimeProfileId, 1),
+                "claude:anthropic",
+                model_id="forbidden",
+                display_label="Forbidden",
+            )
+    finally:
+        await service.close()
+
+
+async def test_catalogues_are_isolated_by_canonical_principal(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path, count=2)
+    service = await _open(fixture, adapter=_QueueAdapter([_batch("one"), _batch("two")]))
+    first = service.authority_for_principal(_id(PrincipalId, 1))
+    second = service.authority_for_principal(_id(PrincipalId, 2))
+    try:
+        await service.refresh(first, _id(RuntimeProfileId, 1), "claude:anthropic")
+        await service.refresh(second, _id(RuntimeProfileId, 2), "claude:anthropic")
+        first_snapshot = await service.inspect(first, _id(RuntimeProfileId, 1), "claude:anthropic")
+        second_snapshot = await service.inspect(second, _id(RuntimeProfileId, 2), "claude:anthropic")
+        with pytest.raises(ModelCatalogueAccessDenied):
+            await service.inspect(first, _id(RuntimeProfileId, 2), "claude:anthropic")
+    finally:
+        await service.close()
+
+    assert _entry(first_snapshot, "one").status == ModelCatalogueEntryStatus.AVAILABLE
+    assert all(entry.model_id != "two" for entry in first_snapshot.entries)
+    assert _entry(second_snapshot, "two").status == ModelCatalogueEntryStatus.AVAILABLE
+    assert all(entry.model_id != "one" for entry in second_snapshot.entries)
+
+
+async def test_operator_can_refresh_all_contexts_with_unforgeable_authority(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path, count=2)
+    service = await _open(fixture, adapter=_QueueAdapter([_batch("one"), _batch("two")]))
+    try:
+        results = await service.refresh_all(service.operator_authority())
+        with pytest.raises(ModelCatalogueAccessDenied):
+            await service.refresh_all(ModelCatalogueOperatorAuthority(object()))
+    finally:
+        await service.close()
+
+    assert len(results) == 2
+    assert all(result.status == ModelCatalogueRefreshStatus.SUCCEEDED for result in results)

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -411,7 +411,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -524,7 +524,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -382,7 +382,7 @@ class TestAtomicTerminalTransactions:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 38
+            assert await upgraded.schema_version() == 39
             assert await _post_run_effect_count(upgraded) == 1
             async with upgraded.connection.execute(
                 "SELECT status, source_message_id, result_message_id FROM workshop_post_run_effects WHERE run_id = ?",


### PR DESCRIPTION
## Summary

- add schema v39 durable storage for canonical refresh contexts, discovered entries, and operator-managed catalogue entries
- add a transport-neutral refresh coordinator with principal-scoped and trusted operator authority, per-lane serialization, transactional replacement, generation-based stale-result rejection, explicit invalidation, and optional periodic refresh
- preserve last-known-good observations through failures, timeouts, malformed responses, unsupported enumeration, expiry, executable/auth changes, and other inventory invalidations
- merge discovered, curated, operator-managed, and retained selected/default models while preserving provenance and explicit availability status
- wire the catalogue into core startup and shutdown without registering provider adapters, making network calls, invoking backends, or entering the readiness-critical path

## Selection safety

- catalogue state is observation-only and has no mutation path into runtime settings
- newly discovered models may appear without a Kai release; only explicit protected `allowed_models` ceilings constrain discovered IDs
- omitted selected/default models remain visible as `not_advertised`
- operator add/update/deactivate operations affect catalogue presentation only
- successful and failed refresh tests assert the canonical runtime-settings row is unchanged before and after all catalogue mutations

## Failure and isolation guarantees

- same-process requests serialize per canonical lane
- database generations prevent a slower cross-process result from overwriting a newer refresh
- raw exceptions and secret-bearing provider responses are never persisted or exposed
- exact canonical principal/profile ownership gates every non-operator read and refresh
- operator all-context authority uses a service-issued, identity-checked capability

## Verification

- `make check`
- `make typecheck`
- focused catalogue, inventory, host, and migration suite: 76 passed
- full suite: 6182 passed

Closes #1168
