### PR TITLE
Discover OpenCode models for canonical runtime profiles

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -43,6 +43,7 @@ from kai.workshop.memory_queries import WorkshopMemoryQueryService
 from kai.workshop.model_catalogue import WorkshopModelCatalogueService
 from kai.workshop.model_discovery_inventory import WorkshopModelDiscoveryInventoryService
 from kai.workshop.notification_preferences import WorkshopNotificationPreferenceService
+from kai.workshop.opencode_model_discovery import OpenCodeModelDiscoveryAdapter
 from kai.workshop.post_run_effects import WorkshopPostRunEffectService
 from kai.workshop.preferences import WorkshopPreferenceService
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
@@ -317,6 +318,9 @@ class KaiApplicationHost:
                 adapters={
                     "claude": ClaudeModelDiscoveryAdapter(),
                     "codex": CodexModelDiscoveryAdapter(
+                        service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
+                    ),
+                    "opencode": OpenCodeModelDiscoveryAdapter(
                         service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
                     ),
                 },

--- a/src/kai/workshop/claude_model_discovery.py
+++ b/src/kai/workshop/claude_model_discovery.py
@@ -30,7 +30,7 @@ from kai.workshop.model_discovery_inventory import (
     ModelDiscoveryReadiness,
 )
 
-_SOURCE = "anthropic-models-api:v1/models"
+_SOURCE = "anthropic-models-api-v1-models"
 _DEFAULT_BASE_URL = "https://api.anthropic.com"
 _ANTHROPIC_VERSION = "2023-06-01"
 _TTL_SECONDS = 21_600

--- a/src/kai/workshop/codex_model_discovery.py
+++ b/src/kai/workshop/codex_model_discovery.py
@@ -34,7 +34,7 @@ from kai.workshop.model_discovery_inventory import (
     ModelDiscoveryReadiness,
 )
 
-_SOURCE = "codex-app-server:model/list"
+_SOURCE = "codex-app-server-model-list"
 _TTL_SECONDS = 21_600
 _PAGE_LIMIT = 100
 _MAX_PAGES = 20

