### PR TITLE
feat: discover Codex models canonically

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -26,6 +26,7 @@ from kai.workshop.client_preferences import (
     ClientVoiceCapability,
     WorkshopClientPreferenceService,
 )
+from kai.workshop.codex_model_discovery import CodexModelDiscoveryAdapter
 from kai.workshop.conversation_runs import WorkshopConversationRunService
 from kai.workshop.delivery_authority import (
     DeliveryAuthorityEpoch,
@@ -312,6 +313,11 @@ class KaiApplicationHost:
                     lane.provider,
                     allowed_models=lane.allowed_models,
                 ),
+                adapters={
+                    "codex": CodexModelDiscoveryAdapter(
+                        service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
+                    )
+                },
             )
             delivery_authority_epoch = (await WorkshopConversationDeliveryAuthority(client_store).activate()).epoch
             private_execution = await WorkshopPrivateTextExecutionService.open_and_start(

--- a/src/kai/workshop/codex_model_discovery.py
+++ b/src/kai/workshop/codex_model_discovery.py
@@ -1,0 +1,427 @@
+"""Metadata-only Codex model discovery through the app-server protocol.
+
+Protocol contract verified 2026-08-28 against OpenAI's
+``codex-rs/app-server-protocol/src/protocol/v2/model.rs`` and the app-server
+README. The supported request is paginated ``model/list``; the provider model
+identifier is the response's ``model`` field, separate from ``displayName``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pwd
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import kai
+from kai.backend import sanitize_agent_environment
+from kai.config import DATA_DIR, resolve_claude_user
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+    ModelDiscoveryBatch,
+    ModelDiscoveryCandidate,
+    ModelDiscoveryUnsupported,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryAuthMode,
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryReadiness,
+)
+
+_SOURCE = "codex-app-server:model/list"
+_TTL_SECONDS = 21_600
+_PAGE_LIMIT = 100
+_MAX_PAGES = 20
+_MAX_MODELS = _PAGE_LIMIT * _MAX_PAGES
+_STREAM_LIMIT = 16 * 1024 * 1024
+_CLOSE_TIMEOUT_SECONDS = 3.0
+_AUTH_MARKERS = (
+    "401",
+    "auth",
+    "credential",
+    "expired",
+    "log in",
+    "logged in",
+    "login",
+    "sign in",
+    "signed in",
+    "token",
+    "unauthorized",
+)
+_PRESERVED_AUTH_VARS = (
+    "CODEX_HOME",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+)
+
+
+class _CodexProtocolError(RuntimeError):
+    """A sanitized app-server protocol failure."""
+
+
+class _CodexRpcError(_CodexProtocolError):
+    def __init__(self, code: int | None, message: str) -> None:
+        super().__init__("Codex app-server rejected a metadata request")
+        self.code = code
+        self.message = message
+
+
+@dataclass(frozen=True, slots=True)
+class _CodexLaunch:
+    argv: tuple[str, ...]
+    cwd: str | None
+    environment: Mapping[str, str]
+    cross_user: bool
+
+
+class CodexModelDiscoveryAdapter:
+    """Enumerate the models visible to one canonical Codex auth context.
+
+    The adapter starts a short-lived ``codex app-server``, performs only the
+    required initialize handshake and paginated ``model/list`` requests, then
+    closes stdin. It never starts a thread, turn, or model-generation request.
+    """
+
+    def __init__(
+        self,
+        *,
+        service_os_user: str,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        if not service_os_user.strip():
+            raise ValueError("service_os_user must be non-empty")
+        self._service_os_user = service_os_user.strip()
+        self._environment = os.environ if environment is None else environment
+
+    async def discover(self, lane: ModelDiscoveryBackendInventory) -> ModelDiscoveryBatch:
+        self._validate_lane(lane)
+        launch = _build_launch(
+            lane,
+            service_os_user=self._service_os_user,
+            environment=self._environment,
+        )
+        process = await asyncio.create_subprocess_exec(
+            *launch.argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=launch.cwd,
+            env=dict(launch.environment),
+            start_new_session=launch.cross_user,
+            limit=_STREAM_LIMIT,
+        )
+        stderr_task = asyncio.create_task(_discard_stream(process.stderr))
+        try:
+            if process.stdin is None or process.stdout is None:
+                raise _CodexProtocolError("Codex app-server pipes are unavailable")
+            rpc = _CodexRpcClient(process.stdin, process.stdout)
+            await rpc.request(
+                "initialize",
+                {
+                    "clientInfo": {
+                        "name": "kai-model-discovery",
+                        "version": kai.__version__,
+                    },
+                    "capabilities": {
+                        "optOutNotificationMethods": [
+                            "account/updated",
+                            "mcpServer/startupStatus/updated",
+                            "remoteControl/status/changed",
+                        ]
+                    },
+                },
+            )
+            await rpc.notify("initialized")
+            models = await _list_models(rpc)
+            return ModelDiscoveryBatch(_SOURCE, models, ttl_seconds=_TTL_SECONDS)
+        except _CodexRpcError as exc:
+            if _is_authentication_error(exc):
+                raise ModelDiscoveryAuthenticationError from exc
+            raise _CodexProtocolError from exc
+        finally:
+            await _finish_process_cleanup(process, stderr_task)
+
+    @staticmethod
+    def _validate_lane(lane: ModelDiscoveryBackendInventory) -> None:
+        if lane.backend != "codex" or lane.provider != "openai":
+            raise ModelDiscoveryUnsupported
+        if lane.executable.readiness != ModelDiscoveryReadiness.READY:
+            raise ModelDiscoveryUnsupported
+        if not lane.executable.configured_path or not lane.executable.resolved_path:
+            raise ModelDiscoveryUnsupported
+        if lane.auth.mode == ModelDiscoveryAuthMode.API_KEY and lane.auth.configured is not True:
+            raise ModelDiscoveryAuthenticationError
+
+
+class _CodexRpcClient:
+    def __init__(self, stdin: asyncio.StreamWriter, stdout: asyncio.StreamReader) -> None:
+        self._stdin = stdin
+        self._stdout = stdout
+        self._next_id = 1
+
+    async def notify(self, method: str) -> None:
+        await self._write({"method": method})
+
+    async def request(self, method: str, params: Mapping[str, object]) -> Mapping[str, object]:
+        request_id = self._next_id
+        self._next_id += 1
+        await self._write({"id": request_id, "method": method, "params": params})
+        while True:
+            line = await self._stdout.readline()
+            if not line:
+                raise _CodexProtocolError("Codex app-server closed before responding")
+            try:
+                message = json.loads(line)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ModelCatalogueValidationError("Codex app-server emitted malformed JSON") from exc
+            if not isinstance(message, dict) or message.get("id") != request_id:
+                continue
+            error = message.get("error")
+            if error is not None:
+                raise _rpc_error(error)
+            result = message.get("result")
+            if not isinstance(result, dict):
+                raise ModelCatalogueValidationError("Codex app-server response has no result object")
+            return result
+
+    async def _write(self, message: Mapping[str, object]) -> None:
+        self._stdin.write(json.dumps(message, separators=(",", ":"), ensure_ascii=True).encode("utf-8") + b"\n")
+        await self._stdin.drain()
+
+
+async def _list_models(rpc: _CodexRpcClient) -> tuple[ModelDiscoveryCandidate, ...]:
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    candidates: list[ModelDiscoveryCandidate] = []
+    for _page in range(_MAX_PAGES):
+        result = await rpc.request(
+            "model/list",
+            {
+                "cursor": cursor,
+                "limit": _PAGE_LIMIT,
+                "includeHidden": False,
+            },
+        )
+        page, next_cursor = _parse_model_list_page(result)
+        candidates.extend(page)
+        if len(candidates) > _MAX_MODELS:
+            raise ModelCatalogueValidationError("Codex model catalogue exceeds the safety limit")
+        if next_cursor is None:
+            return tuple(candidates)
+        if next_cursor in seen_cursors:
+            raise ModelCatalogueValidationError("Codex model catalogue repeated a pagination cursor")
+        seen_cursors.add(next_cursor)
+        cursor = next_cursor
+    raise ModelCatalogueValidationError("Codex model catalogue pagination did not terminate")
+
+
+def _parse_model_list_page(result: Mapping[str, object]) -> tuple[tuple[ModelDiscoveryCandidate, ...], str | None]:
+    raw_models = result.get("data")
+    if not isinstance(raw_models, list):
+        raise ModelCatalogueValidationError("Codex model catalogue data must be a list")
+    next_cursor = result.get("nextCursor")
+    if next_cursor is not None and (not isinstance(next_cursor, str) or not next_cursor):
+        raise ModelCatalogueValidationError("Codex model catalogue cursor is invalid")
+    models = tuple(_parse_model(value) for value in raw_models)
+    return models, next_cursor
+
+
+def _parse_model(value: object) -> ModelDiscoveryCandidate:
+    if not isinstance(value, dict):
+        raise ModelCatalogueValidationError("Codex model entry must be an object")
+    model_id = _required_text(value, "model")
+    display_label = _required_text(value, "displayName")
+    picker_id = _required_text(value, "id")
+    hidden = value.get("hidden")
+    if not isinstance(hidden, bool):
+        raise ModelCatalogueValidationError("Codex model hidden flag must be boolean")
+    if hidden:
+        raise ModelCatalogueValidationError("Codex returned a hidden model without being asked")
+
+    capabilities: dict[str, object] = {
+        "codex_picker_id": picker_id,
+        "description": _required_text(value, "description", allow_empty=True),
+        "hidden": hidden,
+        "supported_reasoning_efforts": _reasoning_efforts(value.get("supportedReasoningEfforts")),
+        "default_reasoning_effort": _required_text(value, "defaultReasoningEffort"),
+        "input_modalities": _text_list(value.get("inputModalities", []), "inputModalities"),
+        "supports_personality": _optional_bool(value, "supportsPersonality", False),
+        "multi_agent_version": _optional_text(value, "multiAgentVersion"),
+        "additional_speed_tiers": _text_list(value.get("additionalSpeedTiers", []), "additionalSpeedTiers"),
+        "service_tiers": _service_tiers(value.get("serviceTiers", [])),
+        "default_service_tier": _optional_text(value, "defaultServiceTier"),
+        "is_default": _required_bool(value, "isDefault"),
+        "model_specialty": _optional_text(value, "modelSpecialty"),
+        "upgrade": _optional_text(value, "upgrade"),
+    }
+    return ModelDiscoveryCandidate(model_id, display_label, capabilities)
+
+
+def _reasoning_efforts(value: object) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        raise ModelCatalogueValidationError("Codex reasoning efforts must be a list")
+    results: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise ModelCatalogueValidationError("Codex reasoning effort must be an object")
+        results.append(
+            {
+                "effort": _required_text(item, "reasoningEffort"),
+                "description": _required_text(item, "description", allow_empty=True),
+            }
+        )
+    return results
+
+
+def _service_tiers(value: object) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        raise ModelCatalogueValidationError("Codex service tiers must be a list")
+    results: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise ModelCatalogueValidationError("Codex service tier must be an object")
+        results.append(
+            {
+                "id": _required_text(item, "id"),
+                "name": _required_text(item, "name"),
+                "description": _required_text(item, "description", allow_empty=True),
+            }
+        )
+    return results
+
+
+def _text_list(value: object, field: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        raise ModelCatalogueValidationError(f"Codex {field} must be a list of text values")
+    return list(value)
+
+
+def _required_text(value: Mapping[str, Any], field: str, *, allow_empty: bool = False) -> str:
+    item = value.get(field)
+    if not isinstance(item, str) or (not allow_empty and not item.strip()):
+        raise ModelCatalogueValidationError(f"Codex model field {field} must be text")
+    return item
+
+
+def _optional_text(value: Mapping[str, Any], field: str) -> str | None:
+    item = value.get(field)
+    if item is None:
+        return None
+    if not isinstance(item, str) or not item.strip():
+        raise ModelCatalogueValidationError(f"Codex model field {field} must be text or null")
+    return item
+
+
+def _required_bool(value: Mapping[str, Any], field: str) -> bool:
+    item = value.get(field)
+    if not isinstance(item, bool):
+        raise ModelCatalogueValidationError(f"Codex model field {field} must be boolean")
+    return item
+
+
+def _optional_bool(value: Mapping[str, Any], field: str, default: bool) -> bool:
+    item = value.get(field, default)
+    if not isinstance(item, bool):
+        raise ModelCatalogueValidationError(f"Codex model field {field} must be boolean")
+    return item
+
+
+def _rpc_error(value: object) -> _CodexRpcError:
+    if not isinstance(value, dict):
+        return _CodexRpcError(None, "")
+    code = value.get("code")
+    message = value.get("message")
+    return _CodexRpcError(code if isinstance(code, int) else None, message if isinstance(message, str) else "")
+
+
+def _is_authentication_error(error: _CodexRpcError) -> bool:
+    if error.code in {401, 403}:
+        return True
+    lowered = error.message.lower()
+    return any(marker in lowered for marker in _AUTH_MARKERS)
+
+
+def _build_launch(
+    lane: ModelDiscoveryBackendInventory,
+    *,
+    service_os_user: str,
+    environment: Mapping[str, str],
+) -> _CodexLaunch:
+    command = lane.executable.configured_path
+    if command is None:
+        raise ModelDiscoveryUnsupported
+    try:
+        home = Path(pwd.getpwnam(lane.effective_os_user).pw_dir)
+    except KeyError as exc:
+        raise ModelDiscoveryUnsupported from exc
+    env = sanitize_agent_environment(dict(environment))
+    target_user = None if lane.effective_os_user == service_os_user else resolve_claude_user(lane.effective_os_user)
+    argv = [command, "app-server"]
+    if target_user is not None:
+        env["TMPDIR"] = str(DATA_DIR / "tmp" / target_user)
+        argv = wrap_command_for_target_user(
+            argv,
+            target_user=target_user,
+            working_directory=home,
+            preserve_env=(*_PRESERVED_AUTH_VARS, "TMPDIR"),
+        )
+    return _CodexLaunch(
+        tuple(argv),
+        subprocess_spawn_cwd(home, target_user=target_user),
+        env,
+        target_user is not None,
+    )
+
+
+async def _discard_stream(stream: asyncio.StreamReader | None) -> None:
+    if stream is None:
+        return
+    while await stream.read(64 * 1024):
+        pass
+
+
+async def _close_process(
+    process: asyncio.subprocess.Process,
+    stderr_task: asyncio.Task[None],
+) -> None:
+    if process.stdin is not None:
+        process.stdin.close()
+    try:
+        async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+            await process.wait()
+    except TimeoutError:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+        await process.wait()
+    try:
+        async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+            await stderr_task
+    except TimeoutError:
+        stderr_task.cancel()
+        try:
+            await stderr_task
+        except asyncio.CancelledError:
+            pass
+
+
+async def _finish_process_cleanup(
+    process: asyncio.subprocess.Process,
+    stderr_task: asyncio.Task[None],
+) -> None:
+    cleanup = asyncio.create_task(_close_process(process, stderr_task))
+    try:
+        await asyncio.shield(cleanup)
+    except asyncio.CancelledError:
+        # Discovery is normally cancelled by the catalogue's timeout. Finish
+        # the bounded EOF shutdown before propagating cancellation so the
+        # short-lived app-server cannot become an orphaned background process.
+        await cleanup
+        raise

--- a/src/kai/workshop/model_catalogue.py
+++ b/src/kai/workshop/model_catalogue.py
@@ -43,6 +43,10 @@ class ModelDiscoveryUnsupported(ModelCatalogueError):
     """A backend/auth context does not support model enumeration."""
 
 
+class ModelDiscoveryAuthenticationError(ModelCatalogueError):
+    """The backend account cannot authenticate metadata discovery."""
+
+
 class ModelCatalogueEntryStatus(StrEnum):
     AVAILABLE = "available"
     NOT_ADVERTISED = "not_advertised"
@@ -466,6 +470,15 @@ class WorkshopModelCatalogueService:
                     ModelCatalogueRefreshStatus.UNSUPPORTED,
                     "enumeration_unsupported",
                     "This backend context does not support model enumeration",
+                )
+            except ModelDiscoveryAuthenticationError:
+                return await self._complete_failure(
+                    lane,
+                    generation,
+                    ModelCatalogueRefreshStatus.FAILED,
+                    "authentication_required",
+                    f"{lane.backend.title()} authentication is unavailable; "
+                    "log in again or verify the configured API key",
                 )
             except ModelCatalogueValidationError:
                 return await self._complete_failure(

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -14,6 +14,7 @@ from kai.workshop.bootstrap import (
     bootstrap_default_workshop,
     bootstrap_human_principal_id,
 )
+from kai.workshop.codex_model_discovery import CodexModelDiscoveryAdapter
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
@@ -229,13 +230,16 @@ class _FakeAppearancePreferences:
 
 
 class _FakeModelCatalogue:
+    adapters = None
+
     def __init__(self, events: list[str]) -> None:
         self.events = events
 
     @classmethod
-    async def open(cls, *_args, **_kwargs):
+    async def open(cls, *_args, **kwargs):
         events = _FakeExecutionFactory.events
         events.append("model-catalogue:open")
+        cls.adapters = kwargs.get("adapters")
         return cls(events)
 
     async def close(self) -> None:
@@ -418,6 +422,9 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
         },
     }
     assert services.subprocess_pool is not None
+    assert _FakeModelCatalogue.adapters is not None
+    assert set(_FakeModelCatalogue.adapters) == {"codex"}
+    assert isinstance(_FakeModelCatalogue.adapters["codex"], CodexModelDiscoveryAdapter)
     assert services.delivery_policy.enabled_transports == frozenset()
     assert host_dependencies == [
         "pool:start",

--- a/tests/test_workshop_codex_model_discovery.py
+++ b/tests/test_workshop_codex_model_discovery.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+import os
+import pwd
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kai.workshop import codex_model_discovery as discovery_module
+from kai.workshop.codex_model_discovery import CodexModelDiscoveryAdapter
+from kai.workshop.domain import PrincipalId, RuntimeProfileId
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryAuthContext,
+    ModelDiscoveryAuthMode,
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryCacheInputs,
+    ModelDiscoveryExecutableIdentity,
+    ModelDiscoveryReadiness,
+    ModelDiscoverySelectionStatus,
+)
+
+
+def _id(identifier_type, value: int):
+    return identifier_type(f"{identifier_type.prefix}_{value:032x}")
+
+
+def _lane(
+    executable: Path,
+    *,
+    value: int = 1,
+    os_user: str | None = None,
+    auth_mode: ModelDiscoveryAuthMode = ModelDiscoveryAuthMode.SUBSCRIPTION,
+    auth_configured: bool | None = None,
+) -> ModelDiscoveryBackendInventory:
+    principal_id = _id(PrincipalId, value)
+    profile_id = _id(RuntimeProfileId, value)
+    effective_user = os_user or pwd.getpwuid(os.getuid()).pw_name
+    executable_identity = ModelDiscoveryExecutableIdentity(
+        configured_path=str(executable),
+        resolved_path=str(executable.resolve()),
+        fingerprint=f"executable-{value}",
+        readiness=ModelDiscoveryReadiness.READY,
+        diagnostic=None,
+    )
+    auth = ModelDiscoveryAuthContext(
+        auth_mode,
+        "backend login" if auth_mode == ModelDiscoveryAuthMode.SUBSCRIPTION else "OPENAI_API_KEY",
+        auth_configured,
+        f"auth-{value}",
+    )
+    cache_inputs = ModelDiscoveryCacheInputs(
+        version=1,
+        principal_id=principal_id,
+        runtime_profile_id=profile_id,
+        backend="codex",
+        provider="openai",
+        os_user=effective_user,
+        executable_fingerprint=executable_identity.fingerprint,
+        auth_fingerprint=auth.fingerprint,
+        default_model="gpt-default",
+        allowed_models=None,
+        role_models=(),
+    )
+    return ModelDiscoveryBackendInventory(
+        option_id="codex:openai",
+        backend="codex",
+        provider="openai",
+        selected=True,
+        status=ModelDiscoverySelectionStatus.SELECTED,
+        readiness=ModelDiscoveryReadiness.UNVERIFIED,
+        effective_os_user=effective_user,
+        executable=executable_identity,
+        auth=auth,
+        default_model="gpt-default",
+        allowed_models=None,
+        role_models=(),
+        cache_inputs=cache_inputs,
+        cache_key=f"cache-{value}",
+        diagnostic=None,
+    )
+
+
+def _model(model: str, *, label: str | None = None) -> dict[str, object]:
+    return {
+        "id": f"picker-{model}",
+        "model": model,
+        "upgrade": None,
+        "displayName": label or model,
+        "description": f"Description for {model}",
+        "modelSpecialty": None,
+        "hidden": False,
+        "supportedReasoningEfforts": [
+            {"reasoningEffort": "high", "description": "High"},
+            {"reasoningEffort": "low", "description": "Low"},
+        ],
+        "defaultReasoningEffort": "high",
+        "inputModalities": ["text", "image"],
+        "supportsPersonality": True,
+        "multiAgentVersion": "v2",
+        "additionalSpeedTiers": ["fast"],
+        "serviceTiers": [{"id": "priority", "name": "Priority", "description": "Fast queue"}],
+        "defaultServiceTier": "priority",
+        "isDefault": model == "gpt-alpha",
+    }
+
+
+def _fake_app_server(
+    tmp_path: Path,
+    pages: list[dict[str, object]],
+    *,
+    error_message: str | None = None,
+) -> tuple[Path, Path]:
+    executable = tmp_path / "codex-fixture"
+    request_log = tmp_path / "requests.jsonl"
+    script = f"""#!{sys.executable}
+import json
+import sys
+
+pages = {pages!r}
+error_message = {error_message!r}
+request_log = {str(request_log)!r}
+page = 0
+for line in sys.stdin:
+    request = json.loads(line)
+    with open(request_log, "a", encoding="utf-8") as output:
+        output.write(json.dumps(request, separators=(",", ":")) + "\\n")
+    if "id" not in request:
+        continue
+    if request["method"] == "initialize":
+        response = {{"id": request["id"], "result": {{"userAgent": "fixture"}}}}
+    elif error_message is not None:
+        response = {{
+            "id": request["id"],
+            "error": {{"code": 401, "message": error_message}},
+        }}
+    else:
+        response = {{"id": request["id"], "result": pages[page]}}
+        page += 1
+    print(json.dumps(response, separators=(",", ":")), flush=True)
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    return executable, request_log
+
+
+async def test_adapter_uses_paginated_metadata_only_model_list(tmp_path: Path) -> None:
+    executable, request_log = _fake_app_server(
+        tmp_path,
+        [
+            {"data": [_model("gpt-alpha", label="GPT Alpha")], "nextCursor": "page-2"},
+            {"data": [_model("gpt-beta", label="GPT Beta")], "nextCursor": None},
+        ],
+    )
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = CodexModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    batch = await adapter.discover(_lane(executable, os_user=current_user))
+
+    assert batch.source == "codex-app-server:model/list"
+    assert batch.ttl_seconds == 21_600
+    assert [candidate.model_id for candidate in batch.models] == ["gpt-alpha", "gpt-beta"]
+    assert batch.models[0].display_label == "GPT Alpha"
+    assert batch.models[0].capabilities == {
+        "additional_speed_tiers": ["fast"],
+        "codex_picker_id": "picker-gpt-alpha",
+        "default_reasoning_effort": "high",
+        "default_service_tier": "priority",
+        "description": "Description for gpt-alpha",
+        "hidden": False,
+        "input_modalities": ["text", "image"],
+        "is_default": True,
+        "model_specialty": None,
+        "multi_agent_version": "v2",
+        "service_tiers": [{"id": "priority", "name": "Priority", "description": "Fast queue"}],
+        "supported_reasoning_efforts": [
+            {"effort": "high", "description": "High"},
+            {"effort": "low", "description": "Low"},
+        ],
+        "supports_personality": True,
+        "upgrade": None,
+    }
+    requests = [json.loads(line) for line in request_log.read_text(encoding="utf-8").splitlines()]
+    assert [request["method"] for request in requests] == [
+        "initialize",
+        "initialized",
+        "model/list",
+        "model/list",
+    ]
+    assert requests[2]["params"] == {
+        "cursor": None,
+        "limit": 100,
+        "includeHidden": False,
+    }
+    assert requests[3]["params"]["cursor"] == "page-2"
+    assert not {"thread/start", "turn/start"} & {request["method"] for request in requests}
+
+
+async def test_adapter_classifies_authentication_without_leaking_rpc_message(tmp_path: Path) -> None:
+    secret = "expired token secret-account-value"
+    executable, _request_log = _fake_app_server(tmp_path, [], error_message=secret)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = CodexModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    with pytest.raises(ModelDiscoveryAuthenticationError) as caught:
+        await adapter.discover(_lane(executable, os_user=current_user))
+
+    assert secret not in str(caught.value)
+    assert secret not in repr(caught.value)
+
+
+def test_parser_rejects_malformed_and_unrequested_hidden_entries() -> None:
+    malformed = _model("gpt-alpha")
+    malformed["supportedReasoningEfforts"] = "high"
+    with pytest.raises(ModelCatalogueValidationError, match="reasoning efforts"):
+        discovery_module._parse_model_list_page({"data": [malformed], "nextCursor": None})
+
+    hidden = _model("gpt-hidden")
+    hidden["hidden"] = True
+    with pytest.raises(ModelCatalogueValidationError, match="hidden model"):
+        discovery_module._parse_model_list_page({"data": [hidden], "nextCursor": None})
+
+
+def test_launch_uses_canonical_os_user_auth_context_and_scrubs_control_plane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "codex"
+    executable.write_text("fixture", encoding="utf-8")
+    executable.chmod(0o700)
+    alice_home = tmp_path / "alice"
+    bob_home = tmp_path / "bob"
+    alice_home.mkdir()
+    bob_home.mkdir()
+    homes = {"alice": alice_home, "bob": bob_home}
+    monkeypatch.setattr(
+        discovery_module.pwd,
+        "getpwnam",
+        lambda user: SimpleNamespace(pw_dir=str(homes[user])),
+    )
+    environment = {
+        "OPENAI_API_KEY": "provider-key",
+        "TELEGRAM_BOT_TOKEN": "control-plane-secret",
+    }
+
+    alice = discovery_module._build_launch(
+        _lane(executable, value=1, os_user="alice"),
+        service_os_user="kai",
+        environment=environment,
+    )
+    bob = discovery_module._build_launch(
+        _lane(executable, value=2, os_user="bob"),
+        service_os_user="kai",
+        environment=environment,
+    )
+
+    assert alice.argv[:6] == ("sudo", "-H", "-D", str(alice_home), "-u", "alice")
+    assert bob.argv[:6] == ("sudo", "-H", "-D", str(bob_home), "-u", "bob")
+    assert alice.argv[-2:] == (str(executable), "app-server")
+    assert alice.cwd is None
+    assert alice.cross_user is True
+    assert alice.environment["OPENAI_API_KEY"] == "provider-key"
+    assert "TELEGRAM_BOT_TOKEN" not in alice.environment
+    assert alice.environment["TMPDIR"].endswith("/tmp/alice")
+    assert bob.environment["TMPDIR"].endswith("/tmp/bob")
+    assert alice.argv != bob.argv
+
+
+def test_api_key_lane_without_key_fails_before_starting_process(tmp_path: Path) -> None:
+    executable = tmp_path / "codex"
+    executable.write_text("fixture", encoding="utf-8")
+    executable.chmod(0o700)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = CodexModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    with pytest.raises(ModelDiscoveryAuthenticationError):
+        adapter._validate_lane(
+            _lane(
+                executable,
+                os_user=current_user,
+                auth_mode=ModelDiscoveryAuthMode.API_KEY,
+                auth_configured=False,
+            )
+        )

--- a/tests/test_workshop_model_catalogue.py
+++ b/tests/test_workshop_model_catalogue.py
@@ -21,6 +21,7 @@ from kai.workshop.model_catalogue import (
     ModelCatalogueOperatorAuthority,
     ModelCatalogueRefreshStatus,
     ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
     ModelDiscoveryBatch,
     ModelDiscoveryCandidate,
     ModelDiscoveryUnsupported,
@@ -218,6 +219,7 @@ async def test_failures_preserve_last_known_good_and_sanitize_diagnostics(tmp_pa
             object(),
             RuntimeError("secret-bearing raw response"),
             ModelDiscoveryUnsupported(),
+            ModelDiscoveryAuthenticationError("raw secret must not persist"),
         ]
     )
     service = await _open(fixture, adapter=adapter)
@@ -229,6 +231,7 @@ async def test_failures_preserve_last_known_good_and_sanitize_diagnostics(tmp_pa
         malformed = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
         failed = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
         unsupported = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
+        authentication = await service.refresh(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
         snapshot = await service.inspect(authority, _id(RuntimeProfileId, 1), "claude:anthropic")
     finally:
         await service.close()
@@ -236,14 +239,20 @@ async def test_failures_preserve_last_known_good_and_sanitize_diagnostics(tmp_pa
     assert malformed.status == ModelCatalogueRefreshStatus.MALFORMED
     assert failed.status == ModelCatalogueRefreshStatus.FAILED
     assert unsupported.status == ModelCatalogueRefreshStatus.UNSUPPORTED
-    assert all(result.preserved_last_known_good for result in (malformed, failed, unsupported))
+    assert authentication.status == ModelCatalogueRefreshStatus.FAILED
+    assert all(result.preserved_last_known_good for result in (malformed, failed, unsupported, authentication))
+    assert snapshot.refresh is not None
+    assert snapshot.refresh.error_code == "authentication_required"
+    assert snapshot.refresh.error_detail == (
+        "Claude authentication is unavailable; log in again or verify the configured API key"
+    )
+    assert "raw secret" not in repr(snapshot)
     assert _entry(snapshot, "known-good").status == ModelCatalogueEntryStatus.AVAILABLE
     assert snapshot.stale is True
-    assert snapshot.refresh is not None
-    assert snapshot.refresh.error_detail == "This backend context does not support model enumeration"
     assert "secret-bearing" not in repr(snapshot)
     raw_database = fixture.database.read_bytes()
     assert b"secret-bearing" not in raw_database
+    assert b"raw secret" not in raw_database
 
 
 async def test_timeout_and_missing_adapter_preserve_catalogue(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add a Codex `model/list` discovery adapter to the canonical durable model catalogue
- run metadata discovery in each runtime profile's effective OS-user and authentication context
- preserve curated and last-known-good choices when discovery is unavailable or authentication expires
- retain provider model IDs separately from display labels and normalized capability metadata
- register Codex discovery in the transport-neutral application host for future Workshop, Telegram, and CLI refresh surfaces

## Protocol and safety

- verified the supported paginated `model/list` contract against OpenAI's current Codex app-server README, protocol schema, implementation, and tests
- perform only `initialize`, `initialized`, and `model/list`; never start a thread, turn, or generation request
- request only visible picker models and enforce bounded pages, model counts, line sizes, TTL, and process shutdown
- keep credentials out of arguments, logs, durable diagnostics, and catalogue rows
- translate expired login/API-key failures into a sanitized `authentication_required` status
- preserve principal isolation through the canonical runtime-profile/auth cache lane

## Testing

- `make check`
- `make typecheck`
- focused tests: 23 passed
- full suite: 6,187 passed
- fixture app-server tests cover handshake, pagination, field normalization, OS-user isolation, control-plane secret scrubbing, malformed responses, and authentication failures without using a live account or invoking a model

Closes #725
