### PR TITLE
Workshop channels: add channel lifecycle API

### DIFF
--- a/src/kai/workshop/channel_lifecycle.py
+++ b/src/kai/workshop/channel_lifecycle.py
@@ -1,0 +1,327 @@
+"""Canonical, transport-independent Workshop channel creation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from kai.workshop.domain import (
+    AgentId,
+    ChannelAgentId,
+    ChannelId,
+    ChannelMembershipId,
+    EventEnvelope,
+    PrincipalId,
+    RuntimeAssignmentId,
+    RuntimeProfileId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import WorkshopEventStore
+
+
+class WorkshopChannelLifecycleError(RuntimeError):
+    """A canonical channel lifecycle operation could not be completed."""
+
+
+class WorkshopChannelLifecycleAccessDenied(WorkshopChannelLifecycleError):
+    """The principal cannot create a channel in the requested Workshop."""
+
+
+class WorkshopChannelLifecycleValidationError(WorkshopChannelLifecycleError):
+    """A channel creation request is malformed or references unavailable state."""
+
+
+class WorkshopChannelLifecycleStorageError(WorkshopChannelLifecycleError):
+    """Canonical channel creation could not be persisted atomically."""
+
+
+@dataclass(frozen=True, slots=True)
+class CreatedWorkshopChannel:
+    """The canonical identity and immutable creation properties of a group channel."""
+
+    channel_id: ChannelId
+    workshop_id: WorkshopId
+    name: str
+    visibility: str
+    origin_channel_id: ChannelId | None
+    owner_principal_id: PrincipalId
+    agent_ids: tuple[AgentId, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _AgentAttachment:
+    agent_id: AgentId
+    principal_id: PrincipalId
+    runtime_profile_id: RuntimeProfileId
+
+
+def _normalize_name(value: object) -> str:
+    if not isinstance(value, str):
+        raise WorkshopChannelLifecycleValidationError("Channel name must be text")
+    normalized = value.strip()
+    if not normalized or len(normalized) > 200:
+        raise WorkshopChannelLifecycleValidationError("Channel name must contain 1 through 200 characters")
+    return normalized
+
+
+def _normalize_agents(values: object) -> tuple[AgentId, ...]:
+    if not isinstance(values, list) or not values or len(values) > 16:
+        raise WorkshopChannelLifecycleValidationError("agent_ids must contain 1 through 16 canonical agent IDs")
+    try:
+        normalized = tuple(AgentId(value) for value in values)
+    except (TypeError, ValueError) as exc:
+        raise WorkshopChannelLifecycleValidationError("agent_ids must contain canonical agent IDs") from exc
+    if len(set(normalized)) != len(normalized):
+        raise WorkshopChannelLifecycleValidationError("agent_ids must not contain duplicates")
+    return normalized
+
+
+def _normalize_origin(value: object) -> ChannelId | None:
+    if value is None:
+        return None
+    try:
+        return ChannelId(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as exc:
+        raise WorkshopChannelLifecycleValidationError("origin_channel_id must be a canonical channel ID") from exc
+
+
+class WorkshopChannelLifecycleService:
+    """Create private group channels from canonical client authority."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def create_group(
+        self,
+        principal_id: PrincipalId,
+        *,
+        name: object,
+        agent_ids: object,
+        origin_channel_id: object = None,
+    ) -> CreatedWorkshopChannel:
+        if not isinstance(principal_id, PrincipalId):
+            raise WorkshopChannelLifecycleAccessDenied("Canonical human principal is required")
+        normalized_name = _normalize_name(name)
+        normalized_agents = _normalize_agents(agent_ids)
+        normalized_origin = _normalize_origin(origin_channel_id)
+
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            workshop_id = await self._resolve_workshop(principal_id, normalized_origin)
+            attachments = await self._resolve_agent_attachments(
+                principal_id,
+                workshop_id,
+                normalized_agents,
+            )
+            channel_id = ChannelId.new()
+            now = datetime.now(UTC)
+            events = self._creation_events(
+                workshop_id=workshop_id,
+                channel_id=channel_id,
+                principal_id=principal_id,
+                name=normalized_name,
+                origin_channel_id=normalized_origin,
+                attachments=attachments,
+                occurred_at=now,
+            )
+            for event in events:
+                result = await self._store.append_in_transaction(event)
+                if not result.inserted:
+                    raise WorkshopChannelLifecycleError("New channel event identity unexpectedly already exists")
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            await connection.commit()
+        except WorkshopChannelLifecycleError:
+            await connection.rollback()
+            raise
+        except Exception as exc:
+            await connection.rollback()
+            raise WorkshopChannelLifecycleStorageError("Channel creation could not be persisted") from exc
+
+        return CreatedWorkshopChannel(
+            channel_id=channel_id,
+            workshop_id=workshop_id,
+            name=normalized_name,
+            visibility="private",
+            origin_channel_id=normalized_origin,
+            owner_principal_id=principal_id,
+            agent_ids=tuple(attachment.agent_id for attachment in attachments),
+        )
+
+    async def _resolve_workshop(
+        self,
+        principal_id: PrincipalId,
+        origin_channel_id: ChannelId | None,
+    ) -> WorkshopId:
+        if origin_channel_id is not None:
+            async with self._store.connection.execute(
+                "SELECT c.workshop_id FROM channels c "
+                "JOIN channel_memberships cm ON cm.channel_id = c.id "
+                "AND cm.principal_id = ? "
+                "JOIN workshop_memberships wm ON wm.workshop_id = c.workshop_id "
+                "AND wm.principal_id = cm.principal_id "
+                "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+                "WHERE c.id = ?",
+                (principal_id, origin_channel_id),
+            ) as cursor:
+                rows = list(await cursor.fetchall())
+        else:
+            async with self._store.connection.execute(
+                "SELECT wm.workshop_id FROM workshop_memberships wm "
+                "JOIN principals p ON p.id = wm.principal_id AND p.kind = 'human' "
+                "WHERE wm.principal_id = ? ORDER BY wm.workshop_id",
+                (principal_id,),
+            ) as cursor:
+                rows = list(await cursor.fetchall())
+        if len(rows) != 1:
+            raise WorkshopChannelLifecycleAccessDenied("Channel creation requires one accessible Workshop context")
+        return WorkshopId(str(rows[0][0]))
+
+    async def _resolve_agent_attachments(
+        self,
+        principal_id: PrincipalId,
+        workshop_id: WorkshopId,
+        agent_ids: tuple[AgentId, ...],
+    ) -> tuple[_AgentAttachment, ...]:
+        placeholders = ",".join("?" for _ in agent_ids)
+        async with self._store.connection.execute(
+            "SELECT a.id, a.principal_id, ra.runtime_profile_id "
+            "FROM agents a "
+            "JOIN workshop_memberships agent_wm ON agent_wm.workshop_id = a.workshop_id "
+            "AND agent_wm.principal_id = a.principal_id AND agent_wm.role = 'agent' "
+            "JOIN channel_agents ca ON ca.agent_id = a.id "
+            "JOIN channels c ON c.id = ca.channel_id AND c.workshop_id = a.workshop_id "
+            "AND c.kind = 'direct' "
+            "JOIN channel_memberships cm ON cm.channel_id = c.id "
+            "AND cm.principal_id = ? AND cm.role = 'owner' "
+            "JOIN channel_agent_runtime_assignments ra ON ra.channel_id = c.id "
+            "AND ra.agent_id = a.id "
+            f"WHERE a.workshop_id = ? AND a.id IN ({placeholders}) "
+            "ORDER BY a.id",
+            (principal_id, workshop_id, *agent_ids),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        by_agent: dict[AgentId, list[_AgentAttachment]] = {}
+        for row in rows:
+            attachment = _AgentAttachment(
+                AgentId(str(row[0])),
+                PrincipalId(str(row[1])),
+                RuntimeProfileId(str(row[2])),
+            )
+            by_agent.setdefault(attachment.agent_id, []).append(attachment)
+        if any(len(by_agent.get(agent_id, ())) != 1 for agent_id in agent_ids):
+            raise WorkshopChannelLifecycleValidationError(
+                "Every requested agent must be attached to the creator's direct channel"
+            )
+        return tuple(by_agent[agent_id][0] for agent_id in agent_ids)
+
+    @staticmethod
+    def _creation_events(
+        *,
+        workshop_id: WorkshopId,
+        channel_id: ChannelId,
+        principal_id: PrincipalId,
+        name: str,
+        origin_channel_id: ChannelId | None,
+        attachments: tuple[_AgentAttachment, ...],
+        occurred_at: datetime,
+    ) -> tuple[EventEnvelope, ...]:
+        metadata = {"source": "workshop_client"}
+        channel_payload: dict[str, object] = {
+            "kind": "group",
+            "name": name,
+            "visibility": "private",
+        }
+        if origin_channel_id is not None:
+            channel_payload["origin_channel_id"] = origin_channel_id
+        events = [
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_CREATED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="channel",
+                aggregate_id=channel_id,
+                actor_principal_id=principal_id,
+                occurred_at=occurred_at,
+                idempotency_key=f"workshop-client:channel:{channel_id}:created",
+                payload=channel_payload,
+                metadata=metadata,
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="channel_membership",
+                aggregate_id=ChannelMembershipId.derived(channel_id, f"principal:{principal_id}"),
+                actor_principal_id=principal_id,
+                occurred_at=occurred_at,
+                idempotency_key=f"workshop-client:channel:{channel_id}:member:{principal_id}",
+                payload={
+                    "channel_id": channel_id,
+                    "principal_id": principal_id,
+                    "role": "owner",
+                },
+                metadata=metadata,
+            ),
+        ]
+        for attachment in attachments:
+            events.extend(
+                (
+                    EventEnvelope.create(
+                        event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                        event_version=1,
+                        workshop_id=workshop_id,
+                        aggregate_type="channel_membership",
+                        aggregate_id=ChannelMembershipId.derived(
+                            channel_id,
+                            f"principal:{attachment.principal_id}",
+                        ),
+                        actor_principal_id=principal_id,
+                        occurred_at=occurred_at,
+                        idempotency_key=(f"workshop-client:channel:{channel_id}:member:{attachment.principal_id}"),
+                        payload={
+                            "channel_id": channel_id,
+                            "principal_id": attachment.principal_id,
+                            "role": "participant",
+                        },
+                        metadata=metadata,
+                    ),
+                    EventEnvelope.create(
+                        event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
+                        event_version=1,
+                        workshop_id=workshop_id,
+                        aggregate_type="channel_agent",
+                        aggregate_id=ChannelAgentId.derived(
+                            channel_id,
+                            f"agent:{attachment.agent_id}",
+                        ),
+                        actor_principal_id=principal_id,
+                        occurred_at=occurred_at,
+                        idempotency_key=(f"workshop-client:channel:{channel_id}:agent:{attachment.agent_id}"),
+                        payload={"channel_id": channel_id, "agent_id": attachment.agent_id},
+                        metadata=metadata,
+                    ),
+                    EventEnvelope.create(
+                        event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
+                        event_version=1,
+                        workshop_id=workshop_id,
+                        aggregate_type="runtime_assignment",
+                        aggregate_id=RuntimeAssignmentId.derived(
+                            channel_id,
+                            f"runtime-profile:{attachment.agent_id}",
+                        ),
+                        actor_principal_id=principal_id,
+                        occurred_at=occurred_at,
+                        idempotency_key=(f"workshop-client:channel:{channel_id}:runtime:{attachment.agent_id}"),
+                        payload={
+                            "channel_id": channel_id,
+                            "agent_id": attachment.agent_id,
+                            "runtime_profile_id": attachment.runtime_profile_id,
+                        },
+                        metadata=metadata,
+                    ),
+                )
+            )
+        return tuple(events)

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -37,6 +37,14 @@ from kai.workshop.artifacts import (
     WorkshopArtifactService,
 )
 from kai.workshop.authorization import CanonicalChannelAuthorizer
