### PR TITLE
Discover Claude models canonically

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -21,6 +21,7 @@ from kai.config import Config, models_for_backend_policy
 from kai.pool import SubprocessPool
 from kai.workshop.appearance_preferences import WorkshopAppearancePreferenceService
 from kai.workshop.artifacts import WorkshopArtifactService
+from kai.workshop.claude_model_discovery import ClaudeModelDiscoveryAdapter
 from kai.workshop.client_commands import WorkshopClientCommandExecutor
 from kai.workshop.client_preferences import (
     ClientVoiceCapability,
@@ -314,9 +315,10 @@ class KaiApplicationHost:
                     allowed_models=lane.allowed_models,
                 ),
                 adapters={
+                    "claude": ClaudeModelDiscoveryAdapter(),
                     "codex": CodexModelDiscoveryAdapter(
                         service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
-                    )
+                    ),
                 },
             )
             delivery_authority_epoch = (await WorkshopConversationDeliveryAuthority(client_store).activate()).epoch

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -217,11 +217,9 @@ PROVIDER_KEY_VARS: dict[str, str] = {
 # Goose passes model IDs through verbatim to the provider API - no
 # aliasing layer - so these must be the exact strings the APIs accept.
 PROVIDER_MODELS: dict[str, dict[str, str]] = {
-    # Claude Code accepts short aliases that auto-resolve to the
-    # current SKU. Listing the aliases here keeps the registry stable
-    # across Anthropic version bumps; the CLI handles the resolution.
-    # Verified 2026-08-10 against Claude Code CLI docs and local
-    # `claude --help`.
+    # These rolling aliases are accepted by both the Anthropic provider
+    # surface and Claude Code. Claude-Code-only selectors live in
+    # CLAUDE_MODELS below so they never leak into Goose's API model list.
     "anthropic": {
         "fable": "\U0001f52e Fable",
         "opus": "\U0001f9e0 Opus",
@@ -264,6 +262,21 @@ PROVIDER_MODELS: dict[str, dict[str, str]] = {
         "deepseek-v4-pro": "DeepSeek V4 Pro",
         "deepseek-v4-flash": "DeepSeek V4 Flash",
     },
+}
+
+# Claude Code's complete curated alias fallback. ``default`` is deliberately
+# absent: in Kai it means clear the principal's model override through the
+# settings reset operation, never store a literal provider model. The
+# documented ``[1m]`` forms are runtime selectors, represented explicitly
+# instead of scraping labels from the interactive picker. Verified 2026-08-28
+# against Claude Code's official model-configuration reference. ``fable``
+# remains a Kai-supported rolling alias from the installed Claude surface.
+CLAUDE_MODELS: dict[str, str] = {
+    **PROVIDER_MODELS["anthropic"],
+    "best": "\U0001f3c6 Best available",
+    "opus[1m]": "\U0001f9e0 Opus · 1M context",
+    "opusplan": "\U0001f9e0 Opus plan / Sonnet execution",
+    "sonnet[1m]": "\u26a1 Sonnet · 1M context",
 }
 
 # Strongest curated model for provider-only callers such as the model
@@ -338,6 +351,7 @@ OPEN_ENDED_PROVIDERS: frozenset[str] = frozenset({"openrouter", "ollama"})
 # remain loadable for one release and are canonicalized at apply time.
 _ALL_CURATED_MODELS: frozenset[str] = frozenset(
     list(model for models in PROVIDER_MODELS.values() for model in models)
+    + list(CLAUDE_MODELS.keys())
     + list(CODEX_MODELS.keys())
     + list(_LEGACY_CODEX_MODEL_ALIASES.keys())
 )
@@ -911,11 +925,13 @@ def validate_model_for_backend_policy(
     """
     if backend == "codex":
         base_allowed = model in CODEX_MODELS
+    elif backend == "claude" and eff_provider == "anthropic":
+        base_allowed = model in CLAUDE_MODELS or model.startswith("claude-")
     elif backend == "opencode":
         base_allowed = is_opencode_model_shape(model)
     elif backend == "pi":
         base_allowed = is_pi_model_shape(model, eff_provider)
-    elif (backend == "claude" or (backend == "goose" and eff_provider == "anthropic")) and model.startswith("claude-"):
+    elif backend == "goose" and eff_provider == "anthropic" and model.startswith("claude-"):
         base_allowed = True
     else:
         base_allowed = validate_model_for_provider(model, eff_provider)
@@ -1082,6 +1098,8 @@ def models_for_backend_policy(
     """Return curated models constrained by an already-resolved policy."""
     if agent_backend == "codex":
         models = CODEX_MODELS
+    elif agent_backend == "claude" and eff_provider == "anthropic":
+        models = CLAUDE_MODELS
     elif agent_backend in {"opencode", "pi"} or eff_provider in OPEN_ENDED_PROVIDERS:
         return None
     else:

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -51,6 +51,7 @@ from kai.config import (
     _VALID_ROLES,
     BACKEND_PROVIDERS,
     BACKENDS_NEEDING_PROVIDER_PROMPT,
+    CLAUDE_MODELS,
     CODEX_EFFORT_LEVELS,
     CODEX_MODELS,
     EFFORT_LEVELS,
@@ -8629,7 +8630,7 @@ def _backend_registry_entries(
                 "driver": "claude",
                 "runtime": "local_process",
                 "command": command,
-                "allowed_models": sorted((*PROVIDER_MODELS["anthropic"].keys(), "claude-*")),
+                "allowed_models": sorted((*CLAUDE_MODELS.keys(), "claude-*")),
             }
         elif backend == "codex":
             entries[backend] = {

--- a/src/kai/workshop/claude_model_discovery.py
+++ b/src/kai/workshop/claude_model_discovery.py
@@ -1,0 +1,198 @@
+"""Metadata-only Claude model discovery and subscription fallback policy.
+
+Protocol contract verified 2026-08-28 against Anthropic's Models API and
+Claude Code model-configuration documentation. API-key contexts enumerate
+with ``GET /v1/models``. Claude subscription authentication has no documented
+machine-readable listing command, so those lanes deliberately report
+unsupported and retain Kai's curated aliases plus canonical operator entries.
+No message or model-generation endpoint is used.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+import aiohttp
+
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+    ModelDiscoveryBatch,
+    ModelDiscoveryCandidate,
+    ModelDiscoveryUnsupported,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryAuthMode,
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryReadiness,
+)
+
+_SOURCE = "anthropic-models-api:v1/models"
+_DEFAULT_BASE_URL = "https://api.anthropic.com"
+_ANTHROPIC_VERSION = "2023-06-01"
+_TTL_SECONDS = 21_600
+_PAGE_LIMIT = 1000
+_MAX_PAGES = 20
+_MAX_MODELS = _PAGE_LIMIT * _MAX_PAGES
+_MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+_REQUEST_TIMEOUT_SECONDS = 20.0
+
+
+class _ClaudeDiscoveryError(RuntimeError):
+    """A sanitized Models API transport failure."""
+
+
+class ClaudeModelDiscoveryAdapter:
+    """Enumerate models visible to one canonical Claude API-key context.
+
+    Subscription-backed Claude Code credentials cannot be reused against the
+    public Models API and Claude Code documents no metadata-only listing
+    command. Returning ``ModelDiscoveryUnsupported`` for that lane makes the
+    catalogue expose curated and operator-managed entries without probing an
+    interactive picker or invoking a model.
+    """
+
+    def __init__(self, *, environment: Mapping[str, str] | None = None) -> None:
+        self._environment = os.environ if environment is None else environment
+
+    async def discover(self, lane: ModelDiscoveryBackendInventory) -> ModelDiscoveryBatch:
+        api_key, endpoint = self._discovery_context(lane)
+        models: list[ModelDiscoveryCandidate] = []
+        after_id: str | None = None
+        seen_cursors: set[str] = set()
+        timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_SECONDS)
+        headers = {
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "x-api-key": api_key,
+        }
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                for _page in range(_MAX_PAGES):
+                    query: dict[str, str] = {"limit": str(_PAGE_LIMIT)}
+                    if after_id is not None:
+                        query["after_id"] = after_id
+                    url = f"{endpoint}?{urlencode(query)}"
+                    # Do not forward the API key across redirects. Operators
+                    # must configure the final metadata endpoint explicitly.
+                    async with session.get(url, headers=headers, allow_redirects=False) as response:
+                        if response.status in {401, 403}:
+                            raise ModelDiscoveryAuthenticationError
+                        if response.status < 200 or response.status >= 300:
+                            raise _ClaudeDiscoveryError("Anthropic Models API metadata request failed")
+                        body = await response.content.read(_MAX_RESPONSE_BYTES + 1)
+                    if len(body) > _MAX_RESPONSE_BYTES:
+                        raise ModelCatalogueValidationError(
+                            "Anthropic model catalogue response exceeds the safety limit"
+                        )
+                    page, next_cursor = _parse_page(body)
+                    models.extend(page)
+                    if len(models) > _MAX_MODELS:
+                        raise ModelCatalogueValidationError("Anthropic model catalogue exceeds the safety limit")
+                    if next_cursor is None:
+                        return ModelDiscoveryBatch(_SOURCE, tuple(models), ttl_seconds=_TTL_SECONDS)
+                    if next_cursor in seen_cursors:
+                        raise ModelCatalogueValidationError("Anthropic model catalogue repeated a pagination cursor")
+                    seen_cursors.add(next_cursor)
+                    after_id = next_cursor
+        except (ModelCatalogueValidationError, ModelDiscoveryAuthenticationError):
+            raise
+        except (aiohttp.ClientError, TimeoutError) as exc:
+            raise _ClaudeDiscoveryError("Anthropic Models API metadata request failed") from exc
+        raise ModelCatalogueValidationError("Anthropic model catalogue pagination did not terminate")
+
+    def _discovery_context(self, lane: ModelDiscoveryBackendInventory) -> tuple[str, str]:
+        if lane.backend != "claude" or lane.provider != "anthropic":
+            raise ModelDiscoveryUnsupported
+        if lane.executable.readiness != ModelDiscoveryReadiness.READY:
+            raise ModelDiscoveryUnsupported
+        if lane.auth.mode == ModelDiscoveryAuthMode.SUBSCRIPTION:
+            raise ModelDiscoveryUnsupported
+        if lane.auth.mode != ModelDiscoveryAuthMode.API_KEY or lane.auth.configured is not True:
+            raise ModelDiscoveryAuthenticationError
+        api_key = self._environment.get("ANTHROPIC_API_KEY", "").strip()
+        if not api_key:
+            raise ModelDiscoveryAuthenticationError
+        base_url = self._environment.get("ANTHROPIC_BASE_URL", _DEFAULT_BASE_URL).strip()
+        return api_key, _models_endpoint(base_url)
+
+
+def _models_endpoint(base_url: str) -> str:
+    parsed = urlsplit(base_url)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ModelCatalogueValidationError("Anthropic base URL is invalid for model discovery")
+    path = f"{parsed.path.rstrip('/')}/v1/models"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _parse_page(body: bytes) -> tuple[tuple[ModelDiscoveryCandidate, ...], str | None]:
+    try:
+        value = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ModelCatalogueValidationError("Anthropic model catalogue response is malformed JSON") from exc
+    if not isinstance(value, dict):
+        raise ModelCatalogueValidationError("Anthropic model catalogue response must be an object")
+    raw_models = value.get("data")
+    has_more = value.get("has_more")
+    last_id = value.get("last_id")
+    if not isinstance(raw_models, list):
+        raise ModelCatalogueValidationError("Anthropic model catalogue data must be a list")
+    if not isinstance(has_more, bool):
+        raise ModelCatalogueValidationError("Anthropic model catalogue has_more must be boolean")
+    if last_id is not None and (not isinstance(last_id, str) or not last_id.strip()):
+        raise ModelCatalogueValidationError("Anthropic model catalogue last_id is invalid")
+    if has_more and last_id is None:
+        raise ModelCatalogueValidationError("Anthropic model catalogue omitted its next cursor")
+    models = tuple(_parse_model(item) for item in raw_models)
+    return models, last_id if has_more else None
+
+
+def _parse_model(value: object) -> ModelDiscoveryCandidate:
+    if not isinstance(value, dict):
+        raise ModelCatalogueValidationError("Anthropic model entry must be an object")
+    model_id = _required_text(value, "id")
+    display_label = _required_text(value, "display_name")
+    if value.get("type") != "model":
+        raise ModelCatalogueValidationError("Anthropic model type must be model")
+    capabilities = value.get("capabilities")
+    if capabilities is not None and not isinstance(capabilities, dict):
+        raise ModelCatalogueValidationError("Anthropic model capabilities must be an object or null")
+    try:
+        json.dumps(capabilities, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ModelCatalogueValidationError("Anthropic model capabilities are not JSON-safe") from exc
+    return ModelDiscoveryCandidate(
+        model_id,
+        display_label,
+        {
+            "created_at": _required_text(value, "created_at"),
+            "max_input_tokens": _optional_integer(value, "max_input_tokens"),
+            "max_output_tokens": _optional_integer(value, "max_tokens"),
+            "provider_capabilities": capabilities or {},
+        },
+    )
+
+
+def _required_text(value: Mapping[str, object], field: str) -> str:
+    item = value.get(field)
+    if not isinstance(item, str) or not item.strip():
+        raise ModelCatalogueValidationError(f"Anthropic model field {field} must be text")
+    return item
+
+
+def _optional_integer(value: Mapping[str, object], field: str) -> int | None:
+    item = value.get(field)
+    if item is None:
+        return None
+    if isinstance(item, bool) or not isinstance(item, int) or item < 0:
+        raise ModelCatalogueValidationError(f"Anthropic model field {field} must be a non-negative integer or null")
+    return item

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -14,6 +14,7 @@ from kai.workshop.bootstrap import (
     bootstrap_default_workshop,
     bootstrap_human_principal_id,
 )
+from kai.workshop.claude_model_discovery import ClaudeModelDiscoveryAdapter
 from kai.workshop.codex_model_discovery import CodexModelDiscoveryAdapter
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
@@ -423,7 +424,8 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
     }
     assert services.subprocess_pool is not None
     assert _FakeModelCatalogue.adapters is not None
-    assert set(_FakeModelCatalogue.adapters) == {"codex"}
+    assert set(_FakeModelCatalogue.adapters) == {"claude", "codex"}
+    assert isinstance(_FakeModelCatalogue.adapters["claude"], ClaudeModelDiscoveryAdapter)
     assert isinstance(_FakeModelCatalogue.adapters["codex"], CodexModelDiscoveryAdapter)
     assert services.delivery_policy.enabled_transports == frozenset()
     assert host_dependencies == [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3190,9 +3190,9 @@ class TestModelsForBackend:
         assert models_for_backend("goose", "openai") is PROVIDER_MODELS["openai"]
 
     def test_claude_returns_anthropic_provider_models(self):
-        from kai.config import PROVIDER_MODELS, models_for_backend
+        from kai.config import CLAUDE_MODELS, models_for_backend
 
-        assert models_for_backend("claude", "anthropic") is PROVIDER_MODELS["anthropic"]
+        assert models_for_backend("claude", "anthropic") is CLAUDE_MODELS
 
     def test_open_ended_provider_returns_none(self):
         from kai.config import models_for_backend

--- a/tests/test_workshop_claude_model_discovery.py
+++ b/tests/test_workshop_claude_model_discovery.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+import pwd
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kai.config import CLAUDE_MODELS, PROVIDER_MODELS, models_for_backend, validate_model_for_backend
+from kai.workshop import claude_model_discovery as discovery_module
+from kai.workshop.claude_model_discovery import ClaudeModelDiscoveryAdapter
+from kai.workshop.domain import PrincipalId, RuntimeProfileId
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+    ModelDiscoveryUnsupported,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryAuthContext,
+    ModelDiscoveryAuthMode,
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryCacheInputs,
+    ModelDiscoveryExecutableIdentity,
+    ModelDiscoveryReadiness,
+    ModelDiscoverySelectionStatus,
+)
+
+
+def _id(identifier_type, value: int):
+    return identifier_type(f"{identifier_type.prefix}_{value:032x}")
+
+
+def _lane(
+    executable: Path,
+    *,
+    value: int = 1,
+    auth_mode: ModelDiscoveryAuthMode = ModelDiscoveryAuthMode.API_KEY,
+    auth_configured: bool | None = True,
+) -> ModelDiscoveryBackendInventory:
+    principal_id = _id(PrincipalId, value)
+    profile_id = _id(RuntimeProfileId, value)
+    effective_user = pwd.getpwuid(0).pw_name
+    executable_identity = ModelDiscoveryExecutableIdentity(
+        configured_path=str(executable),
+        resolved_path=str(executable.resolve()),
+        fingerprint=f"executable-{value}",
+        readiness=ModelDiscoveryReadiness.READY,
+        diagnostic=None,
+    )
+    auth = ModelDiscoveryAuthContext(
+        auth_mode,
+        "ANTHROPIC_API_KEY" if auth_mode == ModelDiscoveryAuthMode.API_KEY else "backend login",
+        auth_configured,
+        f"auth-{value}",
+    )
+    cache_inputs = ModelDiscoveryCacheInputs(
+        version=1,
+        principal_id=principal_id,
+        runtime_profile_id=profile_id,
+        backend="claude",
+        provider="anthropic",
+        os_user=effective_user,
+        executable_fingerprint=executable_identity.fingerprint,
+        auth_fingerprint=auth.fingerprint,
+        default_model="sonnet",
+        allowed_models=None,
+        role_models=(),
+    )
+    return ModelDiscoveryBackendInventory(
+        option_id="claude:anthropic",
+        backend="claude",
+        provider="anthropic",
+        selected=True,
+        status=ModelDiscoverySelectionStatus.SELECTED,
+        readiness=ModelDiscoveryReadiness.READY,
+        effective_os_user=effective_user,
+        executable=executable_identity,
+        auth=auth,
+        default_model="sonnet",
+        allowed_models=None,
+        role_models=(),
+        cache_inputs=cache_inputs,
+        cache_key=f"cache-{value}",
+        diagnostic=None,
+    )
+
+
+def _model(model_id: str, display_name: str) -> dict[str, object]:
+    return {
+        "id": model_id,
+        "display_name": display_name,
+        "type": "model",
+        "created_at": "2026-08-28T00:00:00Z",
+        "max_input_tokens": 1_000_000,
+        "max_tokens": 128_000,
+        "capabilities": {
+            "image_input": {"supported": True},
+            "effort": {"high": {"supported": True}},
+        },
+    }
+
+
+def _http_fixture(pages: list[dict[str, object]], *, status: int = 200):
+    responses = []
+    for page in pages:
+        response = MagicMock()
+        response.status = status
+        response.content.read = AsyncMock(return_value=json.dumps(page).encode())
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=response)
+        context.__aexit__ = AsyncMock(return_value=None)
+        responses.append(context)
+    session = MagicMock()
+    session.get = MagicMock(side_effect=responses)
+    session_context = MagicMock()
+    session_context.__aenter__ = AsyncMock(return_value=session)
+    session_context.__aexit__ = AsyncMock(return_value=None)
+    return session, session_context
+
+
+async def test_api_key_discovery_uses_paginated_metadata_only_models_api(tmp_path: Path) -> None:
+    executable = tmp_path / "claude"
+    executable.write_text("fixture", encoding="utf-8")
+    session, session_context = _http_fixture(
+        [
+            {
+                "data": [_model("claude-opus-5", "Claude Opus 5")],
+                "has_more": True,
+                "last_id": "claude-opus-5",
+            },
+            {
+                "data": [_model("claude-sonnet-5", "Claude Sonnet 5")],
+                "has_more": False,
+                "last_id": "claude-sonnet-5",
+            },
+        ]
+    )
+    adapter = ClaudeModelDiscoveryAdapter(
+        environment={
+            "ANTHROPIC_API_KEY": "provider-secret",
+            "ANTHROPIC_BASE_URL": "https://gateway.example/api/",
+            "TELEGRAM_BOT_TOKEN": "control-plane-secret",
+        }
+    )
+
+    with patch.object(discovery_module.aiohttp, "ClientSession", return_value=session_context):
+        batch = await adapter.discover(_lane(executable))
+
+    assert batch.source == "anthropic-models-api:v1/models"
+    assert batch.ttl_seconds == 21_600
+    assert [candidate.model_id for candidate in batch.models] == ["claude-opus-5", "claude-sonnet-5"]
+    assert batch.models[0].capabilities == {
+        "created_at": "2026-08-28T00:00:00Z",
+        "max_input_tokens": 1_000_000,
+        "max_output_tokens": 128_000,
+        "provider_capabilities": {
+            "image_input": {"supported": True},
+            "effort": {"high": {"supported": True}},
+        },
+    }
+    first = session.get.call_args_list[0]
+    second = session.get.call_args_list[1]
+    assert first.args == ("https://gateway.example/api/v1/models?limit=1000",)
+    assert second.args == ("https://gateway.example/api/v1/models?limit=1000&after_id=claude-opus-5",)
+    assert first.kwargs["headers"] == {
+        "anthropic-version": "2023-06-01",
+        "x-api-key": "provider-secret",
+    }
+    assert first.kwargs["allow_redirects"] is False
+    assert "control-plane-secret" not in repr(session.get.call_args_list)
+
+
+async def test_subscription_context_uses_curated_fallback_without_http(tmp_path: Path) -> None:
+    executable = tmp_path / "claude"
+    executable.write_text("fixture", encoding="utf-8")
+    adapter = ClaudeModelDiscoveryAdapter(environment={})
+
+    with (
+        patch.object(discovery_module.aiohttp, "ClientSession") as client_session,
+        pytest.raises(ModelDiscoveryUnsupported),
+    ):
+        await adapter.discover(
+            _lane(
+                executable,
+                auth_mode=ModelDiscoveryAuthMode.SUBSCRIPTION,
+                auth_configured=None,
+            )
+        )
+
+    client_session.assert_not_called()
+    assert set(CLAUDE_MODELS) == {
+        "best",
+        "fable",
+        "haiku",
+        "opus",
+        "opus[1m]",
+        "opusplan",
+        "sonnet",
+        "sonnet[1m]",
+    }
+
+
+async def test_authentication_failure_is_secret_free(tmp_path: Path) -> None:
+    executable = tmp_path / "claude"
+    executable.write_text("fixture", encoding="utf-8")
+    _session, session_context = _http_fixture([{}], status=401)
+    secret = "anthropic-secret-value"
+    adapter = ClaudeModelDiscoveryAdapter(environment={"ANTHROPIC_API_KEY": secret})
+
+    with (
+        patch.object(discovery_module.aiohttp, "ClientSession", return_value=session_context),
+        pytest.raises(ModelDiscoveryAuthenticationError) as caught,
+    ):
+        await adapter.discover(_lane(executable))
+
+    assert secret not in str(caught.value)
+    assert secret not in repr(caught.value)
+
+
+def test_default_is_reset_semantics_not_a_stored_claude_model() -> None:
+    assert "default" not in CLAUDE_MODELS
+    assert validate_model_for_backend("default", "claude", "anthropic") is False
+    assert validate_model_for_backend("best", "claude", "anthropic") is True
+    assert validate_model_for_backend("opusplan", "claude", "anthropic") is True
+    assert validate_model_for_backend("opus[1m]", "claude", "anthropic") is True
+    assert models_for_backend("claude", "anthropic") is CLAUDE_MODELS
+    assert "opusplan" not in PROVIDER_MODELS["anthropic"]
+    assert validate_model_for_backend("opusplan", "goose", "anthropic") is False
+
+
+def test_parser_rejects_malformed_metadata_and_base_urls() -> None:
+    malformed = _model("claude-opus-5", "Claude Opus 5")
+    malformed["capabilities"] = ["vision"]
+    with pytest.raises(ModelCatalogueValidationError, match="capabilities"):
+        discovery_module._parse_page(json.dumps({"data": [malformed], "has_more": False, "last_id": None}).encode())
+
+    with pytest.raises(ModelCatalogueValidationError, match="base URL"):
+        discovery_module._models_endpoint("https://secret@example.com?token=secret")
+
+
+def test_api_key_lane_requires_present_key_without_exposing_environment(tmp_path: Path) -> None:
+    executable = tmp_path / "claude"
+    executable.write_text("fixture", encoding="utf-8")
+    adapter = ClaudeModelDiscoveryAdapter(environment={"TELEGRAM_BOT_TOKEN": "secret"})
+
+    with pytest.raises(ModelDiscoveryAuthenticationError):
+        adapter._discovery_context(_lane(executable))
+
+    assert "secret" not in repr(adapter)


### PR DESCRIPTION
Closes #726

## Summary

- discover Claude models for API-key runtime contexts through Anthropic's metadata-only `GET /v1/models` API
- keep Claude subscription contexts on curated aliases plus canonical operator-managed entries because Claude Code exposes no documented machine-readable model-list command
- define Claude-only `best`, `opusplan`, and documented 1M selectors without leaking them into Goose's Anthropic provider surface
- keep `default` as Kai's model-reset operation rather than a literal stored model selection
- register Claude discovery alongside Codex in the transport-neutral application host

## Safety and authority

- never invokes Claude Code or any model-generation endpoint
- scopes each result through the existing canonical runtime-profile, principal, OS-user, provider, executable, and non-secret authentication cache key
- sends API credentials only to the configured final Models endpoint and disables redirects
- bounds request duration, response size, page count, and model count
- sanitizes authentication and transport failures before the catalogue coordinator persists status
- preserves selected/default/workspace models and active sessions through the existing catalogue invariants

## Verification

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q` — 6193 passed

The protocol choice was verified on 2026-08-28 against Anthropic's official Models API and Claude Code model-configuration documentation.
