### PR TITLE
Discover Goose models canonically

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -37,6 +37,7 @@ from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.github_automation import WorkshopGitHubAutomationService
 from kai.workshop.github_settings import WorkshopGitHubSettingsService
+from kai.workshop.goose_model_discovery import GooseModelDiscoveryAdapter
 from kai.workshop.integration_notifications import WorkshopIntegrationNotificationService
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
@@ -318,6 +319,9 @@ class KaiApplicationHost:
                 adapters={
                     "claude": ClaudeModelDiscoveryAdapter(),
                     "codex": CodexModelDiscoveryAdapter(
+                        service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
+                    ),
+                    "goose": GooseModelDiscoveryAdapter(
                         service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
                     ),
                     "opencode": OpenCodeModelDiscoveryAdapter(

--- a/src/kai/workshop/goose_model_discovery.py
+++ b/src/kai/workshop/goose_model_discovery.py
@@ -1,0 +1,353 @@
+"""Metadata-only Goose model discovery through Goose's ACP schema.
+
+Protocol contract verified 2026-08-28 against Goose's generated ACP schema
+and ``ProviderSupportedModelsListRequest`` implementation.  The adapter starts
+a short-lived ``goose acp`` process in the canonical runtime profile's effective
+OS-user context, initializes ACP, and sends only
+``_goose/unstable/providers/supported-models/list``.  Goose delegates that
+request to the selected provider's native ``fetch_supported_models`` method.
+No session is created and no prompt or model-generation request is sent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pwd
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+import kai
+from kai.acp import _kill_target_user_tree
+from kai.backend import sanitize_agent_environment
+from kai.config import DATA_DIR, resolve_claude_user
+from kai.goose import goose_provider_id
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+    ModelDiscoveryBatch,
+    ModelDiscoveryCandidate,
+    ModelDiscoveryUnsupported,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryReadiness,
+)
+
+_SOURCE = "goose-acp-provider-supported-models"
+_METHOD = "_goose/unstable/providers/supported-models/list"
+_TTL_SECONDS = 21_600
+_RPC_TIMEOUT_SECONDS = 20.0
+_CLOSE_TIMEOUT_SECONDS = 3.0
+_STREAM_LIMIT = 16 * 1024 * 1024
+_MAX_MODELS = 20_000
+_MAX_MODEL_ID_CHARACTERS = 512
+_AUTH_MARKERS = (
+    "auth",
+    "credential",
+    "expired",
+    "not configured",
+    "sign in",
+    "token",
+    "unauthorized",
+)
+_UNSUPPORTED_MARKERS = (
+    "does not support",
+    "not supported",
+    "unknown provider",
+)
+_PRESERVED_AUTH_VARS = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENROUTER_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "ANTHROPIC_HOST",
+    "OPENAI_HOST",
+    "OPENAI_BASE_PATH",
+    "OLLAMA_HOST",
+    "GOOSE_PROVIDER",
+    "GOOSE_MODEL",
+)
+
+
+class _GooseProtocolError(RuntimeError):
+    """A sanitized Goose ACP metadata failure."""
+
+
+class _GooseRpcError(_GooseProtocolError):
+    def __init__(self, *, authentication: bool, unsupported: bool) -> None:
+        super().__init__("Goose ACP rejected a metadata request")
+        self.authentication = authentication
+        self.unsupported = unsupported
+
+
+@dataclass(frozen=True, slots=True)
+class _GooseLaunch:
+    argv: tuple[str, ...]
+    cwd: str | None
+    environment: Mapping[str, str]
+    target_user: str | None
+
+
+class GooseModelDiscoveryAdapter:
+    """Enumerate models visible to one canonical Goose provider context."""
+
+    def __init__(
+        self,
+        *,
+        service_os_user: str,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        if not service_os_user.strip():
+            raise ValueError("service_os_user must be non-empty")
+        self._service_os_user = service_os_user.strip()
+        self._environment = os.environ if environment is None else environment
+
+    async def discover(self, lane: ModelDiscoveryBackendInventory) -> ModelDiscoveryBatch:
+        self._validate_lane(lane)
+        launch = _build_launch(
+            lane,
+            service_os_user=self._service_os_user,
+            environment=self._environment,
+        )
+        process = await asyncio.create_subprocess_exec(
+            *launch.argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=launch.cwd,
+            env=dict(launch.environment),
+            start_new_session=launch.target_user is not None,
+            limit=_STREAM_LIMIT,
+        )
+        stderr_task = asyncio.create_task(_discard_stream(process.stderr))
+        try:
+            if process.stdin is None or process.stdout is None:
+                raise _GooseProtocolError("Goose ACP pipes are unavailable")
+            rpc = _GooseRpcClient(process.stdin, process.stdout)
+            await rpc.request(
+                "initialize",
+                {
+                    "protocolVersion": "v1",
+                    "clientInfo": {
+                        "name": "kai-model-discovery",
+                        "version": kai.__version__,
+                    },
+                },
+            )
+            result = await rpc.request(
+                _METHOD,
+                {"providerId": goose_provider_id(lane.provider)},
+            )
+            candidates = _parse_supported_models(result, goose_provider_id(lane.provider))
+            return ModelDiscoveryBatch(_SOURCE, candidates, ttl_seconds=_TTL_SECONDS)
+        except _GooseRpcError as exc:
+            if exc.authentication:
+                raise ModelDiscoveryAuthenticationError from exc
+            if exc.unsupported:
+                raise ModelDiscoveryUnsupported from exc
+            raise _GooseProtocolError from exc
+        finally:
+            await _finish_process_cleanup(
+                process,
+                stderr_task,
+                target_user=launch.target_user,
+            )
+
+    @staticmethod
+    def _validate_lane(lane: ModelDiscoveryBackendInventory) -> None:
+        if lane.backend != "goose":
+            raise ModelDiscoveryUnsupported
+        if lane.executable.readiness != ModelDiscoveryReadiness.READY:
+            raise ModelDiscoveryUnsupported
+        if not lane.executable.configured_path or not lane.executable.resolved_path:
+            raise ModelDiscoveryUnsupported
+
+
+class _GooseRpcClient:
+    def __init__(self, stdin: asyncio.StreamWriter, stdout: asyncio.StreamReader) -> None:
+        self._stdin = stdin
+        self._stdout = stdout
+        self._next_id = 1
+
+    async def request(self, method: str, params: Mapping[str, object]) -> Mapping[str, object]:
+        request_id = self._next_id
+        self._next_id += 1
+        message = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        self._stdin.write(json.dumps(message, separators=(",", ":"), ensure_ascii=True).encode() + b"\n")
+        await self._stdin.drain()
+        while True:
+            try:
+                line = await asyncio.wait_for(
+                    self._stdout.readline(),
+                    timeout=_RPC_TIMEOUT_SECONDS,
+                )
+            except TimeoutError as exc:
+                raise _GooseProtocolError("Goose ACP metadata request timed out") from exc
+            if not line:
+                raise _GooseProtocolError("Goose ACP exited before responding")
+            try:
+                response = json.loads(line)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise ModelCatalogueValidationError("Goose ACP emitted malformed JSON") from exc
+            if not isinstance(response, dict) or response.get("id") != request_id:
+                continue
+            if "error" in response:
+                raise _classify_rpc_error(response.get("error"))
+            result = response.get("result")
+            if not isinstance(result, dict):
+                raise ModelCatalogueValidationError("Goose ACP metadata response has no result object")
+            return result
+
+
+def _classify_rpc_error(value: object) -> _GooseRpcError:
+    if not isinstance(value, dict):
+        return _GooseRpcError(authentication=False, unsupported=False)
+    code = value.get("code")
+    parts = (value.get("message"), value.get("data"))
+    text = " ".join(item for item in parts if isinstance(item, str)).lower()
+    authentication = code in {401, 403} or any(marker in text for marker in _AUTH_MARKERS)
+    unsupported = not authentication and (code == -32601 or any(marker in text for marker in _UNSUPPORTED_MARKERS))
+    return _GooseRpcError(authentication=authentication, unsupported=unsupported)
+
+
+def _parse_supported_models(
+    result: Mapping[str, object],
+    expected_provider_id: str,
+) -> tuple[ModelDiscoveryCandidate, ...]:
+    provider_id = result.get("providerId")
+    if provider_id != expected_provider_id:
+        raise ModelCatalogueValidationError("Goose ACP returned a mismatched provider identifier")
+    models = result.get("models")
+    if not isinstance(models, list) or len(models) > _MAX_MODELS:
+        raise ModelCatalogueValidationError("Goose ACP model catalogue must be a bounded list")
+    candidates: list[ModelDiscoveryCandidate] = []
+    seen: set[str] = set()
+    for value in models:
+        if (
+            not isinstance(value, str)
+            or not value.strip()
+            or value != value.strip()
+            or len(value) > _MAX_MODEL_ID_CHARACTERS
+        ):
+            raise ModelCatalogueValidationError("Goose ACP returned an invalid model identifier")
+        if value in seen:
+            raise ModelCatalogueValidationError("Goose ACP returned a duplicate model identifier")
+        seen.add(value)
+        candidates.append(
+            ModelDiscoveryCandidate(
+                value,
+                value,
+                {"provider_id": expected_provider_id},
+            )
+        )
+    return tuple(candidates)
+
+
+def _build_launch(
+    lane: ModelDiscoveryBackendInventory,
+    *,
+    service_os_user: str,
+    environment: Mapping[str, str],
+) -> _GooseLaunch:
+    command = lane.executable.configured_path
+    if command is None:
+        raise ModelDiscoveryUnsupported
+    try:
+        home = Path(pwd.getpwnam(lane.effective_os_user).pw_dir)
+    except KeyError as exc:
+        raise ModelDiscoveryUnsupported from exc
+    env = sanitize_agent_environment(dict(environment))
+    env["GOOSE_PROVIDER"] = goose_provider_id(lane.provider)
+    env["GOOSE_MODEL"] = lane.default_model
+    target_user = None if lane.effective_os_user == service_os_user else resolve_claude_user(lane.effective_os_user)
+    argv = [command, "acp"]
+    if target_user is not None:
+        # ``sudo -H`` selects the target user's Goose configuration.  Do not
+        # carry a service-user XDG override across that identity boundary.
+        env.pop("XDG_CONFIG_HOME", None)
+        env.pop("XDG_DATA_HOME", None)
+        env["TMPDIR"] = str(DATA_DIR / "tmp" / target_user)
+        argv = wrap_command_for_target_user(
+            argv,
+            target_user=target_user,
+            working_directory=home,
+            preserve_env=(*_PRESERVED_AUTH_VARS, "TMPDIR"),
+        )
+    return _GooseLaunch(
+        tuple(argv),
+        subprocess_spawn_cwd(home, target_user=target_user),
+        env,
+        target_user,
+    )
+
+
+async def _discard_stream(stream: asyncio.StreamReader | None) -> None:
+    if stream is None:
+        return
+    while await stream.read(64 * 1024):
+        pass
+
+
+async def _close_process(
+    process: asyncio.subprocess.Process,
+    stderr_task: asyncio.Task[None],
+    *,
+    target_user: str | None,
+) -> None:
+    if process.stdin is not None:
+        process.stdin.close()
+    try:
+        async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+            await process.wait()
+    except TimeoutError:
+        if target_user is not None:
+            await _kill_target_user_tree(
+                target_user=target_user,
+                pgid=process.pid,
+                purpose="model discovery timeout",
+                backend="goose",
+            )
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+        await process.wait()
+    try:
+        async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+            await stderr_task
+    except TimeoutError:
+        stderr_task.cancel()
+        try:
+            await stderr_task
+        except asyncio.CancelledError:
+            pass
+
+
+async def _finish_process_cleanup(
+    process: asyncio.subprocess.Process,
+    stderr_task: asyncio.Task[None],
+    *,
+    target_user: str | None,
+) -> None:
+    cleanup = asyncio.create_task(
+        _close_process(
+            process,
+            stderr_task,
+            target_user=target_user,
+        )
+    )
+    try:
+        await asyncio.shield(cleanup)
+    except asyncio.CancelledError:
+        await cleanup
+        raise

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -24,6 +24,7 @@ from kai.workshop.execution_state import (
     WorkshopExecutionStateNamespace,
     WorkshopExecutionStateRegistry,
 )
+from kai.workshop.goose_model_discovery import GooseModelDiscoveryAdapter
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.internal_api_contexts import (
     WorkshopInternalAPIContextRegistry,
@@ -425,9 +426,10 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
     }
     assert services.subprocess_pool is not None
     assert _FakeModelCatalogue.adapters is not None
-    assert set(_FakeModelCatalogue.adapters) == {"claude", "codex", "opencode"}
+    assert set(_FakeModelCatalogue.adapters) == {"claude", "codex", "goose", "opencode"}
     assert isinstance(_FakeModelCatalogue.adapters["claude"], ClaudeModelDiscoveryAdapter)
     assert isinstance(_FakeModelCatalogue.adapters["codex"], CodexModelDiscoveryAdapter)
+    assert isinstance(_FakeModelCatalogue.adapters["goose"], GooseModelDiscoveryAdapter)
     assert isinstance(_FakeModelCatalogue.adapters["opencode"], OpenCodeModelDiscoveryAdapter)
     assert services.delivery_policy.enabled_transports == frozenset()
     assert host_dependencies == [

--- a/tests/test_workshop_goose_model_discovery.py
+++ b/tests/test_workshop_goose_model_discovery.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pwd
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kai.workshop import goose_model_discovery as discovery_module
+from kai.workshop import model_catalogue as catalogue_module
+from kai.workshop.goose_model_discovery import GooseModelDiscoveryAdapter
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+    ModelDiscoveryUnsupported,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryAuthContext,
+    ModelDiscoveryAuthMode,
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryCacheInputs,
+    ModelDiscoveryExecutableIdentity,
+    ModelDiscoveryReadiness,
+    ModelDiscoverySelectionStatus,
+)
+
+
+def _id(identifier_type, value: int):
+    return identifier_type(f"{identifier_type.prefix}_{value:032x}")
+
+
+def _lane(
+    executable: Path,
+    *,
+    value: int = 1,
+    os_user: str | None = None,
+    provider: str = "openrouter",
+    backend: str = "goose",
+) -> ModelDiscoveryBackendInventory:
+    from kai.workshop.domain import PrincipalId, RuntimeProfileId
+
+    principal_id = _id(PrincipalId, value)
+    profile_id = _id(RuntimeProfileId, value)
+    effective_user = os_user or pwd.getpwuid(os.getuid()).pw_name
+    executable_identity = ModelDiscoveryExecutableIdentity(
+        configured_path=str(executable),
+        resolved_path=str(executable.resolve()),
+        fingerprint=f"executable-{value}",
+        readiness=ModelDiscoveryReadiness.READY,
+        diagnostic=None,
+    )
+    auth = ModelDiscoveryAuthContext(
+        ModelDiscoveryAuthMode.BACKEND_MANAGED,
+        "backend configuration",
+        None,
+        f"auth-{value}",
+    )
+    cache_inputs = ModelDiscoveryCacheInputs(
+        version=1,
+        principal_id=principal_id,
+        runtime_profile_id=profile_id,
+        backend=backend,
+        provider=provider,
+        os_user=effective_user,
+        executable_fingerprint=executable_identity.fingerprint,
+        auth_fingerprint=auth.fingerprint,
+        default_model="configured-model",
+        allowed_models=None,
+        role_models=(),
+    )
+    return ModelDiscoveryBackendInventory(
+        option_id=f"{backend}:{provider}",
+        backend=backend,
+        provider=provider,
+        selected=True,
+        status=ModelDiscoverySelectionStatus.SELECTED,
+        readiness=ModelDiscoveryReadiness.UNVERIFIED,
+        effective_os_user=effective_user,
+        executable=executable_identity,
+        auth=auth,
+        default_model="configured-model",
+        allowed_models=None,
+        role_models=(),
+        cache_inputs=cache_inputs,
+        cache_key=f"cache-{value}",
+        diagnostic=None,
+    )
+
+
+def _fake_goose(
+    tmp_path: Path,
+    *,
+    result: object | None = None,
+    error: object | None = None,
+) -> tuple[Path, Path]:
+    executable = tmp_path / "goose-fixture"
+    request_log = tmp_path / "requests.jsonl"
+    script = f"""#!{sys.executable}
+import json
+import os
+import sys
+
+request_log = {str(request_log)!r}
+result = {result!r}
+error = {error!r}
+
+for index in range(2):
+    line = sys.stdin.readline()
+    if not line:
+        sys.exit(2)
+    request = json.loads(line)
+    with open(request_log, "a", encoding="utf-8") as output:
+        output.write(json.dumps({{
+            "method": request.get("method"),
+            "params": request.get("params"),
+            "provider": os.environ.get("GOOSE_PROVIDER"),
+            "model": os.environ.get("GOOSE_MODEL"),
+            "has_provider_key": bool(os.environ.get("OPENROUTER_API_KEY")),
+            "has_control_secret": bool(os.environ.get("TELEGRAM_BOT_TOKEN")),
+        }}) + "\\n")
+    if index == 0:
+        response = {{"jsonrpc": "2.0", "id": request["id"], "result": {{"protocolVersion": "v1"}}}}
+    elif error is not None:
+        response = {{"jsonrpc": "2.0", "id": request["id"], "error": error}}
+    else:
+        response = {{"jsonrpc": "2.0", "id": request["id"], "result": result}}
+    sys.stdout.write(json.dumps(response) + "\\n")
+    sys.stdout.flush()
+
+sys.stdin.read()
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    return executable, request_log
+
+
+def test_source_is_a_valid_canonical_catalogue_identifier() -> None:
+    normalized = catalogue_module._normalize_batch(
+        catalogue_module.ModelDiscoveryBatch(discovery_module._SOURCE, ()),
+    )
+    assert normalized.source == discovery_module._SOURCE
+
+
+async def test_adapter_uses_goose_metadata_request_without_session_or_generation(
+    tmp_path: Path,
+) -> None:
+    executable, request_log = _fake_goose(
+        tmp_path,
+        result={
+            "providerId": "openrouter",
+            "models": [
+                "anthropic/claude-sonnet-4-6",
+                "openai/gpt-5.5",
+            ],
+        },
+    )
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = GooseModelDiscoveryAdapter(
+        service_os_user=current_user,
+        environment={
+            "OPENROUTER_API_KEY": "provider-secret",
+            "TELEGRAM_BOT_TOKEN": "control-plane-secret",
+        },
+    )
+
+    batch = await adapter.discover(_lane(executable, os_user=current_user))
+
+    assert batch.source == "goose-acp-provider-supported-models"
+    assert batch.ttl_seconds == 21_600
+    assert [candidate.model_id for candidate in batch.models] == [
+        "anthropic/claude-sonnet-4-6",
+        "openai/gpt-5.5",
+    ]
+    assert batch.models[0].display_label == "anthropic/claude-sonnet-4-6"
+    assert batch.models[0].capabilities == {"provider_id": "openrouter"}
+    assert "provider-secret" not in repr(batch)
+    requests = [json.loads(line) for line in request_log.read_text(encoding="utf-8").splitlines()]
+    assert [request["method"] for request in requests] == [
+        "initialize",
+        "_goose/unstable/providers/supported-models/list",
+    ]
+    assert requests[1]["params"] == {"providerId": "openrouter"}
+    assert all(request["provider"] == "openrouter" for request in requests)
+    assert all(request["model"] == "configured-model" for request in requests)
+    assert all(request["has_provider_key"] is True for request in requests)
+    assert all(request["has_control_secret"] is False for request in requests)
+    assert not any(request["method"] in {"session/new", "session/prompt"} for request in requests)
+
+
+async def test_adapter_uses_goose_wire_name_for_deepseek(tmp_path: Path) -> None:
+    executable, request_log = _fake_goose(
+        tmp_path,
+        result={"providerId": "custom_deepseek", "models": ["deepseek-v4-pro"]},
+    )
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = GooseModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    batch = await adapter.discover(
+        _lane(executable, os_user=current_user, provider="deepseek"),
+    )
+
+    assert [candidate.model_id for candidate in batch.models] == ["deepseek-v4-pro"]
+    requests = [json.loads(line) for line in request_log.read_text(encoding="utf-8").splitlines()]
+    assert requests[1]["params"] == {"providerId": "custom_deepseek"}
+    assert requests[1]["provider"] == "custom_deepseek"
+
+
+@pytest.mark.parametrize(
+    ("error", "exception"),
+    [
+        (
+            {"code": -32000, "message": "Authentication required", "data": "credentials rejected"},
+            ModelDiscoveryAuthenticationError,
+        ),
+        (
+            {"code": -32602, "message": "Invalid params", "data": "Provider is not configured: openai"},
+            ModelDiscoveryAuthenticationError,
+        ),
+        (
+            {"code": -32602, "message": "Invalid params", "data": "Unknown provider: missing"},
+            ModelDiscoveryUnsupported,
+        ),
+        (
+            {"code": -32601, "message": "Method not found"},
+            ModelDiscoveryUnsupported,
+        ),
+    ],
+)
+async def test_adapter_classifies_authentication_and_unsupported_failures(
+    tmp_path: Path,
+    error: object,
+    exception: type[Exception],
+) -> None:
+    executable, _ = _fake_goose(tmp_path, error=error)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = GooseModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    with pytest.raises(exception):
+        await adapter.discover(_lane(executable, os_user=current_user))
+
+
+def test_parser_accepts_empty_models_and_rejects_unsafe_content() -> None:
+    assert (
+        discovery_module._parse_supported_models(
+            {"providerId": "openai", "models": []},
+            "openai",
+        )
+        == ()
+    )
+
+    with pytest.raises(ModelCatalogueValidationError, match="mismatched provider"):
+        discovery_module._parse_supported_models(
+            {"providerId": "anthropic", "models": []},
+            "openai",
+        )
+    with pytest.raises(ModelCatalogueValidationError, match="duplicate"):
+        discovery_module._parse_supported_models(
+            {"providerId": "openai", "models": ["gpt-5.5", "gpt-5.5"]},
+            "openai",
+        )
+    with pytest.raises(ModelCatalogueValidationError, match="invalid model"):
+        discovery_module._parse_supported_models(
+            {"providerId": "openai", "models": [" secret\n"]},
+            "openai",
+        )
+
+
+def test_launch_uses_canonical_user_auth_context_and_scrubs_control_plane(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "goose"
+    executable.write_text("fixture", encoding="utf-8")
+    executable.chmod(0o700)
+    alice_home = tmp_path / "alice"
+    alice_home.mkdir()
+    monkeypatch.setattr(
+        discovery_module.pwd,
+        "getpwnam",
+        lambda user: SimpleNamespace(pw_dir=str(alice_home)),
+    )
+    environment = {
+        "OPENROUTER_API_KEY": "provider-key",
+        "XDG_CONFIG_HOME": "/configured/goose",
+        "TELEGRAM_BOT_TOKEN": "control-plane-secret",
+    }
+
+    launch = discovery_module._build_launch(
+        _lane(executable, os_user="alice"),
+        service_os_user="kai",
+        environment=environment,
+    )
+
+    assert launch.argv[:6] == ("sudo", "-H", "-D", str(alice_home), "-u", "alice")
+    assert launch.argv[-3:] == ("--", str(executable), "acp")
+    assert launch.cwd is None
+    assert launch.target_user == "alice"
+    assert launch.environment["OPENROUTER_API_KEY"] == "provider-key"
+    assert "XDG_CONFIG_HOME" not in launch.environment
+    assert launch.environment["GOOSE_PROVIDER"] == "openrouter"
+    assert launch.environment["GOOSE_MODEL"] == "configured-model"
+    assert "TELEGRAM_BOT_TOKEN" not in launch.environment
+    assert launch.environment["TMPDIR"].endswith("/tmp/alice")
+    preserve_arg = next(arg for arg in launch.argv if arg.startswith("--preserve-env="))
+    assert "OPENROUTER_API_KEY" in preserve_arg
+    assert "XDG_CONFIG_HOME" not in preserve_arg
+    assert "TELEGRAM_BOT_TOKEN" not in preserve_arg
+
+
+def test_adapter_rejects_non_goose_or_unavailable_lanes(tmp_path: Path) -> None:
+    executable = tmp_path / "goose"
+    executable.write_text("fixture", encoding="utf-8")
+    executable.chmod(0o700)
+    adapter = GooseModelDiscoveryAdapter(service_os_user="kai", environment={})
+
+    with pytest.raises(ModelDiscoveryUnsupported):
+        adapter._validate_lane(_lane(executable, backend="opencode"))
+
+    lane = _lane(executable)
+    unavailable = ModelDiscoveryExecutableIdentity(
+        configured_path=lane.executable.configured_path,
+        resolved_path=None,
+        fingerprint=lane.executable.fingerprint,
+        readiness=ModelDiscoveryReadiness.UNAVAILABLE,
+        diagnostic="missing",
+    )
+    lane = ModelDiscoveryBackendInventory(
+        option_id=lane.option_id,
+        backend=lane.backend,
+        provider=lane.provider,
+        selected=lane.selected,
+        status=lane.status,
+        readiness=lane.readiness,
+        effective_os_user=lane.effective_os_user,
+        executable=unavailable,
+        auth=lane.auth,
+        default_model=lane.default_model,
+        allowed_models=lane.allowed_models,
+        role_models=lane.role_models,
+        cache_inputs=lane.cache_inputs,
+        cache_key=lane.cache_key,
+        diagnostic=lane.diagnostic,
+    )
+    with pytest.raises(ModelDiscoveryUnsupported):
+        adapter._validate_lane(lane)
+
+
+async def test_timeout_reaps_goose_metadata_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "goose-hung-fixture"
+    pid_file = tmp_path / "pid"
+    script = f"""#!{sys.executable}
+import json
+import os
+import sys
+import time
+from pathlib import Path
+Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+sys.stdin.readline()
+time.sleep(60)
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    monkeypatch.setattr(discovery_module, "_RPC_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(discovery_module, "_CLOSE_TIMEOUT_SECONDS", 0.2)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = GooseModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    with pytest.raises(discovery_module._GooseProtocolError, match="timed out"):
+        await adapter.discover(_lane(executable, os_user=current_user))
+
+    pid = int(pid_file.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)
+
+
+async def test_cancellation_reaps_goose_metadata_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "goose-cancel-fixture"
+    pid_file = tmp_path / "pid"
+    script = f"""#!{sys.executable}
+import os
+import sys
+import time
+from pathlib import Path
+Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+sys.stdin.readline()
+time.sleep(60)
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    monkeypatch.setattr(discovery_module, "_RPC_TIMEOUT_SECONDS", 60.0)
+    monkeypatch.setattr(discovery_module, "_CLOSE_TIMEOUT_SECONDS", 0.2)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = GooseModelDiscoveryAdapter(service_os_user=current_user, environment={})
+    task = asyncio.create_task(adapter.discover(_lane(executable, os_user=current_user)))
+    for _ in range(100):
+        if pid_file.exists():
+            break
+        await asyncio.sleep(0.01)
+    assert pid_file.exists()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pid = int(pid_file.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)


### PR DESCRIPTION
## Summary

- add metadata-only Goose model discovery through Goose's generated ACP schema
- execute discovery in each canonical runtime profile's effective OS-user, provider, configuration, and authentication context
- preserve configured/curated model fallback for unsupported, older, or unauthenticated Goose contexts
- register the adapter with the transport-neutral application host

## Discovery boundary

Kai starts a short-lived `goose acp` process and sends only:

1. the ACP `initialize` handshake
2. `_goose/unstable/providers/supported-models/list`

Goose delegates the second request to the selected provider's native `fetch_supported_models()` implementation. Kai never creates an ACP session, sends a prompt, invokes a model, runs `goose configure`, or parses terminal output.

The adapter:

- uses the protected backend executable and canonical effective OS user
- preserves only Goose/provider configuration needed across the user boundary
- strips Kai control-plane secrets
- validates and bounds every returned model identifier
- maps authentication and unsupported-interface failures to canonical catalogue states
- preserves last-known-good and explicit configured models through the existing catalogue service
- closes or force-reaps the subprocess on success, failure, timeout, and cancellation

## Verification

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q`
- 6,212 tests passed

Closes #728
