### PR TITLE
Discover Pi models canonically

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -45,6 +45,7 @@ from kai.workshop.model_catalogue import WorkshopModelCatalogueService
 from kai.workshop.model_discovery_inventory import WorkshopModelDiscoveryInventoryService
 from kai.workshop.notification_preferences import WorkshopNotificationPreferenceService
 from kai.workshop.opencode_model_discovery import OpenCodeModelDiscoveryAdapter
+from kai.workshop.pi_model_discovery import PiModelDiscoveryAdapter
 from kai.workshop.post_run_effects import WorkshopPostRunEffectService
 from kai.workshop.preferences import WorkshopPreferenceService
 from kai.workshop.private_text_execution import WorkshopPrivateTextExecutionService
@@ -325,6 +326,9 @@ class KaiApplicationHost:
                         service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
                     ),
                     "opencode": OpenCodeModelDiscoveryAdapter(
+                        service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
+                    ),
+                    "pi": PiModelDiscoveryAdapter(
                         service_os_user=pwd.getpwuid(os.geteuid()).pw_name,
                     ),
                 },

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -47,7 +47,7 @@ from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_targe
 
 log = logging.getLogger(__name__)
 
-_PI_THINKING_LEVELS = frozenset({"off", "minimal", "low", "medium", "high", "xhigh"})
+_PI_THINKING_LEVELS = frozenset({"off", "minimal", "low", "medium", "high", "xhigh", "max"})
 _PI_PROVIDER_ENV_VARS: dict[str, tuple[str, ...]] = {
     "anthropic": ("ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN"),
     "deepseek": ("DEEPSEEK_API_KEY",),

--- a/src/kai/workshop/pi_model_discovery.py
+++ b/src/kai/workshop/pi_model_discovery.py
@@ -1,0 +1,433 @@
+"""Metadata-only Pi model discovery through Pi's documented JSONL RPC mode.
+
+The adapter starts an ephemeral Pi process in the canonical runtime profile's
+effective OS-user and authentication context, sends only
+``get_available_models``, and closes stdin.  Ambient project resources and
+tools are disabled, and no prompt or model-generation request is submitted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pwd
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from kai.acp import _kill_target_user_tree
+from kai.backend import sanitize_agent_environment
+from kai.config import DATA_DIR, is_pi_model_shape, resolve_claude_user
+from kai.pi import _PI_ALL_PROVIDER_ENV_VARS, _pi_provider_env_vars, _split_pi_model
+from kai.pi_rpc import (
+    PI_RPC_STREAM_LIMIT,
+    PiRpcCommandError,
+    PiRpcEOFError,
+    PiRpcProtocolError,
+    PiRpcTransport,
+    require_pi_rpc_response,
+)
+from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+    ModelDiscoveryBatch,
+    ModelDiscoveryCandidate,
+    ModelDiscoveryUnsupported,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryAuthMode,
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryReadiness,
+)
+
+_SOURCE = "pi-rpc-get-available-models"
+_TTL_SECONDS = 21_600
+_CLOSE_TIMEOUT_SECONDS = 3.0
+_MAX_MODELS = 20_000
+_MAX_CANDIDATES = 160_000
+_MAX_MODEL_ID_CHARACTERS = 512
+_MAX_PROVIDER_CHARACTERS = 128
+_REQUEST_ID = "kai-model-discovery"
+_THINKING_LEVELS = ("off", "minimal", "low", "medium", "high", "xhigh", "max")
+_AUTH_MARKERS = (
+    "auth",
+    "credential",
+    "expired",
+    "log in",
+    "login",
+    "not configured",
+    "sign in",
+    "token",
+    "unauthorized",
+)
+_UNSUPPORTED_MARKERS = (
+    "not supported",
+    "unknown command",
+    "unknown request",
+    "unsupported command",
+)
+_PRESERVED_RUNTIME_VARS = (
+    "PI_SKIP_VERSION_CHECK",
+    "PI_TELEMETRY",
+    "TMPDIR",
+)
+
+
+class _PiDiscoveryError(RuntimeError):
+    """A sanitized Pi discovery failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class _PiLaunch:
+    argv: tuple[str, ...]
+    cwd: str | None
+    environment: Mapping[str, str]
+    target_user: str | None
+
+
+class PiModelDiscoveryAdapter:
+    """Enumerate models visible to one canonical Pi provider context."""
+
+    def __init__(
+        self,
+        *,
+        service_os_user: str,
+        environment: Mapping[str, str] | None = None,
+    ) -> None:
+        if not service_os_user.strip():
+            raise ValueError("service_os_user must be non-empty")
+        self._service_os_user = service_os_user.strip()
+        self._environment = os.environ if environment is None else environment
+
+    async def discover(self, lane: ModelDiscoveryBackendInventory) -> ModelDiscoveryBatch:
+        self._validate_lane(lane)
+        launch = _build_launch(
+            lane,
+            service_os_user=self._service_os_user,
+            environment=self._environment,
+        )
+        process = await asyncio.create_subprocess_exec(
+            *launch.argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=launch.cwd,
+            env=dict(launch.environment),
+            start_new_session=launch.target_user is not None,
+            limit=PI_RPC_STREAM_LIMIT,
+        )
+        stderr_task = asyncio.create_task(_discard_stream(process.stderr))
+        try:
+            if process.stdin is None or process.stdout is None:
+                raise _PiDiscoveryError("Pi RPC pipes are unavailable")
+            transport = PiRpcTransport(process.stdin, process.stdout)
+            await transport.send({"id": _REQUEST_ID, "type": "get_available_models"})
+            result = await _receive_result(transport)
+            candidates = _parse_available_models(result, lane.provider)
+            if not candidates:
+                raise ModelDiscoveryAuthenticationError
+            return ModelDiscoveryBatch(_SOURCE, candidates, ttl_seconds=_TTL_SECONDS)
+        except PiRpcCommandError as exc:
+            detail = exc.detail.lower()
+            if any(marker in detail for marker in _AUTH_MARKERS):
+                raise ModelDiscoveryAuthenticationError from exc
+            if any(marker in detail for marker in _UNSUPPORTED_MARKERS):
+                raise ModelDiscoveryUnsupported from exc
+            raise _PiDiscoveryError("Pi rejected its model metadata request") from exc
+        except (PiRpcEOFError, PiRpcProtocolError) as exc:
+            raise _PiDiscoveryError("Pi model metadata protocol failed") from exc
+        finally:
+            await _finish_process_cleanup(
+                process,
+                stderr_task,
+                target_user=launch.target_user,
+            )
+
+    @staticmethod
+    def _validate_lane(lane: ModelDiscoveryBackendInventory) -> None:
+        if lane.backend != "pi":
+            raise ModelDiscoveryUnsupported
+        if lane.executable.readiness != ModelDiscoveryReadiness.READY:
+            raise ModelDiscoveryUnsupported
+        if not lane.executable.configured_path or not lane.executable.resolved_path:
+            raise ModelDiscoveryUnsupported
+        if lane.auth.mode == ModelDiscoveryAuthMode.API_KEY and lane.auth.configured is not True:
+            raise ModelDiscoveryAuthenticationError
+
+
+async def _receive_result(transport: PiRpcTransport) -> object:
+    # Pi currently responds directly, but tolerate documented asynchronous
+    # startup events without accepting a response for another request.
+    for _ in range(128):
+        message = await transport.receive()
+        if message.get("type") != "response":
+            continue
+        return require_pi_rpc_response(
+            message,
+            request_id=_REQUEST_ID,
+            command="get_available_models",
+        )
+    raise ModelCatalogueValidationError("Pi emitted too many records before model metadata")
+
+
+def _parse_available_models(
+    value: object,
+    provider_id: str,
+) -> tuple[ModelDiscoveryCandidate, ...]:
+    if not isinstance(value, dict):
+        raise ModelCatalogueValidationError("Pi model metadata must be an object")
+    models = value.get("models")
+    if not isinstance(models, list) or len(models) > _MAX_MODELS:
+        raise ModelCatalogueValidationError("Pi model metadata must contain a bounded model list")
+
+    candidates: list[ModelDiscoveryCandidate] = []
+    seen_models: set[str] = set()
+    for model in models:
+        if not isinstance(model, dict):
+            raise ModelCatalogueValidationError("Pi model metadata entry must be an object")
+        observed_provider = _required_text(
+            model,
+            "provider",
+            maximum=_MAX_PROVIDER_CHARACTERS,
+        )
+        if observed_provider != provider_id:
+            continue
+        model_id = _required_text(
+            model,
+            "id",
+            maximum=_MAX_MODEL_ID_CHARACTERS,
+        )
+        full_id = f"{observed_provider}/{model_id}"
+        if len(full_id) > _MAX_MODEL_ID_CHARACTERS or not is_pi_model_shape(full_id, provider_id):
+            raise ModelCatalogueValidationError("Pi returned an invalid provider/model identifier")
+        if full_id in seen_models:
+            raise ModelCatalogueValidationError("Pi returned a duplicate provider/model identifier")
+        seen_models.add(full_id)
+
+        reasoning = model.get("reasoning")
+        if not isinstance(reasoning, bool):
+            raise ModelCatalogueValidationError("Pi model reasoning capability must be boolean")
+        label = _optional_text(model, "name", maximum=_MAX_MODEL_ID_CHARACTERS) or full_id
+        thinking_levels = _supported_thinking_levels(model, reasoning=reasoning)
+        base_capabilities: dict[str, object] = {
+            "provider_id": observed_provider,
+            "api": _optional_text(model, "api", maximum=128),
+            "reasoning": reasoning,
+            "thinking_levels": list(thinking_levels),
+            "input": _input_modalities(model.get("input")),
+        }
+        candidates.append(ModelDiscoveryCandidate(full_id, label, base_capabilities))
+        if reasoning:
+            for level in thinking_levels:
+                suffixed_id = f"{full_id}:{level}"
+                if len(suffixed_id) > _MAX_MODEL_ID_CHARACTERS:
+                    raise ModelCatalogueValidationError("Pi thinking selection exceeds the model identifier limit")
+                capabilities = {**base_capabilities, "thinking_level": level}
+                candidates.append(
+                    ModelDiscoveryCandidate(
+                        suffixed_id,
+                        f"{label} - {level}",
+                        capabilities,
+                    )
+                )
+        if len(candidates) > _MAX_CANDIDATES:
+            raise ModelCatalogueValidationError("Pi expanded model catalogue exceeds the safety limit")
+    return tuple(candidates)
+
+
+def _supported_thinking_levels(
+    model: Mapping[str, object],
+    *,
+    reasoning: bool,
+) -> tuple[str, ...]:
+    if not reasoning:
+        return ("off",)
+    raw_map = model.get("thinkingLevelMap")
+    if raw_map is not None and not isinstance(raw_map, dict):
+        raise ModelCatalogueValidationError("Pi thinking-level map must be an object")
+    level_map = raw_map or {}
+    for key, mapped in level_map.items():
+        if key not in _THINKING_LEVELS or (mapped is not None and not isinstance(mapped, str)):
+            raise ModelCatalogueValidationError("Pi thinking-level map contains invalid metadata")
+    supported: list[str] = []
+    for level in _THINKING_LEVELS:
+        if level in level_map and level_map[level] is None:
+            continue
+        if level in {"xhigh", "max"} and level not in level_map:
+            continue
+        supported.append(level)
+    return tuple(supported)
+
+
+def _required_text(
+    value: Mapping[str, object],
+    field: str,
+    *,
+    maximum: int,
+) -> str:
+    text = _optional_text(value, field, maximum=maximum)
+    if text is None:
+        raise ModelCatalogueValidationError(f"Pi model field {field} must be text")
+    return text
+
+
+def _optional_text(
+    value: Mapping[str, object],
+    field: str,
+    *,
+    maximum: int,
+) -> str | None:
+    item = value.get(field)
+    if item is None:
+        return None
+    if (
+        not isinstance(item, str)
+        or not item.strip()
+        or item != item.strip()
+        or len(item) > maximum
+        or any(ord(character) < 32 for character in item)
+    ):
+        raise ModelCatalogueValidationError(f"Pi model field {field} must be bounded text")
+    return item
+
+
+def _input_modalities(value: object) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise ModelCatalogueValidationError("Pi model input capability must be a non-empty list")
+    if not all(isinstance(item, str) and item in {"text", "image"} for item in value) or len(set(value)) != len(value):
+        raise ModelCatalogueValidationError("Pi model input capability contains invalid metadata")
+    return list(value)
+
+
+def _build_launch(
+    lane: ModelDiscoveryBackendInventory,
+    *,
+    service_os_user: str,
+    environment: Mapping[str, str],
+) -> _PiLaunch:
+    command = lane.executable.configured_path
+    if command is None:
+        raise ModelDiscoveryUnsupported
+    try:
+        home = Path(pwd.getpwnam(lane.effective_os_user).pw_dir)
+    except KeyError as exc:
+        raise ModelDiscoveryUnsupported from exc
+
+    try:
+        provider, model_id, thinking = _split_pi_model(lane.default_model, lane.provider)
+    except ValueError as exc:
+        raise ModelDiscoveryUnsupported from exc
+    env = sanitize_agent_environment(dict(environment))
+    selected_provider_vars = frozenset(_pi_provider_env_vars(provider))
+    for name in _PI_ALL_PROVIDER_ENV_VARS - selected_provider_vars:
+        env.pop(name, None)
+    # Disable Pi's version check and telemetry while leaving provider-owned
+    # dynamic catalogue refreshes available to this metadata operation.
+    env["PI_SKIP_VERSION_CHECK"] = "1"
+    env["PI_TELEMETRY"] = "0"
+
+    argv = [
+        command,
+        "--mode",
+        "rpc",
+        "--provider",
+        provider,
+        "--model",
+        f"{provider}/{model_id}",
+    ]
+    if thinking is not None:
+        argv.extend(("--thinking", thinking))
+    argv.extend(
+        (
+            "--no-session",
+            "--no-approve",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--no-context-files",
+            "--no-tools",
+        )
+    )
+
+    target_user = None if lane.effective_os_user == service_os_user else resolve_claude_user(lane.effective_os_user)
+    if target_user is not None:
+        env["TMPDIR"] = str(DATA_DIR / "tmp" / target_user)
+        argv = wrap_command_for_target_user(
+            argv,
+            target_user=target_user,
+            working_directory=home,
+            preserve_env=(
+                *_pi_provider_env_vars(provider),
+                *_PRESERVED_RUNTIME_VARS,
+            ),
+        )
+    return _PiLaunch(
+        tuple(argv),
+        subprocess_spawn_cwd(home, target_user=target_user),
+        env,
+        target_user,
+    )
+
+
+async def _discard_stream(stream: asyncio.StreamReader | None) -> None:
+    if stream is None:
+        return
+    while await stream.read(64 * 1024):
+        pass
+
+
+async def _close_process(
+    process: asyncio.subprocess.Process,
+    stderr_task: asyncio.Task[None],
+    *,
+    target_user: str | None,
+) -> None:
+    if process.stdin is not None:
+        process.stdin.close()
+    try:
+        async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+            await process.wait()
+    except TimeoutError:
+        if target_user is not None:
+            await _kill_target_user_tree(
+                target_user=target_user,
+                pgid=process.pid,
+                purpose="model discovery timeout",
+                backend="pi",
+            )
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+        await process.wait()
+    try:
+        async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+            await stderr_task
+    except TimeoutError:
+        stderr_task.cancel()
+        try:
+            await stderr_task
+        except asyncio.CancelledError:
+            pass
+
+
+async def _finish_process_cleanup(
+    process: asyncio.subprocess.Process,
+    stderr_task: asyncio.Task[None],
+    *,
+    target_user: str | None,
+) -> None:
+    cleanup = asyncio.create_task(
+        _close_process(
+            process,
+            stderr_task,
+            target_user=target_user,
+        )
+    )
+    try:
+        await asyncio.shield(cleanup)
+    except asyncio.CancelledError:
+        await cleanup
+        raise

--- a/tests/test_application_host.py
+++ b/tests/test_application_host.py
@@ -31,6 +31,7 @@ from kai.workshop.internal_api_contexts import (
     WorkshopInternalAPIExecutionContext,
 )
 from kai.workshop.opencode_model_discovery import OpenCodeModelDiscoveryAdapter
+from kai.workshop.pi_model_discovery import PiModelDiscoveryAdapter
 from kai.workshop.run_execution_authority import (
     RunAttemptStatus,
     RunExecutionSelection,
@@ -426,11 +427,12 @@ async def test_core_starts_and_stops_without_a_telegram_application(host_depende
     }
     assert services.subprocess_pool is not None
     assert _FakeModelCatalogue.adapters is not None
-    assert set(_FakeModelCatalogue.adapters) == {"claude", "codex", "goose", "opencode"}
+    assert set(_FakeModelCatalogue.adapters) == {"claude", "codex", "goose", "opencode", "pi"}
     assert isinstance(_FakeModelCatalogue.adapters["claude"], ClaudeModelDiscoveryAdapter)
     assert isinstance(_FakeModelCatalogue.adapters["codex"], CodexModelDiscoveryAdapter)
     assert isinstance(_FakeModelCatalogue.adapters["goose"], GooseModelDiscoveryAdapter)
     assert isinstance(_FakeModelCatalogue.adapters["opencode"], OpenCodeModelDiscoveryAdapter)
+    assert isinstance(_FakeModelCatalogue.adapters["pi"], PiModelDiscoveryAdapter)
     assert services.delivery_policy.enabled_transports == frozenset()
     assert host_dependencies == [
         "pool:start",

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -73,6 +73,13 @@ class TestPiModelParsing:
     def test_provider_model_and_thinking_suffix(self):
         assert _split_pi_model("openai/gpt-5.6-sol:xhigh") == ("openai", "gpt-5.6-sol", "xhigh")
 
+    def test_max_thinking_suffix(self):
+        assert _split_pi_model("anthropic/claude-opus-4-6:max") == (
+            "anthropic",
+            "claude-opus-4-6",
+            "max",
+        )
+
     def test_ollama_tag_is_part_of_model_id(self):
         assert _split_pi_model("ollama/llama4:70b") == ("ollama", "llama4:70b", None)
 

--- a/tests/test_workshop_pi_model_discovery.py
+++ b/tests/test_workshop_pi_model_discovery.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pwd
+import sys
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kai.workshop import model_catalogue as catalogue_module
+from kai.workshop import pi_model_discovery as discovery_module
+from kai.workshop.model_catalogue import (
+    ModelCatalogueValidationError,
+    ModelDiscoveryAuthenticationError,
+    ModelDiscoveryUnsupported,
+)
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryAuthContext,
+    ModelDiscoveryAuthMode,
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryCacheInputs,
+    ModelDiscoveryExecutableIdentity,
+    ModelDiscoveryReadiness,
+    ModelDiscoverySelectionStatus,
+)
+from kai.workshop.pi_model_discovery import PiModelDiscoveryAdapter
+
+
+def _id(identifier_type, value: int):
+    return identifier_type(f"{identifier_type.prefix}_{value:032x}")
+
+
+def _lane(
+    executable: Path,
+    *,
+    value: int = 1,
+    os_user: str | None = None,
+    provider: str = "openai",
+    backend: str = "pi",
+    model: str = "openai/gpt-5.6-sol:xhigh",
+    auth_mode: ModelDiscoveryAuthMode = ModelDiscoveryAuthMode.BACKEND_MANAGED,
+    auth_configured: bool | None = None,
+) -> ModelDiscoveryBackendInventory:
+    from kai.workshop.domain import PrincipalId, RuntimeProfileId
+
+    principal_id = _id(PrincipalId, value)
+    profile_id = _id(RuntimeProfileId, value)
+    effective_user = os_user or pwd.getpwuid(os.getuid()).pw_name
+    executable_identity = ModelDiscoveryExecutableIdentity(
+        configured_path=str(executable),
+        resolved_path=str(executable.resolve()),
+        fingerprint=f"executable-{value}",
+        readiness=ModelDiscoveryReadiness.READY,
+        diagnostic=None,
+    )
+    auth = ModelDiscoveryAuthContext(
+        auth_mode,
+        "backend configuration",
+        auth_configured,
+        f"auth-{value}",
+    )
+    cache_inputs = ModelDiscoveryCacheInputs(
+        version=1,
+        principal_id=principal_id,
+        runtime_profile_id=profile_id,
+        backend=backend,
+        provider=provider,
+        os_user=effective_user,
+        executable_fingerprint=executable_identity.fingerprint,
+        auth_fingerprint=auth.fingerprint,
+        default_model=model,
+        allowed_models=None,
+        role_models=(),
+    )
+    return ModelDiscoveryBackendInventory(
+        option_id=f"{backend}:{provider}",
+        backend=backend,
+        provider=provider,
+        selected=True,
+        status=ModelDiscoverySelectionStatus.SELECTED,
+        readiness=ModelDiscoveryReadiness.UNVERIFIED,
+        effective_os_user=effective_user,
+        executable=executable_identity,
+        auth=auth,
+        default_model=model,
+        allowed_models=None,
+        role_models=(),
+        cache_inputs=cache_inputs,
+        cache_key=f"cache-{value}",
+        diagnostic=None,
+    )
+
+
+def _model(
+    provider: str,
+    model_id: str,
+    *,
+    name: str | None = None,
+    reasoning: bool = False,
+    thinking_level_map: dict[str, str | None] | None = None,
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "provider": provider,
+        "id": model_id,
+        "name": name or model_id,
+        "api": "openai-responses",
+        "reasoning": reasoning,
+        "input": ["text", "image"],
+    }
+    if thinking_level_map is not None:
+        result["thinkingLevelMap"] = thinking_level_map
+    return result
+
+
+def _fake_pi(
+    tmp_path: Path,
+    *,
+    data: object | None = None,
+    error: str | None = None,
+) -> tuple[Path, Path]:
+    executable = tmp_path / "pi-fixture"
+    request_log = tmp_path / "pi-request.json"
+    script = f"""#!{sys.executable}
+import json
+import os
+import sys
+
+request_log = {str(request_log)!r}
+data = {data!r}
+error = {error!r}
+request = json.loads(sys.stdin.readline())
+with open(request_log, "w", encoding="utf-8") as output:
+    json.dump({{
+        "request": request,
+        "argv": sys.argv[1:],
+        "has_provider_key": bool(os.environ.get("OPENAI_API_KEY")),
+        "has_other_provider_key": bool(os.environ.get("ANTHROPIC_API_KEY")),
+        "has_control_secret": bool(os.environ.get("TELEGRAM_BOT_TOKEN")),
+        "skip_version_check": os.environ.get("PI_SKIP_VERSION_CHECK"),
+        "telemetry": os.environ.get("PI_TELEMETRY"),
+    }}, output)
+if error is None:
+    response = {{
+        "id": request["id"],
+        "type": "response",
+        "command": request["type"],
+        "success": True,
+        "data": data,
+    }}
+else:
+    response = {{
+        "id": request["id"],
+        "type": "response",
+        "command": request["type"],
+        "success": False,
+        "error": error,
+    }}
+sys.stdout.write(json.dumps(response) + "\\n")
+sys.stdout.flush()
+sys.stdin.read()
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    return executable, request_log
+
+
+def test_source_is_a_valid_canonical_catalogue_identifier() -> None:
+    normalized = catalogue_module._normalize_batch(
+        catalogue_module.ModelDiscoveryBatch(discovery_module._SOURCE, ()),
+    )
+    assert normalized.source == discovery_module._SOURCE
+
+
+async def test_adapter_uses_metadata_only_rpc_in_effective_auth_context(tmp_path: Path) -> None:
+    executable, request_log = _fake_pi(
+        tmp_path,
+        data={
+            "models": [
+                _model("anthropic", "claude-sonnet-4-6"),
+                _model("openai", "gpt-5.6-sol", name="GPT-5.6 Sol", reasoning=True),
+            ]
+        },
+    )
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = PiModelDiscoveryAdapter(
+        service_os_user=current_user,
+        environment={
+            "OPENAI_API_KEY": "provider-secret",
+            "ANTHROPIC_API_KEY": "other-provider-secret",
+            "TELEGRAM_BOT_TOKEN": "control-plane-secret",
+        },
+    )
+
+    batch = await adapter.discover(_lane(executable, os_user=current_user))
+
+    assert batch.source == "pi-rpc-get-available-models"
+    assert batch.ttl_seconds == 21_600
+    assert [candidate.model_id for candidate in batch.models] == [
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-sol:off",
+        "openai/gpt-5.6-sol:minimal",
+        "openai/gpt-5.6-sol:low",
+        "openai/gpt-5.6-sol:medium",
+        "openai/gpt-5.6-sol:high",
+    ]
+    assert batch.models[0].display_label == "GPT-5.6 Sol"
+    assert batch.models[-1].display_label == "GPT-5.6 Sol - high"
+    assert batch.models[0].capabilities == {
+        "provider_id": "openai",
+        "api": "openai-responses",
+        "reasoning": True,
+        "thinking_levels": ["off", "minimal", "low", "medium", "high"],
+        "input": ["text", "image"],
+    }
+    assert "provider-secret" not in repr(batch)
+
+    record = json.loads(request_log.read_text(encoding="utf-8"))
+    assert record["request"] == {
+        "id": "kai-model-discovery",
+        "type": "get_available_models",
+    }
+    assert record["has_provider_key"] is True
+    assert record["has_other_provider_key"] is False
+    assert record["has_control_secret"] is False
+    assert record["skip_version_check"] == "1"
+    assert record["telemetry"] == "0"
+    assert record["argv"][:6] == [
+        "--mode",
+        "rpc",
+        "--provider",
+        "openai",
+        "--model",
+        "openai/gpt-5.6-sol",
+    ]
+    assert record["argv"][6:8] == ["--thinking", "xhigh"]
+    for flag in (
+        "--no-session",
+        "--no-approve",
+        "--no-extensions",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-themes",
+        "--no-context-files",
+        "--no-tools",
+    ):
+        assert flag in record["argv"]
+    assert not any(item in record["request"] for item in ("message", "prompt", "session"))
+
+
+def test_parser_preserves_provider_prefix_colons_and_supported_thinking_suffixes() -> None:
+    candidates = discovery_module._parse_available_models(
+        {
+            "models": [
+                _model("ollama", "llama4:70b"),
+                _model(
+                    "openai",
+                    "gpt-5.6-sol",
+                    reasoning=True,
+                    thinking_level_map={"minimal": None, "xhigh": "xhigh", "max": "max"},
+                ),
+            ]
+        },
+        "ollama",
+    )
+    assert [candidate.model_id for candidate in candidates] == ["ollama/llama4:70b"]
+
+    reasoning_candidates = discovery_module._parse_available_models(
+        {
+            "models": [
+                _model(
+                    "openai",
+                    "gpt-5.6-sol",
+                    reasoning=True,
+                    thinking_level_map={"minimal": None, "xhigh": "xhigh", "max": "max"},
+                )
+            ]
+        },
+        "openai",
+    )
+    assert [candidate.model_id for candidate in reasoning_candidates] == [
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-sol:off",
+        "openai/gpt-5.6-sol:low",
+        "openai/gpt-5.6-sol:medium",
+        "openai/gpt-5.6-sol:high",
+        "openai/gpt-5.6-sol:xhigh",
+        "openai/gpt-5.6-sol:max",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("error", "exception"),
+    [
+        ("Provider is not configured: openai", ModelDiscoveryAuthenticationError),
+        ("Authentication token expired", ModelDiscoveryAuthenticationError),
+        ("Unknown command: get_available_models", ModelDiscoveryUnsupported),
+    ],
+)
+async def test_adapter_classifies_authentication_and_unsupported_failures(
+    tmp_path: Path,
+    error: str,
+    exception: type[Exception],
+) -> None:
+    executable, _ = _fake_pi(tmp_path, error=error)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = PiModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    with pytest.raises(exception):
+        await adapter.discover(_lane(executable, os_user=current_user))
+
+
+async def test_no_models_for_requested_provider_is_authentication_failure(tmp_path: Path) -> None:
+    executable, _ = _fake_pi(
+        tmp_path,
+        data={"models": [_model("anthropic", "claude-sonnet-4-6")]},
+    )
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = PiModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    with pytest.raises(ModelDiscoveryAuthenticationError):
+        await adapter.discover(_lane(executable, os_user=current_user))
+
+
+@pytest.mark.parametrize(
+    "models",
+    [
+        [_model("openai", "gpt-5.6-sol"), _model("openai", "gpt-5.6-sol")],
+        [{"provider": "openai", "id": "gpt\nsecret", "reasoning": False, "input": ["text"]}],
+        [_model("openai", "gpt", reasoning=True, thinking_level_map={"turbo": "turbo"})],
+    ],
+)
+def test_parser_rejects_malformed_or_duplicate_metadata(models: list[object]) -> None:
+    with pytest.raises(ModelCatalogueValidationError):
+        discovery_module._parse_available_models({"models": models}, "openai")
+
+
+def test_launch_uses_canonical_user_home_and_subscription_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "pi"
+    executable.write_text("fixture", encoding="utf-8")
+    executable.chmod(0o700)
+    alice_home = tmp_path / "alice"
+    alice_home.mkdir()
+    monkeypatch.setattr(
+        discovery_module.pwd,
+        "getpwnam",
+        lambda user: SimpleNamespace(pw_dir=str(alice_home)),
+    )
+    lane = _lane(
+        executable,
+        os_user="alice",
+        provider="openai-codex",
+        model="openai-codex/gpt-5.6-sol:xhigh",
+        auth_mode=ModelDiscoveryAuthMode.SUBSCRIPTION,
+        auth_configured=None,
+    )
+
+    launch = discovery_module._build_launch(
+        lane,
+        service_os_user="kai",
+        environment={
+            "OPENAI_API_KEY": "unrelated-key",
+            "TELEGRAM_BOT_TOKEN": "control-plane-secret",
+        },
+    )
+
+    assert launch.argv[:6] == ("sudo", "-H", "-D", str(alice_home), "-u", "alice")
+    assert launch.cwd is None
+    assert launch.target_user == "alice"
+    assert "OPENAI_API_KEY" not in launch.environment
+    assert "TELEGRAM_BOT_TOKEN" not in launch.environment
+    assert launch.environment["TMPDIR"].endswith("/tmp/alice")
+    assert "--no-session" in launch.argv
+    preserve_arg = next(arg for arg in launch.argv if arg.startswith("--preserve-env="))
+    assert "PI_SKIP_VERSION_CHECK" in preserve_arg
+    assert "PI_TELEMETRY" in preserve_arg
+    assert "OPENAI_API_KEY" not in preserve_arg
+    assert "TELEGRAM_BOT_TOKEN" not in preserve_arg
+
+
+def test_adapter_rejects_non_pi_unavailable_and_unconfigured_api_key_lanes(tmp_path: Path) -> None:
+    executable = tmp_path / "pi"
+    executable.write_text("fixture", encoding="utf-8")
+    executable.chmod(0o700)
+    adapter = PiModelDiscoveryAdapter(service_os_user="kai", environment={})
+
+    with pytest.raises(ModelDiscoveryUnsupported):
+        adapter._validate_lane(_lane(executable, backend="opencode"))
+
+    lane = _lane(executable)
+    with pytest.raises(ModelDiscoveryUnsupported):
+        adapter._validate_lane(
+            replace(
+                lane,
+                executable=replace(
+                    lane.executable,
+                    resolved_path=None,
+                    readiness=ModelDiscoveryReadiness.UNAVAILABLE,
+                ),
+            )
+        )
+
+    with pytest.raises(ModelDiscoveryAuthenticationError):
+        adapter._validate_lane(
+            _lane(
+                executable,
+                auth_mode=ModelDiscoveryAuthMode.API_KEY,
+                auth_configured=False,
+            )
+        )
+
+
+async def test_timeout_reaps_pi_metadata_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "pi-hung-fixture"
+    pid_file = tmp_path / "pid"
+    script = f"""#!{sys.executable}
+import os
+import sys
+import time
+from pathlib import Path
+Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+sys.stdin.readline()
+time.sleep(60)
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    monkeypatch.setattr(discovery_module, "_CLOSE_TIMEOUT_SECONDS", 0.2)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = PiModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    with pytest.raises(TimeoutError):
+        async with asyncio.timeout(0.2):
+            await adapter.discover(_lane(executable, os_user=current_user))
+
+    pid = int(pid_file.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)
+
+
+async def test_cancellation_reaps_pi_metadata_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "pi-cancel-fixture"
+    pid_file = tmp_path / "pid"
+    script = f"""#!{sys.executable}
+import os
+import sys
+import time
+from pathlib import Path
+Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
+sys.stdin.readline()
+time.sleep(60)
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    monkeypatch.setattr(discovery_module, "_CLOSE_TIMEOUT_SECONDS", 0.2)
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = PiModelDiscoveryAdapter(service_os_user=current_user, environment={})
+    task = asyncio.create_task(adapter.discover(_lane(executable, os_user=current_user)))
+    for _ in range(100):
+        if pid_file.exists():
+            break
+        await asyncio.sleep(0.01)
+    assert pid_file.exists()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pid = int(pid_file.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)


### PR DESCRIPTION
## Summary

- discover Pi's authenticated model inventory through its documented metadata-only `get_available_models` RPC command
- run discovery in the canonical runtime profile's effective OS-user, provider, and authentication context while excluding unrelated provider and control-plane secrets
- expose provider-qualified model choices plus only the thinking suffixes Pi reports as supported, including colon-bearing model IDs and `max`
- preserve the canonical catalogue's existing selected-entry and last-known-good behavior when Pi is unavailable, unauthenticated, unsupported, malformed, or slow
- register Pi alongside the existing Claude, Codex, Goose, and OpenCode discovery adapters

Pi runs ephemerally with project resources and tools disabled. The adapter sends no prompt, creates no durable session, and makes no model-generation request.

Official protocol references:

- https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/rpc.md#get_available_models
- https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/usage.md

## Testing

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest -q tests/test_workshop_pi_model_discovery.py tests/test_pi.py tests/test_application_host.py` (51 passed)
- `.venv/bin/python -m pytest -q` (6227 passed)

Closes #1165
