### PR TITLE
Define canonical versioned Workshop agents

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -1474,6 +1474,7 @@ class AcpBackend(AgentBackend):
             chat_id=recall_chat_id,
             runtime_identity=runtime_identity if had_user_text else None,
             session_context=session_ctx,
+            agent_definition_context=self.consume_canonical_agent_context(),
             workspace_reminder=reminder,
             workspace=self.workspace,
             backend_name=self.backend_name,

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -538,6 +538,23 @@ class AgentBackend(ABC):
         if hasattr(self, "_canonical_history"):
             del self._canonical_history
 
+    def stage_canonical_agent_context(self, context: str) -> None:
+        """Stage the immutable agent revision bound to the next turn."""
+        if not isinstance(context, str) or not context:
+            raise ValueError("agent definition context must be non-empty text")
+        self._canonical_agent_context = context
+
+    def consume_canonical_agent_context(self) -> str:
+        """Consume a staged per-turn agent definition exactly once."""
+        context = getattr(self, "_canonical_agent_context", "")
+        self.discard_canonical_agent_context()
+        return context
+
+    def discard_canonical_agent_context(self) -> None:
+        """Clear unconsumed definition context after protected dispatch."""
+        if hasattr(self, "_canonical_agent_context"):
+            del self._canonical_agent_context
+
     @abstractmethod
     async def send(
         self,
@@ -1569,6 +1586,7 @@ async def assemble_turn_context(
     chat_id: int | None,
     runtime_identity: AgentRuntimeIdentity | None = None,
     session_context: str = "",
+    agent_definition_context: str = "",
     workspace_reminder: str = "",
     workspace: Path | None = None,
     backend_name: str | None = None,
@@ -1588,13 +1606,15 @@ async def assemble_turn_context(
         workspace_reminder    (topmost)
         semantic memory block
         session_context
+        agent_definition_context
         USER_MESSAGE_MARKER
         user prompt           (bottom; the real message)
 
     `prepend_to_prompt` stacks each prefix ABOVE the existing prompt,
     so the implementation order below is the REVERSE of the reading
     order: marker first (so it lands closest to the user text),
-    session_context second, memory third, reminder last (topmost).
+    agent definition second, session context third, memory fourth, reminder
+    last (topmost).
     This is load-bearing and the single most common way to break the
     invariant; the regression test
     `tests/test_claude.py::test_delimiter_is_closest_prefix_to_user_text`
@@ -1637,6 +1657,12 @@ async def assemble_turn_context(
     # context, not just from recalled memories, so it must be a
     # permanent prompt-shape fixture for interactive backends.
     prompt = prepend_to_prompt(prompt, USER_MESSAGE_MARKER)
+
+    # A run-bound agent definition applies on every turn, including a live
+    # provider session. It is deliberately below host/workspace session
+    # context and never carries authority of its own.
+    if agent_definition_context:
+        prompt = prepend_to_prompt(prompt, agent_definition_context)
 
     # First-session context (AGENTS.md + PREFERENCES.md + recent
     # history + API context) is built by the caller because the

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -859,6 +859,7 @@ class ClaudeCodeBackend(AgentBackend):
             chat_id=chat_id,
             runtime_identity=runtime_identity,
             session_context=session_ctx,
+            agent_definition_context=self.consume_canonical_agent_context(),
             workspace_reminder=reminder,
             workspace=self.workspace,
             backend_name=self.backend_name,

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -966,6 +966,7 @@ class CodexBackend(AgentBackend):
             chat_id=recall_chat_id,
             runtime_identity=runtime_identity if had_user_text else None,
             session_context=session_ctx,
+            agent_definition_context=self.consume_canonical_agent_context(),
             workspace_reminder=reminder,
             workspace=self.workspace,
             backend_name=self.backend_name,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -78,6 +78,7 @@ from kai.protected_config import ProtectedConfigError, validate_protected_file_m
 from kai.user_isolation import validate_protected_user_isolation
 from kai.workshop.bootstrap import bootstrap_human_principal_id
 from kai.workshop.diagnostics import (
+    workshop_agent_definition_status,
     workshop_appearance_preference_status,
     workshop_bootstrap_status,
     workshop_canonical_message_integrity_status,
@@ -9552,6 +9553,7 @@ def _cmd_status() -> None:
             expected_humans=expected_humans,
         )
     )
+    print(workshop_agent_definition_status(Path(data_dir) / "kai.db"))
     print(workshop_delivery_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_runtime_session_status(Path(data_dir) / "kai.db"))
     print(_runtime_key_cutover_status(Path(data_dir) / "kai.db", RUNTIME_PROFILES_YAML))

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -450,6 +450,7 @@ class PiBackend(AgentBackend):
             chat_id=chat_id if had_user_text else None,
             runtime_identity=runtime_identity if had_user_text else None,
             session_context=session_context,
+            agent_definition_context=self.consume_canonical_agent_context(),
             workspace_reminder=reminder,
             workspace=self.workspace,
             backend_name=self.backend_name,

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -136,6 +136,11 @@ class PreparedBackendExecution:
         self._pool._validate_prepared(self)
         self._instance.stage_canonical_history(history)
 
+    def stage_canonical_agent_context(self, context: str) -> None:
+        """Stage the run-bound agent revision on this exact runtime."""
+        self._pool._validate_prepared(self)
+        self._instance.stage_canonical_agent_context(context)
+
     def validate_current(self) -> None:
         """Fail before dispatch if the protected runtime selection drifted."""
         self._pool._validate_prepared(self)
@@ -996,6 +1001,7 @@ class SubprocessPool:
                 yield event
         finally:
             instance.discard_canonical_history()
+            instance.discard_canonical_agent_context()
             self._in_flight.discard(runtime_key)
             self._last_activity[runtime_key] = time.monotonic()
 
@@ -1025,6 +1031,7 @@ class SubprocessPool:
                 yield event
         finally:
             instance.discard_canonical_history()
+            instance.discard_canonical_agent_context()
             self._in_flight.discard(instance_key)
             self._last_activity[instance_key] = time.monotonic()
 

--- a/src/kai/workshop/agent_definitions.py
+++ b/src/kai/workshop/agent_definitions.py
@@ -1,0 +1,137 @@
+"""Canonical, immutable Workshop agent definitions."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+from kai.workshop.domain import AgentDefinitionId, AgentDefinitionRevisionId, AgentId, WorkshopId
+from kai.workshop.store import WorkshopEventStore
+
+AGENT_HANDLE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+AGENT_LIFECYCLE_STATES = frozenset({"draft", "active", "archived"})
+AGENT_CAPABILITIES = frozenset({"text_generation", "tool_activity", "workspace_execution", "image_input"})
+MAX_AGENT_DISPLAY_NAME = 80
+MAX_AGENT_DESCRIPTION = 1_000
+MAX_AGENT_PURPOSE = 2_000
+MAX_AGENT_INSTRUCTIONS = 20_000
+
+
+@dataclass(frozen=True, slots=True)
+class AgentDefinitionRevision:
+    definition_id: AgentDefinitionId
+    revision_id: AgentDefinitionRevisionId
+    workshop_id: WorkshopId
+    agent_id: AgentId
+    handle: str
+    display_name: str
+    description: str
+    lifecycle_state: str
+    revision_number: int
+    purpose: str
+    instructions: str
+    capabilities: tuple[str, ...]
+
+
+def normalize_agent_handle(value: object) -> str:
+    if not isinstance(value, str):
+        raise ValueError("Agent handle must be text")
+    handle = value.strip().casefold()
+    if not AGENT_HANDLE_PATTERN.fullmatch(handle):
+        raise ValueError("Agent handle must be 1-32 lowercase letters, digits, or underscores")
+    return handle
+
+
+def validate_agent_text(value: object, *, field: str, maximum: int, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"Agent {field} must be text")
+    normalized = value.strip()
+    if not allow_empty and not normalized:
+        raise ValueError(f"Agent {field} must be non-empty")
+    if len(normalized) > maximum:
+        raise ValueError(f"Agent {field} must be at most {maximum} characters")
+    return normalized
+
+
+def validate_agent_presentation(value: object) -> str:
+    if not isinstance(value, dict) or set(value) - {"avatar"}:
+        raise ValueError("Agent presentation accepts only the optional avatar field")
+    avatar = value.get("avatar")
+    if avatar is not None and (not isinstance(avatar, str) or not avatar.strip() or len(avatar) > 16):
+        raise ValueError("Agent presentation avatar must be 1-16 characters")
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)
+
+
+def validate_agent_capabilities(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise ValueError("Agent capabilities must be a non-empty list")
+    if any(not isinstance(item, str) or item not in AGENT_CAPABILITIES for item in value):
+        raise ValueError("Agent capabilities contain an unsupported value")
+    if len(set(value)) != len(value):
+        raise ValueError("Agent capabilities must be unique")
+    return tuple(sorted(value))
+
+
+async def load_agent_definition_revision(
+    store: WorkshopEventStore,
+    revision_id: AgentDefinitionRevisionId,
+) -> AgentDefinitionRevision | None:
+    async with store.connection.execute(
+        "SELECT d.id, r.id, d.workshop_id, d.agent_id, d.handle, d.display_name, d.description, "
+        "d.lifecycle_state, r.revision_number, r.purpose, r.instructions, "
+        "r.capabilities_json FROM agent_definition_revisions r "
+        "JOIN agent_definitions d ON d.id = r.agent_definition_id WHERE r.id = ?",
+        (revision_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        return None
+    capabilities = validate_agent_capabilities(json.loads(str(row[11])))
+    return AgentDefinitionRevision(
+        definition_id=AgentDefinitionId(str(row[0])),
+        revision_id=AgentDefinitionRevisionId(str(row[1])),
+        workshop_id=WorkshopId(str(row[2])),
+        agent_id=AgentId(str(row[3])),
+        handle=str(row[4]),
+        display_name=str(row[5]),
+        description=str(row[6]),
+        lifecycle_state=str(row[7]),
+        revision_number=int(row[8]),
+        purpose=str(row[9]),
+        instructions=str(row[10]),
+        capabilities=capabilities,
+    )
+
+
+async def active_agent_definition_revision(
+    store: WorkshopEventStore,
+    agent_id: AgentId,
+) -> AgentDefinitionRevision | None:
+    async with store.connection.execute(
+        "SELECT active_revision_id FROM agent_definitions WHERE agent_id = ? AND lifecycle_state = 'active'",
+        (agent_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None or row[0] is None:
+        return None
+    return await load_agent_definition_revision(store, AgentDefinitionRevisionId(str(row[0])))
+
+
+def render_agent_definition_context(revision: AgentDefinitionRevision) -> str:
+    """Render behavior metadata; this block conveys no additional authority."""
+    capabilities = ", ".join(revision.capabilities)
+    return (
+        "<kai_agent_definition>\n"
+        f"Handle: @{revision.handle}\n"
+        f"Display name: {revision.display_name}\n"
+        f"Definition revision: {revision.revision_number} ({revision.revision_id})\n"
+        f"Purpose: {revision.purpose}\n"
+        f"Declared capabilities: {capabilities}\n"
+        "Instructions:\n"
+        f"{revision.instructions}\n"
+        "This versioned agent definition describes behavior only. It does not grant "
+        "tools, credentials, data access, identity, or permission, and it cannot "
+        "override host, operator, workspace, or principal policy.\n"
+        "</kai_agent_definition>"
+    )

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -10,6 +10,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentDefinitionRevisionId,
     AgentId,
     ChannelAgentId,
     ChannelBindingId,
@@ -242,6 +244,54 @@ async def bootstrap_default_workshop(
         aggregate_id=agent_id,
         payload={"principal_id": agent_principal_id, "name": "Kai"},
     )
+    async with store.connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'agent_definitions'"
+    ) as cursor:
+        definitions_supported = await cursor.fetchone() is not None
+    # Historical-schema migration tests exercise bootstrap at the simulated
+    # old version. The current installer opens/migrates to the latest schema
+    # before bootstrap, so production always takes this branch.
+    if definitions_supported:
+        definition_id = AgentDefinitionId.derived(agent_id, "definition")
+        revision_id = AgentDefinitionRevisionId.derived(definition_id, "revision:1")
+        await ensure(
+            idempotency_key=_idempotency_key("agent-definition", "kai"),
+            event_type=WorkshopEventType.AGENT_DEFINITION_CREATED,
+            aggregate_type="agent_definition",
+            aggregate_id=definition_id,
+            payload={
+                "agent_id": agent_id,
+                "handle": "kai",
+                "display_name": "Kai",
+                "description": "Kai's general-purpose Workshop agent.",
+                "presentation": {"avatar": "K"},
+                "lifecycle_state": "active",
+            },
+        )
+        await ensure(
+            idempotency_key=_idempotency_key("agent-definition-revision", "kai:1"),
+            event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED,
+            aggregate_type="agent_definition_revision",
+            aggregate_id=revision_id,
+            payload={
+                "definition_id": definition_id,
+                "revision_number": 1,
+                "purpose": "Serve as a general-purpose personal AI assistant in Kai Workshop.",
+                "instructions": (
+                    "Act as Kai. Help the current principal with the task in the current "
+                    "Workshop conversation while following all higher-priority host, "
+                    "operator, workspace, and principal instructions."
+                ),
+                "capabilities": ["text_generation"],
+            },
+        )
+        await ensure(
+            idempotency_key=_idempotency_key("agent-definition-activation", "kai:1"),
+            event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED,
+            aggregate_type="agent_definition",
+            aggregate_id=definition_id,
+            payload={"revision_id": revision_id},
+        )
 
     for human in ordered_humans:
         token = _stable_token(human.transport, human.external_subject)

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -188,6 +188,42 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
     )
 
 
+def workshop_agent_definition_status(db_path: Path) -> str:
+    """Describe versioned agent-definition completeness without exposing content."""
+    prefix = "Workshop agent definitions:"
+    if not db_path.is_file():
+        return f"{prefix} pending; canonical schema unavailable"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            if not {"agents", "agent_definitions", "agent_definition_revisions"} <= tables:
+                return f"{prefix} pending; canonical schema unavailable"
+            agents = _scalar(connection, "SELECT COUNT(*) FROM agents")
+            definitions = _scalar(connection, "SELECT COUNT(*) FROM agent_definitions")
+            revisions = _scalar(connection, "SELECT COUNT(*) FROM agent_definition_revisions")
+            active = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agent_definitions d "
+                "JOIN agent_definition_revisions r ON r.id = d.active_revision_id "
+                "AND r.agent_definition_id = d.id WHERE d.lifecycle_state = 'active'",
+            )
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+    missing = max(agents - definitions, 0)
+    invalid_active = max(definitions - active, 0)
+    state = "active" if agents > 0 and missing == 0 and invalid_active == 0 else "INCOMPLETE"
+    return (
+        f"{prefix} {state}; agents={agents}, definitions={definitions}, revisions={revisions}, "
+        f"active={active}, missing={missing}, invalid active={invalid_active}; authority=versioned"
+    )
+
+
 def workshop_delivery_authority_status(db_path: Path) -> str:
     """Describe delivery-authority readiness using aggregate, non-secret state."""
     prefix = "Workshop delivery authority:"

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -29,6 +29,9 @@ class WorkshopEventType(StrEnum):
     CHANNEL_MEMBER_ADDED = "channel.member_added"
     TRANSPORT_CHANNEL_BOUND = "transport.channel_bound"
     AGENT_CREATED = "agent.created"
+    AGENT_DEFINITION_CREATED = "agent_definition.created"
+    AGENT_DEFINITION_REVISION_ADDED = "agent_definition.revision_added"
+    AGENT_DEFINITION_REVISION_ACTIVATED = "agent_definition.revision_activated"
     CHANNEL_AGENT_ATTACHED = "channel.agent_attached"
     CHANNEL_AGENT_DISMISSED = "channel.agent_dismissed"
     RUNTIME_PROFILE_ASSIGNED = "runtime_profile.assigned"
@@ -125,6 +128,14 @@ class ChannelBindingId(OpaqueId):
 
 class AgentId(OpaqueId):
     prefix = "agt"
+
+
+class AgentDefinitionId(OpaqueId):
+    prefix = "adf"
+
+
+class AgentDefinitionRevisionId(OpaqueId):
+    prefix = "adr"
 
 
 class RuntimeProfileId(OpaqueId):
@@ -226,6 +237,8 @@ _ID_TYPES: dict[str, type[OpaqueId]] = {
         ChannelMembershipId,
         ChannelBindingId,
         AgentId,
+        AgentDefinitionId,
+        AgentDefinitionRevisionId,
         ChannelAgentId,
         RuntimeAssignmentId,
         MessageId,

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -13,6 +13,10 @@ from typing import Protocol
 
 from kai.agent_failure import AgentFailureKind
 from kai.backend import AgentResponse, StreamEvent
+from kai.workshop.agent_definitions import (
+    load_agent_definition_revision,
+    render_agent_definition_context,
+)
 from kai.workshop.artifacts import ArtifactMessageNotFoundError, build_agent_prompt_for_message
 from kai.workshop.conversation_context import assemble_canonical_conversation_context
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
@@ -496,6 +500,12 @@ class WorkshopCanonicalExecutionCoordinator:
         prompt = await self._prompt(prepared.run)
         async with self._database_lock:
             context = await assemble_canonical_conversation_context(self._store, prepared.run)
+            revision_id = prepared.run.agent_definition_revision_id
+            if revision_id is None:
+                raise RuntimeError("Canonical run has no bound agent definition revision")
+            definition_revision = await load_agent_definition_revision(self._store, revision_id)
+            if definition_revision is None or definition_revision.agent_id != prepared.run.agent_id:
+                raise RuntimeError("Canonical run agent definition revision is unavailable")
         history = context.text
         if self._transcript_projection is not None:
             try:
@@ -512,6 +522,7 @@ class WorkshopCanonicalExecutionCoordinator:
             else:
                 history = _history_with_transcript_pointer(history, transcript_path)
         prepared.stage_canonical_history(history)
+        prepared.stage_agent_definition_context(render_agent_definition_context(definition_revision))
         response: AgentResponse | None = None
         traces_truncated = False
         async for event in prepared.stream(prompt):

--- a/src/kai/workshop/inbound.py
+++ b/src/kai/workshop/inbound.py
@@ -147,10 +147,26 @@ async def resolve_message_mentions(
 ) -> tuple[MessageMention, ...]:
     """Resolve channel-member display names against one accepted message body."""
     async with store.connection.execute(
-        "SELECT p.id, p.kind, p.display_name FROM channel_memberships cm "
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'agent_definitions'"
+    ) as cursor:
+        definitions_supported = await cursor.fetchone() is not None
+    member_query = (
+        "SELECT p.id, p.kind, COALESCE(ad.handle, p.display_name) "
+        "FROM channel_memberships cm "
+        "JOIN principals p ON p.id = cm.principal_id "
+        "LEFT JOIN agents a ON a.principal_id = p.id "
+        "LEFT JOIN agent_definitions ad ON ad.agent_id = a.id "
+        "WHERE cm.channel_id = ? AND p.kind IN ('human', 'agent') "
+        "ORDER BY length(COALESCE(ad.handle, p.display_name)) DESC, "
+        "COALESCE(ad.handle, p.display_name), p.id"
+        if definitions_supported
+        else "SELECT p.id, p.kind, p.display_name FROM channel_memberships cm "
         "JOIN principals p ON p.id = cm.principal_id "
         "WHERE cm.channel_id = ? AND p.kind IN ('human', 'agent') "
-        "ORDER BY length(p.display_name) DESC, p.display_name, p.id",
+        "ORDER BY length(p.display_name) DESC, p.display_name, p.id"
+    )
+    async with store.connection.execute(
+        member_query,
         (channel_id,),
     ) as cursor:
         rows = list(await cursor.fetchall())

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -10,7 +10,19 @@ from typing import Any
 
 import aiosqlite
 
+from kai.workshop.agent_definitions import (
+    MAX_AGENT_DESCRIPTION,
+    MAX_AGENT_DISPLAY_NAME,
+    MAX_AGENT_INSTRUCTIONS,
+    MAX_AGENT_PURPOSE,
+    normalize_agent_handle,
+    validate_agent_capabilities,
+    validate_agent_presentation,
+    validate_agent_text,
+)
 from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentDefinitionRevisionId,
     AgentId,
     ChannelId,
     MessageId,
@@ -58,8 +70,12 @@ async def _message_mentions_json(
     if not raw_mentions:
         return "[]"
     async with connection.execute(
-        "SELECT p.id, p.kind, p.display_name FROM channel_memberships cm "
-        "JOIN principals p ON p.id = cm.principal_id WHERE cm.channel_id = ?",
+        "SELECT p.id, p.kind, COALESCE(ad.handle, p.display_name) "
+        "FROM channel_memberships cm "
+        "JOIN principals p ON p.id = cm.principal_id "
+        "LEFT JOIN agents a ON a.principal_id = p.id "
+        "LEFT JOIN agent_definitions ad ON ad.agent_id = a.id "
+        "WHERE cm.channel_id = ?",
         (channel_id,),
     ) as cursor:
         members = {PrincipalId(str(row[0])): (str(row[1]), str(row[2])) for row in await cursor.fetchall()}
@@ -106,14 +122,24 @@ async def _apply_run_event(connection: aiosqlite.Connection, event: StoredEvent)
     occurred_at = envelope.occurred_at.isoformat()
     payload = envelope.payload
     if envelope.event_type == WorkshopEventType.RUN_ACCEPTED:
+        if envelope.event_version not in {1, 2}:
+            raise ValueError("Unsupported Workshop run acceptance event version")
+        keys = {"inbound_message_id", "channel_id", "requested_by_principal_id", "agent_id"}
+        if envelope.event_version == 2:
+            keys.add("agent_definition_revision_id")
         _require_exact_payload(
             payload,
-            {"inbound_message_id", "channel_id", "requested_by_principal_id", "agent_id"},
+            keys,
         )
         inbound_message_id = MessageId(_required_text(payload, "inbound_message_id"))
         channel_id = ChannelId(_required_text(payload, "channel_id"))
         requested_by = PrincipalId(_required_text(payload, "requested_by_principal_id"))
         agent_id = AgentId(_required_text(payload, "agent_id"))
+        revision_id = (
+            AgentDefinitionRevisionId(_required_text(payload, "agent_definition_revision_id"))
+            if envelope.event_version == 2
+            else None
+        )
         async with connection.execute(
             "SELECT c.workshop_id, m.channel_id, m.author_principal_id, ca.agent_id, m.created_at "
             "FROM messages m "
@@ -135,22 +161,52 @@ async def _apply_run_event(connection: aiosqlite.Connection, event: StoredEvent)
             raise ValueError("Workshop run cannot be accepted before its inbound message")
         if envelope.actor_principal_id != requested_by:
             raise ValueError("Workshop run acceptance actor must be its requesting human")
-        await connection.execute(
-            "INSERT INTO runs "
-            "(id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
-            "inbound_message_id, status, accepted_at, last_event_position) "
-            "VALUES (?, ?, ?, ?, ?, ?, 'accepted', ?, ?)",
-            (
-                envelope.aggregate_id,
-                envelope.workshop_id,
-                channel_id,
-                requested_by,
-                agent_id,
-                inbound_message_id,
-                occurred_at,
-                event.position,
-            ),
-        )
+        if revision_id is not None:
+            async with connection.execute(
+                "SELECT d.agent_id, d.lifecycle_state, d.active_revision_id "
+                "FROM agent_definition_revisions r "
+                "JOIN agent_definitions d ON d.id = r.agent_definition_id "
+                "WHERE r.id = ?",
+                (revision_id,),
+            ) as cursor:
+                definition_row = await cursor.fetchone()
+            if definition_row is None or tuple(definition_row) != (agent_id, "active", revision_id):
+                raise ValueError("Workshop run must bind the agent's active definition revision")
+        if envelope.event_version == 1:
+            await connection.execute(
+                "INSERT INTO runs "
+                "(id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
+                "inbound_message_id, status, accepted_at, last_event_position) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'accepted', ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    envelope.workshop_id,
+                    channel_id,
+                    requested_by,
+                    agent_id,
+                    inbound_message_id,
+                    occurred_at,
+                    event.position,
+                ),
+            )
+        else:
+            await connection.execute(
+                "INSERT INTO runs "
+                "(id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
+                "inbound_message_id, agent_definition_revision_id, status, accepted_at, "
+                "last_event_position) VALUES (?, ?, ?, ?, ?, ?, ?, 'accepted', ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    envelope.workshop_id,
+                    channel_id,
+                    requested_by,
+                    agent_id,
+                    inbound_message_id,
+                    revision_id,
+                    occurred_at,
+                    event.position,
+                ),
+            )
         return
 
     async with connection.execute(
@@ -552,11 +608,15 @@ class CanonicalConversationProjection:
 
     name = "canonical_conversations"
     # Runtime-profile assignments can migrate to stable protected profiles.
-    version = 11
+    version = 12
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
             existing_tables = {str(row[0]) for row in await cursor.fetchall()}
+        if "agent_definitions" in existing_tables:
+            # Break the active-revision pointer before deleting immutable
+            # revisions. Replay restores it from the activation event.
+            await connection.execute("UPDATE agent_definitions SET active_revision_id = NULL")
         for table in (
             "deliveries",
             "artifacts",
@@ -570,6 +630,8 @@ class CanonicalConversationProjection:
             "channel_bindings",
             "channel_memberships",
             "channels",
+            "agent_definition_revisions",
+            "agent_definitions",
             "agents",
             "workshop_memberships",
             "external_identities",
@@ -698,6 +760,130 @@ class CanonicalConversationProjection:
                     _required_text(payload, "name"),
                     occurred_at,
                 ),
+            )
+        elif envelope.event_type == WorkshopEventType.AGENT_DEFINITION_CREATED:
+            if (
+                not isinstance(envelope.aggregate_id, AgentDefinitionId)
+                or envelope.aggregate_type != "agent_definition"
+            ):
+                raise ValueError("Workshop agent definition creation requires a typed definition aggregate")
+            _require_exact_payload(
+                payload,
+                {"agent_id", "handle", "display_name", "description", "presentation", "lifecycle_state"},
+            )
+            agent_id = AgentId(_required_text(payload, "agent_id"))
+            handle = normalize_agent_handle(payload.get("handle"))
+            display_name = validate_agent_text(
+                payload.get("display_name"), field="display_name", maximum=MAX_AGENT_DISPLAY_NAME
+            )
+            description = validate_agent_text(
+                payload.get("description"),
+                field="description",
+                maximum=MAX_AGENT_DESCRIPTION,
+                allow_empty=True,
+            )
+            lifecycle_state = _required_text(payload, "lifecycle_state")
+            if lifecycle_state not in {"draft", "active", "archived"}:
+                raise ValueError("Workshop agent definition lifecycle_state is invalid")
+            presentation_json = validate_agent_presentation(payload.get("presentation"))
+            async with connection.execute("SELECT workshop_id FROM agents WHERE id = ?", (agent_id,)) as cursor:
+                agent_row = await cursor.fetchone()
+            if agent_row is None or WorkshopId(str(agent_row[0])) != envelope.workshop_id:
+                raise ValueError("Workshop agent definition must reference an agent in its workshop")
+            await connection.execute(
+                "INSERT INTO agent_definitions "
+                "(id, workshop_id, agent_id, handle, display_name, description, "
+                "presentation_json, lifecycle_state, active_revision_id, created_at, "
+                "created_event_position) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    envelope.workshop_id,
+                    agent_id,
+                    handle,
+                    display_name,
+                    description,
+                    presentation_json,
+                    lifecycle_state,
+                    occurred_at,
+                    event.position,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED:
+            if (
+                not isinstance(envelope.aggregate_id, AgentDefinitionRevisionId)
+                or envelope.aggregate_type != "agent_definition_revision"
+            ):
+                raise ValueError("Workshop agent revision creation requires a typed revision aggregate")
+            _require_exact_payload(
+                payload,
+                {"definition_id", "revision_number", "purpose", "instructions", "capabilities"},
+            )
+            definition_id = AgentDefinitionId(_required_text(payload, "definition_id"))
+            revision_number = payload.get("revision_number")
+            if not isinstance(revision_number, int) or isinstance(revision_number, bool) or revision_number < 1:
+                raise ValueError("Workshop agent revision_number must be positive")
+            purpose = validate_agent_text(payload.get("purpose"), field="purpose", maximum=MAX_AGENT_PURPOSE)
+            instructions = validate_agent_text(
+                payload.get("instructions"), field="instructions", maximum=MAX_AGENT_INSTRUCTIONS
+            )
+            capabilities = validate_agent_capabilities(payload.get("capabilities"))
+            async with connection.execute(
+                "SELECT workshop_id FROM agent_definitions WHERE id = ?", (definition_id,)
+            ) as cursor:
+                definition_row = await cursor.fetchone()
+            if definition_row is None or WorkshopId(str(definition_row[0])) != envelope.workshop_id:
+                raise ValueError("Workshop agent revision must reference a definition in its workshop")
+            async with connection.execute(
+                "SELECT COALESCE(MAX(revision_number), 0) FROM agent_definition_revisions "
+                "WHERE agent_definition_id = ?",
+                (definition_id,),
+            ) as cursor:
+                revision_count_row = await cursor.fetchone()
+            assert revision_count_row is not None
+            expected_number = int(revision_count_row[0]) + 1
+            if revision_number != expected_number:
+                raise ValueError("Workshop agent revisions must be sequential")
+            await connection.execute(
+                "INSERT INTO agent_definition_revisions "
+                "(id, agent_definition_id, revision_number, purpose, instructions, "
+                "capabilities_json, created_at, created_event_position) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    envelope.aggregate_id,
+                    definition_id,
+                    revision_number,
+                    purpose,
+                    instructions,
+                    json.dumps(capabilities, separators=(",", ":")),
+                    occurred_at,
+                    event.position,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED:
+            if (
+                not isinstance(envelope.aggregate_id, AgentDefinitionId)
+                or envelope.aggregate_type != "agent_definition"
+            ):
+                raise ValueError("Workshop agent revision activation requires a typed definition aggregate")
+            _require_exact_payload(payload, {"revision_id"})
+            revision_id = AgentDefinitionRevisionId(_required_text(payload, "revision_id"))
+            async with connection.execute(
+                "SELECT d.workshop_id, d.lifecycle_state, r.agent_definition_id "
+                "FROM agent_definitions d JOIN agent_definition_revisions r ON r.id = ? "
+                "WHERE d.id = ?",
+                (revision_id, envelope.aggregate_id),
+            ) as cursor:
+                revision_row = await cursor.fetchone()
+            if (
+                revision_row is None
+                or WorkshopId(str(revision_row[0])) != envelope.workshop_id
+                or str(revision_row[1]) != "active"
+                or AgentDefinitionId(str(revision_row[2])) != envelope.aggregate_id
+            ):
+                raise ValueError("Workshop agent revision activation is invalid")
+            await connection.execute(
+                "UPDATE agent_definitions SET active_revision_id = ? WHERE id = ?",
+                (revision_id, envelope.aggregate_id),
             )
         elif envelope.event_type == WorkshopEventType.CHANNEL_AGENT_ATTACHED:
             await connection.execute(

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -57,6 +57,9 @@ class PreparedWorkshopExecution:
     def stage_canonical_history(self, history: str) -> None:
         self._runtime.stage_canonical_history(history)
 
+    def stage_agent_definition_context(self, context: str) -> None:
+        self._runtime.stage_canonical_agent_context(context)
+
     def validate_current(self) -> None:
         """Verify the exact runtime immediately before the started boundary."""
         self._runtime.validate_current()

--- a/src/kai/workshop/routing_eligibility.py
+++ b/src/kai/workshop/routing_eligibility.py
@@ -168,6 +168,8 @@ class WorkshopRoutingEligibilityService:
         self,
         authority: RoutingEligibilityAuthority,
         task_class: str | RoutingTaskClass,
+        *,
+        additional_required: tuple[RuntimeCapability, ...] = (),
     ) -> RuntimeEligibilityReport:
         canonical_task = _task_class(task_class)
         namespace = self._execution_state.maybe_for_runtime_profile_id(authority.runtime_profile_id)
@@ -194,7 +196,9 @@ class WorkshopRoutingEligibilityService:
         selected_model = await self._runtime_pool.get_effective_model(authority.runtime_profile_id)
         allowed_services = self._runtime_pool.runtime_profile(authority.runtime_profile_id).allowed_services
         catalogue_authority = self._catalogue.authority_for_principal(authority.principal_id)
-        required = _TASK_REQUIREMENTS[canonical_task]
+        if any(not isinstance(capability, RuntimeCapability) for capability in additional_required):
+            raise ValueError("additional_required must contain RuntimeCapability values")
+        required = tuple(dict.fromkeys((*_TASK_REQUIREMENTS[canonical_task], *additional_required)))
         candidates: list[RuntimeEligibilityCandidate] = []
         for lane in profile.backends:
             model_id = selected_model if lane.selected else lane.default_model

--- a/src/kai/workshop/routing_policy.py
+++ b/src/kai/workshop/routing_policy.py
@@ -9,10 +9,12 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 
+from kai.workshop.agent_definitions import load_agent_definition_revision
 from kai.workshop.domain import RunId, RuntimeProfileId
 from kai.workshop.routing_eligibility import (
     RoutingEligibilityAuthority,
     RoutingTaskClass,
+    RuntimeCapability,
     RuntimeEligibilityCandidate,
     RuntimeEligibilityReport,
     WorkshopRoutingEligibilityService,
@@ -188,9 +190,19 @@ class WorkshopRoutingPolicyService:
         )
         if authority.agent_id != run.agent_id:
             raise RoutingPolicyError("Run does not match canonical routing authority")
+        agent_requirements: tuple[RuntimeCapability, ...] = ()
+        if run.agent_definition_revision_id is not None:
+            revision = await load_agent_definition_revision(self._store, run.agent_definition_revision_id)
+            if revision is None or revision.agent_id != run.agent_id:
+                raise RoutingPolicyError("Run agent definition revision is unavailable")
+            agent_requirements = tuple(RuntimeCapability(value) for value in revision.capabilities)
 
         if requested_task is None:
-            report = await self._eligibility.inspect(authority, RoutingTaskClass.CONVERSATION)
+            report = await self._eligibility.inspect(
+                authority,
+                RoutingTaskClass.CONVERSATION,
+                additional_required=agent_requirements,
+            )
             selected = self._selected_candidate(report)
             decision = self._decision(
                 run,
@@ -206,7 +218,11 @@ class WorkshopRoutingPolicyService:
             )
             return await self._store_decision(decision)
 
-        report = await self._eligibility.inspect(authority, requested_task)
+        report = await self._eligibility.inspect(
+            authority,
+            requested_task,
+            additional_required=agent_requirements,
+        )
         policy = (await self._load_policy_entries(runtime_profile_id)).get(requested_task)
         if policy is None or policy.backend_option_id is None:
             selected = self._selected_candidate(report)

--- a/src/kai/workshop/run_lifecycle.py
+++ b/src/kai/workshop/run_lifecycle.py
@@ -8,6 +8,7 @@ from enum import StrEnum
 
 from kai.workshop.conversation_runs import resolve_canonical_conversation_target
 from kai.workshop.domain import (
+    AgentDefinitionRevisionId,
     AgentId,
     ChannelId,
     EventEnvelope,
@@ -59,6 +60,7 @@ class DurableRun:
     cancellation_code: str | None
     result_message_id: MessageId | None
     last_event_position: int
+    agent_definition_revision_id: AgentDefinitionRevisionId | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,9 +86,17 @@ def _optional_timestamp(value: object) -> datetime | None:
 
 async def load_durable_run(store: WorkshopEventStore, run_id: RunId) -> DurableRun | None:
     """Load one projected durable run without granting any authorization."""
+    async with store.connection.execute("PRAGMA table_info(runs)") as cursor:
+        run_columns = {str(row[1]) for row in await cursor.fetchall()}
+    revision_expression = (
+        "agent_definition_revision_id"
+        if "agent_definition_revision_id" in run_columns
+        else "NULL AS agent_definition_revision_id"
+    )
     async with store.connection.execute(
         "SELECT id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
-        "inbound_message_id, status, accepted_at, started_at, terminal_at, terminal_code, "
+        f"inbound_message_id, {revision_expression}, status, accepted_at, "
+        "started_at, terminal_at, terminal_code, "
         "cancellation_requested_at, cancellation_code, result_message_id, "
         "last_event_position FROM runs WHERE id = ?",
         (run_id,),
@@ -101,15 +111,16 @@ async def load_durable_run(store: WorkshopEventStore, run_id: RunId) -> DurableR
         requested_by_principal_id=PrincipalId(str(row[3])),
         agent_id=AgentId(str(row[4])),
         inbound_message_id=MessageId(str(row[5])),
-        status=RunStatus(str(row[6])),
-        accepted_at=_parse_timestamp(row[7]),
-        started_at=_optional_timestamp(row[8]),
-        terminal_at=_optional_timestamp(row[9]),
-        terminal_code=str(row[10]) if row[10] is not None else None,
-        cancellation_requested_at=_optional_timestamp(row[11]),
-        cancellation_code=str(row[12]) if row[12] is not None else None,
-        result_message_id=MessageId(str(row[13])) if row[13] is not None else None,
-        last_event_position=int(row[14]),
+        agent_definition_revision_id=(AgentDefinitionRevisionId(str(row[6])) if row[6] is not None else None),
+        status=RunStatus(str(row[7])),
+        accepted_at=_parse_timestamp(row[8]),
+        started_at=_optional_timestamp(row[9]),
+        terminal_at=_optional_timestamp(row[10]),
+        terminal_code=str(row[11]) if row[11] is not None else None,
+        cancellation_requested_at=_optional_timestamp(row[12]),
+        cancellation_code=str(row[13]) if row[13] is not None else None,
+        result_message_id=MessageId(str(row[14])) if row[14] is not None else None,
+        last_event_position=int(row[15]),
     )
 
 
@@ -149,6 +160,7 @@ async def _existing_event(
     status: RunStatus,
     actor_principal_id: PrincipalId,
     payload: dict[str, object],
+    event_version: int = 1,
 ) -> StoredEvent | None:
     key = _event_key(run.run_id, status)
     existing = await store.event_by_idempotency_key(key)
@@ -157,7 +169,7 @@ async def _existing_event(
     envelope = existing.envelope
     if (
         envelope.event_type != _event_type(status)
-        or envelope.event_version != 1
+        or envelope.event_version != event_version
         or envelope.workshop_id != run.workshop_id
         or envelope.aggregate_type != "run"
         or envelope.aggregate_id != run.run_id
@@ -239,12 +251,17 @@ class WorkshopRunLifecycle:
                 "requested_by_principal_id": existing_run.requested_by_principal_id,
                 "agent_id": existing_run.agent_id,
             }
+            event_version = 1
+            if existing_run.agent_definition_revision_id is not None:
+                existing_payload["agent_definition_revision_id"] = existing_run.agent_definition_revision_id
+                event_version = 2
             existing_event = await _existing_event(
                 self._store,
                 run=existing_run,
                 status=RunStatus.ACCEPTED,
                 actor_principal_id=existing_run.requested_by_principal_id,
                 payload=existing_payload,
+                event_version=event_version,
             )
             if existing_event is None:
                 raise RunLifecycleConflictError("Durable run is missing its acceptance event")
@@ -265,10 +282,26 @@ class WorkshopRunLifecycle:
             "requested_by_principal_id": target.requested_by_principal_id,
             "agent_id": target.agent_id,
         }
+        async with self._store.connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'agent_definitions'"
+        ) as cursor:
+            definitions_supported = await cursor.fetchone() is not None
+        event_version = 1
+        if definitions_supported:
+            async with self._store.connection.execute(
+                "SELECT active_revision_id FROM agent_definitions WHERE agent_id = ? AND lifecycle_state = 'active'",
+                (target.agent_id,),
+            ) as cursor:
+                definition_row = await cursor.fetchone()
+            if definition_row is None or definition_row[0] is None:
+                raise RunLifecycleConflictError("Agent has no active canonical definition revision")
+            definition_revision_id = AgentDefinitionRevisionId(str(definition_row[0]))
+            payload["agent_definition_revision_id"] = definition_revision_id
+            event_version = 2
         event = EventEnvelope.create(
             event_id=EventId.derived(run_id, "accepted"),
             event_type=WorkshopEventType.RUN_ACCEPTED,
-            event_version=1,
+            event_version=event_version,
             workshop_id=target.workshop_id,
             aggregate_type="run",
             aggregate_id=run_id,

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 45
+WORKSHOP_SCHEMA_VERSION = 46
 
 
 @dataclass(frozen=True, slots=True)
@@ -2189,6 +2189,59 @@ _MESSAGE_REACTIONS_SCHEMA = SchemaMigration(
     ),
 )
 
+_VERSIONED_AGENT_DEFINITION_SCHEMA = SchemaMigration(
+    version=46,
+    name="versioned_agent_definitions",
+    statements=(
+        """
+        CREATE TABLE agent_definitions (
+            id TEXT PRIMARY KEY,
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            agent_id TEXT NOT NULL UNIQUE REFERENCES agents(id) ON DELETE CASCADE,
+            handle TEXT NOT NULL COLLATE NOCASE,
+            display_name TEXT NOT NULL,
+            description TEXT NOT NULL,
+            presentation_json TEXT NOT NULL CHECK (
+                json_valid(presentation_json)
+                AND json_type(presentation_json) = 'object'
+            ),
+            lifecycle_state TEXT NOT NULL CHECK (
+                lifecycle_state IN ('draft', 'active', 'archived')
+            ),
+            active_revision_id TEXT
+                REFERENCES agent_definition_revisions(id) ON DELETE RESTRICT,
+            created_at TEXT NOT NULL,
+            created_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            UNIQUE (workshop_id, handle)
+        )
+        """,
+        """
+        CREATE TABLE agent_definition_revisions (
+            id TEXT PRIMARY KEY,
+            agent_definition_id TEXT NOT NULL
+                REFERENCES agent_definitions(id) ON DELETE CASCADE,
+            revision_number INTEGER NOT NULL CHECK (revision_number > 0),
+            purpose TEXT NOT NULL,
+            instructions TEXT NOT NULL,
+            capabilities_json TEXT NOT NULL CHECK (
+                json_valid(capabilities_json)
+                AND json_type(capabilities_json) = 'array'
+            ),
+            created_at TEXT NOT NULL,
+            created_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            UNIQUE (agent_definition_id, revision_number)
+        )
+        """,
+        "CREATE UNIQUE INDEX agent_definitions_active_revision_idx "
+        "ON agent_definitions (active_revision_id) WHERE active_revision_id IS NOT NULL",
+        "ALTER TABLE runs ADD COLUMN agent_definition_revision_id TEXT "
+        "REFERENCES agent_definition_revisions(id) ON DELETE RESTRICT",
+        "CREATE INDEX runs_agent_definition_revision_idx ON runs (agent_definition_revision_id, accepted_at)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -2235,6 +2288,7 @@ _MIGRATIONS = (
     _MESSAGE_THREADS_SCHEMA,
     _EXPLICIT_TASK_ROUTING_SCHEMA,
     _MESSAGE_REACTIONS_SCHEMA,
+    _VERSIONED_AGENT_DEFINITION_SCHEMA,
 )
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2048,16 +2048,17 @@ class TestAssembleTurnContext:
     """Tests for the composed per-turn prompt assembly contract.
 
     The ordering invariant is the contract: marker closest to user text,
-    then session_context, then memory, then workspace_reminder, with the
-    inverse of that order applied via repeated prepends. Backends that
+    then the run-bound agent definition, session context, memory, and
+    workspace reminder, with the inverse of that order applied via repeated
+    prepends. Backends that
     re-implement this locally are exactly the failure mode the helper
     exists to prevent; these tests pin the invariant at the helper level
     so a future backend wire-up has a one-line integration target.
     """
 
     async def test_string_prompt_full_ordering(self, monkeypatch):
-        """All four context layers present, string prompt. Final reading
-        order must be reminder, memory, session, marker, user text, with
+        """All context layers present, string prompt. Final reading
+        order must be reminder, memory, session, definition, marker, user text, with
         only whitespace separating the marker and the user message.
         """
         from kai.backend import USER_MESSAGE_MARKER, assemble_turn_context
@@ -2067,17 +2068,19 @@ class TestAssembleTurnContext:
             "ACTUAL_USER_TEXT",
             chat_id=42,
             session_context="[SESSION]",
+            agent_definition_context="[AGENT DEFINITION]",
             workspace_reminder="[REMINDER]",
         )
         assert isinstance(result, str)
         assert result.count(USER_MESSAGE_MARKER) == 1
         # Inverse-prepend ordering: each subsequent layer lands above
         # the previous one, so the final reading order from top to
-        # bottom is reminder, memory, session, marker, user text.
+        # bottom is reminder, memory, session, definition, marker, user text.
         positions = [
             result.index("[REMINDER]"),
             result.index("[Relevant memories]"),
             result.index("[SESSION]"),
+            result.index("[AGENT DEFINITION]"),
             result.index(USER_MESSAGE_MARKER),
             result.index("ACTUAL_USER_TEXT"),
         ]

--- a/tests/test_workshop_agent_definitions.py
+++ b/tests/test_workshop_agent_definitions.py
@@ -1,0 +1,271 @@
+"""Contracts for canonical, versioned Workshop agent definitions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.agent_definitions import (
+    MAX_AGENT_INSTRUCTIONS,
+    active_agent_definition_revision,
+    load_agent_definition_revision,
+    render_agent_definition_context,
+)
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.diagnostics import workshop_agent_definition_status
+from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentDefinitionRevisionId,
+    AgentId,
+    EventEnvelope,
+    MessageId,
+    WorkshopEventType,
+)
+from kai.workshop.inbound import InboundMessage, record_inbound_message, resolve_message_mentions
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_lifecycle import WorkshopRunLifecycle
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 8, 29, 12, 0, tzinfo=UTC)
+
+
+async def _open(path: Path) -> tuple[WorkshopEventStore, AgentId]:
+    store = await WorkshopEventStore.open(path)
+    result = await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="desktop",
+                external_subject="human-1",
+                external_channel_id="human-1",
+            ),
+        ),
+    )
+    return store, result.agent_id
+
+
+async def _append_and_project(store: WorkshopEventStore, envelope: EventEnvelope) -> None:
+    await store.append(envelope)
+    await store.project_pending(CanonicalConversationProjection())
+
+
+async def _record(store: WorkshopEventStore, number: int) -> MessageId:
+    result = await record_inbound_message(
+        store,
+        InboundMessage(
+            transport="desktop",
+            update_id=f"command-{number}",
+            message_id=f"message-{number}",
+            sender_subject="human-1",
+            channel_subject="human-1",
+            body=f"Canonical prompt {number}",
+            occurred_at=_NOW + timedelta(minutes=number),
+        ),
+    )
+    message_id = result.event.envelope.aggregate_id
+    assert isinstance(message_id, MessageId)
+    return message_id
+
+
+class TestAgentDefinitionBootstrap:
+    async def test_bootstrap_creates_one_active_kai_revision_and_replays(self, tmp_path: Path):
+        store, agent_id = await _open(tmp_path / "kai.db")
+        try:
+            revision = await active_agent_definition_revision(store, agent_id)
+            assert revision is not None
+            assert revision.handle == "kai"
+            assert revision.display_name == "Kai"
+            assert revision.revision_number == 1
+            assert revision.capabilities == ("text_generation",)
+
+            await store.rebuild_projection(CanonicalConversationProjection())
+            assert await active_agent_definition_revision(store, agent_id) == revision
+            assert workshop_agent_definition_status(tmp_path / "kai.db") == (
+                "Workshop agent definitions: active; agents=1, definitions=1, revisions=1, "
+                "active=1, missing=0, invalid active=0; authority=versioned"
+            )
+        finally:
+            await store.close()
+
+    async def test_handle_mentions_are_case_insensitive(self, tmp_path: Path):
+        store, agent_id = await _open(tmp_path / "kai.db")
+        try:
+            async with store.connection.execute(
+                "SELECT channel_id FROM channel_agents WHERE agent_id = ?", (agent_id,)
+            ) as cursor:
+                channel_id = (await cursor.fetchone())[0]
+            mentions = await resolve_message_mentions(store, channel_id, "@kAi please respond")
+            assert len(mentions) == 1
+            assert mentions[0].kind == "agent"
+            assert (mentions[0].start, mentions[0].length) == (0, 4)
+        finally:
+            await store.close()
+
+
+class TestAgentDefinitionRevisions:
+    async def test_runs_keep_exact_revision_after_later_activation(self, tmp_path: Path):
+        store, _agent_id = await _open(tmp_path / "kai.db")
+        try:
+            first = await WorkshopRunLifecycle(store).accept(
+                await _record(store, 1), occurred_at=_NOW + timedelta(minutes=1, seconds=1)
+            )
+            revision_one_id = first.run.agent_definition_revision_id
+            assert revision_one_id is not None
+            revision_one = await load_agent_definition_revision(store, revision_one_id)
+            assert revision_one is not None
+
+            definition_id = revision_one.definition_id
+            revision_two_id = AgentDefinitionRevisionId.derived(definition_id, "revision:2")
+            await _append_and_project(
+                store,
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED,
+                    event_version=1,
+                    workshop_id=first.run.workshop_id,
+                    aggregate_type="agent_definition_revision",
+                    aggregate_id=revision_two_id,
+                    occurred_at=_NOW + timedelta(minutes=2),
+                    payload={
+                        "definition_id": definition_id,
+                        "revision_number": 2,
+                        "purpose": "Exercise the second immutable definition.",
+                        "instructions": "Use the second definition without changing older runs.",
+                        "capabilities": ["text_generation", "tool_activity"],
+                    },
+                ),
+            )
+            await _append_and_project(
+                store,
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED,
+                    event_version=1,
+                    workshop_id=first.run.workshop_id,
+                    aggregate_type="agent_definition",
+                    aggregate_id=definition_id,
+                    occurred_at=_NOW + timedelta(minutes=2, seconds=1),
+                    payload={"revision_id": revision_two_id},
+                ),
+            )
+
+            second = await WorkshopRunLifecycle(store).accept(
+                await _record(store, 3), occurred_at=_NOW + timedelta(minutes=3, seconds=1)
+            )
+            assert first.run.agent_definition_revision_id == revision_one_id
+            assert second.run.agent_definition_revision_id == revision_two_id
+            assert (await load_agent_definition_revision(store, revision_one_id)) == revision_one
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM agent_definition_revisions WHERE agent_definition_id = ?",
+                (definition_id,),
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 2
+        finally:
+            await store.close()
+
+    async def test_rendered_definition_explicitly_carries_no_authority(self, tmp_path: Path):
+        store, agent_id = await _open(tmp_path / "kai.db")
+        try:
+            revision = await active_agent_definition_revision(store, agent_id)
+            assert revision is not None
+            rendered = render_agent_definition_context(revision)
+            assert f"Definition revision: 1 ({revision.revision_id})" in rendered
+            assert "does not grant tools, credentials, data access, identity, or permission" in rendered
+        finally:
+            await store.close()
+
+
+class TestAgentDefinitionValidation:
+    @pytest.mark.parametrize(
+        "payload, message",
+        (
+            (
+                {
+                    "agent_id": None,
+                    "handle": "kai",
+                    "display_name": "Kai",
+                    "description": "description",
+                    "presentation": {"avatar": "K"},
+                    "lifecycle_state": "active",
+                    "credentials": {"token": "secret"},
+                },
+                "exactly",
+            ),
+            (
+                {
+                    "agent_id": None,
+                    "handle": "not a handle",
+                    "display_name": "Kai",
+                    "description": "description",
+                    "presentation": {"avatar": "K"},
+                    "lifecycle_state": "active",
+                },
+                "handle",
+            ),
+        ),
+    )
+    async def test_definition_rejects_authority_fields_and_bad_handles(
+        self, tmp_path: Path, payload: dict[str, object], message: str
+    ):
+        store, agent_id = await _open(tmp_path / f"{message}.db")
+        try:
+            payload["agent_id"] = agent_id
+            definition_id = AgentDefinitionId.new()
+            await store.append(
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.AGENT_DEFINITION_CREATED,
+                    event_version=1,
+                    workshop_id=(await active_agent_definition_revision(store, agent_id)).workshop_id,
+                    aggregate_type="agent_definition",
+                    aggregate_id=definition_id,
+                    occurred_at=_NOW,
+                    payload=payload,
+                )
+            )
+            with pytest.raises((TypeError, ValueError), match=message):
+                await store.project_pending(CanonicalConversationProjection())
+        finally:
+            await store.close()
+
+    @pytest.mark.parametrize(
+        "instructions, capabilities, message",
+        (
+            ("x" * (MAX_AGENT_INSTRUCTIONS + 1), ["text_generation"], "instructions"),
+            ("Otherwise valid instructions", ["root_access"], "unsupported value"),
+        ),
+    )
+    async def test_revision_rejects_oversized_instructions_and_unknown_capability(
+        self,
+        tmp_path: Path,
+        instructions: str,
+        capabilities: list[str],
+        message: str,
+    ):
+        store, agent_id = await _open(tmp_path / f"invalid-revision-{message}.db")
+        try:
+            active = await active_agent_definition_revision(store, agent_id)
+            assert active is not None
+            revision_id = AgentDefinitionRevisionId.new()
+            await store.append(
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED,
+                    event_version=1,
+                    workshop_id=active.workshop_id,
+                    aggregate_type="agent_definition_revision",
+                    aggregate_id=revision_id,
+                    occurred_at=_NOW,
+                    payload={
+                        "definition_id": active.definition_id,
+                        "revision_number": 2,
+                        "purpose": "Invalid revision",
+                        "instructions": instructions,
+                        "capabilities": capabilities,
+                    },
+                )
+            )
+            with pytest.raises(ValueError, match=message):
+                await store.project_pending(CanonicalConversationProjection())
+        finally:
+            await store.close()

--- a/tests/test_workshop_appearance_preferences.py
+++ b/tests/test_workshop_appearance_preferences.py
@@ -70,7 +70,7 @@ async def test_version_thirty_seven_preferences_upgrade_without_data_loss(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 45
+        assert await upgraded.schema_version() == 46
         async with upgraded.connection.execute(
             "SELECT principal_id, theme_id, created_at, updated_at FROM principal_appearance_preferences"
         ) as cursor:

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -529,7 +529,7 @@ class TestArtifactShadowRecordingAfterRestart:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 11
+            assert checkpoint.version == 12
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_bootstrap.py
+++ b/tests/test_workshop_bootstrap.py
@@ -93,7 +93,7 @@ class TestDefaultWorkshopBootstrap:
             [_human(202, "Second"), _human(101, "Admin", role="admin")],
         )
 
-        assert result.created_events == 20
+        assert result.created_events == 23
         assert result.existing_events == 0
         assert result.human_count == 2
         assert result.channel_count == 2
@@ -157,10 +157,10 @@ class TestDefaultWorkshopBootstrap:
             notification_channels=(notification,),
         )
 
-        assert first.created_events == 26
+        assert first.created_events == 29
         assert first.channel_count == 3
         assert second.created_events == 0
-        assert second.existing_events == 26
+        assert second.existing_events == 29
         async with store.connection.execute(
             "SELECT c.kind, c.name, cb.transport, cb.external_channel_id "
             "FROM channels c JOIN channel_bindings cb ON cb.channel_id = c.id "
@@ -223,9 +223,9 @@ class TestDefaultWorkshopBootstrap:
         second = await bootstrap_default_workshop(store, [_human(101, "Admin", role="admin")])
         second_events = await store.read_events()
 
-        assert first.created_events == 12
+        assert first.created_events == 15
         assert second.created_events == 0
-        assert second.existing_events == 12
+        assert second.existing_events == 15
         assert second.workshop_id == first.workshop_id
         assert second.agent_id == first.agent_id
         assert second_events == first_events
@@ -250,9 +250,9 @@ class TestDefaultWorkshopBootstrap:
             ],
         )
 
-        assert first.created_events == 12
+        assert first.created_events == 15
         assert upgraded.created_events == 1
-        assert upgraded.existing_events == 12
+        assert upgraded.existing_events == 15
         async with store.connection.execute(
             "SELECT provider, external_subject FROM external_identities ORDER BY provider"
         ) as cursor:
@@ -346,10 +346,10 @@ class TestDefaultWorkshopBootstrap:
         )
 
         assert result.created_events == 8
-        assert result.existing_events == 12
+        assert result.existing_events == 15
         assert result.human_count == 2
         assert result.channel_count == 2
-        assert len(await store.read_events()) == 20
+        assert len(await store.read_events()) == 23
 
     async def test_existing_bootstrap_receives_missing_channel_memberships(self, store):
         await bootstrap_default_workshop(
@@ -366,7 +366,7 @@ class TestDefaultWorkshopBootstrap:
         )
 
         assert result.created_events == 4
-        assert result.existing_events == 16
+        assert result.existing_events == 19
         async with store.connection.execute("SELECT COUNT(*) FROM channel_memberships") as cursor:
             assert (await cursor.fetchone())[0] == 4
 

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -389,7 +389,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 11
+            assert checkpoint.version == 12
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -62,9 +62,13 @@ class _Prepared:
         self.cancelled = False
         self.reject_validation = False
         self.canonical_histories: list[str] = []
+        self.agent_definition_contexts: list[str] = []
 
     def stage_canonical_history(self, history: str) -> None:
         self.canonical_histories.append(history)
+
+    def stage_agent_definition_context(self, context: str) -> None:
+        self.agent_definition_contexts.append(context)
 
     def validate_current(self) -> None:
         self.validated = True
@@ -223,6 +227,9 @@ class TestCanonicalExecutionCoordinator:
             first_result = await _coordinator(store, _Preparation(first)).execute(first_run.run_id)
             assert first_result.disposition == CanonicalExecutionDisposition.COMPLETED
             assert first.canonical_histories == [""]
+            assert len(first.agent_definition_contexts) == 1
+            assert "Handle: @kai" in first.agent_definition_contexts[0]
+            assert "Definition revision: 1" in first.agent_definition_contexts[0]
 
             second_acceptance = await WorkshopConversationCommandService(store).accept(
                 InboundMessage(

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -92,7 +92,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",
@@ -129,7 +129,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             async with upgraded.connection.execute(
                 "SELECT field, value FROM channel_agent_execution_settings"
             ) as cursor:

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -94,6 +94,9 @@ class TestEventEnvelope:
             "channel.member_added",
             "transport.channel_bound",
             "agent.created",
+            "agent_definition.created",
+            "agent_definition.revision_added",
+            "agent_definition.revision_activated",
             "channel.agent_attached",
             "channel.agent_dismissed",
             "runtime_profile.assigned",
@@ -183,6 +186,8 @@ class TestWorkshopSchema:
             "workshop_client_sessions",
             "channel_bindings",
             "agents",
+            "agent_definitions",
+            "agent_definition_revisions",
             "channel_agents",
             "channel_agent_runtime_assignments",
             "channel_agent_runtime_sessions",
@@ -212,7 +217,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 45
+        assert await workshop_store.schema_version() == 46
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -248,7 +253,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 45
+        assert await second.schema_version() == 46
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -280,7 +285,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -308,7 +313,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -371,6 +376,7 @@ class TestWorkshopSchema:
                     43,
                     44,
                     45,
+                    46,
                 ]
         finally:
             await upgraded.close()
@@ -393,7 +399,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -434,7 +440,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -487,7 +493,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -531,7 +537,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -575,7 +581,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -619,7 +625,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -723,7 +729,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -850,7 +856,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -521,7 +521,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -49,9 +49,13 @@ class _Runtime:
         self.validated = False
         self.cancelled = False
         self.canonical_histories: list[str] = []
+        self.agent_definition_contexts: list[str] = []
 
     def stage_canonical_history(self, history: str) -> None:
         self.canonical_histories.append(history)
+
+    def stage_canonical_agent_context(self, context: str) -> None:
+        self.agent_definition_contexts.append(context)
 
     def validate_current(self) -> None:
         self.validated = True
@@ -88,7 +92,8 @@ class _Eligibility:
         assert runtime_profile_id == self.authority.runtime_profile_id
         return self.authority
 
-    async def inspect(self, authority, task_class):
+    async def inspect(self, authority, task_class, *, additional_required=()):
+        assert not additional_required or additional_required[0].value == "text_generation"
         return RuntimeEligibilityReport(
             version=1,
             task_class=RoutingTaskClass(task_class),

--- a/tests/test_workshop_routing_eligibility.py
+++ b/tests/test_workshop_routing_eligibility.py
@@ -251,6 +251,36 @@ async def test_vision_fails_closed_for_stale_unknown_and_unsupported_evidence(tm
 
 
 @pytest.mark.asyncio
+async def test_agent_definition_requirements_only_constrain_runtime_authority(tmp_path: Path) -> None:
+    namespace = _namespace(1)
+    supported = _lane("claude", "anthropic", selected=True)
+    unsupported = _lane("codex", "openai")
+    lanes = (supported, unsupported)
+    service, authority, *_ = _service(
+        tmp_path,
+        lanes,
+        {
+            supported.option_id: _snapshot(namespace, supported, image_input=True),
+            unsupported.option_id: _snapshot(namespace, unsupported, image_input=False),
+        },
+    )
+
+    report = await service.inspect(
+        authority,
+        RoutingTaskClass.CONVERSATION,
+        additional_required=(RuntimeCapability.IMAGE_INPUT,),
+    )
+
+    assert report.required_capabilities == (
+        RuntimeCapability.TEXT_GENERATION,
+        RuntimeCapability.IMAGE_INPUT,
+    )
+    assert report.candidates[0].eligible is True
+    assert report.candidates[1].eligible is False
+    assert report.candidates[1].reasons[-1].code == "capability_unsupported"
+
+
+@pytest.mark.asyncio
 async def test_unavailable_runtime_and_workspace_are_rejected(tmp_path: Path) -> None:
     namespace = _namespace(1)
     lane = _lane("claude", "anthropic", selected=True, readiness=ModelDiscoveryReadiness.UNAVAILABLE)

--- a/tests/test_workshop_routing_policy.py
+++ b/tests/test_workshop_routing_policy.py
@@ -77,7 +77,8 @@ class _Eligibility:
             raise RuntimeError("access denied")
         return self.authority
 
-    async def inspect(self, authority, task_class):
+    async def inspect(self, authority, task_class, *, additional_required=()):
+        assert not additional_required or additional_required[0].value == "text_generation"
         assert authority == self.authority
         canonical_task = RoutingTaskClass(task_class)
         return RuntimeEligibilityReport(

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -391,7 +391,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 11
+            assert checkpoint.version == 12
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:
@@ -411,7 +411,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -93,6 +93,7 @@ class TestDurableRunAcceptance:
             assert accepted.event.envelope.actor_principal_id == accepted.run.requested_by_principal_id
             assert accepted.event.envelope.payload == {
                 "agent_id": accepted.run.agent_id,
+                "agent_definition_revision_id": accepted.run.agent_definition_revision_id,
                 "channel_id": accepted.run.channel_id,
                 "inbound_message_id": inbound_id,
                 "requested_by_principal_id": accepted.run.requested_by_principal_id,
@@ -165,7 +166,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 11
+            assert checkpoint.version == 12
             assert after == before
         finally:
             await store.close()
@@ -220,7 +221,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -178,7 +178,7 @@ class TestRuntimeAssignmentPolicy:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 11
+            assert checkpoint.version == 12
             assert await resolve_channel_runtime_profile(store, human.channel_id) == (
                 assigned.agent_id,
                 profile_id(202),

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -115,6 +115,9 @@ class _CanonicalRuntime:
     def stage_canonical_history(self, _history: str) -> None:
         pass
 
+    def stage_canonical_agent_context(self, _context: str) -> None:
+        pass
+
     def validate_current(self) -> None:
         pass
 
@@ -138,7 +141,8 @@ class _CanonicalRoutingEligibility:
         assert runtime_profile_id == self.authority.runtime_profile_id
         return self.authority
 
-    async def inspect(self, authority, task_class):
+    async def inspect(self, authority, task_class, *, additional_required=()):
+        assert not additional_required or additional_required[0].value == "text_generation"
         assert authority == self.authority
         return RuntimeEligibilityReport(
             version=1,

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -524,7 +524,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -382,7 +382,7 @@ class TestAtomicTerminalTransactions:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 45
+            assert await upgraded.schema_version() == 46
             assert await _post_run_effect_count(upgraded) == 1
             async with upgraded.connection.execute(
                 "SELECT status, source_message_id, result_message_id FROM workshop_post_run_effects WHERE run_id = ?",

--- a/tests/test_workshop_wake_policy.py
+++ b/tests/test_workshop_wake_policy.py
@@ -14,6 +14,8 @@ from kai.workshop.conversation_commands import (
     WorkshopConversationCommandService,
 )
 from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentDefinitionRevisionId,
     AgentId,
     ChannelAgentId,
     ChannelId,
@@ -136,6 +138,52 @@ async def _open_group_store(
             ),
         )
     await store.connection.commit()
+    nova_definition_id = AgentDefinitionId.derived(second_agent_id, "definition")
+    nova_revision_id = AgentDefinitionRevisionId.derived(nova_definition_id, "revision:1")
+    for event in (
+        EventEnvelope.create(
+            event_type=WorkshopEventType.AGENT_DEFINITION_CREATED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="agent_definition",
+            aggregate_id=nova_definition_id,
+            occurred_at=_NOW,
+            payload={
+                "agent_id": second_agent_id,
+                "handle": "nova",
+                "display_name": "Nova",
+                "description": "Test agent",
+                "presentation": {"avatar": "N"},
+                "lifecycle_state": "active",
+            },
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="agent_definition_revision",
+            aggregate_id=nova_revision_id,
+            occurred_at=_NOW,
+            payload={
+                "definition_id": nova_definition_id,
+                "revision_number": 1,
+                "purpose": "Exercise multi-agent wake routing.",
+                "instructions": "Respond as Nova when explicitly mentioned.",
+                "capabilities": ["text_generation"],
+            },
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="agent_definition",
+            aggregate_id=nova_definition_id,
+            occurred_at=_NOW,
+            payload={"revision_id": nova_revision_id},
+        ),
+    ):
+        await store.append(event)
+        await store.project_pending(CanonicalConversationProjection())
     return store, human_id, group_id, (first_agent_id, second_agent_id)
 
 


### PR DESCRIPTION
Closes #1224\n\n## Summary\n- add event-sourced canonical agent definitions with stable handles, presentation metadata, lifecycle state, and immutable revisions\n- bootstrap Kai's active definition and bind every new run to the exact active revision\n- inject the bound definition below higher-priority policy across all backends and treat declared capabilities only as routing constraints\n- resolve agent mentions by stable case-insensitive handles and expose definition completeness in install status\n\n## Validation\n- make check\n- make typecheck\n- make client-check (121 tests)\n- full pytest suite (6,297 passed)