+from kai.workshop.channel_lifecycle import (
+    CreatedWorkshopChannel,
+    WorkshopChannelLifecycleAccessDenied,
+    WorkshopChannelLifecycleError,
+    WorkshopChannelLifecycleService,
+    WorkshopChannelLifecycleStorageError,
+    WorkshopChannelLifecycleValidationError,
+)
 from kai.workshop.client_commands import (
     ClientCommandExecutorUnavailableError,
     ClientCommandSubmission,
@@ -149,6 +157,7 @@ from kai.workshop.timeline import (
 _TIMELINE_PATH = "/v1/channels/{channel_id}/timeline"
 _TIMELINE_EVENTS_PATH = "/v1/channels/{channel_id}/events"
 _CLIENT_NAVIGATION_PATH = "/v1/client/navigation"
+_CHANNEL_CREATION_PATH = "/v1/channels"
 _ENROLLMENT_REDEMPTION_PATH = "/v1/client/enrollment/redeem"
 _COMMAND_SUBMISSION_PATH = "/v1/channels/{channel_id}/commands"
 _ARTIFACT_CONTENT_PATH = "/v1/channels/{channel_id}/artifacts/{artifact_id}/content"
@@ -204,6 +213,8 @@ _CLIENT_PREFERENCE_REQUEST_FIELDS = frozenset({"revision", "binding_choice_id", 
 _MAX_CLIENT_PREFERENCE_BODY_BYTES = 2_048
 _APPEARANCE_PREFERENCE_REQUEST_FIELDS = frozenset({"revision", "theme_id"})
 _MAX_APPEARANCE_PREFERENCE_BODY_BYTES = 1_024
+_CHANNEL_CREATION_REQUEST_FIELDS = frozenset({"name", "agent_ids", "origin_channel_id"})
+_MAX_CHANNEL_CREATION_BODY_BYTES = 8_192
 _DECIMAL_INTEGER = re.compile(r"^[0-9]+$")
 _CLIENT_MESSAGE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _EVENT_BATCH_SIZE = 100
@@ -516,6 +527,24 @@ def _serialize_appearance_preferences(
             if snapshot.mutation is not None
             else None
         ),
+    }
+
+
+def _serialize_created_channel(
+    channel: CreatedWorkshopChannel,
+) -> dict[str, object]:
+    return {
+        "version": 1,
+        "channel": {
+            "channel_id": str(channel.channel_id),
+            "workshop_id": str(channel.workshop_id),
+            "name": channel.name,
+            "kind": "group",
+            "visibility": channel.visibility,
+            "origin_channel_id": (str(channel.origin_channel_id) if channel.origin_channel_id is not None else None),
+            "role": "owner",
+            "agent_ids": [str(agent_id) for agent_id in channel.agent_ids],
+        },
     }
 
 
@@ -2690,6 +2719,89 @@ async def _handle_client_navigation(
     )
 
 
+async def _handle_channel_creation(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopChannelLifecycleService,
+) -> web.Response:
+    """Create one private canonical group channel for the authenticated human."""
+    principal_id = await authenticator.authenticate(request)
+    if not isinstance(principal_id, PrincipalId):
+        response = _error_response(
+            status=401,
+            code="authentication_required",
+            message="Authentication required",
+        )
+        response.headers["WWW-Authenticate"] = "Bearer"
+        return response
+    if request.query or request.content_type != "application/json":
+        return _error_response(
+            status=400,
+            code="invalid_request",
+            message="Invalid channel creation request",
+        )
+    if request.content_length is not None and request.content_length > _MAX_CHANNEL_CREATION_BODY_BYTES:
+        return _error_response(
+            status=400,
+            code="invalid_request",
+            message="Channel creation request is too large",
+        )
+    raw = await request.content.read(_MAX_CHANNEL_CREATION_BODY_BYTES + 1)
+    if len(raw) > _MAX_CHANNEL_CREATION_BODY_BYTES:
+        return _error_response(
+            status=400,
+            code="invalid_request",
+            message="Channel creation request is too large",
+        )
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, ValueError):
+        payload = None
+    if (
+        not isinstance(payload, dict)
+        or not {"name", "agent_ids"}.issubset(payload)
+        or not set(payload).issubset(_CHANNEL_CREATION_REQUEST_FIELDS)
+    ):
+        return _error_response(
+            status=400,
+            code="invalid_request",
+            message="Invalid channel creation request",
+        )
+    try:
+        created = await service.create_group(
+            principal_id,
+            name=payload["name"],
+            agent_ids=payload["agent_ids"],
+            origin_channel_id=payload.get("origin_channel_id"),
+        )
+    except WorkshopChannelLifecycleAccessDenied:
+        return _error_response(
+            status=403,
+            code="access_denied",
+            message="Access denied",
+        )
+    except WorkshopChannelLifecycleValidationError as exc:
+        return _error_response(
+            status=400,
+            code="invalid_request",
+            message=str(exc),
+        )
+    except WorkshopChannelLifecycleStorageError:
+        return _error_response(
+            status=503,
+            code="channel_creation_unavailable",
+            message="Channel creation is temporarily unavailable",
+        )
+    except WorkshopChannelLifecycleError:
+        return _error_response(
+            status=409,
+            code="channel_creation_conflict",
+            message="Channel creation conflicted with current state",
+        )
+    return _json_response(_serialize_created_channel(created), status=201)
+
+
 async def _handle_channel_timeline(
     request: web.Request,
     *,
@@ -3540,6 +3652,7 @@ def register_workshop_read_routes(
     if event_poll_interval <= 0 or event_heartbeat_interval <= 0 or event_authentication_recheck_interval <= 0:
         raise ValueError("Event-stream intervals must be positive")
     stream_limiter = event_stream_limiter or WorkshopEventStreamLimiter()
+    channel_lifecycle = WorkshopChannelLifecycleService(store)
     shutdown_event = asyncio.Event()
 
     async def stop_event_streams(_app: web.Application) -> None:
@@ -3564,6 +3677,14 @@ def register_workshop_read_routes(
                 authenticator=authenticator,
             )
 
+    async def handle_channel_creation(request: web.Request) -> web.Response:
+        async with request_lock:
+            return await _handle_channel_creation(
+                request,
+                authenticator=authenticator,
+                service=channel_lifecycle,
+            )
+
     async def handle_channel_event_stream(request: web.Request) -> web.StreamResponse:
         return await _handle_channel_event_stream(
             request,
@@ -3579,6 +3700,7 @@ def register_workshop_read_routes(
         )
 
     app.router.add_get(_CLIENT_NAVIGATION_PATH, handle_client_navigation)
+    app.router.add_post(_CHANNEL_CREATION_PATH, handle_channel_creation)
     app.router.add_get(_TIMELINE_PATH, handle_channel_timeline)
     app.router.add_get(_TIMELINE_EVENTS_PATH, handle_channel_event_stream)
     if preference_documents is not None:

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 39
+WORKSHOP_SCHEMA_VERSION = 40
 
 
 @dataclass(frozen=True, slots=True)
@@ -1933,6 +1933,42 @@ _CANONICAL_MODEL_CATALOGUE_SCHEMA = SchemaMigration(
     ),
 )
 
+_REUSABLE_GROUP_RUNTIME_ASSIGNMENT_SCHEMA = SchemaMigration(
+    version=40,
+    name="reusable_group_runtime_assignments",
+    statements=(
+        """
+        CREATE TABLE channel_agent_runtime_assignments_v40 (
+            id TEXT PRIMARY KEY,
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+            runtime_profile_id TEXT NOT NULL CHECK (
+                length(runtime_profile_id) BETWEEN 1 AND 128
+            ),
+            created_at TEXT NOT NULL,
+            created_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            UNIQUE (channel_id, agent_id)
+        )
+        """,
+        """
+        INSERT INTO channel_agent_runtime_assignments_v40 (
+            id, channel_id, agent_id, runtime_profile_id, created_at,
+            created_event_position
+        ) SELECT
+            id, channel_id, agent_id, runtime_profile_id, created_at,
+            created_event_position
+          FROM channel_agent_runtime_assignments
+        """,
+        "DROP TABLE channel_agent_runtime_assignments",
+        "ALTER TABLE channel_agent_runtime_assignments_v40 RENAME TO channel_agent_runtime_assignments",
+        "CREATE INDEX channel_agent_runtime_profile_idx ON channel_agent_runtime_assignments (runtime_profile_id)",
+        "CREATE UNIQUE INDEX channel_agent_runtime_assignment_tuple_idx "
+        "ON channel_agent_runtime_assignments "
+        "(channel_id, agent_id, runtime_profile_id)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -1973,6 +2009,7 @@ _MIGRATIONS = (
     _PRINCIPAL_APPEARANCE_PREFERENCES_SCHEMA,
     _DURABLE_PRINCIPAL_APPEARANCE_PREFERENCES_SCHEMA,
     _CANONICAL_MODEL_CATALOGUE_SCHEMA,
+    _REUSABLE_GROUP_RUNTIME_ASSIGNMENT_SCHEMA,
 )
 
 

--- a/src/kai/workshop/storage_namespaces.py
+++ b/src/kai/workshop/storage_namespaces.py
@@ -77,10 +77,14 @@ class WorkshopChannelHistoryRegistry:
     ) -> WorkshopChannelHistoryRegistry:
         """Resolve protected runtime assignments to canonical channels."""
         async with store.connection.execute(
-            "SELECT runtime_profile_id, channel_id FROM channel_agent_runtime_assignments ORDER BY runtime_profile_id"
+            "SELECT ra.runtime_profile_id, ra.channel_id, c.kind "
+            "FROM channel_agent_runtime_assignments ra "
+            "JOIN channels c ON c.id = ra.channel_id "
+            "ORDER BY ra.runtime_profile_id, "
+            "CASE c.kind WHEN 'direct' THEN 0 ELSE 1 END, ra.channel_id"
         ) as cursor:
             assignment_rows = list(await cursor.fetchall())
-        channel_by_profile: dict[RuntimeProfileId, ChannelId] = {}
+        channels_by_profile: dict[RuntimeProfileId, list[tuple[ChannelId, str]]] = {}
         for row in assignment_rows:
             try:
                 profile_id = RuntimeProfileId(str(row[0]))
@@ -89,28 +93,29 @@ class WorkshopChannelHistoryRegistry:
                 raise WorkshopStorageNamespaceError(
                     "Runtime history assignment contains an invalid opaque identifier"
                 ) from exc
-            if profile_id in channel_by_profile and channel_by_profile[profile_id] != channel_id:
-                raise WorkshopStorageNamespaceError("Runtime profile maps to multiple history channels")
-            channel_by_profile[profile_id] = channel_id
+            channels_by_profile.setdefault(profile_id, []).append((channel_id, str(row[2])))
 
         runtime_aliases: dict[int, ChannelId] = {}
-        namespaces: list[WorkshopChannelHistoryNamespace] = []
-        namespace_channels: set[ChannelId] = set()
+        legacy_key_by_channel: dict[ChannelId, int | None] = {}
         for profile in runtime_profiles.profiles:
-            channel_id = channel_by_profile.get(profile.profile_id)
-            if channel_id is None:
+            assignments = channels_by_profile.get(profile.profile_id, [])
+            direct_channels = {channel_id for channel_id, kind in assignments if kind == "direct"}
+            if len(direct_channels) != 1:
                 raise WorkshopStorageNamespaceError("Protected runtime profile has no canonical history channel")
+            direct_channel_id = next(iter(direct_channels))
             legacy_runtime_key = runtime_profiles.legacy_runtime_key(profile.profile_id)
             if legacy_runtime_key is not None:
-                runtime_aliases[legacy_runtime_key] = channel_id
-            if channel_id not in namespace_channels:
-                namespaces.append(
-                    WorkshopChannelHistoryNamespace(
-                        channel_id,
-                        legacy_runtime_key,
-                    )
-                )
-                namespace_channels.add(channel_id)
+                runtime_aliases[legacy_runtime_key] = direct_channel_id
+            for channel_id, _kind in assignments:
+                channel_legacy_key = legacy_runtime_key if channel_id == direct_channel_id else None
+                existing = legacy_key_by_channel.get(channel_id)
+                if existing is not None and existing != channel_legacy_key:
+                    raise WorkshopStorageNamespaceError("Channel history namespace has conflicting runtime aliases")
+                legacy_key_by_channel[channel_id] = channel_legacy_key
+        namespaces = [
+            WorkshopChannelHistoryNamespace(channel_id, legacy_key)
+            for channel_id, legacy_key in legacy_key_by_channel.items()
+        ]
         return cls(tuple(namespaces), runtime_aliases=runtime_aliases)
 
     @property

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -859,6 +859,7 @@ class TestNotificationChatIdMutations:
             assert lan_paths == {
                 "/v1/client/enrollment/redeem",
                 "/v1/client/navigation",
+                "/v1/channels",
                 "/v1/channels/{channel_id}/timeline",
                 "/v1/channels/{channel_id}/events",
                 "/v1/channels/{channel_id}/artifacts/{artifact_id}/content",

--- a/tests/test_workshop_appearance_preferences.py
+++ b/tests/test_workshop_appearance_preferences.py
@@ -70,7 +70,7 @@ async def test_version_thirty_seven_preferences_upgrade_without_data_loss(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 39
+        assert await upgraded.schema_version() == 40
         async with upgraded.connection.execute(
             "SELECT principal_id, theme_id, created_at, updated_at FROM principal_appearance_preferences"
         ) as cursor:

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -47,11 +47,13 @@ from kai.workshop.client_sessions import (
 )
 from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.domain import (
+    AgentId,
     ChannelId,
     ChannelMembershipId,
     MessageId,
     PrincipalId,
     RunId,
+    WorkshopEventType,
 )
 from kai.workshop.execution_coordinator import CanonicalCancellationDisposition
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
@@ -112,7 +114,10 @@ from kai.workshop.settings_workspaces import (
     WorkspaceConfigSnapshot,
     WorkspaceOption,
 )
-from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
+from kai.workshop.storage_namespaces import (
+    WorkshopChannelHistoryRegistry,
+    WorkshopPrincipalStorageRegistry,
+)
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id, profile_registry
 
@@ -1161,6 +1166,237 @@ class TestWorkshopNavigationHTTPContract:
             ]
             assert direct["agents"] == []
             assert direct["can_submit_commands"] is False
+        finally:
+            await client.close()
+            await store.close()
+
+
+class TestWorkshopChannelLifecycleHTTPContract:
+    async def test_creates_one_private_canonical_group_without_transport_binding(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, alice_channel, _, _ = await _open_store(tmp_path / "kai.db")
+        async with store.connection.execute(
+            "SELECT ca.agent_id FROM channel_agents ca WHERE ca.channel_id = ?",
+            (alice_channel,),
+        ) as cursor:
+            agent_row = await cursor.fetchone()
+        assert agent_row is not None
+        agent_id = AgentId(str(agent_row[0]))
+        async with store.connection.execute("SELECT * FROM event_log ORDER BY position") as cursor:
+            bootstrap_events = [tuple(row) for row in await cursor.fetchall()]
+        async with store.connection.execute("SELECT * FROM channels ORDER BY id") as cursor:
+            bootstrap_channels = {str(row[0]): tuple(row) for row in await cursor.fetchall()}
+        async with store.connection.execute("SELECT * FROM channel_memberships ORDER BY id") as cursor:
+            bootstrap_memberships = {str(row[0]): tuple(row) for row in await cursor.fetchall()}
+        async with store.connection.execute(
+            "SELECT * FROM channels WHERE id = ?",
+            (alice_channel,),
+        ) as cursor:
+            origin_before = tuple(await cursor.fetchone())
+
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id}),
+        )
+        try:
+            response = await client.post(
+                "/v1/channels",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "name": "  Release planning  ",
+                    "agent_ids": [agent_id],
+                    "origin_channel_id": alice_channel,
+                },
+            )
+
+            assert response.status == 201
+            payload = await response.json()
+            channel = payload["channel"]
+            channel_id = ChannelId(channel["channel_id"])
+            assert channel == {
+                "channel_id": channel_id,
+                "workshop_id": payload["channel"]["workshop_id"],
+                "name": "Release planning",
+                "kind": "group",
+                "visibility": "private",
+                "origin_channel_id": alice_channel,
+                "role": "owner",
+                "agent_ids": [agent_id],
+            }
+
+            async with store.connection.execute(
+                "SELECT event_type, payload_json FROM event_log WHERE position > ? ORDER BY position",
+                (len(bootstrap_events),),
+            ) as cursor:
+                created_events = list(await cursor.fetchall())
+            assert [str(row[0]) for row in created_events] == [
+                WorkshopEventType.CHANNEL_CREATED,
+                WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                WorkshopEventType.CHANNEL_AGENT_ATTACHED,
+                WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
+            ]
+            assert json.loads(str(created_events[0][1])) == {
+                "kind": "group",
+                "name": "Release planning",
+                "origin_channel_id": alice_channel,
+                "visibility": "private",
+            }
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_bindings WHERE channel_id = ?",
+                (channel_id,),
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute(
+                "SELECT * FROM event_log WHERE position <= ? ORDER BY position",
+                (len(bootstrap_events),),
+            ) as cursor:
+                assert [tuple(row) for row in await cursor.fetchall()] == bootstrap_events
+            async with store.connection.execute(
+                "SELECT * FROM channels WHERE id = ?",
+                (alice_channel,),
+            ) as cursor:
+                assert tuple(await cursor.fetchone()) == origin_before
+            async with store.connection.execute("SELECT * FROM channels ORDER BY id") as cursor:
+                current_channels = {str(row[0]): tuple(row) for row in await cursor.fetchall()}
+            assert {
+                channel_key: current_channels[channel_key] for channel_key in bootstrap_channels
+            } == bootstrap_channels
+            async with store.connection.execute("SELECT * FROM channel_memberships ORDER BY id") as cursor:
+                current_memberships = {str(row[0]): tuple(row) for row in await cursor.fetchall()}
+            assert {
+                membership_key: current_memberships[membership_key] for membership_key in bootstrap_memberships
+            } == bootstrap_memberships
+
+            navigation_response = await client.get(
+                "/v1/client/navigation",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert navigation_response.status == 200
+            navigation = await navigation_response.json()
+            visible = next(item for item in navigation["workshops"][0]["channels"] if item["channel_id"] == channel_id)
+            assert visible["kind"] == "group"
+            assert visible["name"] == "Release planning"
+            assert visible["role"] == "owner"
+            assert visible["agents"] == [{"agent_id": agent_id, "name": "Kai"}]
+            assert visible["can_submit_commands"] is True
+
+            history = await WorkshopChannelHistoryRegistry.from_store(
+                store,
+                profile_registry(101, 202),
+            )
+            assert channel_id in {namespace.channel_id for namespace in history.namespaces}
+            assert history.for_compatibility_chat_id(101).channel_id == alice_channel
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_unknown_agent_rejects_the_entire_event_set(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, alice_channel, _, _ = await _open_store(tmp_path / "kai.db")
+        async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+            event_count = int((await cursor.fetchone())[0])
+        async with store.connection.execute("SELECT COUNT(*) FROM channels") as cursor:
+            channel_count = int((await cursor.fetchone())[0])
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id}),
+        )
+        try:
+            response = await client.post(
+                "/v1/channels",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "name": "Must not exist",
+                    "agent_ids": [AgentId.new()],
+                    "origin_channel_id": alice_channel,
+                },
+            )
+
+            assert response.status == 400
+            assert (await response.json())["error"]["code"] == "invalid_request"
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                assert int((await cursor.fetchone())[0]) == event_count
+            async with store.connection.execute("SELECT COUNT(*) FROM channels") as cursor:
+                assert int((await cursor.fetchone())[0]) == channel_count
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_projection_failure_rolls_back_every_creation_event(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, alice_channel, _, _ = await _open_store(tmp_path / "kai.db")
+        async with store.connection.execute(
+            "SELECT agent_id FROM channel_agents WHERE channel_id = ?",
+            (alice_channel,),
+        ) as cursor:
+            agent_id = AgentId(str((await cursor.fetchone())[0]))
+        async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+            event_count = int((await cursor.fetchone())[0])
+        async with store.connection.execute("SELECT COUNT(*) FROM channels") as cursor:
+            channel_count = int((await cursor.fetchone())[0])
+        await store.connection.execute(
+            "CREATE TRIGGER reject_new_channel_agent "
+            "BEFORE INSERT ON channel_agents "
+            "BEGIN SELECT RAISE(ABORT, 'forced projection failure'); END"
+        )
+        await store.connection.commit()
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id}),
+        )
+        try:
+            response = await client.post(
+                "/v1/channels",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "name": "Must roll back",
+                    "agent_ids": [agent_id],
+                    "origin_channel_id": alice_channel,
+                },
+            )
+
+            assert response.status == 503
+            assert (await response.json())["error"] == {
+                "code": "channel_creation_unavailable",
+                "message": "Channel creation is temporarily unavailable",
+            }
+            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+                assert int((await cursor.fetchone())[0]) == event_count
+            async with store.connection.execute("SELECT COUNT(*) FROM channels") as cursor:
+                assert int((await cursor.fetchone())[0]) == channel_count
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_authentication_precedes_channel_request_validation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id}),
+        )
+        try:
+            unauthenticated = await client.post(
+                "/v1/channels?unsupported=1",
+                data="not-json",
+            )
+            malformed = await client.post(
+                "/v1/channels?unsupported=1",
+                headers={"Authorization": "Bearer alice"},
+                data="not-json",
+            )
+
+            assert unauthenticated.status == 401
+            assert malformed.status == 400
         finally:
             await client.close()
             await store.close()

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -92,7 +92,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",
@@ -129,7 +129,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             async with upgraded.connection.execute(
                 "SELECT field, value FROM channel_agent_execution_settings"
             ) as cursor:

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -208,12 +208,27 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 39
+        assert await workshop_store.schema_version() == 40
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
         assert "delivery_outbox_purpose_due_idx" in indexes
         assert "delivery_outbox_purpose_binding_order_idx" in indexes