--- a/src/kai/workshop/opencode_model_discovery.py
+++ b/src/kai/workshop/opencode_model_discovery.py
@@ -1,0 +1,403 @@
+"""Metadata-only OpenCode model discovery through the headless server API.
+
+Protocol contract verified 2026-08-28 against OpenCode's server reference and
+generated SDK types.  The adapter starts a short-lived, loopback-only
+``opencode serve`` process and reads ``GET /provider``.  That documented route
+returns both the provider catalogue and the providers connected in the
+effective user authentication context.  No session or generation endpoint is
+used.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import pwd
+import secrets
+import socket
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlencode
+
+import aiohttp
+
+from kai.backend import sanitize_agent_environment
+from kai.config import DATA_DIR, is_opencode_model_shape, resolve_claude_user
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+    ModelDiscoveryBatch,
+    ModelDiscoveryCandidate,
+    ModelDiscoveryUnsupported,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryReadiness,
+)
+
+_SOURCE = "opencode-server-provider"
+_TTL_SECONDS = 21_600
+_STARTUP_TIMEOUT_SECONDS = 10.0
+_REQUEST_TIMEOUT_SECONDS = 20.0
+_POLL_INTERVAL_SECONDS = 0.05
+_CLOSE_TIMEOUT_SECONDS = 3.0
+_MAX_RESPONSE_BYTES = 32 * 1024 * 1024
+_MAX_PROVIDERS = 1_000
+_MAX_MODELS = 20_000
+_SERVER_USERNAME = "kai-model-discovery"
+_PRESERVED_AUTH_VARS = (
+    "ANTHROPIC_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OPENCODE_CONFIG",
+    "OPENCODE_CONFIG_DIR",
+    "OPENCODE_MODELS_URL",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+)
+
+
+class _OpenCodeDiscoveryError(RuntimeError):
+    """A sanitized headless-server discovery failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class _OpenCodeLaunch:
+    argv: tuple[str, ...]
+    cwd: str | None
+    environment: Mapping[str, str]
+    directory: Path
+    password: str
+
+
+class OpenCodeModelDiscoveryAdapter:
+    """Enumerate models visible to one canonical OpenCode auth context."""
+
+    def __init__(
+        self,
+        *,
+        service_os_user: str,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        if not service_os_user.strip():
+            raise ValueError("service_os_user must be non-empty")
+        self._service_os_user = service_os_user.strip()
+        self._environment = os.environ if environment is None else environment
+
+    async def discover(self, lane: ModelDiscoveryBackendInventory) -> ModelDiscoveryBatch:
+        self._validate_lane(lane)
+        port = _reserve_loopback_port()
+        launch = _build_launch(
+            lane,
+            port=port,
+            service_os_user=self._service_os_user,
+            environment=self._environment,
+        )
+        process = await asyncio.create_subprocess_exec(
+            *launch.argv,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+            cwd=launch.cwd,
+            env=dict(launch.environment),
+            start_new_session=True,
+        )
+        try:
+            timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_SECONDS)
+            credential = base64.b64encode(f"{_SERVER_USERNAME}:{launch.password}".encode()).decode("ascii")
+            headers = {"Authorization": f"Basic {credential}"}
+            async with aiohttp.ClientSession(timeout=timeout, headers=headers) as session:
+                await _wait_until_ready(session, process, port)
+                body = await _get_provider_catalogue(session, port, launch.directory)
+            candidates = _parse_provider_catalogue(body, lane.provider)
+            return ModelDiscoveryBatch(_SOURCE, candidates, ttl_seconds=_TTL_SECONDS)
+        finally:
+            await _finish_process_cleanup(process)
+
+    @staticmethod
+    def _validate_lane(lane: ModelDiscoveryBackendInventory) -> None:
+        if lane.backend != "opencode":
+            raise ModelDiscoveryUnsupported
+        if lane.executable.readiness != ModelDiscoveryReadiness.READY:
+            raise ModelDiscoveryUnsupported
+        if not lane.executable.configured_path or not lane.executable.resolved_path:
+            raise ModelDiscoveryUnsupported
+
+
+def _reserve_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+    if not isinstance(port, int) or port <= 0:
+        raise _OpenCodeDiscoveryError("OpenCode discovery could not reserve a loopback port")
+    return port
+
+
+def _build_launch(
+    lane: ModelDiscoveryBackendInventory,
+    *,
+    port: int,
+    service_os_user: str,
+    environment: Mapping[str, str],
+) -> _OpenCodeLaunch:
+    command = lane.executable.configured_path
+    if command is None:
+        raise ModelDiscoveryUnsupported
+    try:
+        home = Path(pwd.getpwnam(lane.effective_os_user).pw_dir)
+    except KeyError as exc:
+        raise ModelDiscoveryUnsupported from exc
+    password = secrets.token_urlsafe(32)
+    env = sanitize_agent_environment(dict(environment))
+    # Discovery must load the effective user's real OpenCode configuration,
+    # not a one-turn model override inherited from another process.
+    env.pop("OPENCODE_CONFIG_CONTENT", None)
+    env["OPENCODE_SERVER_USERNAME"] = _SERVER_USERNAME
+    env["OPENCODE_SERVER_PASSWORD"] = password
+    target_user = None if lane.effective_os_user == service_os_user else resolve_claude_user(lane.effective_os_user)
+    argv = [
+        command,
+        "serve",
+        "--hostname",
+        "127.0.0.1",
+        "--port",
+        str(port),
+    ]
+    if target_user is not None:
+        env["TMPDIR"] = str(DATA_DIR / "tmp" / target_user)
+        argv = wrap_command_for_target_user(
+            argv,
+            target_user=target_user,
+            working_directory=home,
+            preserve_env=(
+                *_PRESERVED_AUTH_VARS,
+                "OPENCODE_SERVER_USERNAME",
+                "OPENCODE_SERVER_PASSWORD",
+                "TMPDIR",
+            ),
+        )
+    return _OpenCodeLaunch(
+        tuple(argv),
+        subprocess_spawn_cwd(home, target_user=target_user),
+        env,
+        home,
+        password,
+    )
+
+
+async def _wait_until_ready(
+    session: aiohttp.ClientSession,
+    process: asyncio.subprocess.Process,
+    port: int,
+) -> None:
+    url = f"http://127.0.0.1:{port}/global/health"
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _STARTUP_TIMEOUT_SECONDS
+    while True:
+        if process.returncode is not None:
+            raise _OpenCodeDiscoveryError("OpenCode metadata server exited during startup")
+        try:
+            async with session.get(url, allow_redirects=False) as response:
+                if response.status == 200:
+                    body = await response.content.read(1025)
+                    if len(body) > 1024:
+                        raise ModelCatalogueValidationError("OpenCode health response exceeds the safety limit")
+                    value = json.loads(body)
+                    if isinstance(value, dict) and value.get("healthy") is True:
+                        return
+        except (aiohttp.ClientError, UnicodeDecodeError, json.JSONDecodeError):
+            pass
+        if loop.time() >= deadline:
+            raise _OpenCodeDiscoveryError("OpenCode metadata server did not become ready")
+        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+
+
+async def _get_provider_catalogue(
+    session: aiohttp.ClientSession,
+    port: int,
+    directory: Path,
+) -> bytes:
+    query = urlencode({"directory": str(directory)})
+    url = f"http://127.0.0.1:{port}/provider?{query}"
+    try:
+        async with session.get(url, allow_redirects=False) as response:
+            if response.status in {401, 403}:
+                raise ModelDiscoveryAuthenticationError
+            if response.status < 200 or response.status >= 300:
+                raise _OpenCodeDiscoveryError("OpenCode provider metadata request failed")
+            body = await response.content.read(_MAX_RESPONSE_BYTES + 1)
+    except (ModelDiscoveryAuthenticationError, _OpenCodeDiscoveryError):
+        raise
+    except (aiohttp.ClientError, TimeoutError) as exc:
+        raise _OpenCodeDiscoveryError("OpenCode provider metadata request failed") from exc
+    if len(body) > _MAX_RESPONSE_BYTES:
+        raise ModelCatalogueValidationError("OpenCode provider catalogue exceeds the safety limit")
+    return body
+
+
+def _parse_provider_catalogue(body: bytes, provider_id: str) -> tuple[ModelDiscoveryCandidate, ...]:
+    try:
+        value = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ModelCatalogueValidationError("OpenCode provider catalogue is malformed JSON") from exc
+    if not isinstance(value, dict):
+        raise ModelCatalogueValidationError("OpenCode provider catalogue must be an object")
+    providers = value.get("all")
+    connected = value.get("connected")
+    if not isinstance(providers, list) or len(providers) > _MAX_PROVIDERS:
+        raise ModelCatalogueValidationError("OpenCode provider catalogue has an invalid provider list")
+    if not isinstance(connected, list) or not all(isinstance(item, str) and item for item in connected):
+        raise ModelCatalogueValidationError("OpenCode provider catalogue has an invalid connected list")
+
+    matching = [provider for provider in providers if isinstance(provider, dict) and provider.get("id") == provider_id]
+    if len(matching) > 1:
+        raise ModelCatalogueValidationError("OpenCode provider catalogue contains a duplicate provider")
+    if not matching:
+        raise ModelDiscoveryUnsupported
+    if provider_id not in connected:
+        raise ModelDiscoveryAuthenticationError
+    provider = matching[0]
+    name = _required_text(provider, "name", context="provider")
+    models = provider.get("models")
+    if not isinstance(models, dict) or len(models) > _MAX_MODELS:
+        raise ModelCatalogueValidationError("OpenCode provider model catalogue must be an object")
+    return tuple(_parse_model(provider_id, name, key, model) for key, model in sorted(models.items()))
+
+
+def _parse_model(
+    provider_id: str,
+    provider_name: str,
+    catalogue_key: object,
+    value: object,
+) -> ModelDiscoveryCandidate:
+    if not isinstance(catalogue_key, str) or not catalogue_key:
+        raise ModelCatalogueValidationError("OpenCode model catalogue key must be text")
+    if not isinstance(value, dict):
+        raise ModelCatalogueValidationError("OpenCode model entry must be an object")
+    model_id = _required_text(value, "id", context="model")
+    if catalogue_key != model_id:
+        raise ModelCatalogueValidationError("OpenCode model key and identifier do not match")
+    full_id = f"{provider_id}/{model_id}"
+    if not is_opencode_model_shape(full_id):
+        raise ModelCatalogueValidationError("OpenCode returned an invalid provider/model identifier")
+
+    capabilities: dict[str, object] = {
+        "provider_name": provider_name,
+        "release_date": _required_text(value, "release_date", context="model"),
+        "attachment": _required_bool(value, "attachment"),
+        "reasoning": _required_bool(value, "reasoning"),
+        "temperature": _required_bool(value, "temperature"),
+        "tool_call": _required_bool(value, "tool_call"),
+        "experimental": _optional_bool(value, "experimental"),
+        "status": _optional_status(value),
+        "limits": _limits(value.get("limit")),
+        "modalities": _modalities(value.get("modalities")),
+    }
+    return ModelDiscoveryCandidate(
+        full_id,
+        _required_text(value, "name", context="model"),
+        capabilities,
+    )
+
+
+def _required_text(value: Mapping[str, object], field: str, *, context: str) -> str:
+    item = value.get(field)
+    if not isinstance(item, str) or not item.strip():
+        raise ModelCatalogueValidationError(f"OpenCode {context} field {field} must be text")
+    return item
+
+
+def _required_bool(value: Mapping[str, object], field: str) -> bool:
+    item = value.get(field)
+    if not isinstance(item, bool):
+        raise ModelCatalogueValidationError(f"OpenCode model field {field} must be boolean")
+    return item
+
+
+def _optional_bool(value: Mapping[str, object], field: str) -> bool | None:
+    item = value.get(field)
+    if item is None:
+        return None
+    if not isinstance(item, bool):
+        raise ModelCatalogueValidationError(f"OpenCode model field {field} must be boolean or null")
+    return item
+
+
+def _optional_status(value: Mapping[str, object]) -> str | None:
+    status = value.get("status")
+    if status is None:
+        return None
+    if status not in {"active", "alpha", "beta", "deprecated"}:
+        raise ModelCatalogueValidationError("OpenCode model status is invalid")
+    assert isinstance(status, str)
+    return status
+
+
+def _limits(value: object) -> dict[str, int]:
+    if not isinstance(value, dict):
+        raise ModelCatalogueValidationError("OpenCode model limits must be an object")
+    return {
+        "context": _nonnegative_integer(value, "context"),
+        "output": _nonnegative_integer(value, "output"),
+    }
+
+
+def _nonnegative_integer(value: Mapping[str, object], field: str) -> int:
+    item = value.get(field)
+    if isinstance(item, bool) or not isinstance(item, int) or item < 0:
+        raise ModelCatalogueValidationError(f"OpenCode model field {field} must be a non-negative integer")
+    return item
+
+
+def _modalities(value: object) -> dict[str, list[str]] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ModelCatalogueValidationError("OpenCode model modalities must be an object or null")
+    return {
+        "input": _modality_list(value.get("input"), "input"),
+        "output": _modality_list(value.get("output"), "output"),
+    }
+
+
+def _modality_list(value: object, field: str) -> list[str]:
+    allowed = {"audio", "image", "pdf", "text", "video"}
+    if not isinstance(value, list) or not all(isinstance(item, str) and item in allowed for item in value):
+        raise ModelCatalogueValidationError(f"OpenCode model {field} modalities are invalid")
+    return list(value)
+
+
+async def _close_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        await process.wait()
+        return
+    try:
+        process.terminate()
+    except ProcessLookupError:
+        pass
+    try:
+        async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+            await process.wait()
+            return
+    except TimeoutError:
+        pass
+    try:
+        process.kill()
+    except ProcessLookupError:
+        pass
+    await process.wait()
+
+
+async def _finish_process_cleanup(process: asyncio.subprocess.Process) -> None:
+    cleanup = asyncio.create_task(_close_process(process))
+    try:
+        await asyncio.shield(cleanup)
+    except asyncio.CancelledError:
+        await cleanup
+        raise

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -29,6 +29,7 @@ from kai.workshop.internal_api_contexts import (
     WorkshopInternalAPIContextRegistry,
     WorkshopInternalAPIExecutionContext,
 )
