### PR TITLE
fix: honor pending canonical model in routing

### DIFF
--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -1398,9 +1398,9 @@ class SubprocessPool:
         Use this in command handlers that display the current model
         (like /models) where accuracy matters more than speed.
         """
-        _, chat_id, profile = self._resolve_runtime(runtime)
+        runtime_key, chat_id, profile = self._resolve_runtime(runtime)
         instance = self.get_if_exists(runtime)
-        if instance:
+        if instance and runtime_key not in self._pending_settings_restore:
             return instance.model
         if profile is None:
             defaults = await sessions.resolve_user_defaults(chat_id, self._config)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -954,7 +954,27 @@ class TestPropertyAccessors:
         pool = SubprocessPool(config=_make_config(), services_info=[])
         instance = pool.get(111)
         instance.model = "opus"
+        pool._pending_settings_restore.discard(111)
         assert await pool.get_effective_model(111) == "opus"
+
+    @pytest.mark.asyncio
+    async def test_get_effective_model_pending_instance_reads_canonical_setting(self):
+        """A fresh protected instance cannot hide its persisted model override."""
+        pool = SubprocessPool(
+            config=_make_config(default_model="sonnet"),
+            services_info=[],
+            runtime_profiles=profile_registry(111),
+        )
+        instance = pool.get(111)
+        assert instance.model == "gpt-5.6-sol"
+        assert profile_id(111) in pool._pending_settings_restore
+
+        with patch(
+            "kai.pool.sessions.get_canonical_execution_settings",
+            new_callable=AsyncMock,
+            return_value={"model": "gpt-5.5"},
+        ):
+            assert await pool.get_effective_model(111) == "gpt-5.5"
 
     @pytest.mark.asyncio
     async def test_get_effective_model_no_instance(self):


### PR DESCRIPTION
## Summary
- resolve a protected runtime's effective model from canonical storage while a fresh instance still has pending settings
- prevent ordinary Workshop runs from snapshotting the static profile model and then rejecting the correctly restored principal model
- add regression coverage for a fresh protected instance with a non-default canonical model

## Root cause
#1231 made ordinary agent-definition-bound runs pass through durable routing decisions. Eligibility restored the workspace first, which created a backend instance with its static profile model. The subsequent effective-model read trusted that not-yet-hydrated instance instead of canonical storage, producing a durable decision that disagreed with dispatch and retried forever.

## Validation
- make check
- make typecheck
- 93 pool tests
- 23 routing/execution tests
- full suite: 6,298 passed