+        async with workshop_store.connection.execute("PRAGMA index_list(channel_agent_runtime_assignments)") as cursor:
+            assignment_indexes = [(str(row[1]), bool(row[2])) for row in await cursor.fetchall()]
+        unique_assignment_columns: set[tuple[str, ...]] = set()
+        for index_name, unique in assignment_indexes:
+            if not unique:
+                continue
+            async with workshop_store.connection.execute(f"PRAGMA index_info({index_name})") as cursor:
+                unique_assignment_columns.add(tuple(str(row[2]) for row in await cursor.fetchall()))
+        assert ("runtime_profile_id",) not in unique_assignment_columns
+        assert ("channel_id", "agent_id") in unique_assignment_columns
+        assert (
+            "channel_id",
+            "agent_id",
+            "runtime_profile_id",
+        ) in unique_assignment_columns
         async with workshop_store.connection.execute("PRAGMA foreign_key_list(workshop_post_run_effects)") as cursor:
             assert await cursor.fetchall() == []
 
@@ -223,7 +238,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 39
+        assert await second.schema_version() == 40
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -255,7 +270,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -283,7 +298,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -340,6 +355,7 @@ class TestWorkshopSchema:
                     37,
                     38,
                     39,
+                    40,
                 ]
         finally:
             await upgraded.close()
