### PR TITLE
Fix OpenCode model discovery timeouts

### DIFF
--- a/src/kai/workshop/opencode_model_discovery.py
+++ b/src/kai/workshop/opencode_model_discovery.py
@@ -1,29 +1,22 @@
-"""Metadata-only OpenCode model discovery through the headless server API.
+"""Metadata-only OpenCode model discovery through its documented CLI.
 
-Protocol contract verified 2026-08-28 against OpenCode's server reference and
-generated SDK types.  The adapter starts a short-lived, loopback-only
-``opencode serve`` process and reads ``GET /provider``.  That documented route
-returns both the provider catalogue and the providers connected in the
-effective user authentication context.  No session or generation endpoint is
-used.
+OpenCode documents ``opencode models [provider] --refresh`` as the
+non-interactive command for refreshing its models.dev cache and listing the
+models available from one configured provider.  The command emits one
+``provider/model`` identifier per line and does not create a session or invoke
+a model.
 """
 
 from __future__ import annotations
 
 import asyncio
-import base64
-import json
 import os
 import pwd
-import secrets
-import socket
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from urllib.parse import urlencode
 
-import aiohttp
-
+from kai.acp import _kill_target_user_tree
 from kai.backend import sanitize_agent_environment
 from kai.config import DATA_DIR, is_opencode_model_shape, resolve_claude_user
 from kai.subprocess_identity import subprocess_spawn_cwd, wrap_command_for_target_user
@@ -39,16 +32,30 @@ from kai.workshop.model_discovery_inventory import (
     ModelDiscoveryReadiness,
 )
 
-_SOURCE = "opencode-server-provider"
+_SOURCE = "opencode-cli-models"
 _TTL_SECONDS = 21_600
-_STARTUP_TIMEOUT_SECONDS = 10.0
-_REQUEST_TIMEOUT_SECONDS = 20.0
-_POLL_INTERVAL_SECONDS = 0.05
 _CLOSE_TIMEOUT_SECONDS = 3.0
-_MAX_RESPONSE_BYTES = 32 * 1024 * 1024
-_MAX_PROVIDERS = 1_000
+_MAX_OUTPUT_BYTES = 32 * 1024 * 1024
 _MAX_MODELS = 20_000
-_SERVER_USERNAME = "kai-model-discovery"
+_MAX_MODEL_ID_BYTES = 512
+_READ_CHUNK_BYTES = 64 * 1024
+_AUTH_MARKERS = (
+    "api key",
+    "auth",
+    "credential",
+    "log in",
+    "login",
+    "not configured",
+    "provider not found",
+    "sign in",
+    "token",
+    "unauthorized",
+)
+_UNSUPPORTED_MARKERS = (
+    "unknown command",
+    "unknown option",
+    "unsupported command",
+)
 _PRESERVED_AUTH_VARS = (
     "ANTHROPIC_API_KEY",
     "DEEPSEEK_API_KEY",
@@ -57,6 +64,8 @@ _PRESERVED_AUTH_VARS = (
     "OPENROUTER_API_KEY",
     "OPENCODE_CONFIG",
     "OPENCODE_CONFIG_DIR",
+    "OPENCODE_DISABLE_MODELS_FETCH",
+    "OPENCODE_MODELS_PATH",
     "OPENCODE_MODELS_URL",
     "XDG_CONFIG_HOME",
     "XDG_DATA_HOME",
@@ -64,7 +73,7 @@ _PRESERVED_AUTH_VARS = (
 
 
 class _OpenCodeDiscoveryError(RuntimeError):
-    """A sanitized headless-server discovery failure."""
+    """A sanitized OpenCode metadata-command failure."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,12 +81,17 @@ class _OpenCodeLaunch:
     argv: tuple[str, ...]
     cwd: str | None
     environment: Mapping[str, str]
-    directory: Path
-    password: str
+    target_user: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _CapturedOutput:
+    data: bytes
+    overflowed: bool
 
 
 class OpenCodeModelDiscoveryAdapter:
-    """Enumerate models visible to one canonical OpenCode auth context."""
+    """Enumerate models visible to one canonical OpenCode provider context."""
 
     def __init__(
         self,
@@ -92,33 +106,38 @@ class OpenCodeModelDiscoveryAdapter:
 
     async def discover(self, lane: ModelDiscoveryBackendInventory) -> ModelDiscoveryBatch:
         self._validate_lane(lane)
-        port = _reserve_loopback_port()
         launch = _build_launch(
             lane,
-            port=port,
             service_os_user=self._service_os_user,
             environment=self._environment,
         )
         process = await asyncio.create_subprocess_exec(
             *launch.argv,
             stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
             cwd=launch.cwd,
             env=dict(launch.environment),
-            start_new_session=True,
+            start_new_session=launch.target_user is not None,
         )
+        stdout_task = asyncio.create_task(_read_bounded(process.stdout))
+        stderr_task = asyncio.create_task(_read_bounded(process.stderr))
         try:
-            timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_SECONDS)
-            credential = base64.b64encode(f"{_SERVER_USERNAME}:{launch.password}".encode()).decode("ascii")
-            headers = {"Authorization": f"Basic {credential}"}
-            async with aiohttp.ClientSession(timeout=timeout, headers=headers) as session:
-                await _wait_until_ready(session, process, port)
-                body = await _get_provider_catalogue(session, port, launch.directory)
-            candidates = _parse_provider_catalogue(body, lane.provider)
-            return ModelDiscoveryBatch(_SOURCE, candidates, ttl_seconds=_TTL_SECONDS)
+            returncode = await process.wait()
+            stdout, stderr = await asyncio.gather(stdout_task, stderr_task)
+            if stdout.overflowed or stderr.overflowed:
+                raise ModelCatalogueValidationError("OpenCode model command output exceeds the safety limit")
+            if returncode != 0:
+                _raise_command_failure(stdout.data, stderr.data)
+            models = _parse_models_output(stdout.data, lane.provider)
+            return ModelDiscoveryBatch(_SOURCE, models, ttl_seconds=_TTL_SECONDS)
         finally:
-            await _finish_process_cleanup(process)
+            await _finish_process_cleanup(
+                process,
+                stdout_task,
+                stderr_task,
+                target_user=launch.target_user,
+            )
 
     @staticmethod
     def _validate_lane(lane: ModelDiscoveryBackendInventory) -> None:
@@ -130,19 +149,9 @@ class OpenCodeModelDiscoveryAdapter:
             raise ModelDiscoveryUnsupported
 
 
-def _reserve_loopback_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
-        listener.bind(("127.0.0.1", 0))
-        port = listener.getsockname()[1]
-    if not isinstance(port, int) or port <= 0:
-        raise _OpenCodeDiscoveryError("OpenCode discovery could not reserve a loopback port")
-    return port
-
-
 def _build_launch(
     lane: ModelDiscoveryBackendInventory,
     *,
-    port: int,
     service_os_user: str,
     environment: Mapping[str, str],
 ) -> _OpenCodeLaunch:
@@ -153,249 +162,138 @@ def _build_launch(
         home = Path(pwd.getpwnam(lane.effective_os_user).pw_dir)
     except KeyError as exc:
         raise ModelDiscoveryUnsupported from exc
-    password = secrets.token_urlsafe(32)
     env = sanitize_agent_environment(dict(environment))
     # Discovery must load the effective user's real OpenCode configuration,
     # not a one-turn model override inherited from another process.
     env.pop("OPENCODE_CONFIG_CONTENT", None)
-    env["OPENCODE_SERVER_USERNAME"] = _SERVER_USERNAME
-    env["OPENCODE_SERVER_PASSWORD"] = password
+    env["NO_COLOR"] = "1"
+    argv = [command, "models", lane.provider, "--refresh"]
     target_user = None if lane.effective_os_user == service_os_user else resolve_claude_user(lane.effective_os_user)
-    argv = [
-        command,
-        "serve",
-        "--hostname",
-        "127.0.0.1",
-        "--port",
-        str(port),
-    ]
     if target_user is not None:
         env["TMPDIR"] = str(DATA_DIR / "tmp" / target_user)
         argv = wrap_command_for_target_user(
             argv,
             target_user=target_user,
             working_directory=home,
-            preserve_env=(
-                *_PRESERVED_AUTH_VARS,
-                "OPENCODE_SERVER_USERNAME",
-                "OPENCODE_SERVER_PASSWORD",
-                "TMPDIR",
-            ),
+            preserve_env=(*_PRESERVED_AUTH_VARS, "NO_COLOR", "TMPDIR"),
         )
     return _OpenCodeLaunch(
         tuple(argv),
         subprocess_spawn_cwd(home, target_user=target_user),
         env,
-        home,
-        password,
+        target_user,
     )
 
 
-async def _wait_until_ready(
-    session: aiohttp.ClientSession,
-    process: asyncio.subprocess.Process,
-    port: int,
-) -> None:
-    url = f"http://127.0.0.1:{port}/global/health"
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + _STARTUP_TIMEOUT_SECONDS
-    while True:
-        if process.returncode is not None:
-            raise _OpenCodeDiscoveryError("OpenCode metadata server exited during startup")
-        try:
-            async with session.get(url, allow_redirects=False) as response:
-                if response.status == 200:
-                    body = await response.content.read(1025)
-                    if len(body) > 1024:
-                        raise ModelCatalogueValidationError("OpenCode health response exceeds the safety limit")
-                    value = json.loads(body)
-                    if isinstance(value, dict) and value.get("healthy") is True:
-                        return
-        except (aiohttp.ClientError, UnicodeDecodeError, json.JSONDecodeError):
-            pass
-        if loop.time() >= deadline:
-            raise _OpenCodeDiscoveryError("OpenCode metadata server did not become ready")
-        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+async def _read_bounded(stream: asyncio.StreamReader | None) -> _CapturedOutput:
+    if stream is None:
+        return _CapturedOutput(b"", False)
+    output = bytearray()
+    overflowed = False
+    while chunk := await stream.read(_READ_CHUNK_BYTES):
+        if overflowed:
+            continue
+        remaining = _MAX_OUTPUT_BYTES + 1 - len(output)
+        output.extend(chunk[:remaining])
+        overflowed = len(output) > _MAX_OUTPUT_BYTES
+    return _CapturedOutput(bytes(output[:_MAX_OUTPUT_BYTES]), overflowed)
 
 
-async def _get_provider_catalogue(
-    session: aiohttp.ClientSession,
-    port: int,
-    directory: Path,
-) -> bytes:
-    query = urlencode({"directory": str(directory)})
-    url = f"http://127.0.0.1:{port}/provider?{query}"
-    try:
-        async with session.get(url, allow_redirects=False) as response:
-            if response.status in {401, 403}:
-                raise ModelDiscoveryAuthenticationError
-            if response.status < 200 or response.status >= 300:
-                raise _OpenCodeDiscoveryError("OpenCode provider metadata request failed")
-            body = await response.content.read(_MAX_RESPONSE_BYTES + 1)
-    except (ModelDiscoveryAuthenticationError, _OpenCodeDiscoveryError):
-        raise
-    except (aiohttp.ClientError, TimeoutError) as exc:
-        raise _OpenCodeDiscoveryError("OpenCode provider metadata request failed") from exc
-    if len(body) > _MAX_RESPONSE_BYTES:
-        raise ModelCatalogueValidationError("OpenCode provider catalogue exceeds the safety limit")
-    return body
-
-
-def _parse_provider_catalogue(body: bytes, provider_id: str) -> tuple[ModelDiscoveryCandidate, ...]:
-    try:
-        value = json.loads(body)
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ModelCatalogueValidationError("OpenCode provider catalogue is malformed JSON") from exc
-    if not isinstance(value, dict):
-        raise ModelCatalogueValidationError("OpenCode provider catalogue must be an object")
-    providers = value.get("all")
-    connected = value.get("connected")
-    if not isinstance(providers, list) or len(providers) > _MAX_PROVIDERS:
-        raise ModelCatalogueValidationError("OpenCode provider catalogue has an invalid provider list")
-    if not isinstance(connected, list) or not all(isinstance(item, str) and item for item in connected):
-        raise ModelCatalogueValidationError("OpenCode provider catalogue has an invalid connected list")
-
-    matching = [provider for provider in providers if isinstance(provider, dict) and provider.get("id") == provider_id]
-    if len(matching) > 1:
-        raise ModelCatalogueValidationError("OpenCode provider catalogue contains a duplicate provider")
-    if not matching:
-        raise ModelDiscoveryUnsupported
-    if provider_id not in connected:
+def _raise_command_failure(stdout: bytes, stderr: bytes) -> None:
+    detail = (stderr + b"\n" + stdout).decode("utf-8", errors="ignore").lower()
+    if any(marker in detail for marker in _AUTH_MARKERS):
         raise ModelDiscoveryAuthenticationError
-    provider = matching[0]
-    name = _required_text(provider, "name", context="provider")
-    models = provider.get("models")
-    if not isinstance(models, dict) or len(models) > _MAX_MODELS:
-        raise ModelCatalogueValidationError("OpenCode provider model catalogue must be an object")
-    return tuple(_parse_model(provider_id, name, key, model) for key, model in sorted(models.items()))
+    if any(marker in detail for marker in _UNSUPPORTED_MARKERS):
+        raise ModelDiscoveryUnsupported
+    raise _OpenCodeDiscoveryError("OpenCode model metadata command failed")
 
 
-def _parse_model(
-    provider_id: str,
-    provider_name: str,
-    catalogue_key: object,
-    value: object,
-) -> ModelDiscoveryCandidate:
-    if not isinstance(catalogue_key, str) or not catalogue_key:
-        raise ModelCatalogueValidationError("OpenCode model catalogue key must be text")
-    if not isinstance(value, dict):
-        raise ModelCatalogueValidationError("OpenCode model entry must be an object")
-    model_id = _required_text(value, "id", context="model")
-    if catalogue_key != model_id:
-        raise ModelCatalogueValidationError("OpenCode model key and identifier do not match")
-    full_id = f"{provider_id}/{model_id}"
-    if not is_opencode_model_shape(full_id):
-        raise ModelCatalogueValidationError("OpenCode returned an invalid provider/model identifier")
-
-    capabilities: dict[str, object] = {
-        "provider_name": provider_name,
-        "release_date": _required_text(value, "release_date", context="model"),
-        "attachment": _required_bool(value, "attachment"),
-        "reasoning": _required_bool(value, "reasoning"),
-        "temperature": _required_bool(value, "temperature"),
-        "tool_call": _required_bool(value, "tool_call"),
-        "experimental": _optional_bool(value, "experimental"),
-        "status": _optional_status(value),
-        "limits": _limits(value.get("limit")),
-        "modalities": _modalities(value.get("modalities")),
-    }
-    return ModelDiscoveryCandidate(
-        full_id,
-        _required_text(value, "name", context="model"),
-        capabilities,
-    )
-
-
-def _required_text(value: Mapping[str, object], field: str, *, context: str) -> str:
-    item = value.get(field)
-    if not isinstance(item, str) or not item.strip():
-        raise ModelCatalogueValidationError(f"OpenCode {context} field {field} must be text")
-    return item
-
-
-def _required_bool(value: Mapping[str, object], field: str) -> bool:
-    item = value.get(field)
-    if not isinstance(item, bool):
-        raise ModelCatalogueValidationError(f"OpenCode model field {field} must be boolean")
-    return item
-
-
-def _optional_bool(value: Mapping[str, object], field: str) -> bool | None:
-    item = value.get(field)
-    if item is None:
-        return None
-    if not isinstance(item, bool):
-        raise ModelCatalogueValidationError(f"OpenCode model field {field} must be boolean or null")
-    return item
-
-
-def _optional_status(value: Mapping[str, object]) -> str | None:
-    status = value.get("status")
-    if status is None:
-        return None
-    if status not in {"active", "alpha", "beta", "deprecated"}:
-        raise ModelCatalogueValidationError("OpenCode model status is invalid")
-    assert isinstance(status, str)
-    return status
-
-
-def _limits(value: object) -> dict[str, int]:
-    if not isinstance(value, dict):
-        raise ModelCatalogueValidationError("OpenCode model limits must be an object")
-    return {
-        "context": _nonnegative_integer(value, "context"),
-        "output": _nonnegative_integer(value, "output"),
-    }
-
-
-def _nonnegative_integer(value: Mapping[str, object], field: str) -> int:
-    item = value.get(field)
-    if isinstance(item, bool) or not isinstance(item, int) or item < 0:
-        raise ModelCatalogueValidationError(f"OpenCode model field {field} must be a non-negative integer")
-    return item
-
-
-def _modalities(value: object) -> dict[str, list[str]] | None:
-    if value is None:
-        return None
-    if not isinstance(value, dict):
-        raise ModelCatalogueValidationError("OpenCode model modalities must be an object or null")
-    return {
-        "input": _modality_list(value.get("input"), "input"),
-        "output": _modality_list(value.get("output"), "output"),
-    }
-
-
-def _modality_list(value: object, field: str) -> list[str]:
-    allowed = {"audio", "image", "pdf", "text", "video"}
-    if not isinstance(value, list) or not all(isinstance(item, str) and item in allowed for item in value):
-        raise ModelCatalogueValidationError(f"OpenCode model {field} modalities are invalid")
-    return list(value)
-
-
-async def _close_process(process: asyncio.subprocess.Process) -> None:
-    if process.returncode is not None:
-        await process.wait()
-        return
+def _parse_models_output(body: bytes, provider_id: str) -> tuple[ModelDiscoveryCandidate, ...]:
     try:
-        process.terminate()
-    except ProcessLookupError:
-        pass
-    try:
-        async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+        text = body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ModelCatalogueValidationError("OpenCode model command output is not UTF-8") from exc
+    prefix = f"{provider_id}/"
+    candidates: list[ModelDiscoveryCandidate] = []
+    seen: set[str] = set()
+    for raw_line in text.splitlines():
+        model_id = raw_line.strip()
+        if not model_id:
+            continue
+        if len(model_id.encode("utf-8")) > _MAX_MODEL_ID_BYTES:
+            raise ModelCatalogueValidationError("OpenCode returned an oversized model identifier")
+        if not model_id.startswith(prefix) or not is_opencode_model_shape(model_id):
+            raise ModelCatalogueValidationError("OpenCode returned an invalid provider/model identifier")
+        if model_id in seen:
+            raise ModelCatalogueValidationError("OpenCode returned a duplicate provider/model identifier")
+        seen.add(model_id)
+        candidates.append(
+            ModelDiscoveryCandidate(
+                model_id,
+                model_id,
+                {"provider_id": provider_id},
+            )
+        )
+        if len(candidates) > _MAX_MODELS:
+            raise ModelCatalogueValidationError("OpenCode model catalogue exceeds the safety limit")
+    return tuple(candidates)
+
+
+async def _close_process(
+    process: asyncio.subprocess.Process,
+    stdout_task: asyncio.Task[_CapturedOutput],
+    stderr_task: asyncio.Task[_CapturedOutput],
+    *,
+    target_user: str | None,
+) -> None:
+    if process.returncode is None:
+        try:
+            process.terminate()
+        except ProcessLookupError:
+            pass
+        try:
+            async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+                await process.wait()
+        except TimeoutError:
+            if target_user is not None:
+                await _kill_target_user_tree(
+                    target_user=target_user,
+                    pgid=process.pid,
+                    purpose="model discovery timeout",
+                    backend="opencode",
+                )
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
             await process.wait()
-            return
-    except TimeoutError:
-        pass
-    try:
-        process.kill()
-    except ProcessLookupError:
-        pass
-    await process.wait()
+    for task in (stdout_task, stderr_task):
+        try:
+            async with asyncio.timeout(_CLOSE_TIMEOUT_SECONDS):
+                await task
+        except TimeoutError:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
 
-async def _finish_process_cleanup(process: asyncio.subprocess.Process) -> None:
-    cleanup = asyncio.create_task(_close_process(process))
+async def _finish_process_cleanup(
+    process: asyncio.subprocess.Process,
+    stdout_task: asyncio.Task[_CapturedOutput],
+    stderr_task: asyncio.Task[_CapturedOutput],
+    *,
+    target_user: str | None,
+) -> None:
+    cleanup = asyncio.create_task(
+        _close_process(
+            process,
+            stdout_task,
+            stderr_task,
+            target_user=target_user,
+        )
+    )
     try:
         await asyncio.shield(cleanup)
     except asyncio.CancelledError:

--- a/tests/test_workshop_opencode_model_discovery.py
+++ b/tests/test_workshop_opencode_model_discovery.py
@@ -92,23 +92,45 @@ def _lane(
     )
 
 
-def _model(model_id: str, *, name: str = "Claude Sonnet") -> dict[str, object]:
-    return {
-        "id": model_id,
-        "name": name,
-        "release_date": "2026-08-01",
-        "attachment": True,
-        "reasoning": True,
-        "temperature": True,
-        "tool_call": True,
-        "cost": {"input": 1, "output": 2},
-        "limit": {"context": 200_000, "output": 64_000},
-        "modalities": {"input": ["text", "image"], "output": ["text"]},
-        "status": "active",
-        "experimental": False,
-        "options": {"apiKey": "provider-secret"},
-        "headers": {"authorization": "Bearer provider-secret"},
-    }
+def _fake_command(
+    tmp_path: Path,
+    *,
+    stdout: bytes = b"",
+    stderr: bytes = b"",
+    returncode: int = 0,
+) -> tuple[Path, Path]:
+    executable = tmp_path / "opencode-fixture"
+    invocation_log = tmp_path / "invocation.json"
+    stdout_value = base64.b64encode(stdout).decode("ascii")
+    stderr_value = base64.b64encode(stderr).decode("ascii")
+    script = f"""#!{sys.executable}
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+
+Path({str(invocation_log)!r}).write_text(json.dumps({{
+    "argv": sys.argv[1:],
+    "environment": {{
+        key: os.environ.get(key)
+        for key in (
+            "NO_COLOR",
+            "OPENROUTER_API_KEY",
+            "OPENCODE_CONFIG_CONTENT",
+            "TELEGRAM_BOT_TOKEN",
+        )
+    }},
+}}), encoding="utf-8")
+sys.stdout.buffer.write(base64.b64decode({stdout_value!r}))
+sys.stdout.buffer.flush()
+sys.stderr.buffer.write(base64.b64decode({stderr_value!r}))
+sys.stderr.buffer.flush()
+raise SystemExit({returncode})
+"""
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o700)
+    return executable, invocation_log
 
 
 def test_registered_adapter_sources_are_valid_canonical_catalogue_ids() -> None:
