### PR TITLE
fix: release aborted Workshop event streams

### DIFF
--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -3081,6 +3081,9 @@ async def _handle_channel_event_stream(
         last_trace_sent: tuple[str, int] | None = None
         await response.write(f": connected\nretry: {_SSE_RETRY_MILLISECONDS}\n\n".encode())
         while True:
+            transport = request.transport
+            if transport is None or transport.is_closing():
+                break
             if run_previews is not None:
                 preview = run_previews.channel_preview(channel_id)
                 if preview is not None:

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -2589,7 +2589,9 @@ class TestWorkshopTimelineEventStreamHTTPContract:
             store,
             _Authenticator({"alice-token": alice_id}),
             event_poll_interval=0.005,
-            event_heartbeat_interval=0.01,
+            # A disconnected client must release its claim during ordinary
+            # polling, without relying on a heartbeat write to discover it.
+            event_heartbeat_interval=30.0,
             event_stream_limiter=limiter,
         )
         first_response = None


### PR DESCRIPTION
## Summary

- detect a closing Workshop SSE transport during the ordinary polling loop
- release per-principal and global stream capacity promptly after browser aborts
- strengthen the disconnect regression to use a 30-second heartbeat, proving release no longer depends on a heartbeat write

## Installed diagnosis

One Daniel Workshop tab exhausted the four-stream per-principal allowance while Scott's separate-principal tab remained open. A fresh stream returned HTTP 429 `stream_capacity_exceeded`; the snapshot and event log both ended at position 6904, excluding timeline corruption. TCP connections churned while stale logical claims remained charged.

## Verification

- `make test` — 6,262 passed
- `make check`
- focused Workshop client API tests — 79 passed

Fixes #1189