@@ -362,7 +378,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -403,7 +419,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -456,7 +472,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -500,7 +516,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -544,7 +560,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -588,7 +604,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -692,7 +708,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -819,7 +835,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -521,7 +521,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -411,7 +411,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -220,7 +220,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -524,7 +524,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -382,7 +382,7 @@ class TestAtomicTerminalTransactions:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 39
+            assert await upgraded.schema_version() == 40
             assert await _post_run_effect_count(upgraded) == 1
             async with upgraded.connection.execute(
                 "SELECT status, source_message_id, result_message_id FROM workshop_post_run_effects WHERE run_id = ?",


### PR DESCRIPTION
Closes #971.

## Summary

- add authenticated `POST /v1/channels` creation for private canonical group channels
- append channel creation, membership, agent attachment, and runtime assignment events atomically
- reuse each selected agent's creator-authorized direct-channel runtime profile without creating a Telegram binding
- allow protected runtime profiles to serve direct and group channels while retaining the direct channel as the sole legacy-history alias authority
- preserve existing bootstrap channels and memberships and expose the new group through client navigation

## Validation

- `make check`
- `make typecheck`
- `.venv/bin/python -m pytest` (6,254 passed)
- focused channel lifecycle, schema, navigation, rollback, and LAN route-surface tests

The root-only installer dry-run could not be executed in the managed terminal because `sudo` requires an interactive password.