+from kai.workshop.opencode_model_discovery import OpenCodeModelDiscoveryAdapter
 from kai.workshop.run_execution_authority import (
     RunAttemptStatus,
     RunExecutionSelection,
@@ -424,9 +425,10 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
     }
     assert services.subprocess_pool is not None
     assert _FakeModelCatalogue.adapters is not None
-    assert set(_FakeModelCatalogue.adapters) == {"claude", "codex"}
+    assert set(_FakeModelCatalogue.adapters) == {"claude", "codex", "opencode"}
     assert isinstance(_FakeModelCatalogue.adapters["claude"], ClaudeModelDiscoveryAdapter)
     assert isinstance(_FakeModelCatalogue.adapters["codex"], CodexModelDiscoveryAdapter)
+    assert isinstance(_FakeModelCatalogue.adapters["opencode"], OpenCodeModelDiscoveryAdapter)
     assert services.delivery_policy.enabled_transports == frozenset()
     assert host_dependencies == [
         "pool:start",

--- a/tests/test_workshop_claude_model_discovery.py
+++ b/tests/test_workshop_claude_model_discovery.py
@@ -147,7 +147,7 @@ async def test_api_key_discovery_uses_paginated_metadata_only_models_api(tmp_pat
     with patch.object(discovery_module.aiohttp, "ClientSession", return_value=session_context):
         batch = await adapter.discover(_lane(executable))
 
-    assert batch.source == "anthropic-models-api:v1/models"
+    assert batch.source == "anthropic-models-api-v1-models"
     assert batch.ttl_seconds == 21_600
     assert [candidate.model_id for candidate in batch.models] == ["claude-opus-5", "claude-sonnet-5"]
     assert batch.models[0].capabilities == {

--- a/tests/test_workshop_codex_model_discovery.py
+++ b/tests/test_workshop_codex_model_discovery.py
@@ -163,7 +163,7 @@ async def test_adapter_uses_paginated_metadata_only_model_list(tmp_path: Path) -
 
     batch = await adapter.discover(_lane(executable, os_user=current_user))
 
-    assert batch.source == "codex-app-server:model/list"
+    assert batch.source == "codex-app-server-model-list"
     assert batch.ttl_seconds == 21_600
     assert [candidate.model_id for candidate in batch.models] == ["gpt-alpha", "gpt-beta"]
     assert batch.models[0].display_label == "GPT Alpha"

--- a/tests/test_workshop_opencode_model_discovery.py
+++ b/tests/test_workshop_opencode_model_discovery.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import pwd
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kai.workshop import claude_model_discovery, codex_model_discovery
+from kai.workshop import model_catalogue as catalogue_module
+from kai.workshop import opencode_model_discovery as discovery_module
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+    ModelDiscoveryUnsupported,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryAuthContext,
+    ModelDiscoveryAuthMode,
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryCacheInputs,
+    ModelDiscoveryExecutableIdentity,
+    ModelDiscoveryReadiness,
+    ModelDiscoverySelectionStatus,
+)
+from kai.workshop.opencode_model_discovery import OpenCodeModelDiscoveryAdapter
+
+
+def _id(identifier_type, value: int):
+    return identifier_type(f"{identifier_type.prefix}_{value:032x}")
+
+
+def _lane(
+    executable: Path,
+    *,
+    value: int = 1,
+    os_user: str | None = None,
+    provider: str = "openrouter",
+) -> ModelDiscoveryBackendInventory:
+    from kai.workshop.domain import PrincipalId, RuntimeProfileId
+
+    principal_id = _id(PrincipalId, value)
+    profile_id = _id(RuntimeProfileId, value)
+    effective_user = os_user or pwd.getpwuid(os.getuid()).pw_name
+    executable_identity = ModelDiscoveryExecutableIdentity(
+        configured_path=str(executable),
+        resolved_path=str(executable.resolve()),
+        fingerprint=f"executable-{value}",
+        readiness=ModelDiscoveryReadiness.READY,
+        diagnostic=None,
+    )
+    auth = ModelDiscoveryAuthContext(
+        ModelDiscoveryAuthMode.BACKEND_MANAGED,
+        "backend configuration",
+        None,
+        f"auth-{value}",
+    )
+    cache_inputs = ModelDiscoveryCacheInputs(
+        version=1,
+        principal_id=principal_id,
+        runtime_profile_id=profile_id,
+        backend="opencode",
+        provider=provider,
+        os_user=effective_user,
+        executable_fingerprint=executable_identity.fingerprint,
+        auth_fingerprint=auth.fingerprint,
+        default_model=f"{provider}/default",
+        allowed_models=None,
+        role_models=(),
+    )
+    return ModelDiscoveryBackendInventory(
+        option_id=f"opencode:{provider}",
+        backend="opencode",
+        provider=provider,
+        selected=True,
+        status=ModelDiscoverySelectionStatus.SELECTED,
+        readiness=ModelDiscoveryReadiness.UNVERIFIED,
+        effective_os_user=effective_user,
+        executable=executable_identity,
+        auth=auth,
+        default_model=f"{provider}/default",
+        allowed_models=None,
+        role_models=(),
+        cache_inputs=cache_inputs,
+        cache_key=f"cache-{value}",
+        diagnostic=None,
+    )
+
+
+def _model(model_id: str, *, name: str = "Claude Sonnet") -> dict[str, object]:
+    return {
+        "id": model_id,
+        "name": name,
+        "release_date": "2026-08-01",
+        "attachment": True,
+        "reasoning": True,
+        "temperature": True,
+        "tool_call": True,
+        "cost": {"input": 1, "output": 2},
+        "limit": {"context": 200_000, "output": 64_000},
+        "modalities": {"input": ["text", "image"], "output": ["text"]},
+        "status": "active",
+        "experimental": False,
+        "options": {"apiKey": "provider-secret"},
+        "headers": {"authorization": "Bearer provider-secret"},
+    }
+
+
+def test_registered_adapter_sources_are_valid_canonical_catalogue_ids() -> None:
+    for source in (
+        claude_model_discovery._SOURCE,
+        codex_model_discovery._SOURCE,
+        discovery_module._SOURCE,
+    ):
+        normalized = catalogue_module._normalize_batch(
+            catalogue_module.ModelDiscoveryBatch(source, ()),
+        )
+        assert normalized.source == source
+
+
+def _fake_server(
+    tmp_path: Path,
+    payload: object,
+) -> tuple[Path, Path]:
+    executable = tmp_path / "opencode-fixture"
+    request_log = tmp_path / "requests.jsonl"
+    encoded_payload = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+    script = f"""#!{sys.executable}
+import argparse
+import base64
+import json
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+parser = argparse.ArgumentParser()
+parser.add_argument("command")
+parser.add_argument("--hostname", required=True)
+parser.add_argument("--port", required=True, type=int)
+args = parser.parse_args()
+payload = base64.b64decode({encoded_payload!r})
+request_log = {str(request_log)!r}
+expected = "Basic " + base64.b64encode(
+    (os.environ["OPENCODE_SERVER_USERNAME"] + ":" + os.environ["OPENCODE_SERVER_PASSWORD"]).encode()
+).decode()
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        with open(request_log, "a", encoding="utf-8") as output:
+            output.write(json.dumps({{
+                "path": self.path,
+                "authenticated": self.headers.get("Authorization") == expected,
+            }}) + "\\n")
+        if self.headers.get("Authorization") != expected:
+            self.send_response(401)
+            self.end_headers()
+            return
+        if self.path == "/global/health":
+            body = b'{{"healthy":true,"version":"fixture"}}'
+        elif self.path.startswith("/provider?"):
+            body = payload
+        else:
+            self.send_response(404)
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+HTTPServer((args.hostname, args.port), Handler).serve_forever()
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    return executable, request_log
+
+
+async def test_adapter_reads_connected_provider_without_generation_and_preserves_nested_ids(
+    tmp_path: Path,
+) -> None:
+    model_id = "anthropic/claude-sonnet-4-6"
+    payload = {
+        "all": [
+            {
+                "id": "openrouter",
+                "name": "OpenRouter",
+                "models": {model_id: _model(model_id)},
+                "options": {"apiKey": "provider-secret"},
+            }
+        ],
+        "default": {"openrouter": model_id},
+        "connected": ["openrouter"],
+    }
+    executable, request_log = _fake_server(tmp_path, payload)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = OpenCodeModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    batch = await adapter.discover(_lane(executable, os_user=current_user))
+
+    assert batch.source == "opencode-server-provider"
+    assert batch.ttl_seconds == 21_600
+    assert [candidate.model_id for candidate in batch.models] == ["openrouter/anthropic/claude-sonnet-4-6"]
+    assert batch.models[0].display_label == "Claude Sonnet"
+    assert batch.models[0].capabilities == {
+        "attachment": True,
+        "experimental": False,
+        "limits": {"context": 200_000, "output": 64_000},
+        "modalities": {"input": ["text", "image"], "output": ["text"]},
+        "provider_name": "OpenRouter",
+        "reasoning": True,
+        "release_date": "2026-08-01",
+        "status": "active",
+        "temperature": True,
+        "tool_call": True,
+    }
+    assert "provider-secret" not in repr(batch)
+    requests = [json.loads(line) for line in request_log.read_text(encoding="utf-8").splitlines()]
+    assert [request["path"].split("?", 1)[0] for request in requests] == [
+        "/global/health",
+        "/provider",
+    ]
+    assert all(request["authenticated"] is True for request in requests)
+    assert "directory=" in requests[1]["path"]
+    assert not any("session" in request["path"] for request in requests)
+
+
+def test_parser_distinguishes_unavailable_auth_from_unsupported_provider() -> None:
+    model = _model("model")
+    payload = json.dumps(
+        {
+            "all": [{"id": "openrouter", "name": "OpenRouter", "models": {"model": model}}],
+            "connected": [],
+        }
+    ).encode()
+    with pytest.raises(ModelDiscoveryAuthenticationError):
+        discovery_module._parse_provider_catalogue(payload, "openrouter")
+    with pytest.raises(ModelDiscoveryUnsupported):
+        discovery_module._parse_provider_catalogue(payload, "deepseek")
+
+
+def test_parser_accepts_empty_inventory_and_rejects_malformed_or_mismatched_models() -> None:
+    empty = json.dumps(
+        {
+            "all": [{"id": "openrouter", "name": "OpenRouter", "models": {}}],
+            "connected": ["openrouter"],
+        }
+    ).encode()
+    assert discovery_module._parse_provider_catalogue(empty, "openrouter") == ()
+
+    with pytest.raises(ModelCatalogueValidationError, match="malformed JSON"):
+        discovery_module._parse_provider_catalogue(b"not json", "openrouter")
+
+    mismatched = json.dumps(
+        {
+            "all": [
+                {
+                    "id": "openrouter",
+                    "name": "OpenRouter",
+                    "models": {"catalogue-key": _model("different-id")},
+                }
+            ],
+            "connected": ["openrouter"],
+        }
+    ).encode()
+    with pytest.raises(ModelCatalogueValidationError, match="do not match"):
+        discovery_module._parse_provider_catalogue(mismatched, "openrouter")
+
+
+def test_launch_uses_canonical_user_auth_context_and_scrubs_control_plane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "opencode"
+    executable.write_text("fixture", encoding="utf-8")
+    executable.chmod(0o700)
+    alice_home = tmp_path / "alice"
+    alice_home.mkdir()
+    monkeypatch.setattr(
+        discovery_module.pwd,
+        "getpwnam",
+        lambda user: SimpleNamespace(pw_dir=str(alice_home)),
+    )
+    environment = {
+        "OPENROUTER_API_KEY": "provider-key",
+        "OPENCODE_CONFIG_CONTENT": '{"model":"wrong/model"}',
+        "TELEGRAM_BOT_TOKEN": "control-plane-secret",
+    }
+
+    launch = discovery_module._build_launch(
+        _lane(executable, os_user="alice"),
+        port=43123,
+        service_os_user="kai",
+        environment=environment,
+    )
+
+    assert launch.argv[:6] == ("sudo", "-H", "-D", str(alice_home), "-u", "alice")
+    assert launch.argv[-6:] == (
+        str(executable),
+        "serve",
+        "--hostname",
+        "127.0.0.1",
+        "--port",
+        "43123",
+    )
+    assert launch.cwd is None
+    assert launch.directory == alice_home
+    assert launch.environment["OPENROUTER_API_KEY"] == "provider-key"
+    assert "OPENCODE_CONFIG_CONTENT" not in launch.environment
+    assert "TELEGRAM_BOT_TOKEN" not in launch.environment
+    assert launch.environment["OPENCODE_SERVER_USERNAME"] == "kai-model-discovery"
+    assert launch.environment["OPENCODE_SERVER_PASSWORD"] == launch.password
+    assert launch.environment["TMPDIR"].endswith("/tmp/alice")
+    preserve_arg = next(arg for arg in launch.argv if arg.startswith("--preserve-env="))
+    assert "OPENCODE_SERVER_PASSWORD" in preserve_arg
+    assert "TELEGRAM_BOT_TOKEN" not in preserve_arg
+
+
+async def test_startup_timeout_reaps_metadata_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "opencode-hung-fixture"
+    pid_file = tmp_path / "pid"
+    script = f"""#!{sys.executable}
+import os
+import time
+from pathlib import Path
+Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+time.sleep(60)
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    monkeypatch.setattr(discovery_module, "_STARTUP_TIMEOUT_SECONDS", 0.5)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = OpenCodeModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    with pytest.raises(discovery_module._OpenCodeDiscoveryError, match="did not become ready"):
+        await adapter.discover(_lane(executable, os_user=current_user))
+
+    pid = int(pid_file.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)
+
+
+async def test_cancellation_reaps_metadata_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "opencode-cancel-fixture"
+    pid_file = tmp_path / "pid"
+    script = f"""#!{sys.executable}
+import os
+import time
+from pathlib import Path
+Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+time.sleep(60)
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    monkeypatch.setattr(discovery_module, "_STARTUP_TIMEOUT_SECONDS", 60.0)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = OpenCodeModelDiscoveryAdapter(service_os_user=current_user, environment={})
+    task = asyncio.create_task(adapter.discover(_lane(executable, os_user=current_user)))
+    for _ in range(100):
+        if pid_file.exists():
+            break
+        await asyncio.sleep(0.01)
+    assert pid_file.exists()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pid = int(pid_file.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)


### PR DESCRIPTION
Closes #727.

## Summary

- add principal-scoped OpenCode model discovery through the documented headless server `/provider` API
- run discovery under each runtime profile's effective OS-user, configuration, provider, and authentication context
- preserve nested `provider/model` identifiers while retaining only bounded, non-secret model metadata
- bind the short-lived metadata server to loopback, protect it with a random per-run password, and reap it on success, failure, timeout, or cancellation
- register OpenCode with the canonical model catalogue without changing OpenCode's safe free-text model entry or any current/default selection
- normalize Claude, Codex, and OpenCode discovery provenance IDs so successful observations pass the canonical catalogue validator

## Safety and fallback

- no model, session, prompt, or generation endpoint is invoked
- control-plane credentials and inherited one-turn OpenCode model overrides are stripped
- provider options, request headers, API keys, costs, and raw response bodies are never persisted
- disconnected providers are classified as authentication failures; unknown providers remain unsupported, leaving the explicit configured model available
- catalogue timeouts and refresh failures retain the existing last-known-good inventory and selected model

## Validation

- `make check`
- focused cross-adapter catalogue, lifecycle, and application-host tests: 36 passed
- full suite: 6200 passed

## Protocol references

- OpenCode server API: https://opencode.ai/docs/server/
- OpenCode generated provider types: https://github.com/anomalyco/opencode/blob/v1.15.11/packages/sdk/js/src/gen/types.gen.ts
