### PR TITLE
feat: add Workshop agent lifecycle API

### DIFF
--- a/src/kai/workshop/agent_lifecycle.py
+++ b/src/kai/workshop/agent_lifecycle.py
@@ -1,0 +1,635 @@
+"""Admin-authorized lifecycle operations for Workshop agent definitions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from kai.workshop.agent_definitions import (
+    MAX_AGENT_DESCRIPTION,
+    MAX_AGENT_DISPLAY_NAME,
+    MAX_AGENT_INSTRUCTIONS,
+    MAX_AGENT_PURPOSE,
+    normalize_agent_handle,
+    validate_agent_capabilities,
+    validate_agent_presentation,
+    validate_agent_text,
+)
+from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentDefinitionRevisionId,
+    AgentId,
+    EventEnvelope,
+    PrincipalId,
+    WorkshopEventType,
+    WorkshopId,
+    WorkshopMembershipId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+
+_IDEMPOTENCY_KEY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+class WorkshopAgentLifecycleError(RuntimeError):
+    """An agent-definition lifecycle operation could not be completed."""
+
+
+class WorkshopAgentLifecycleAccessDenied(WorkshopAgentLifecycleError):
+    """The principal may not access the requested agent definition."""
+
+
+class WorkshopAgentLifecycleValidationError(WorkshopAgentLifecycleError):
+    """A lifecycle request is malformed."""
+
+
+class WorkshopAgentLifecycleConflict(WorkshopAgentLifecycleError):
+    """A lifecycle request conflicts with current canonical state."""
+
+
+class WorkshopAgentLifecycleStorageError(WorkshopAgentLifecycleError):
+    """A lifecycle request could not be persisted."""
+
+
+@dataclass(frozen=True, slots=True)
+class AgentRevisionSnapshot:
+    revision_id: AgentDefinitionRevisionId
+    revision_number: int
+    purpose: str
+    instructions: str
+    capabilities: tuple[str, ...]
+    created_at: str
+    created_by_principal_id: PrincipalId | None
+    event_position: int
+
+
+@dataclass(frozen=True, slots=True)
+class AgentDefinitionSnapshot:
+    definition_id: AgentDefinitionId
+    workshop_id: WorkshopId
+    agent_id: AgentId
+    handle: str
+    display_name: str
+    description: str
+    presentation: dict[str, object]
+    lifecycle_state: str
+    active_revision_id: AgentDefinitionRevisionId | None
+    state_version: int
+    created_at: str
+    created_by_principal_id: PrincipalId | None
+    revisions: tuple[AgentRevisionSnapshot, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentLifecycleAuthority:
+    principal_id: PrincipalId
+    workshop_id: WorkshopId
+    role: str
+
+
+def _normalize_idempotency_key(value: object) -> str:
+    if not isinstance(value, str) or not _IDEMPOTENCY_KEY_PATTERN.fullmatch(value):
+        raise WorkshopAgentLifecycleValidationError(
+            "idempotency_key must be 1-128 letters, digits, dots, underscores, colons, or hyphens"
+        )
+    return value
+
+
+def _normalize_expected_version(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise WorkshopAgentLifecycleValidationError("expected_version must be a positive integer")
+    return value
+
+
+def _operation_hash(kind: str, payload: dict[str, object]) -> str:
+    encoded = json.dumps(
+        {"kind": kind, "payload": payload},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+class WorkshopAgentLifecycleService:
+    """Manage versioned agent definitions from canonical Workshop authority."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def authority_for(self, principal_id: PrincipalId) -> AgentLifecycleAuthority:
+        workshop_id, role = await self._authority(principal_id)
+        return AgentLifecycleAuthority(principal_id, workshop_id, role)
+
+    async def list_visible(self, principal_id: PrincipalId) -> tuple[AgentDefinitionSnapshot, ...]:
+        workshop_id, role = await self._authority(principal_id)
+        lifecycle_clause = "" if role == "admin" else "AND d.lifecycle_state = 'active'"
+        async with self._store.connection.execute(
+            f"SELECT d.id FROM agent_definitions d WHERE d.workshop_id = ? {lifecycle_clause} ORDER BY d.handle",
+            (workshop_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        snapshots: list[AgentDefinitionSnapshot] = []
+        for row in rows:
+            snapshots.append(await self._snapshot(AgentDefinitionId(str(row[0])), workshop_id=workshop_id))
+        return tuple(snapshots)
+
+    async def get_visible(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+    ) -> AgentDefinitionSnapshot:
+        workshop_id, role = await self._authority(principal_id)
+        snapshot = await self._snapshot_or_denied(definition_id, workshop_id)
+        if role != "admin" and snapshot.lifecycle_state != "active":
+            raise WorkshopAgentLifecycleAccessDenied("Access denied")
+        return snapshot
+
+    async def create_draft(
+        self,
+        principal_id: PrincipalId,
+        *,
+        idempotency_key: object,
+        handle: object,
+        display_name: object,
+        description: object,
+        presentation: object,
+        purpose: object,
+        instructions: object,
+        capabilities: object,
+    ) -> AgentDefinitionSnapshot:
+        workshop_id = await self._admin_workshop(principal_id)
+        key = _normalize_idempotency_key(idempotency_key)
+        try:
+            normalized_handle = normalize_agent_handle(handle)
+            normalized_display_name = validate_agent_text(
+                display_name, field="display_name", maximum=MAX_AGENT_DISPLAY_NAME
+            )
+            normalized_description = validate_agent_text(
+                description,
+                field="description",
+                maximum=MAX_AGENT_DESCRIPTION,
+                allow_empty=True,
+            )
+            presentation_json = validate_agent_presentation(presentation)
+            normalized_purpose = validate_agent_text(purpose, field="purpose", maximum=MAX_AGENT_PURPOSE)
+            normalized_instructions = validate_agent_text(
+                instructions, field="instructions", maximum=MAX_AGENT_INSTRUCTIONS
+            )
+            normalized_capabilities = validate_agent_capabilities(capabilities)
+        except ValueError as exc:
+            raise WorkshopAgentLifecycleValidationError(str(exc)) from exc
+        operation_payload: dict[str, object] = {
+            "handle": normalized_handle,
+            "display_name": normalized_display_name,
+            "description": normalized_description,
+            "presentation": json.loads(presentation_json),
+            "purpose": normalized_purpose,
+            "instructions": normalized_instructions,
+            "capabilities": list(normalized_capabilities),
+        }
+        fingerprint = _operation_hash("create", operation_payload)
+        operation_key = self._operation_key(workshop_id, principal_id, key)
+        definition_id = AgentDefinitionId.derived(workshop_id, f"agent-definition-operation:{principal_id}:{key}")
+        agent_id = AgentId.derived(definition_id, "agent")
+        agent_principal_id = PrincipalId.derived(agent_id, "principal")
+        revision_id = AgentDefinitionRevisionId.derived(definition_id, "revision:1")
+        now = datetime.now(UTC)
+        metadata = {
+            "source": "workshop_client",
+            "operation": "create",
+            "operation_hash": fingerprint,
+            "definition_id": str(definition_id),
+        }
+        events = (
+            EventEnvelope.create(
+                event_type=WorkshopEventType.PRINCIPAL_CREATED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="principal",
+                aggregate_id=agent_principal_id,
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=operation_key,
+                payload={"kind": "agent", "display_name": normalized_display_name},
+                metadata=metadata,
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.WORKSHOP_MEMBER_ADDED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="workshop_membership",
+                aggregate_id=WorkshopMembershipId.derived(agent_id, "membership"),
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=f"{operation_key}:membership",
+                payload={"principal_id": agent_principal_id, "role": "agent"},
+                metadata=metadata,
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.AGENT_CREATED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="agent",
+                aggregate_id=agent_id,
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=f"{operation_key}:agent",
+                payload={"principal_id": agent_principal_id, "name": normalized_display_name},
+                metadata=metadata,
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.AGENT_DEFINITION_CREATED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="agent_definition",
+                aggregate_id=definition_id,
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=f"{operation_key}:definition",
+                payload={
+                    "agent_id": agent_id,
+                    "handle": normalized_handle,
+                    "display_name": normalized_display_name,
+                    "description": normalized_description,
+                    "presentation": json.loads(presentation_json),
+                    "lifecycle_state": "draft",
+                },
+                metadata=metadata,
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="agent_definition_revision",
+                aggregate_id=revision_id,
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=f"{operation_key}:revision",
+                payload={
+                    "definition_id": definition_id,
+                    "revision_number": 1,
+                    "purpose": normalized_purpose,
+                    "instructions": normalized_instructions,
+                    "capabilities": list(normalized_capabilities),
+                },
+                metadata=metadata,
+            ),
+        )
+        return await self._mutate(
+            principal_id,
+            workshop_id,
+            definition_id,
+            operation_key,
+            fingerprint,
+            events,
+            exclusive_handle=normalized_handle,
+        )
+
+    async def add_revision(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+        *,
+        idempotency_key: object,
+        expected_version: object,
+        purpose: object,
+        instructions: object,
+        capabilities: object,
+    ) -> AgentDefinitionSnapshot:
+        workshop_id = await self._admin_workshop(principal_id)
+        key = _normalize_idempotency_key(idempotency_key)
+        expected = _normalize_expected_version(expected_version)
+        try:
+            normalized_purpose = validate_agent_text(purpose, field="purpose", maximum=MAX_AGENT_PURPOSE)
+            normalized_instructions = validate_agent_text(
+                instructions, field="instructions", maximum=MAX_AGENT_INSTRUCTIONS
+            )
+            normalized_capabilities = validate_agent_capabilities(capabilities)
+        except ValueError as exc:
+            raise WorkshopAgentLifecycleValidationError(str(exc)) from exc
+        operation_payload: dict[str, object] = {
+            "definition_id": str(definition_id),
+            "expected_version": expected,
+            "purpose": normalized_purpose,
+            "instructions": normalized_instructions,
+            "capabilities": list(normalized_capabilities),
+        }
+        fingerprint = _operation_hash("revise", operation_payload)
+        operation_key = self._operation_key(workshop_id, principal_id, key)
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            replay = await self._replayed(operation_key, fingerprint, definition_id, workshop_id)
+            if replay is not None:
+                await connection.commit()
+                return replay
+            current = await self._snapshot_or_denied(definition_id, workshop_id)
+            self._require_version(current, expected)
+            if current.lifecycle_state == "archived":
+                raise WorkshopAgentLifecycleConflict("Archived agent definitions cannot be revised")
+            revision_number = len(current.revisions) + 1
+            revision_id = AgentDefinitionRevisionId.derived(definition_id, f"revision:{revision_number}")
+            event = EventEnvelope.create(
+                event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="agent_definition_revision",
+                aggregate_id=revision_id,
+                actor_principal_id=principal_id,
+                occurred_at=datetime.now(UTC),
+                idempotency_key=operation_key,
+                payload={
+                    "definition_id": definition_id,
+                    "revision_number": revision_number,
+                    "purpose": normalized_purpose,
+                    "instructions": normalized_instructions,
+                    "capabilities": list(normalized_capabilities),
+                },
+                metadata=self._metadata("revise", fingerprint, definition_id),
+            )
+            await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            result = await self._snapshot(definition_id, workshop_id=workshop_id)
+            await connection.commit()
+            return result
+        except WorkshopAgentLifecycleError:
+            await connection.rollback()
+            raise
+        except IdempotencyConflictError as exc:
+            await connection.rollback()
+            raise WorkshopAgentLifecycleConflict("Idempotency key conflicts with another request") from exc
+        except Exception as exc:
+            await connection.rollback()
+            raise WorkshopAgentLifecycleStorageError("Agent revision could not be persisted") from exc
+
+    async def activate_revision(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+        *,
+        revision_id: AgentDefinitionRevisionId,
+        idempotency_key: object,
+        expected_version: object,
+    ) -> AgentDefinitionSnapshot:
+        return await self._transition(
+            principal_id,
+            definition_id,
+            operation="activate",
+            event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED,
+            payload={"revision_id": revision_id},
+            idempotency_key=idempotency_key,
+            expected_version=expected_version,
+        )
+
+    async def archive(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+        *,
+        idempotency_key: object,
+        expected_version: object,
+    ) -> AgentDefinitionSnapshot:
+        return await self._transition(
+            principal_id,
+            definition_id,
+            operation="archive",
+            event_type=WorkshopEventType.AGENT_DEFINITION_ARCHIVED,
+            payload={},
+            idempotency_key=idempotency_key,
+            expected_version=expected_version,
+        )
+
+    async def _transition(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+        *,
+        operation: str,
+        event_type: WorkshopEventType,
+        payload: dict[str, object],
+        idempotency_key: object,
+        expected_version: object,
+    ) -> AgentDefinitionSnapshot:
+        workshop_id = await self._admin_workshop(principal_id)
+        key = _normalize_idempotency_key(idempotency_key)
+        expected = _normalize_expected_version(expected_version)
+        operation_payload = {
+            "definition_id": str(definition_id),
+            "expected_version": expected,
+            **{key: str(value) for key, value in payload.items()},
+        }
+        fingerprint = _operation_hash(operation, operation_payload)
+        operation_key = self._operation_key(workshop_id, principal_id, key)
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            replay = await self._replayed(operation_key, fingerprint, definition_id, workshop_id)
+            if replay is not None:
+                await connection.commit()
+                return replay
+            current = await self._snapshot_or_denied(definition_id, workshop_id)
+            self._require_version(current, expected)
+            if current.lifecycle_state == "archived":
+                raise WorkshopAgentLifecycleConflict("Archived agent definitions cannot be changed")
+            if operation == "activate":
+                revision_id = payload["revision_id"]
+                if revision_id not in {revision.revision_id for revision in current.revisions}:
+                    raise WorkshopAgentLifecycleValidationError("Revision is not part of this agent definition")
+            event = EventEnvelope.create(
+                event_type=event_type,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="agent_definition",
+                aggregate_id=definition_id,
+                actor_principal_id=principal_id,
+                occurred_at=datetime.now(UTC),
+                idempotency_key=operation_key,
+                payload=payload,
+                metadata=self._metadata(operation, fingerprint, definition_id),
+            )
+            await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            result = await self._snapshot(definition_id, workshop_id=workshop_id)
+            await connection.commit()
+            return result
+        except WorkshopAgentLifecycleError:
+            await connection.rollback()
+            raise
+        except IdempotencyConflictError as exc:
+            await connection.rollback()
+            raise WorkshopAgentLifecycleConflict("Idempotency key conflicts with another request") from exc
+        except Exception as exc:
+            await connection.rollback()
+            raise WorkshopAgentLifecycleStorageError("Agent lifecycle change could not be persisted") from exc
+
+    async def _mutate(
+        self,
+        principal_id: PrincipalId,
+        workshop_id: WorkshopId,
+        definition_id: AgentDefinitionId,
+        operation_key: str,
+        fingerprint: str,
+        events: tuple[EventEnvelope, ...],
+        exclusive_handle: str | None = None,
+    ) -> AgentDefinitionSnapshot:
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            replay = await self._replayed(operation_key, fingerprint, definition_id, workshop_id)
+            if replay is not None:
+                await connection.commit()
+                return replay
+            if exclusive_handle is not None:
+                async with connection.execute(
+                    "SELECT 1 FROM agent_definitions WHERE workshop_id = ? AND handle = ? COLLATE NOCASE LIMIT 1",
+                    (workshop_id, exclusive_handle),
+                ) as cursor:
+                    if await cursor.fetchone() is not None:
+                        raise WorkshopAgentLifecycleConflict("Agent handle is already in use")
+            for event in events:
+                await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            result = await self._snapshot(definition_id, workshop_id=workshop_id)
+            await connection.commit()
+            return result
+        except WorkshopAgentLifecycleError:
+            await connection.rollback()
+            raise
+        except IdempotencyConflictError as exc:
+            await connection.rollback()
+            raise WorkshopAgentLifecycleConflict("Idempotency key conflicts with another request") from exc
+        except Exception as exc:
+            await connection.rollback()
+            raise WorkshopAgentLifecycleStorageError("Agent definition could not be persisted") from exc
+
+    async def _authority(self, principal_id: PrincipalId) -> tuple[WorkshopId, str]:
+        if not isinstance(principal_id, PrincipalId):
+            raise WorkshopAgentLifecycleAccessDenied("Access denied")
+        async with self._store.connection.execute(
+            "SELECT wm.workshop_id, wm.role FROM workshop_memberships wm "
+            "JOIN principals p ON p.id = wm.principal_id AND p.kind = 'human' "
+            "WHERE wm.principal_id = ? ORDER BY wm.workshop_id",
+            (principal_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if len(rows) != 1:
+            raise WorkshopAgentLifecycleAccessDenied("Access denied")
+        return WorkshopId(str(rows[0][0])), str(rows[0][1])
+
+    async def _admin_workshop(self, principal_id: PrincipalId) -> WorkshopId:
+        workshop_id, role = await self._authority(principal_id)
+        if role != "admin":
+            raise WorkshopAgentLifecycleAccessDenied("Administrator access required")
+        return workshop_id
+
+    async def _snapshot_or_denied(
+        self,
+        definition_id: AgentDefinitionId,
+        workshop_id: WorkshopId,
+    ) -> AgentDefinitionSnapshot:
+        try:
+            return await self._snapshot(definition_id, workshop_id=workshop_id)
+        except WorkshopAgentLifecycleAccessDenied:
+            raise
+
+    async def _snapshot(
+        self,
+        definition_id: AgentDefinitionId,
+        *,
+        workshop_id: WorkshopId,
+    ) -> AgentDefinitionSnapshot:
+        async with self._store.connection.execute(
+            "SELECT d.id, d.workshop_id, d.agent_id, d.handle, d.display_name, d.description, "
+            "presentation_json, lifecycle_state, active_revision_id, created_at, "
+            "created_event_position, e.actor_principal_id FROM agent_definitions d "
+            "JOIN event_log e ON e.position = d.created_event_position "
+            "WHERE d.id = ? AND d.workshop_id = ?",
+            (definition_id, workshop_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise WorkshopAgentLifecycleAccessDenied("Access denied")
+        async with self._store.connection.execute(
+            "SELECT r.id, r.revision_number, r.purpose, r.instructions, r.capabilities_json, "
+            "r.created_at, e.actor_principal_id, r.created_event_position "
+            "FROM agent_definition_revisions r JOIN event_log e "
+            "ON e.position = r.created_event_position WHERE r.agent_definition_id = ? "
+            "ORDER BY r.revision_number",
+            (definition_id,),
+        ) as cursor:
+            revision_rows = list(await cursor.fetchall())
+        revisions = tuple(
+            AgentRevisionSnapshot(
+                revision_id=AgentDefinitionRevisionId(str(revision[0])),
+                revision_number=int(revision[1]),
+                purpose=str(revision[2]),
+                instructions=str(revision[3]),
+                capabilities=validate_agent_capabilities(json.loads(str(revision[4]))),
+                created_at=str(revision[5]),
+                created_by_principal_id=(PrincipalId(str(revision[6])) if revision[6] is not None else None),
+                event_position=int(revision[7]),
+            )
+            for revision in revision_rows
+        )
+        async with self._store.connection.execute(
+            "SELECT COALESCE(MAX(position), ?) FROM event_log WHERE workshop_id = ? "
+            "AND ((aggregate_type = 'agent_definition' AND aggregate_id = ?) "
+            "OR (aggregate_type = 'agent_definition_revision' "
+            "AND json_extract(payload_json, '$.definition_id') = ?))",
+            (int(row[10]), workshop_id, definition_id, definition_id),
+        ) as cursor:
+            version_row = await cursor.fetchone()
+        assert version_row is not None
+        active_revision = row[8]
+        return AgentDefinitionSnapshot(
+            definition_id=AgentDefinitionId(str(row[0])),
+            workshop_id=WorkshopId(str(row[1])),
+            agent_id=AgentId(str(row[2])),
+            handle=str(row[3]),
+            display_name=str(row[4]),
+            description=str(row[5]),
+            presentation=dict(json.loads(str(row[6]))),
+            lifecycle_state=str(row[7]),
+            active_revision_id=(AgentDefinitionRevisionId(str(active_revision)) if active_revision else None),
+            state_version=int(version_row[0]),
+            created_at=str(row[9]),
+            created_by_principal_id=(PrincipalId(str(row[11])) if row[11] is not None else None),
+            revisions=revisions,
+        )
+
+    async def _replayed(
+        self,
+        operation_key: str,
+        fingerprint: str,
+        definition_id: AgentDefinitionId,
+        workshop_id: WorkshopId,
+    ) -> AgentDefinitionSnapshot | None:
+        existing = await self._store.event_by_idempotency_key(operation_key)
+        if existing is None:
+            return None
+        metadata = existing.envelope.metadata
+        if metadata.get("operation_hash") != fingerprint or metadata.get("definition_id") != str(definition_id):
+            raise WorkshopAgentLifecycleConflict("Idempotency key conflicts with another request")
+        return await self._snapshot(definition_id, workshop_id=workshop_id)
+
+    @staticmethod
+    def _require_version(snapshot: AgentDefinitionSnapshot, expected: int) -> None:
+        if snapshot.state_version != expected:
+            raise WorkshopAgentLifecycleConflict("Agent definition changed; refresh and retry")
+
+    @staticmethod
+    def _metadata(operation: str, fingerprint: str, definition_id: AgentDefinitionId) -> dict[str, object]:
+        return {
+            "source": "workshop_client",
+            "operation": operation,
+            "operation_hash": fingerprint,
+            "definition_id": str(definition_id),
+        }
+
+    @staticmethod
+    def _operation_key(workshop_id: WorkshopId, principal_id: PrincipalId, key: str) -> str:
+        return f"workshop-client:agent-lifecycle:{workshop_id}:{principal_id}:{key}"

--- a/src/kai/workshop/channel_lifecycle.py
+++ b/src/kai/workshop/channel_lifecycle.py
@@ -189,6 +189,10 @@ class WorkshopChannelLifecycleService:
         async with self._store.connection.execute(
             "SELECT a.id, a.principal_id, ra.runtime_profile_id "
             "FROM agents a "
+            "JOIN agent_definitions ad ON ad.agent_id = a.id "
+            "AND ad.workshop_id = a.workshop_id "
+            "AND ad.lifecycle_state = 'active' "
+            "AND ad.active_revision_id IS NOT NULL "
             "JOIN workshop_memberships agent_wm ON agent_wm.workshop_id = a.workshop_id "
             "AND agent_wm.principal_id = a.principal_id AND agent_wm.role = 'agent' "
             "JOIN channel_agents ca ON ca.agent_id = a.id "

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -19,6 +19,15 @@ from urllib.parse import quote
 
 from aiohttp import BodyPartReader, web
 
+from kai.workshop.agent_lifecycle import (
+    AgentDefinitionSnapshot,
+    WorkshopAgentLifecycleAccessDenied,
+    WorkshopAgentLifecycleConflict,
+    WorkshopAgentLifecycleError,
+    WorkshopAgentLifecycleService,
+    WorkshopAgentLifecycleStorageError,
+    WorkshopAgentLifecycleValidationError,
+)
 from kai.workshop.appearance_preferences import (
     AppearancePreferenceAuthority,
     AppearancePreferenceSnapshot,
@@ -72,6 +81,8 @@ from kai.workshop.client_preferences import (
 from kai.workshop.client_sessions import EnrollmentGrantUnavailableError, WorkshopClientEnrollmentManager
 from kai.workshop.conversation_commands import ConversationCommandAcceptanceError
 from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentDefinitionRevisionId,
     AgentId,
     ArtifactId,
     ChannelId,
@@ -79,6 +90,7 @@ from kai.workshop.domain import (
     MessageReactionSummary,
     PrincipalId,
     RunId,
+    WorkshopEventType,
 )
 from kai.workshop.execution_coordinator import CanonicalCancellationDisposition
 from kai.workshop.github_settings import (
@@ -200,6 +212,12 @@ _TIMELINE_EVENTS_PATH = "/v1/channels/{channel_id}/events"
 _MESSAGE_REACTIONS_PATH = "/v1/channels/{channel_id}/messages/{message_id}/reactions"
 _CLIENT_NAVIGATION_PATH = "/v1/client/navigation"
 _CHANNEL_CREATION_PATH = "/v1/channels"
+_AGENT_DEFINITIONS_PATH = "/v1/client/agents"
+_AGENT_EVENTS_PATH = "/v1/client/agents/events"
+_AGENT_DEFINITION_PATH = "/v1/client/agents/{definition_id}"
+_AGENT_REVISIONS_PATH = "/v1/client/agents/{definition_id}/revisions"
+_AGENT_ACTIVATION_PATH = "/v1/client/agents/{definition_id}/activate"
+_AGENT_ARCHIVAL_PATH = "/v1/client/agents/{definition_id}/archive"
 _ENROLLMENT_REDEMPTION_PATH = "/v1/client/enrollment/redeem"
 _COMMAND_SUBMISSION_PATH = "/v1/channels/{channel_id}/commands"
 _AGENT_DISMISSAL_PATH = "/v1/channels/{channel_id}/agents/{agent_id}/dismiss"
@@ -263,6 +281,22 @@ _APPEARANCE_PREFERENCE_REQUEST_FIELDS = frozenset({"revision", "theme_id"})
 _MAX_APPEARANCE_PREFERENCE_BODY_BYTES = 1_024
 _CHANNEL_CREATION_REQUEST_FIELDS = frozenset({"name", "agent_ids", "origin_channel_id"})
 _MAX_CHANNEL_CREATION_BODY_BYTES = 8_192
+_AGENT_CREATION_FIELDS = frozenset(
+    {
+        "idempotency_key",
+        "handle",
+        "display_name",
+        "description",
+        "presentation",
+        "purpose",
+        "instructions",
+        "capabilities",
+    }
+)
+_AGENT_REVISION_FIELDS = frozenset({"idempotency_key", "expected_version", "purpose", "instructions", "capabilities"})
+_AGENT_ACTIVATION_FIELDS = frozenset({"idempotency_key", "expected_version", "revision_id"})
+_AGENT_ARCHIVAL_FIELDS = frozenset({"idempotency_key", "expected_version"})
+_MAX_AGENT_LIFECYCLE_BODY_BYTES = 32_768
 _DECIMAL_INTEGER = re.compile(r"^[0-9]+$")
 _CLIENT_MESSAGE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _EVENT_STREAM_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
@@ -594,6 +628,39 @@ def _serialize_created_channel(
             "role": "owner",
             "agent_ids": [str(agent_id) for agent_id in channel.agent_ids],
         },
+    }
+
+
+def _serialize_agent_definition(snapshot: AgentDefinitionSnapshot) -> dict[str, object]:
+    return {
+        "definition_id": str(snapshot.definition_id),
+        "agent_id": str(snapshot.agent_id),
+        "handle": snapshot.handle,
+        "display_name": snapshot.display_name,
+        "description": snapshot.description,
+        "presentation": snapshot.presentation,
+        "lifecycle_state": snapshot.lifecycle_state,
+        "active_revision_id": (str(snapshot.active_revision_id) if snapshot.active_revision_id is not None else None),
+        "state_version": snapshot.state_version,
+        "created_at": snapshot.created_at,
+        "created_by_principal_id": (
+            str(snapshot.created_by_principal_id) if snapshot.created_by_principal_id is not None else None
+        ),
+        "revisions": [
+            {
+                "revision_id": str(revision.revision_id),
+                "revision_number": revision.revision_number,
+                "purpose": revision.purpose,
+                "instructions": revision.instructions,
+                "capabilities": list(revision.capabilities),
+                "created_at": revision.created_at,
+                "created_by_principal_id": (
+                    str(revision.created_by_principal_id) if revision.created_by_principal_id is not None else None
+                ),
+                "event_position": revision.event_position,
+            }
+            for revision in snapshot.revisions
+        ],
     }
 
 
@@ -2710,6 +2777,20 @@ def _parse_event_stream_request(request: web.Request) -> tuple[ChannelId, int | 
     return channel_id, int(value)
 
 
+def _parse_agent_event_stream_request(request: web.Request) -> int | None:
+    if not set(request.query).issubset(_ALLOWED_EVENT_QUERY_PARAMETERS):
+        raise ValueError("Unsupported query parameter")
+    last_event_ids = request.headers.getall("Last-Event-ID", [])
+    if len(last_event_ids) > 1:
+        raise ValueError("Duplicate Last-Event-ID header")
+    value = last_event_ids[0] if last_event_ids else _single_query_value(request, "after_position")
+    if value is None:
+        return None
+    if not _DECIMAL_INTEGER.fullmatch(value):
+        raise ValueError("Invalid agent-event resume position")
+    return int(value)
+
+
 def _event_stream_key(request: web.Request) -> bytes:
     stream_ids = request.headers.getall("X-Kai-Stream-ID", [])
     if len(stream_ids) > 1:
@@ -3131,6 +3212,229 @@ async def _handle_channel_creation(
     return _json_response(_serialize_created_channel(created), status=201)
 
 
+async def _read_agent_lifecycle_payload(
+    request: web.Request,
+    expected_fields: frozenset[str],
+) -> tuple[dict[str, object] | None, web.Response | None]:
+    if request.query or request.content_type != "application/json":
+        return None, _error_response(
+            status=400,
+            code="invalid_request",
+            message="Invalid agent lifecycle request",
+        )
+    if request.content_length is not None and request.content_length > _MAX_AGENT_LIFECYCLE_BODY_BYTES:
+        return None, _error_response(
+            status=400,
+            code="invalid_request",
+            message="Agent lifecycle request is too large",
+        )
+    raw = await request.content.read(_MAX_AGENT_LIFECYCLE_BODY_BYTES + 1)
+    if len(raw) > _MAX_AGENT_LIFECYCLE_BODY_BYTES:
+        return None, _error_response(
+            status=400,
+            code="invalid_request",
+            message="Agent lifecycle request is too large",
+        )
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, ValueError):
+        payload = None
+    if not isinstance(payload, dict) or set(payload) != expected_fields:
+        return None, _error_response(
+            status=400,
+            code="invalid_request",
+            message="Invalid agent lifecycle request",
+        )
+    return payload, None
+
+
+async def _authenticate_agent_lifecycle(
+    request: web.Request,
+    authenticator: WorkshopClientAuthenticator,
+) -> tuple[PrincipalId | None, web.Response | None]:
+    principal_id = await authenticator.authenticate(request)
+    if isinstance(principal_id, PrincipalId):
+        return principal_id, None
+    response = _error_response(
+        status=401,
+        code="authentication_required",
+        message="Authentication required",
+    )
+    response.headers["WWW-Authenticate"] = "Bearer"
+    return None, response
+
+
+def _agent_lifecycle_error_response(exc: WorkshopAgentLifecycleError) -> web.Response:
+    if isinstance(exc, WorkshopAgentLifecycleAccessDenied):
+        return _error_response(status=403, code="access_denied", message="Access denied")
+    if isinstance(exc, WorkshopAgentLifecycleValidationError):
+        return _error_response(status=400, code="invalid_request", message=str(exc))
+    if isinstance(exc, WorkshopAgentLifecycleConflict):
+        return _error_response(
+            status=409,
+            code="agent_lifecycle_conflict",
+            message=str(exc),
+        )
+    if isinstance(exc, WorkshopAgentLifecycleStorageError):
+        return _error_response(
+            status=503,
+            code="agent_lifecycle_unavailable",
+            message="Agent lifecycle is temporarily unavailable",
+        )
+    return _error_response(
+        status=409,
+        code="agent_lifecycle_conflict",
+        message="Agent lifecycle conflicted with current state",
+    )
+
+
+def _agent_definition_id(request: web.Request) -> AgentDefinitionId:
+    try:
+        return AgentDefinitionId(request.match_info["definition_id"])
+    except (TypeError, ValueError) as exc:
+        raise WorkshopAgentLifecycleValidationError("Invalid agent definition") from exc
+
+
+async def _handle_agent_definition_list(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentLifecycleService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid agent list request")
+    try:
+        definitions = await service.list_visible(principal_id)
+    except WorkshopAgentLifecycleError as exc:
+        return _agent_lifecycle_error_response(exc)
+    return _json_response(
+        {"version": 1, "agents": [_serialize_agent_definition(item) for item in definitions]},
+        status=200,
+    )
+
+
+async def _handle_agent_definition_detail(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentLifecycleService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid agent request")
+    try:
+        snapshot = await service.get_visible(principal_id, _agent_definition_id(request))
+    except WorkshopAgentLifecycleError as exc:
+        return _agent_lifecycle_error_response(exc)
+    return _json_response({"version": 1, "agent": _serialize_agent_definition(snapshot)}, status=200)
+
+
+async def _handle_agent_definition_create(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentLifecycleService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    payload, error = await _read_agent_lifecycle_payload(request, _AGENT_CREATION_FIELDS)
+    if error is not None:
+        return error
+    assert payload is not None
+    try:
+        snapshot = await service.create_draft(principal_id, **payload)
+    except WorkshopAgentLifecycleError as exc:
+        return _agent_lifecycle_error_response(exc)
+    return _json_response({"version": 1, "agent": _serialize_agent_definition(snapshot)}, status=201)
+
+
+async def _handle_agent_revision_create(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentLifecycleService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    payload, error = await _read_agent_lifecycle_payload(request, _AGENT_REVISION_FIELDS)
+    if error is not None:
+        return error
+    assert payload is not None
+    try:
+        snapshot = await service.add_revision(principal_id, _agent_definition_id(request), **payload)
+    except WorkshopAgentLifecycleError as exc:
+        return _agent_lifecycle_error_response(exc)
+    return _json_response({"version": 1, "agent": _serialize_agent_definition(snapshot)}, status=201)
+
+
+async def _handle_agent_activation(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentLifecycleService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    payload, error = await _read_agent_lifecycle_payload(request, _AGENT_ACTIVATION_FIELDS)
+    if error is not None:
+        return error
+    assert payload is not None
+    try:
+        try:
+            revision_id = AgentDefinitionRevisionId(payload["revision_id"])  # type: ignore[arg-type]
+        except (TypeError, ValueError) as exc:
+            raise WorkshopAgentLifecycleValidationError("Invalid agent revision") from exc
+        snapshot = await service.activate_revision(
+            principal_id,
+            _agent_definition_id(request),
+            revision_id=revision_id,
+            idempotency_key=payload["idempotency_key"],
+            expected_version=payload["expected_version"],
+        )
+    except WorkshopAgentLifecycleError as exc:
+        return _agent_lifecycle_error_response(exc)
+    return _json_response({"version": 1, "agent": _serialize_agent_definition(snapshot)}, status=200)
+
+
+async def _handle_agent_archival(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentLifecycleService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    payload, error = await _read_agent_lifecycle_payload(request, _AGENT_ARCHIVAL_FIELDS)
+    if error is not None:
+        return error
+    assert payload is not None
+    try:
+        snapshot = await service.archive(
+            principal_id,
+            _agent_definition_id(request),
+            idempotency_key=payload["idempotency_key"],
+            expected_version=payload["expected_version"],
+        )
+    except WorkshopAgentLifecycleError as exc:
+        return _agent_lifecycle_error_response(exc)
+    return _json_response({"version": 1, "agent": _serialize_agent_definition(snapshot)}, status=200)
+
+
 async def _handle_message_reaction(
     request: web.Request,
     *,
@@ -3380,6 +3684,175 @@ def _serialize_run_trace_event(run_id: str, channel_id: str, seq: int) -> bytes:
         sort_keys=True,
     )
     return (f"event: run.trace.updated\ndata: {payload}\n\n").encode()
+
+
+async def _read_agent_lifecycle_events(
+    store: WorkshopEventStore,
+    *,
+    workshop_id: str,
+    role: str,
+    after_position: int,
+) -> tuple[tuple[bytes, ...], int]:
+    event_types = (
+        WorkshopEventType.AGENT_DEFINITION_CREATED,
+        WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED,
+        WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED,
+        WorkshopEventType.AGENT_DEFINITION_ARCHIVED,
+    )
+    visible_types = event_types if role == "admin" else event_types[2:]
+    placeholders = ",".join("?" for _ in visible_types)
+    async with store.connection.execute(
+        "SELECT position, event_type, aggregate_id, payload_json, metadata_json, occurred_at "
+        "FROM event_log WHERE workshop_id = ? AND position > ? "
+        f"AND event_type IN ({placeholders}) ORDER BY position LIMIT ?",
+        (workshop_id, after_position, *visible_types, _EVENT_BATCH_SIZE),
+    ) as cursor:
+        rows = list(await cursor.fetchall())
+    serialized: list[bytes] = []
+    position = after_position
+    for row in rows:
+        position = int(row[0])
+        event_type = str(row[1])
+        payload = json.loads(str(row[3]))
+        metadata = json.loads(str(row[4]))
+        definition_id = metadata.get("definition_id")
+        if not isinstance(definition_id, str):
+            if event_type == WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED:
+                definition_id = payload.get("definition_id")
+            else:
+                definition_id = str(row[2])
+        revision_id: str | None = None
+        if event_type == WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED:
+            revision_id = str(row[2])
+        elif event_type == WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED:
+            candidate = payload.get("revision_id")
+            revision_id = candidate if isinstance(candidate, str) else None
+        event_payload = json.dumps(
+            {
+                "version": 1,
+                "event_position": position,
+                "event_type": event_type,
+                "definition_id": definition_id,
+                "revision_id": revision_id,
+                "occurred_at": str(row[5]),
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        serialized.append((f"id: {position}\nevent: agent.definition.changed\ndata: {event_payload}\n\n").encode())
+    return tuple(serialized), position
+
+
+async def _handle_agent_event_stream(
+    request: web.Request,
+    *,
+    store: WorkshopEventStore,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentLifecycleService,
+    request_lock: asyncio.Lock,
+    poll_interval: float,
+    heartbeat_interval: float,
+    authentication_recheck_interval: float,
+    stream_limiter: WorkshopEventStreamLimiter,
+    shutdown_event: asyncio.Event,
+) -> web.StreamResponse:
+    try:
+        async with request_lock:
+            principal_id = await authenticator.authenticate(request)
+            if not isinstance(principal_id, PrincipalId):
+                response = _error_response(
+                    status=401,
+                    code="authentication_required",
+                    message="Authentication required",
+                )
+                response.headers["WWW-Authenticate"] = "Bearer"
+                return response
+            after_position = _parse_agent_event_stream_request(request)
+            stream_key = _event_stream_key(request)
+            authority = await service.authority_for(principal_id)
+            async with store.connection.execute("SELECT COALESCE(MAX(position), 0) FROM event_log") as cursor:
+                tip = await cursor.fetchone()
+            assert tip is not None
+            current_tip = int(tip[0])
+            if after_position is None:
+                after_position = current_tip
+            elif after_position > current_tip:
+                return _error_response(
+                    status=409,
+                    code="resynchronization_required",
+                    message="Agent definitions resynchronization required",
+                )
+            events, position = await _read_agent_lifecycle_events(
+                store,
+                workshop_id=str(authority.workshop_id),
+                role=authority.role,
+                after_position=after_position,
+            )
+    except WorkshopAgentLifecycleAccessDenied:
+        return _error_response(status=403, code="access_denied", message="Access denied")
+    except (TypeError, ValueError):
+        return _error_response(status=400, code="invalid_request", message="Invalid agent event-stream request")
+
+    claim = stream_limiter.acquire(principal_id, stream_key)
+    if claim is None:
+        response = _error_response(
+            status=429,
+            code="stream_capacity_exceeded",
+            message="Too many active event streams",
+        )
+        response.headers["Retry-After"] = "5"
+        return response
+    response = web.StreamResponse(status=200)
+    try:
+        response.content_type = "text/event-stream"
+        response.charset = "utf-8"
+        _apply_client_security_headers(response)
+        response.headers["X-Accel-Buffering"] = "no"
+        await response.prepare(request)
+        await response.write(f": connected\nretry: {_SSE_RETRY_MILLISECONDS}\n\n".encode())
+        last_heartbeat = time.monotonic()
+        last_authentication_check = last_heartbeat
+        while True:
+            if not stream_limiter.is_current(claim):
+                break
+            transport = request.transport
+            if transport is None or transport.is_closing():
+                break
+            if events:
+                for event in events:
+                    await response.write(event)
+                events = ()
+                last_heartbeat = time.monotonic()
+                continue
+            now = time.monotonic()
+            if now - last_heartbeat >= heartbeat_interval:
+                await response.write(b": keep-alive\n\n")
+                last_heartbeat = now
+            try:
+                await asyncio.wait_for(shutdown_event.wait(), timeout=poll_interval)
+                break
+            except TimeoutError:
+                pass
+            async with request_lock:
+                reauthenticate = time.monotonic() - last_authentication_check >= authentication_recheck_interval
+                if reauthenticate:
+                    authenticated = await authenticator.authenticate(request)
+                    if authenticated != principal_id:
+                        break
+                    authority = await service.authority_for(principal_id)
+                    last_authentication_check = time.monotonic()
+                events, position = await _read_agent_lifecycle_events(
+                    store,
+                    workshop_id=str(authority.workshop_id),
+                    role=authority.role,
+                    after_position=position,
+                )
+    except (BrokenPipeError, ConnectionResetError, WorkshopAgentLifecycleAccessDenied):
+        pass
+    finally:
+        stream_limiter.release(claim)
+    return response
 
 
 async def _latest_channel_trace(store: WorkshopEventStore, channel_id: ChannelId) -> tuple[str, int] | None:
@@ -4210,6 +4683,7 @@ def register_workshop_read_routes(
         raise ValueError("Event-stream intervals must be positive")
     stream_limiter = event_stream_limiter or WorkshopEventStreamLimiter()
     channel_lifecycle = WorkshopChannelLifecycleService(store)
+    agent_lifecycle = WorkshopAgentLifecycleService(store)
     shutdown_event = asyncio.Event()
 
     async def stop_event_streams(_app: web.Application) -> None:
@@ -4250,6 +4724,68 @@ def register_workshop_read_routes(
                 service=channel_lifecycle,
             )
 
+    async def handle_agent_definition_list(request: web.Request) -> web.Response:
+        async with request_lock:
+            return await _handle_agent_definition_list(
+                request,
+                authenticator=authenticator,
+                service=agent_lifecycle,
+            )
+
+    async def handle_agent_definition_create(request: web.Request) -> web.Response:
+        async with request_lock:
+            return await _handle_agent_definition_create(
+                request,
+                authenticator=authenticator,
+                service=agent_lifecycle,
+            )
+
+    async def handle_agent_definition_detail(request: web.Request) -> web.Response:
+        async with request_lock:
+            return await _handle_agent_definition_detail(
+                request,
+                authenticator=authenticator,
+                service=agent_lifecycle,
+            )
+
+    async def handle_agent_revision_create(request: web.Request) -> web.Response:
+        async with request_lock:
+            return await _handle_agent_revision_create(
+                request,
+                authenticator=authenticator,
+                service=agent_lifecycle,
+            )
+
+    async def handle_agent_activation(request: web.Request) -> web.Response:
+        async with request_lock:
+            return await _handle_agent_activation(
+                request,
+                authenticator=authenticator,
+                service=agent_lifecycle,
+            )
+
+    async def handle_agent_archival(request: web.Request) -> web.Response:
+        async with request_lock:
+            return await _handle_agent_archival(
+                request,
+                authenticator=authenticator,
+                service=agent_lifecycle,
+            )
+
+    async def handle_agent_event_stream(request: web.Request) -> web.StreamResponse:
+        return await _handle_agent_event_stream(
+            request,
+            store=store,
+            authenticator=authenticator,
+            service=agent_lifecycle,
+            request_lock=request_lock,
+            poll_interval=event_poll_interval,
+            heartbeat_interval=event_heartbeat_interval,
+            authentication_recheck_interval=event_authentication_recheck_interval,
+            stream_limiter=stream_limiter,
+            shutdown_event=shutdown_event,
+        )
+
     async def handle_channel_event_stream(request: web.Request) -> web.StreamResponse:
         return await _handle_channel_event_stream(
             request,
@@ -4275,6 +4811,13 @@ def register_workshop_read_routes(
 
     app.router.add_get(_CLIENT_NAVIGATION_PATH, handle_client_navigation)
     app.router.add_post(_CHANNEL_CREATION_PATH, handle_channel_creation)
+    app.router.add_get(_AGENT_DEFINITIONS_PATH, handle_agent_definition_list)
+    app.router.add_post(_AGENT_DEFINITIONS_PATH, handle_agent_definition_create)
+    app.router.add_get(_AGENT_EVENTS_PATH, handle_agent_event_stream)
+    app.router.add_get(_AGENT_DEFINITION_PATH, handle_agent_definition_detail)
+    app.router.add_post(_AGENT_REVISIONS_PATH, handle_agent_revision_create)
+    app.router.add_post(_AGENT_ACTIVATION_PATH, handle_agent_activation)
+    app.router.add_post(_AGENT_ARCHIVAL_PATH, handle_agent_archival)
     app.router.add_get(_TIMELINE_PATH, handle_channel_timeline)
     app.router.add_get(_THREAD_TIMELINE_PATH, handle_thread_timeline)
     app.router.add_get(_TIMELINE_EVENTS_PATH, handle_channel_event_stream)

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -32,6 +32,7 @@ class WorkshopEventType(StrEnum):
     AGENT_DEFINITION_CREATED = "agent_definition.created"
     AGENT_DEFINITION_REVISION_ADDED = "agent_definition.revision_added"
     AGENT_DEFINITION_REVISION_ACTIVATED = "agent_definition.revision_activated"
+    AGENT_DEFINITION_ARCHIVED = "agent_definition.archived"
     CHANNEL_AGENT_ATTACHED = "channel.agent_attached"
     CHANNEL_AGENT_DISMISSED = "channel.agent_dismissed"
     RUNTIME_PROFILE_ASSIGNED = "runtime_profile.assigned"

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -607,8 +607,8 @@ class CanonicalConversationProjection:
     """Rebuild the initial Workshop collaboration records from events."""
 
     name = "canonical_conversations"
-    # Runtime-profile assignments can migrate to stable protected profiles.
-    version = 12
+    # Agent definitions project durable draft, active, and archived lifecycle state.
+    version = 13
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -877,13 +877,35 @@ class CanonicalConversationProjection:
             if (
                 revision_row is None
                 or WorkshopId(str(revision_row[0])) != envelope.workshop_id
-                or str(revision_row[1]) != "active"
+                or str(revision_row[1]) == "archived"
                 or AgentDefinitionId(str(revision_row[2])) != envelope.aggregate_id
             ):
                 raise ValueError("Workshop agent revision activation is invalid")
             await connection.execute(
-                "UPDATE agent_definitions SET active_revision_id = ? WHERE id = ?",
+                "UPDATE agent_definitions SET lifecycle_state = 'active', active_revision_id = ? WHERE id = ?",
                 (revision_id, envelope.aggregate_id),
+            )
+        elif envelope.event_type == WorkshopEventType.AGENT_DEFINITION_ARCHIVED:
+            if (
+                not isinstance(envelope.aggregate_id, AgentDefinitionId)
+                or envelope.aggregate_type != "agent_definition"
+            ):
+                raise ValueError("Workshop agent archival requires a typed definition aggregate")
+            _require_exact_payload(payload, set())
+            async with connection.execute(
+                "SELECT workshop_id, lifecycle_state FROM agent_definitions WHERE id = ?",
+                (envelope.aggregate_id,),
+            ) as cursor:
+                definition_row = await cursor.fetchone()
+            if (
+                definition_row is None
+                or WorkshopId(str(definition_row[0])) != envelope.workshop_id
+                or str(definition_row[1]) == "archived"
+            ):
+                raise ValueError("Workshop agent archival is invalid")
+            await connection.execute(
+                "UPDATE agent_definitions SET lifecycle_state = 'archived' WHERE id = ?",
+                (envelope.aggregate_id,),
             )
         elif envelope.event_type == WorkshopEventType.CHANNEL_AGENT_ATTACHED:
             await connection.execute(

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -859,6 +859,12 @@ class TestNotificationChatIdMutations:
             assert lan_paths == {
                 "/v1/client/enrollment/redeem",
                 "/v1/client/navigation",
+                "/v1/client/agents",
+                "/v1/client/agents/events",
+                "/v1/client/agents/{definition_id}",
+                "/v1/client/agents/{definition_id}/revisions",
+                "/v1/client/agents/{definition_id}/activate",
+                "/v1/client/agents/{definition_id}/archive",
                 "/v1/channels",
                 "/v1/channels/{channel_id}/timeline",
                 "/v1/channels/{channel_id}/threads/{root_message_id}",

--- a/tests/test_workshop_agent_definitions.py
+++ b/tests/test_workshop_agent_definitions.py
@@ -13,6 +13,7 @@ from kai.workshop.agent_definitions import (
     load_agent_definition_revision,
     render_agent_definition_context,
 )
+from kai.workshop.agent_lifecycle import WorkshopAgentLifecycleService
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.diagnostics import workshop_agent_definition_status
 from kai.workshop.domain import (
@@ -21,6 +22,7 @@ from kai.workshop.domain import (
     AgentId,
     EventEnvelope,
     MessageId,
+    PrincipalId,
     WorkshopEventType,
 )
 from kai.workshop.inbound import InboundMessage, record_inbound_message, resolve_message_mentions
@@ -173,6 +175,63 @@ class TestAgentDefinitionRevisions:
             rendered = render_agent_definition_context(revision)
             assert f"Definition revision: 1 ({revision.revision_id})" in rendered
             assert "does not grant tools, credentials, data access, identity, or permission" in rendered
+        finally:
+            await store.close()
+
+    async def test_archival_disables_new_resolution_but_preserves_run_provenance(
+        self,
+        tmp_path: Path,
+    ):
+        store, agent_id = await _open(tmp_path / "kai.db")
+        try:
+            active = await active_agent_definition_revision(store, agent_id)
+            assert active is not None
+            accepted = await WorkshopRunLifecycle(store).accept(
+                await _record(store, 1), occurred_at=_NOW + timedelta(minutes=1, seconds=1)
+            )
+            assert accepted.run.agent_definition_revision_id == active.revision_id
+            async with store.connection.execute(
+                "SELECT principal_id FROM external_identities "
+                "WHERE provider = 'desktop' AND external_subject = 'human-1'"
+            ) as cursor:
+                principal_row = await cursor.fetchone()
+            assert principal_row is not None
+            principal_id = PrincipalId(str(principal_row[0]))
+            service = WorkshopAgentLifecycleService(store)
+            current = await service.get_visible(principal_id, active.definition_id)
+            archived = await service.archive(
+                principal_id,
+                active.definition_id,
+                idempotency_key="archive-kai-provenance-test",
+                expected_version=current.state_version,
+            )
+            assert archived.lifecycle_state == "archived"
+            assert archived.active_revision_id == active.revision_id
+            assert await active_agent_definition_revision(store, agent_id) is None
+            preserved = await load_agent_definition_revision(store, active.revision_id)
+            assert preserved is not None
+            assert preserved.revision_id == active.revision_id
+            assert preserved.instructions == active.instructions
+            async with store.connection.execute(
+                "SELECT agent_definition_revision_id FROM runs WHERE id = ?",
+                (accepted.run.run_id,),
+            ) as cursor:
+                run_row = await cursor.fetchone()
+            assert run_row is not None
+            assert AgentDefinitionRevisionId(str(run_row[0])) == active.revision_id
+
+            await store.rebuild_projection(CanonicalConversationProjection())
+            replayed_revision = await load_agent_definition_revision(store, active.revision_id)
+            assert replayed_revision is not None
+            assert replayed_revision.revision_id == active.revision_id
+            assert replayed_revision.instructions == active.instructions
+            async with store.connection.execute(
+                "SELECT agent_definition_revision_id FROM runs WHERE id = ?",
+                (accepted.run.run_id,),
+            ) as cursor:
+                replayed_run = await cursor.fetchone()
+            assert replayed_run is not None
+            assert AgentDefinitionRevisionId(str(replayed_run[0])) == active.revision_id
         finally:
             await store.close()
 

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -529,7 +529,7 @@ class TestArtifactShadowRecordingAfterRestart:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 12
+            assert checkpoint.version == 13
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -49,6 +49,7 @@ from kai.workshop.client_sessions import (
 )
 from kai.workshop.conversation_commands import ConversationCommandDisposition
 from kai.workshop.domain import (
+    AgentDefinitionId,
     AgentId,
     ChannelId,
     ChannelMembershipId,
@@ -1305,7 +1306,353 @@ class TestWorkshopNavigationHTTPContract:
             await store.close()
 
 
+class TestWorkshopAgentLifecycleHTTPContract:
+    @staticmethod
+    def _draft_payload(*, key: str = "create-researcher") -> dict[str, object]:
+        return {
+            "idempotency_key": key,
+            "handle": "researcher",
+            "display_name": "Researcher",
+            "description": "Find and synthesize evidence.",
+            "presentation": {"avatar": "R"},
+            "purpose": "Research bounded questions.",
+            "instructions": "Find reliable evidence and distinguish fact from inference.",
+            "capabilities": ["text_generation", "tool_activity"],
+        }
+
+    async def test_admin_completes_revisioned_lifecycle_and_archive_preserves_history(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, _, bob_id, _ = await _open_store(tmp_path / "kai.db")
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id, "bob": bob_id}),
+        )
+        try:
+            response = await client.post(
+                "/v1/client/agents",
+                headers={"Authorization": "Bearer alice"},
+                json=self._draft_payload(),
+            )
+            assert response.status == 201
+            created = (await response.json())["agent"]
+            definition_id = created["definition_id"]
+            assert created["lifecycle_state"] == "draft"
+            assert created["active_revision_id"] is None
+            assert len(created["revisions"]) == 1
+            assert created["created_by_principal_id"] == str(alice_id)
+            assert created["revisions"][0]["created_by_principal_id"] == str(alice_id)
+
+            replay = await client.post(
+                "/v1/client/agents",
+                headers={"Authorization": "Bearer alice"},
+                json=self._draft_payload(),
+            )
+            assert replay.status == 201
+            assert (await replay.json())["agent"] == created
+            conflict = await client.post(
+                "/v1/client/agents",
+                headers={"Authorization": "Bearer alice"},
+                json={**self._draft_payload(), "display_name": "Different"},
+            )
+            assert conflict.status == 409
+            duplicate_handle = await client.post(
+                "/v1/client/agents",
+                headers={"Authorization": "Bearer alice"},
+                json=self._draft_payload(key="different-operation"),
+            )
+            assert duplicate_handle.status == 409
+
+            member_list = await client.get(
+                "/v1/client/agents",
+                headers={"Authorization": "Bearer bob"},
+            )
+            assert member_list.status == 200
+            assert definition_id not in {item["definition_id"] for item in (await member_list.json())["agents"]}
+            denied = await client.post(
+                f"/v1/client/agents/{definition_id}/revisions",
+                headers={"Authorization": "Bearer bob"},
+                json={
+                    "idempotency_key": "member-revision",
+                    "expected_version": created["state_version"],
+                    "purpose": "Not authorized",
+                    "instructions": "This must not be persisted.",
+                    "capabilities": ["text_generation"],
+                },
+            )
+            assert denied.status == 403
+
+            revision_response = await client.post(
+                f"/v1/client/agents/{definition_id}/revisions",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "idempotency_key": "revision-two",
+                    "expected_version": created["state_version"],
+                    "purpose": "Research bounded questions with citations.",
+                    "instructions": "Find reliable evidence, cite it, and label inference.",
+                    "capabilities": ["text_generation", "tool_activity"],
+                },
+            )
+            assert revision_response.status == 201
+            revised = (await revision_response.json())["agent"]
+            revision_two_id = revised["revisions"][1]["revision_id"]
+            stale = await client.post(
+                f"/v1/client/agents/{definition_id}/activate",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "idempotency_key": "stale-activation",
+                    "expected_version": created["state_version"],
+                    "revision_id": revision_two_id,
+                },
+            )
+            assert stale.status == 409
+
+            activation = await client.post(
+                f"/v1/client/agents/{definition_id}/activate",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "idempotency_key": "activate-two",
+                    "expected_version": revised["state_version"],
+                    "revision_id": revision_two_id,
+                },
+            )
+            assert activation.status == 200
+            active = (await activation.json())["agent"]
+            assert active["lifecycle_state"] == "active"
+            assert active["active_revision_id"] == revision_two_id
+            member_detail = await client.get(
+                f"/v1/client/agents/{definition_id}",
+                headers={"Authorization": "Bearer bob"},
+            )
+            assert member_detail.status == 200
+
+            archival = await client.post(
+                f"/v1/client/agents/{definition_id}/archive",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "idempotency_key": "archive-researcher",
+                    "expected_version": active["state_version"],
+                },
+            )
+            assert archival.status == 200
+            archived = (await archival.json())["agent"]
+            assert archived["lifecycle_state"] == "archived"
+            assert archived["active_revision_id"] == revision_two_id
+            assert len(archived["revisions"]) == 2
+            assert (
+                await client.get(
+                    f"/v1/client/agents/{definition_id}",
+                    headers={"Authorization": "Bearer bob"},
+                )
+            ).status == 403
+
+            await store.rebuild_projection(CanonicalConversationProjection())
+            replayed = await client.get(
+                f"/v1/client/agents/{definition_id}",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert replayed.status == 200
+            replayed_agent = (await replayed.json())["agent"]
+            assert replayed_agent["lifecycle_state"] == "archived"
+            assert replayed_agent["active_revision_id"] == revision_two_id
+            assert [item["revision_number"] for item in replayed_agent["revisions"]] == [1, 2]
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_malformed_authority_and_cross_workshop_ids_fail_closed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, _, bob_id, _ = await _open_store(tmp_path / "kai.db")
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id, "bob": bob_id}),
+        )
+        try:
+            payload = {**self._draft_payload(key="authority-field"), "principal_id": str(bob_id)}
+            malformed = await client.post(
+                "/v1/client/agents",
+                headers={"Authorization": "Bearer alice"},
+                json=payload,
+            )
+            assert malformed.status == 400
+            unknown = AgentDefinitionId.new()
+            hidden = await client.get(
+                f"/v1/client/agents/{unknown}",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert hidden.status == 403
+            invalid = await client.get(
+                "/v1/client/agents/not-an-id",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert invalid.status == 400
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_durable_agent_events_replay_from_canonical_position(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+        client = await _open_client(store, _Authenticator({"alice": alice_id}))
+        try:
+            async with store.connection.execute("SELECT MAX(position) FROM event_log") as cursor:
+                before = int((await cursor.fetchone())[0])
+            created_response = await client.post(
+                "/v1/client/agents",
+                headers={"Authorization": "Bearer alice"},
+                json=self._draft_payload(key="event-replay"),
+            )
+            created = (await created_response.json())["agent"]
+            stream = await client.get(
+                f"/v1/client/agents/events?after_position={before}",
+                headers={
+                    "Authorization": "Bearer alice",
+                    "X-Kai-Stream-ID": "agent-lifecycle-test",
+                },
+            )
+            assert stream.status == 200
+            found: dict[str, object] | None = None
+            for _ in range(20):
+                line = (await stream.content.readline()).decode().strip()
+                if line.startswith("data: "):
+                    candidate = json.loads(line.removeprefix("data: "))
+                    if candidate["definition_id"] == created["definition_id"]:
+                        found = candidate
+                        break
+            assert found is not None
+            assert found["event_type"] == "agent_definition.created"
+            assert isinstance(found["event_position"], int)
+            stream.close()
+
+            impossible = await client.get(
+                "/v1/client/agents/events?after_position=999999999",
+                headers={
+                    "Authorization": "Bearer alice",
+                    "X-Kai-Stream-ID": "agent-lifecycle-invalid-resume",
+                },
+            )
+            assert impossible.status == 409
+            assert (await impossible.json())["error"]["code"] == "resynchronization_required"
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_concurrent_activations_have_one_deterministic_winner(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+        client = await _open_client(store, _Authenticator({"alice": alice_id}))
+        try:
+            created_response = await client.post(
+                "/v1/client/agents",
+                headers={"Authorization": "Bearer alice"},
+                json=self._draft_payload(key="concurrent-agent"),
+            )
+            created = (await created_response.json())["agent"]
+            definition_id = created["definition_id"]
+            first_revision_id = created["revisions"][0]["revision_id"]
+            revision_response = await client.post(
+                f"/v1/client/agents/{definition_id}/revisions",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "idempotency_key": "concurrent-revision-two",
+                    "expected_version": created["state_version"],
+                    "purpose": "Provide a second activation candidate.",
+                    "instructions": "Respond using the second immutable revision.",
+                    "capabilities": ["text_generation"],
+                },
+            )
+            revised = (await revision_response.json())["agent"]
+            second_revision_id = revised["revisions"][1]["revision_id"]
+            expected_version = revised["state_version"]
+
+            first, second = await asyncio.gather(
+                client.post(
+                    f"/v1/client/agents/{definition_id}/activate",
+                    headers={"Authorization": "Bearer alice"},
+                    json={
+                        "idempotency_key": "activate-first-concurrently",
+                        "expected_version": expected_version,
+                        "revision_id": first_revision_id,
+                    },
+                ),
+                client.post(
+                    f"/v1/client/agents/{definition_id}/activate",
+                    headers={"Authorization": "Bearer alice"},
+                    json={
+                        "idempotency_key": "activate-second-concurrently",
+                        "expected_version": expected_version,
+                        "revision_id": second_revision_id,
+                    },
+                ),
+            )
+
+            assert sorted((first.status, second.status)) == [200, 409]
+            current_response = await client.get(
+                f"/v1/client/agents/{definition_id}",
+                headers={"Authorization": "Bearer alice"},
+            )
+            current = (await current_response.json())["agent"]
+            assert current["active_revision_id"] in {
+                first_revision_id,
+                second_revision_id,
+            }
+        finally:
+            await client.close()
+            await store.close()
+
+
 class TestWorkshopChannelLifecycleHTTPContract:
+    async def test_archived_agent_cannot_be_enabled_in_a_new_channel(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, alice_channel, _, _ = await _open_store(tmp_path / "kai.db")
+        async with store.connection.execute(
+            "SELECT agent_id FROM channel_agents WHERE channel_id = ?",
+            (alice_channel,),
+        ) as cursor:
+            agent_id = AgentId(str((await cursor.fetchone())[0]))
+        client = await _open_client(store, _Authenticator({"alice": alice_id}))
+        try:
+            agents_response = await client.get(
+                "/v1/client/agents",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert agents_response.status == 200
+            definition = next(item for item in (await agents_response.json())["agents"] if item["agent_id"] == agent_id)
+            archived_response = await client.post(
+                f"/v1/client/agents/{definition['definition_id']}/archive",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "idempotency_key": "archive-before-channel-enable",
+                    "expected_version": definition["state_version"],
+                },
+            )
+            assert archived_response.status == 200
+
+            response = await client.post(
+                "/v1/channels",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "name": "Must not enable archived agent",
+                    "agent_ids": [agent_id],
+                    "origin_channel_id": alice_channel,
+                },
+            )
+
+            assert response.status == 400
+            assert (await response.json())["error"]["code"] == "invalid_request"
+        finally:
+            await client.close()
+            await store.close()
+
     async def test_creates_one_private_canonical_group_without_transport_binding(
         self,
         tmp_path: Path,

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -389,7 +389,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 12
+            assert checkpoint.version == 13
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -97,6 +97,7 @@ class TestEventEnvelope:
             "agent_definition.created",
             "agent_definition.revision_added",
             "agent_definition.revision_activated",
+            "agent_definition.archived",
             "channel.agent_attached",
             "channel.agent_dismissed",
             "runtime_profile.assigned",

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -391,7 +391,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 12
+            assert checkpoint.version == 13
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -166,7 +166,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 12
+            assert checkpoint.version == 13
             assert after == before
         finally:
             await store.close()

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -178,7 +178,7 @@ class TestRuntimeAssignmentPolicy:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 12
+            assert checkpoint.version == 13
             assert await resolve_channel_runtime_profile(store, human.channel_id) == (
                 assigned.agent_id,
                 profile_id(202),


### PR DESCRIPTION
## Summary
- add a canonical admin-authorized service for draft, revision, activation, and archival of Workshop agent definitions
- expose strict authenticated lifecycle and durable SSE APIs with idempotency and optimistic concurrency
- preserve immutable authorship and run provenance while preventing archived agents from new runs or channel enablement
- add authorization, isolation, replay, concurrency, malformed-input, and projection coverage

## Validation
- make check
- make typecheck
- make test (6304 passed)

Closes #1227