@@ -123,155 +145,106 @@ def test_registered_adapter_sources_are_valid_canonical_catalogue_ids() -> None:
         assert normalized.source == source
 
 
-def _fake_server(
-    tmp_path: Path,
-    payload: object,
-) -> tuple[Path, Path]:
-    executable = tmp_path / "opencode-fixture"
-    request_log = tmp_path / "requests.jsonl"
-    encoded_payload = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
-    script = f"""#!{sys.executable}
-import argparse
-import base64
-import json
-import os
-from http.server import BaseHTTPRequestHandler, HTTPServer
-
-parser = argparse.ArgumentParser()
-parser.add_argument("command")
-parser.add_argument("--hostname", required=True)
-parser.add_argument("--port", required=True, type=int)
-args = parser.parse_args()
-payload = base64.b64decode({encoded_payload!r})
-request_log = {str(request_log)!r}
-expected = "Basic " + base64.b64encode(
-    (os.environ["OPENCODE_SERVER_USERNAME"] + ":" + os.environ["OPENCODE_SERVER_PASSWORD"]).encode()
-).decode()
-
-class Handler(BaseHTTPRequestHandler):
-    def do_GET(self):
-        with open(request_log, "a", encoding="utf-8") as output:
-            output.write(json.dumps({{
-                "path": self.path,
-                "authenticated": self.headers.get("Authorization") == expected,
-            }}) + "\\n")
-        if self.headers.get("Authorization") != expected:
-            self.send_response(401)
-            self.end_headers()
-            return
-        if self.path == "/global/health":
-            body = b'{{"healthy":true,"version":"fixture"}}'
-        elif self.path.startswith("/provider?"):
-            body = payload
-        else:
-            self.send_response(404)
-            self.end_headers()
-            return
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, format, *args):
-        pass
-
-HTTPServer((args.hostname, args.port), Handler).serve_forever()
-"""
-    executable.write_text(script, encoding="utf-8")
-    executable.chmod(0o700)
-    return executable, request_log
-
-
-async def test_adapter_reads_connected_provider_without_generation_and_preserves_nested_ids(
+async def test_adapter_uses_documented_metadata_command_and_preserves_nested_ids(
     tmp_path: Path,
 ) -> None:
-    model_id = "anthropic/claude-sonnet-4-6"
-    payload = {
-        "all": [
-            {
-                "id": "openrouter",
-                "name": "OpenRouter",
-                "models": {model_id: _model(model_id)},
-                "options": {"apiKey": "provider-secret"},
-            }
-        ],
-        "default": {"openrouter": model_id},
-        "connected": ["openrouter"],
-    }
-    executable, request_log = _fake_server(tmp_path, payload)
+    executable, invocation_log = _fake_command(
+        tmp_path,
+        stdout=(b"openrouter/anthropic/claude-sonnet-4-6\nopenrouter/meta/llama/3\n"),
+    )
     current_user = pwd.getpwuid(os.getuid()).pw_name
     adapter = OpenCodeModelDiscoveryAdapter(service_os_user=current_user, environment={})
 
     batch = await adapter.discover(_lane(executable, os_user=current_user))
 
-    assert batch.source == "opencode-server-provider"
+    assert batch.source == "opencode-cli-models"
     assert batch.ttl_seconds == 21_600
-    assert [candidate.model_id for candidate in batch.models] == ["openrouter/anthropic/claude-sonnet-4-6"]
-    assert batch.models[0].display_label == "Claude Sonnet"
-    assert batch.models[0].capabilities == {
-        "attachment": True,
-        "experimental": False,
-        "limits": {"context": 200_000, "output": 64_000},
-        "modalities": {"input": ["text", "image"], "output": ["text"]},
-        "provider_name": "OpenRouter",
-        "reasoning": True,
-        "release_date": "2026-08-01",
-        "status": "active",
-        "temperature": True,
-        "tool_call": True,
-    }
-    assert "provider-secret" not in repr(batch)
-    requests = [json.loads(line) for line in request_log.read_text(encoding="utf-8").splitlines()]
-    assert [request["path"].split("?", 1)[0] for request in requests] == [
-        "/global/health",
-        "/provider",
+    assert [candidate.model_id for candidate in batch.models] == [
+        "openrouter/anthropic/claude-sonnet-4-6",
+        "openrouter/meta/llama/3",
     ]
-    assert all(request["authenticated"] is True for request in requests)
-    assert "directory=" in requests[1]["path"]
-    assert not any("session" in request["path"] for request in requests)
+    assert [candidate.display_label for candidate in batch.models] == [
+        "openrouter/anthropic/claude-sonnet-4-6",
+        "openrouter/meta/llama/3",
+    ]
+    assert all(candidate.capabilities == {"provider_id": "openrouter"} for candidate in batch.models)
+    invocation = json.loads(invocation_log.read_text(encoding="utf-8"))
+    assert invocation["argv"] == ["models", "openrouter", "--refresh"]
+    assert not {"run", "session", "serve"} & set(invocation["argv"])
+    assert invocation["environment"]["NO_COLOR"] == "1"
 
 
-def test_parser_distinguishes_unavailable_auth_from_unsupported_provider() -> None:
-    model = _model("model")
-    payload = json.dumps(
-        {
-            "all": [{"id": "openrouter", "name": "OpenRouter", "models": {"model": model}}],
-            "connected": [],
-        }
-    ).encode()
-    with pytest.raises(ModelDiscoveryAuthenticationError):
-        discovery_module._parse_provider_catalogue(payload, "openrouter")
-    with pytest.raises(ModelDiscoveryUnsupported):
-        discovery_module._parse_provider_catalogue(payload, "deepseek")
+def test_parser_accepts_empty_inventory_and_nested_model_ids() -> None:
+    assert discovery_module._parse_models_output(b"\n", "deepseek") == ()
+
+    models = discovery_module._parse_models_output(
+        b"deepseek/vendor/family/model\n",
+        "deepseek",
+    )
+
+    assert [model.model_id for model in models] == [
+        "deepseek/vendor/family/model",
+    ]
 
 
-def test_parser_accepts_empty_inventory_and_rejects_malformed_or_mismatched_models() -> None:
-    empty = json.dumps(
-        {
-            "all": [{"id": "openrouter", "name": "OpenRouter", "models": {}}],
-            "connected": ["openrouter"],
-        }
-    ).encode()
-    assert discovery_module._parse_provider_catalogue(empty, "openrouter") == ()
+@pytest.mark.parametrize(
+    ("body", "match"),
+    [
+        (b"\xff", "not UTF-8"),
+        (b"openrouter-model\n", "invalid provider/model"),
+        (b"deepseek/model\n", "invalid provider/model"),
+        (b"openrouter/model\nopenrouter/model\n", "duplicate"),
+    ],
+)
+def test_parser_rejects_malformed_mismatched_and_duplicate_output(
+    body: bytes,
+    match: str,
+) -> None:
+    with pytest.raises(ModelCatalogueValidationError, match=match):
+        discovery_module._parse_models_output(body, "openrouter")
 
-    with pytest.raises(ModelCatalogueValidationError, match="malformed JSON"):
-        discovery_module._parse_provider_catalogue(b"not json", "openrouter")
 
-    mismatched = json.dumps(
-        {
-            "all": [
-                {
-                    "id": "openrouter",
-                    "name": "OpenRouter",
-                    "models": {"catalogue-key": _model("different-id")},
-                }
-            ],
-            "connected": ["openrouter"],
-        }
-    ).encode()
-    with pytest.raises(ModelCatalogueValidationError, match="do not match"):
-        discovery_module._parse_provider_catalogue(mismatched, "openrouter")
+def test_parser_enforces_model_identifier_and_catalogue_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oversized = b"openrouter/" + (b"x" * 512)
+    with pytest.raises(ModelCatalogueValidationError, match="oversized"):
+        discovery_module._parse_models_output(oversized, "openrouter")
+
+    monkeypatch.setattr(discovery_module, "_MAX_MODELS", 1)
+    with pytest.raises(ModelCatalogueValidationError, match="safety limit"):
+        discovery_module._parse_models_output(
+            b"openrouter/one\nopenrouter/two\n",
+            "openrouter",
+        )
+
+
+@pytest.mark.parametrize(
+    ("detail", "error_type"),
+    [
+        (b"Provider not found: openrouter", ModelDiscoveryAuthenticationError),
+        (b"Unknown command: models", ModelDiscoveryUnsupported),
+        (b"unexpected backend failure", discovery_module._OpenCodeDiscoveryError),
+    ],
+)
+async def test_command_failures_are_classified_without_leaking_output(
+    tmp_path: Path,
+    detail: bytes,
+    error_type: type[Exception],
+) -> None:
+    executable, _invocation_log = _fake_command(
+        tmp_path,
+        stderr=detail,
+        returncode=1,
+    )
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    adapter = OpenCodeModelDiscoveryAdapter(service_os_user=current_user, environment={})
+
+    with pytest.raises(error_type) as caught:
+        await adapter.discover(_lane(executable, os_user=current_user))
+
+    assert detail.decode() not in str(caught.value)
+    assert detail.decode() not in repr(caught.value)
 
 
 def test_launch_uses_canonical_user_auth_context_and_scrubs_control_plane(
@@ -296,79 +269,71 @@ def test_launch_uses_canonical_user_auth_context_and_scrubs_control_plane(
 
     launch = discovery_module._build_launch(
         _lane(executable, os_user="alice"),
-        port=43123,
         service_os_user="kai",
         environment=environment,
     )
 
-    assert launch.argv[:6] == ("sudo", "-H", "-D", str(alice_home), "-u", "alice")
-    assert launch.argv[-6:] == (
+    assert launch.argv[:6] == (
+        "sudo",
+        "-H",
+        "-D",
+        str(alice_home),
+        "-u",
+        "alice",
+    )
+    assert launch.argv[-4:] == (
         str(executable),
-        "serve",
-        "--hostname",
-        "127.0.0.1",
-        "--port",
-        "43123",
+        "models",
+        "openrouter",
+        "--refresh",
     )
     assert launch.cwd is None
-    assert launch.directory == alice_home
+    assert launch.target_user == "alice"
     assert launch.environment["OPENROUTER_API_KEY"] == "provider-key"
+    assert launch.environment["NO_COLOR"] == "1"
     assert "OPENCODE_CONFIG_CONTENT" not in launch.environment
     assert "TELEGRAM_BOT_TOKEN" not in launch.environment
-    assert launch.environment["OPENCODE_SERVER_USERNAME"] == "kai-model-discovery"
-    assert launch.environment["OPENCODE_SERVER_PASSWORD"] == launch.password
     assert launch.environment["TMPDIR"].endswith("/tmp/alice")
     preserve_arg = next(arg for arg in launch.argv if arg.startswith("--preserve-env="))
-    assert "OPENCODE_SERVER_PASSWORD" in preserve_arg
+    assert "OPENROUTER_API_KEY" in preserve_arg
+    assert "NO_COLOR" in preserve_arg
     assert "TELEGRAM_BOT_TOKEN" not in preserve_arg
 
 
-async def test_startup_timeout_reaps_metadata_server(
+async def test_output_limit_is_enforced_while_streams_are_drained(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    executable = tmp_path / "opencode-hung-fixture"
-    pid_file = tmp_path / "pid"
-    script = f"""#!{sys.executable}
-import os
-import time
-from pathlib import Path
-Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
-time.sleep(60)
-"""
-    executable.write_text(script, encoding="utf-8")
-    executable.chmod(0o700)
-    monkeypatch.setattr(discovery_module, "_STARTUP_TIMEOUT_SECONDS", 0.5)
+    executable, _invocation_log = _fake_command(
+        tmp_path,
+        stdout=b"openrouter/model-that-is-too-long\n",
+    )
+    monkeypatch.setattr(discovery_module, "_MAX_OUTPUT_BYTES", 8)
     current_user = pwd.getpwuid(os.getuid()).pw_name
     adapter = OpenCodeModelDiscoveryAdapter(service_os_user=current_user, environment={})
 
-    with pytest.raises(discovery_module._OpenCodeDiscoveryError, match="did not become ready"):
+    with pytest.raises(ModelCatalogueValidationError, match="output exceeds"):
         await adapter.discover(_lane(executable, os_user=current_user))
 
-    pid = int(pid_file.read_text(encoding="utf-8"))
-    with pytest.raises(ProcessLookupError):
-        os.kill(pid, 0)
 
-
-async def test_cancellation_reaps_metadata_server(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_cancellation_reaps_metadata_command(tmp_path: Path) -> None:
     executable = tmp_path / "opencode-cancel-fixture"
     pid_file = tmp_path / "pid"
     script = f"""#!{sys.executable}
 import os
 import time
 from pathlib import Path
+
 Path({str(pid_file)!r}).write_text(str(os.getpid()), encoding="utf-8")
 time.sleep(60)
 """
     executable.write_text(script, encoding="utf-8")
     executable.chmod(0o700)
-    monkeypatch.setattr(discovery_module, "_STARTUP_TIMEOUT_SECONDS", 60.0)
     current_user = pwd.getpwuid(os.getuid()).pw_name
     adapter = OpenCodeModelDiscoveryAdapter(service_os_user=current_user, environment={})
-    task = asyncio.create_task(adapter.discover(_lane(executable, os_user=current_user)))
+    task = asyncio.create_task(
+        adapter.discover(_lane(executable, os_user=current_user)),
+    )
     for _ in range(100):
         if pid_file.exists():
             break


### PR DESCRIPTION
## Summary

- replace the short-lived `opencode serve` model-discovery path with OpenCode's documented `opencode models <provider> --refresh` command
- preserve canonical effective-user authentication and configuration while removing inherited one-turn model overrides and control-plane secrets
- parse bounded metadata-only output, retain nested provider model IDs, classify failures without leaking command output, and reap cancelled commands
- replace the server-oriented tests with command-contract, isolation, safety-limit, failure-classification, and cancellation coverage

## Qualification evidence

On the installed host, the command used by the new adapter completed successfully for the affected context:

```text
$ time opencode models deepseek --refresh
deepseek/deepseek-v4-flash
deepseek/deepseek-v4-flash-vision-exp
deepseek/deepseek-v4-pro

real    0m1.239s
user    0m1.100s
sys     0m0.143s
```

The former temporary-server strategy timed out for the same context.

## Validation

- `make check`
- `make typecheck`
- focused model-catalogue and application-host tests: 37 passed
- full suite: 6,250 passed

Closes #727
