### PR TITLE
Enable Workshop agents per principal

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -19,6 +19,7 @@ from kai.backend_registry import (
 )
 from kai.config import Config, models_for_backend_policy
 from kai.pool import SubprocessPool
+from kai.workshop.agent_enablement import WorkshopAgentEnablementService
 from kai.workshop.appearance_preferences import WorkshopAppearancePreferenceService
 from kai.workshop.artifacts import WorkshopArtifactService
 from kai.workshop.claude_model_discovery import ClaudeModelDiscoveryAdapter
@@ -194,6 +195,7 @@ class KaiCoreServices:
     notification_preferences: WorkshopNotificationPreferenceService
     client_preferences: WorkshopClientPreferenceService
     appearance_preferences: WorkshopAppearancePreferenceService
+    agent_enablement: WorkshopAgentEnablementService
     proactive_publication: WorkshopProactivePublicationService
     integration_notifications: WorkshopIntegrationNotificationService
     github_automation: WorkshopGitHubAutomationService
@@ -408,6 +410,13 @@ class KaiApplicationHost:
                 self._client_voice_capabilities,
             )
             appearance_preferences = await WorkshopAppearancePreferenceService.open(Path(self._config.session_db_path))
+            agent_enablement = WorkshopAgentEnablementService(
+                client_store,
+                self._runtime_profiles,
+                self._execution_state,
+                self._internal_api_contexts,
+                runtime_pool,
+            )
             proactive_publication = WorkshopProactivePublicationService(
                 client_store,
                 artifacts,
@@ -464,6 +473,7 @@ class KaiApplicationHost:
                 notification_preferences=notification_preferences,
                 client_preferences=client_preferences,
                 appearance_preferences=appearance_preferences,
+                agent_enablement=agent_enablement,
                 proactive_publication=proactive_publication,
                 integration_notifications=integration_notifications,
                 github_automation=github_automation,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -10172,11 +10172,15 @@ def _internal_api_authority_status(db_path: Path) -> str:
     try:
         connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
         try:
-            profiles = int(connection.execute("SELECT COUNT(*) FROM channel_agent_runtime_assignments").fetchone()[0])
+            profiles = int(
+                connection.execute(
+                    "SELECT COUNT(DISTINCT runtime_profile_id) FROM channel_agent_runtime_assignments"
+                ).fetchone()[0]
+            )
             contexts = int(
                 connection.execute(
                     "SELECT COUNT(*) FROM ("
-                    "SELECT ra.runtime_profile_id "
+                    "SELECT ra.runtime_profile_id, ra.channel_id, ra.agent_id, cm.principal_id "
                     "FROM channel_agent_runtime_assignments ra "
                     "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
                     "JOIN agents a ON a.id = ra.agent_id AND a.workshop_id = c.workshop_id "
@@ -10185,7 +10189,8 @@ def _internal_api_authority_status(db_path: Path) -> str:
                     "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
                     "JOIN workshop_memberships wm ON wm.principal_id = p.id "
                     "AND wm.workshop_id = c.workshop_id "
-                    "GROUP BY ra.runtime_profile_id HAVING COUNT(DISTINCT cm.principal_id) = 1"
+                    "GROUP BY ra.runtime_profile_id, ra.channel_id, ra.agent_id "
+                    "HAVING COUNT(DISTINCT cm.principal_id) = 1"
                     ")"
                 ).fetchone()[0]
             )
@@ -10206,10 +10211,10 @@ def _internal_api_authority_status(db_path: Path) -> str:
         "artifacts",
         "delivery_outbox",
     }
-    status = "active" if profiles > 0 and profiles == contexts and publication_ready else "INCOMPLETE"
+    status = "active" if profiles > 0 and contexts >= profiles and publication_ready else "INCOMPLETE"
     return (
         f"{prefix} {status}; profiles={profiles}, canonical contexts={contexts}, "
-        f"missing={profiles - contexts}; caller identity selectors=disabled, "
+        f"missing={max(0, profiles - contexts)}; caller identity selectors=disabled, "
         f"compatibility adapter=retired, proactive publication="
         f"{'canonical/outbox' if publication_ready else 'unavailable'}"
     )

--- a/src/kai/internal_api_auth.py
+++ b/src/kai/internal_api_auth.py
@@ -123,6 +123,13 @@ class InternalAPIAuth:
         """Return a send-message-only credential for a notification agent."""
         return self._credential_for(self._principal(context, _NOTIFICATION_SCOPES))
 
+    def revoke_agent_context(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        """Revoke the process-local credential for one retired execution lane."""
+        principal = self._agent_principal(context)
+        credential = self._credentials_by_principal.pop(principal, None)
+        if credential is not None:
+            self._principals_by_credential.pop(credential, None)
+
     def authenticate(self, credential: str) -> InternalAPIPrincipal | None:
         """Resolve a credential to its server-owned principal, if valid.
 

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -44,6 +44,7 @@ from kai.config import (
 from kai.goose import GooseBackend
 from kai.internal_api_auth import InternalAPIAuth
 from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workspace_utils import is_workspace_allowed
 
 if TYPE_CHECKING:
@@ -53,13 +54,13 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-type RuntimeSelector = int | RuntimeProfileId
-type RuntimePoolKey = int | RuntimeProfileId
+type RuntimeSelector = int | RuntimeProfileId | WorkshopInternalAPIExecutionContext
+type RuntimePoolKey = int | RuntimeProfileId | WorkshopInternalAPIExecutionContext
 
 
 @dataclass(frozen=True, slots=True)
 class _RoutedRuntimeKey:
-    runtime_profile_id: RuntimeProfileId
+    runtime_key: RuntimePoolKey
     backend_option_id: str
 
 
@@ -292,6 +293,7 @@ class SubprocessPool:
                     profile.profile_id: internal_api_contexts.for_runtime_profile(profile.profile_id)
                     for profile in runtime_profiles.profiles
                 }
+                contexts_by_runtime.update({context: context for context in contexts})
         self._internal_api_contexts = internal_api_contexts
         self._protected_internal_api_contexts = config.protected_install
         self._contexts_by_runtime = contexts_by_runtime
@@ -355,6 +357,29 @@ class SubprocessPool:
                     )
                     selected = ""
             self._selected_backends[profile.profile_id] = selected or profile.default_backend_option.option_id
+        for context in tuple(self._contexts_by_runtime.values()):
+            if not isinstance(context, WorkshopInternalAPIExecutionContext):
+                continue
+            self._register_lane_state(context)
+            namespace = self._canonical_namespace(context)
+            assert namespace is not None
+            selected = (
+                (
+                    await sessions.read_canonical_execution_settings(
+                        Path(self._config.session_db_path),
+                        namespace,
+                    )
+                )
+                .get("backend", "")
+                .strip()
+            )
+            profile = self._runtime_profiles.resolve(context.runtime_profile_id)
+            if selected:
+                try:
+                    selected = profile.backend_option(selected).option_id
+                except WorkshopRuntimeProfileError:
+                    selected = ""
+            self._selected_backends[context] = selected or profile.default_backend_option.option_id
 
     def _backend_option(self, runtime: RuntimeSelector):
         runtime_key, _legacy_key, profile = self._resolve_runtime(runtime)
@@ -376,6 +401,15 @@ class SubprocessPool:
 
         if isinstance(runtime, bool):
             raise TypeError("Runtime selector must be a runtime profile ID or integer")
+        if isinstance(runtime, WorkshopInternalAPIExecutionContext):
+            if self._runtime_profiles is None:
+                raise RuntimeError("Canonical runtime lane requires protected runtime policy")
+            profile = self._runtime_profiles.resolve(runtime.runtime_profile_id)
+            primary = self._contexts_by_runtime.get(profile.profile_id)
+            if primary is None or primary.principal_id != runtime.principal_id:
+                raise RuntimeError("Canonical runtime lane does not own the protected profile")
+            self._register_lane_state(runtime)
+            return runtime, self._runtime_profiles.legacy_runtime_key(profile.profile_id), profile
         if isinstance(runtime, RuntimeProfileId):
             if self._runtime_profiles is None:
                 raise RuntimeError("Runtime profile selector requires protected runtime policy")
@@ -393,6 +427,49 @@ class SubprocessPool:
                 raise
             return runtime, runtime, None
         return profile.profile_id, runtime, profile
+
+    def _register_lane_state(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        """Register one isolated lane while inheriting only protected policy."""
+        existing = self._contexts_by_runtime.get(context)
+        if existing is not None and existing != context:
+            raise RuntimeError("Canonical runtime lane conflicts with existing context")
+        self._contexts_by_runtime[context] = context
+        profile = self._runtime_profiles.resolve(context.runtime_profile_id) if self._runtime_profiles else None
+        if profile is not None:
+            self._services_info_by_runtime[context] = list(self._services_info_by_runtime.get(profile.profile_id, []))
+            primary_backend = self._selected_backends.get(
+                profile.profile_id,
+                profile.default_backend_option.option_id,
+            )
+            self._selected_backends.setdefault(context, primary_backend)
+
+    def register_canonical_lane(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        """Make a newly enabled principal-agent lane immediately executable."""
+        self._resolve_runtime(context)
+        self._internal_api_auth.agent_credential_for(context)
+
+    async def rebind_canonical_lane(
+        self,
+        prior: WorkshopInternalAPIExecutionContext,
+        replacement: WorkshopInternalAPIExecutionContext,
+    ) -> None:
+        """Move an idle lane to another owned profile without touching siblings."""
+        # Revoke before process shutdown so even a stubborn child loses its
+        # authority as soon as the canonical lane is rebound.
+        self._internal_api_auth.revoke_agent_context(prior)
+        await self.force_kill(prior)
+        self._contexts_by_runtime.pop(prior, None)
+        self._services_info_by_runtime.pop(prior, None)
+        self._selected_backends.pop(prior, None)
+        self._backend_transition_locks.pop(prior, None)
+        self.register_canonical_lane(replacement)
+
+    async def suspend_canonical_lane(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        """Stop a disabled lane and revoke its current process credential."""
+        # Authorization changes immediately; process cleanup follows and
+        # cannot extend a disabled lane's access if termination is delayed.
+        self._internal_api_auth.revoke_agent_context(context)
+        await self.force_kill(context)
 
     def _protected_profile(self, runtime: RuntimeSelector):
         """Resolve protected policy while preserving the negative-group bridge."""
@@ -420,7 +497,11 @@ class SubprocessPool:
             channel_id=context.channel_id,
             agent_id=context.agent_id,
             runtime_profile_id=context.runtime_profile_id,
-            legacy_runtime_key=self._runtime_profiles.legacy_runtime_key(profile.profile_id),
+            legacy_runtime_key=(
+                self._runtime_profiles.legacy_runtime_key(profile.profile_id)
+                if runtime_key == profile.profile_id
+                else None
+            ),
         )
 
     def get_runtime_profile(self, runtime: RuntimeSelector) -> ProtectedRuntimeProfile | None:
@@ -519,7 +600,8 @@ class SubprocessPool:
                         f"{profile.home_workspace}. Mount or create it, or update the protected runtime profile."
                     )
                 return profile.home_workspace
-            context = self._contexts_by_runtime.get(profile.profile_id)
+            runtime_key, _, _ = self._resolve_runtime(runtime)
+            context = self._contexts_by_runtime.get(runtime_key) or self._contexts_by_runtime.get(profile.profile_id)
             if context is None:
                 raise RuntimeError("Protected runtime has no canonical home owner")
             path = self._config.session_db_path.parent / "home" / str(context.principal_id)
@@ -890,13 +972,13 @@ class SubprocessPool:
 
     async def prepare_routed_execution(
         self,
-        runtime: RuntimeProfileId,
+        runtime: RuntimeSelector,
         backend_option_id: str,
         model: str,
     ) -> PreparedBackendExecution:
         """Bind an alternate authorized option without changing the selected route."""
         runtime_key, _, profile = self._resolve_runtime(runtime)
-        if profile is None or not isinstance(runtime_key, RuntimeProfileId):
+        if profile is None or isinstance(runtime_key, int):
             raise RuntimeError("Explicit task routing requires a protected runtime profile")
         option = profile.backend_option(backend_option_id)
         selected = self._backend_option(runtime)
@@ -1319,7 +1401,7 @@ class SubprocessPool:
 
     def _profile_has_in_flight(self, runtime_key: RuntimePoolKey) -> bool:
         return any(
-            key == runtime_key or (isinstance(key, _RoutedRuntimeKey) and key.runtime_profile_id == runtime_key)
+            key == runtime_key or (isinstance(key, _RoutedRuntimeKey) and key.runtime_key == runtime_key)
             for key in self._in_flight
         )
 

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -62,6 +62,7 @@ from kai.config import (
 )
 from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, InternalAPIScope
 from kai.job_types import CANONICAL_JOB_TYPES, normalize_job_type
+from kai.workshop.agent_enablement import WorkshopAgentEnablementService
 from kai.workshop.appearance_preferences import WorkshopAppearancePreferenceService
 from kai.workshop.artifacts import MAX_ARTIFACT_BYTES, WorkshopArtifactService
 from kai.workshop.client_api import (
@@ -89,6 +90,7 @@ from kai.workshop.integration_notifications import (
     IntegrationNotification,
     WorkshopIntegrationNotificationService,
 )
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
 from kai.workshop.notification_preferences import WorkshopNotificationPreferenceService
 from kai.workshop.preferences import WorkshopPreferenceService
@@ -264,6 +266,18 @@ def _reject_internal_identity_selectors(payload: dict) -> None:
 
 def _scheduled_job_authority(principal: InternalAPIPrincipal) -> WorkshopScheduledJobAuthority:
     return WorkshopScheduledJobAuthority(
+        principal.principal_id,
+        principal.channel_id,
+        principal.agent_id,
+        principal.runtime_profile_id,
+    )
+
+
+def _internal_execution_context(
+    principal: InternalAPIPrincipal,
+) -> WorkshopInternalAPIExecutionContext:
+    """Recover the exact canonical lane already bound to one credential."""
+    return WorkshopInternalAPIExecutionContext(
         principal.principal_id,
         principal.channel_id,
         principal.agent_id,
@@ -1231,7 +1245,9 @@ async def _handle_send_file(request: web.Request, principal: InternalAPIPrincipa
     if core_host is None:
         return web.json_response({"error": "No workspace configured"}, status=403)
     try:
-        workspace = str(await core_host.services.runtime_pool.get_effective_workspace(principal.runtime_profile_id))
+        workspace = str(
+            await core_host.services.runtime_pool.get_effective_workspace(_internal_execution_context(principal))
+        )
     except Exception:
         log.exception("Internal file workspace resolution failed")
         return web.json_response({"error": "No workspace configured"}, status=403)
@@ -1465,7 +1481,7 @@ async def _handle_memory_add(request: web.Request, principal: InternalAPIPrincip
     try:
         api_config: Config = request.app[CONFIG_KEY]
         workspace = await request.app[CORE_HOST_KEY].services.runtime_pool.get_effective_workspace(
-            principal.runtime_profile_id
+            _internal_execution_context(principal)
         )
         active_project = detect_active_memory_project(
             workspace,
@@ -1796,6 +1812,7 @@ async def _register_workshop_client_api(
     notification_preferences: WorkshopNotificationPreferenceService | None = None,
     client_preferences: WorkshopClientPreferenceService | None = None,
     appearance_preferences: WorkshopAppearancePreferenceService | None = None,
+    agent_enablement: WorkshopAgentEnablementService | None = None,
 ) -> Callable[[web.Application], None]:
     """Register the client API against the core-owned canonical store.
 
@@ -1837,6 +1854,7 @@ async def _register_workshop_client_api(
             notification_preferences=notification_preferences,
             client_preferences=client_preferences,
             appearance_preferences=appearance_preferences,
+            agent_enablement=agent_enablement,
         )
         if command_submitter is not None:
             register_workshop_command_routes(
@@ -1922,6 +1940,7 @@ async def start(
             notification_preferences=getattr(core_services, "notification_preferences", None),
             client_preferences=getattr(core_services, "client_preferences", None),
             appearance_preferences=getattr(core_services, "appearance_preferences", None),
+            agent_enablement=getattr(core_services, "agent_enablement", None),
         )
 
     _runner = web.AppRunner(

--- a/src/kai/workshop/agent_enablement.py
+++ b/src/kai/workshop/agent_enablement.py
@@ -1,0 +1,629 @@
+"""Principal-owned activation of reusable Workshop agent definitions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentEnablementId,
+    AgentId,
+    ChannelAgentId,
+    ChannelId,
+    ChannelMembershipId,
+    EventEnvelope,
+    PrincipalId,
+    RuntimeAssignmentId,
+    RuntimeProfileId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.execution_state import (
+    WorkshopExecutionStateNamespace,
+    WorkshopExecutionStateRegistry,
+)
+from kai.workshop.internal_api_contexts import (
+    WorkshopInternalAPIContextRegistry,
+    WorkshopInternalAPIExecutionContext,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+from kai.workshop.store import IdempotencyConflictError, WorkshopEventStore
+
+_KEY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+
+
+class WorkshopAgentEnablementError(RuntimeError):
+    """A principal-agent enablement operation failed."""
+
+
+class WorkshopAgentEnablementAccessDenied(WorkshopAgentEnablementError):
+    """The acting principal does not own the requested authority."""
+
+
+class WorkshopAgentEnablementConflict(WorkshopAgentEnablementError):
+    """The requested transition conflicts with canonical state."""
+
+
+class WorkshopAgentEnablementValidationError(WorkshopAgentEnablementError):
+    """The requested transition is malformed."""
+
+
+class WorkshopAgentEnablementStorageError(WorkshopAgentEnablementError):
+    """The requested transition could not be persisted."""
+
+
+@dataclass(frozen=True, slots=True)
+class EligibleAgentRuntime:
+    runtime_profile_id: RuntimeProfileId
+    display_name: str
+    backend_options: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PrincipalAgentEnablement:
+    enablement_id: AgentEnablementId | None
+    definition_id: AgentDefinitionId
+    agent_id: AgentId
+    handle: str
+    display_name: str
+    lifecycle_state: str
+    direct_channel_id: ChannelId | None
+    runtime_profile_id: RuntimeProfileId | None
+    state_version: int | None
+    eligible_runtimes: tuple[EligibleAgentRuntime, ...]
+
+
+class WorkshopAgentEnablementService:
+    """Enable an active agent in an isolated direct lane owned by one human."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        runtime_profiles: WorkshopRuntimeProfileRegistry,
+        execution_state: WorkshopExecutionStateRegistry,
+        internal_api_contexts: WorkshopInternalAPIContextRegistry,
+        runtime_pool: WorkshopRuntimePool,
+    ) -> None:
+        self._store = store
+        self._runtime_profiles = runtime_profiles
+        self._execution_state = execution_state
+        self._internal_api_contexts = internal_api_contexts
+        self._runtime_pool = runtime_pool
+
+    async def list_for_principal(
+        self,
+        principal_id: PrincipalId,
+    ) -> tuple[PrincipalAgentEnablement, ...]:
+        workshop_id = await self._workshop_for(principal_id)
+        eligible = await self._eligible_runtimes(principal_id)
+        async with self._store.connection.execute(
+            "SELECT d.id FROM agent_definitions d WHERE d.workshop_id = ? "
+            "AND d.lifecycle_state = 'active' ORDER BY d.handle",
+            (workshop_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        return tuple(
+            [
+                await self._snapshot(
+                    principal_id,
+                    AgentDefinitionId(str(row[0])),
+                    eligible=eligible,
+                )
+                for row in rows
+            ]
+        )
+
+    async def inspect(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+    ) -> PrincipalAgentEnablement:
+        await self._workshop_for(principal_id)
+        return await self._snapshot(principal_id, definition_id)
+
+    async def enable(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+        runtime_profile_id: RuntimeProfileId,
+        *,
+        idempotency_key: object,
+        expected_version: object | None = None,
+    ) -> PrincipalAgentEnablement:
+        key = self._key(idempotency_key)
+        workshop_id = await self._workshop_for(principal_id)
+        eligible = await self._eligible_runtimes(principal_id)
+        if runtime_profile_id not in {item.runtime_profile_id for item in eligible}:
+            raise WorkshopAgentEnablementAccessDenied("Runtime profile is not owned by this principal")
+        fingerprint = self._fingerprint(
+            "enable",
+            definition_id,
+            runtime_profile_id=runtime_profile_id,
+            expected_version=expected_version,
+        )
+        operation_key = self._operation_key(workshop_id, principal_id, key)
+        connection = self._store.connection
+        prior_context: WorkshopInternalAPIExecutionContext | None = None
+        new_context: WorkshopInternalAPIExecutionContext | None = None
+        created = False
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            replay = await self._replayed(operation_key, fingerprint, principal_id, definition_id)
+            if replay is not None:
+                await connection.commit()
+                return replay
+            definition = await self._active_definition(workshop_id, definition_id)
+            current = await self._snapshot(principal_id, definition_id, eligible=eligible)
+            self._check_version(current, expected_version)
+            now = datetime.now(UTC)
+            metadata = {
+                "source": "workshop_client",
+                "operation": "enable",
+                "operation_hash": fingerprint,
+                "definition_id": str(definition_id),
+            }
+            if current.enablement_id is None:
+                created = True
+                enablement_id = AgentEnablementId.derived(definition_id, f"principal:{principal_id}")
+                channel_id = ChannelId.derived(enablement_id, "direct-channel")
+                events = self._creation_events(
+                    workshop_id,
+                    principal_id,
+                    definition_id,
+                    definition,
+                    enablement_id,
+                    channel_id,
+                    runtime_profile_id,
+                    now,
+                    operation_key,
+                    metadata,
+                )
+            else:
+                enablement_id = current.enablement_id
+                assert current.direct_channel_id is not None
+                channel_id = current.direct_channel_id
+                if current.lifecycle_state == "enabled" and current.runtime_profile_id == runtime_profile_id:
+                    raise WorkshopAgentEnablementConflict("Agent is already enabled with this runtime")
+                events: list[EventEnvelope] = []
+                if current.runtime_profile_id != runtime_profile_id:
+                    assert current.runtime_profile_id is not None
+                    assignment_id = RuntimeAssignmentId.derived(channel_id, f"runtime-profile:{definition[0]}")
+                    events.extend(
+                        (
+                            EventEnvelope.create(
+                                event_type=WorkshopEventType.RUNTIME_PROFILE_REASSIGNED,
+                                event_version=1,
+                                workshop_id=workshop_id,
+                                aggregate_type="runtime_assignment",
+                                aggregate_id=assignment_id,
+                                actor_principal_id=principal_id,
+                                occurred_at=now,
+                                idempotency_key=f"{operation_key}:assignment",
+                                payload={
+                                    "channel_id": channel_id,
+                                    "agent_id": definition[0],
+                                    "runtime_profile_id": runtime_profile_id,
+                                },
+                                metadata=metadata,
+                            ),
+                            EventEnvelope.create(
+                                event_type=WorkshopEventType.PRINCIPAL_AGENT_RUNTIME_CHANGED,
+                                event_version=1,
+                                workshop_id=workshop_id,
+                                aggregate_type="agent_enablement",
+                                aggregate_id=enablement_id,
+                                actor_principal_id=principal_id,
+                                occurred_at=now,
+                                idempotency_key=f"{operation_key}:runtime",
+                                payload={"runtime_profile_id": runtime_profile_id},
+                                metadata=metadata,
+                            ),
+                        )
+                    )
+                    prior_context = WorkshopInternalAPIExecutionContext(
+                        principal_id,
+                        channel_id,
+                        definition[0],
+                        current.runtime_profile_id,
+                    )
+                events.append(
+                    self._enablement_event(
+                        workshop_id,
+                        principal_id,
+                        definition_id,
+                        definition[0],
+                        enablement_id,
+                        channel_id,
+                        runtime_profile_id,
+                        now,
+                        operation_key,
+                        metadata,
+                    )
+                )
+            for event in events:
+                await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            result = await self._snapshot(principal_id, definition_id, eligible=eligible)
+            await connection.commit()
+            new_context = WorkshopInternalAPIExecutionContext(
+                principal_id,
+                channel_id,
+                definition[0],
+                runtime_profile_id,
+            )
+        except WorkshopAgentEnablementError:
+            await connection.rollback()
+            raise
+        except IdempotencyConflictError as exc:
+            await connection.rollback()
+            raise WorkshopAgentEnablementConflict("Idempotency key conflicts with another request") from exc
+        except Exception as exc:
+            await connection.rollback()
+            raise WorkshopAgentEnablementStorageError("Agent enablement could not be persisted") from exc
+
+        assert new_context is not None
+        namespace = WorkshopExecutionStateNamespace(
+            new_context.principal_id,
+            new_context.channel_id,
+            new_context.agent_id,
+            new_context.runtime_profile_id,
+            None,
+        )
+        if prior_context is not None:
+            prior_namespace = self._execution_state.maybe_for_principal_channel(
+                principal_id,
+                channel_id,
+            )
+            assert prior_namespace is not None
+            await self._runtime_pool.rebind_canonical_lane(prior_context, new_context)
+            self._execution_state.replace_lane(prior_namespace, namespace)
+            self._internal_api_contexts.replace_context(prior_context, new_context)
+        elif created:
+            self._execution_state.register_lane(namespace)
+            self._internal_api_contexts.register_context(new_context)
+            self._runtime_pool.register_canonical_lane(new_context)
+        else:
+            self._runtime_pool.register_canonical_lane(new_context)
+        return result
+
+    async def disable(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+        *,
+        idempotency_key: object,
+        expected_version: object,
+    ) -> PrincipalAgentEnablement:
+        key = self._key(idempotency_key)
+        workshop_id = await self._workshop_for(principal_id)
+        fingerprint = self._fingerprint("disable", definition_id, expected_version=expected_version)
+        operation_key = self._operation_key(workshop_id, principal_id, key)
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            replay = await self._replayed(operation_key, fingerprint, principal_id, definition_id)
+            if replay is not None:
+                await connection.commit()
+                return replay
+            current = await self._snapshot(principal_id, definition_id)
+            self._check_version(current, expected_version)
+            if current.enablement_id is None or current.lifecycle_state != "enabled":
+                raise WorkshopAgentEnablementConflict("Agent is not enabled")
+            event = EventEnvelope.create(
+                event_type=WorkshopEventType.PRINCIPAL_AGENT_DISABLED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="agent_enablement",
+                aggregate_id=current.enablement_id,
+                actor_principal_id=principal_id,
+                occurred_at=datetime.now(UTC),
+                idempotency_key=operation_key,
+                payload={},
+                metadata={
+                    "source": "workshop_client",
+                    "operation": "disable",
+                    "operation_hash": fingerprint,
+                    "definition_id": str(definition_id),
+                },
+            )
+            await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            result = await self._snapshot(principal_id, definition_id)
+            await connection.commit()
+        except WorkshopAgentEnablementError:
+            await connection.rollback()
+            raise
+        except IdempotencyConflictError as exc:
+            await connection.rollback()
+            raise WorkshopAgentEnablementConflict("Idempotency key conflicts with another request") from exc
+        except Exception as exc:
+            await connection.rollback()
+            raise WorkshopAgentEnablementStorageError("Agent disablement could not be persisted") from exc
+        assert current.direct_channel_id is not None
+        assert current.runtime_profile_id is not None
+        await self._runtime_pool.suspend_canonical_lane(
+            WorkshopInternalAPIExecutionContext(
+                principal_id,
+                current.direct_channel_id,
+                current.agent_id,
+                current.runtime_profile_id,
+            )
+        )
+        return result
+
+    async def _workshop_for(self, principal_id: PrincipalId) -> WorkshopId:
+        if not isinstance(principal_id, PrincipalId):
+            raise WorkshopAgentEnablementAccessDenied("Access denied")
+        async with self._store.connection.execute(
+            "SELECT wm.workshop_id FROM workshop_memberships wm JOIN principals p "
+            "ON p.id = wm.principal_id AND p.kind = 'human' WHERE wm.principal_id = ?",
+            (principal_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        if len(rows) != 1:
+            raise WorkshopAgentEnablementAccessDenied("Access denied")
+        return WorkshopId(str(rows[0][0]))
+
+    async def _eligible_runtimes(
+        self,
+        principal_id: PrincipalId,
+    ) -> tuple[EligibleAgentRuntime, ...]:
+        async with self._store.connection.execute(
+            "SELECT ra.runtime_profile_id FROM channel_agent_runtime_assignments ra "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
+            "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+            "GROUP BY ra.runtime_profile_id HAVING COUNT(DISTINCT cm.principal_id) = 1 "
+            "AND MIN(cm.principal_id) = ? ORDER BY ra.runtime_profile_id",
+            (principal_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        result: list[EligibleAgentRuntime] = []
+        for row in rows:
+            try:
+                profile = self._runtime_profiles.resolve(RuntimeProfileId(str(row[0])))
+            except Exception:
+                continue
+            result.append(
+                EligibleAgentRuntime(
+                    profile.profile_id,
+                    profile.display_name,
+                    tuple(option.option_id for option in profile.backend_options),
+                )
+            )
+        return tuple(result)
+
+    async def _active_definition(
+        self,
+        workshop_id: WorkshopId,
+        definition_id: AgentDefinitionId,
+    ) -> tuple[AgentId, PrincipalId, str, str]:
+        async with self._store.connection.execute(
+            "SELECT d.agent_id, a.principal_id, d.handle, d.display_name "
+            "FROM agent_definitions d JOIN agents a ON a.id = d.agent_id "
+            "WHERE d.id = ? AND d.workshop_id = ? AND d.lifecycle_state = 'active' "
+            "AND d.active_revision_id IS NOT NULL",
+            (definition_id, workshop_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise WorkshopAgentEnablementAccessDenied("Active agent definition is unavailable")
+        return AgentId(str(row[0])), PrincipalId(str(row[1])), str(row[2]), str(row[3])
+
+    async def _snapshot(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+        *,
+        eligible: tuple[EligibleAgentRuntime, ...] | None = None,
+    ) -> PrincipalAgentEnablement:
+        workshop_id = await self._workshop_for(principal_id)
+        async with self._store.connection.execute(
+            "SELECT d.agent_id, d.handle, d.display_name, d.lifecycle_state, e.id, "
+            "e.direct_channel_id, e.runtime_profile_id, e.lifecycle_state, e.last_event_position "
+            "FROM agent_definitions d LEFT JOIN principal_agent_enablements e "
+            "ON e.agent_definition_id = d.id AND e.principal_id = ? "
+            "WHERE d.id = ? AND d.workshop_id = ?",
+            (principal_id, definition_id, workshop_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None or str(row[3]) != "active":
+            raise WorkshopAgentEnablementAccessDenied("Active agent definition is unavailable")
+        return PrincipalAgentEnablement(
+            AgentEnablementId(str(row[4])) if row[4] is not None else None,
+            definition_id,
+            AgentId(str(row[0])),
+            str(row[1]),
+            str(row[2]),
+            str(row[7]) if row[7] is not None else "available",
+            ChannelId(str(row[5])) if row[5] is not None else None,
+            RuntimeProfileId(str(row[6])) if row[6] is not None else None,
+            int(row[8]) if row[8] is not None else None,
+            eligible if eligible is not None else await self._eligible_runtimes(principal_id),
+        )
+
+    def _creation_events(
+        self,
+        workshop_id: WorkshopId,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+        definition: tuple[AgentId, PrincipalId, str, str],
+        enablement_id: AgentEnablementId,
+        channel_id: ChannelId,
+        runtime_profile_id: RuntimeProfileId,
+        now: datetime,
+        operation_key: str,
+        metadata: dict[str, str],
+    ) -> list[EventEnvelope]:
+        agent_id, agent_principal_id, _handle, display_name = definition
+        assignment_id = RuntimeAssignmentId.derived(channel_id, f"runtime-profile:{agent_id}")
+        return [
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_CREATED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="channel",
+                aggregate_id=channel_id,
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=f"{operation_key}:channel",
+                payload={"kind": "direct", "name": display_name},
+                metadata=metadata,
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="channel_membership",
+                aggregate_id=ChannelMembershipId.derived(channel_id, f"human:{principal_id}"),
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=f"{operation_key}:human",
+                payload={"channel_id": channel_id, "principal_id": principal_id, "role": "owner"},
+                metadata=metadata,
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="channel_membership",
+                aggregate_id=ChannelMembershipId.derived(channel_id, f"agent:{agent_principal_id}"),
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=f"{operation_key}:agent-member",
+                payload={
+                    "channel_id": channel_id,
+                    "principal_id": agent_principal_id,
+                    "role": "participant",
+                },
+                metadata=metadata,
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="channel_agent",
+                aggregate_id=ChannelAgentId.derived(channel_id, f"agent:{agent_id}"),
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=f"{operation_key}:attachment",
+                payload={"channel_id": channel_id, "agent_id": agent_id},
+                metadata=metadata,
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="runtime_assignment",
+                aggregate_id=assignment_id,
+                actor_principal_id=principal_id,
+                occurred_at=now,
+                idempotency_key=f"{operation_key}:assignment",
+                payload={
+                    "channel_id": channel_id,
+                    "agent_id": agent_id,
+                    "runtime_profile_id": runtime_profile_id,
+                },
+                metadata=metadata,
+            ),
+            self._enablement_event(
+                workshop_id,
+                principal_id,
+                definition_id,
+                agent_id,
+                enablement_id,
+                channel_id,
+                runtime_profile_id,
+                now,
+                operation_key,
+                metadata,
+            ),
+        ]
+
+    @staticmethod
+    def _enablement_event(
+        workshop_id: WorkshopId,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+        agent_id: AgentId,
+        enablement_id: AgentEnablementId,
+        channel_id: ChannelId,
+        runtime_profile_id: RuntimeProfileId,
+        now: datetime,
+        operation_key: str,
+        metadata: dict[str, str],
+    ) -> EventEnvelope:
+        return EventEnvelope.create(
+            event_type=WorkshopEventType.PRINCIPAL_AGENT_ENABLED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="agent_enablement",
+            aggregate_id=enablement_id,
+            actor_principal_id=principal_id,
+            occurred_at=now,
+            idempotency_key=operation_key,
+            payload={
+                "principal_id": principal_id,
+                "agent_definition_id": definition_id,
+                "agent_id": agent_id,
+                "direct_channel_id": channel_id,
+                "runtime_profile_id": runtime_profile_id,
+            },
+            metadata=metadata,
+        )
+
+    async def _replayed(
+        self,
+        operation_key: str,
+        fingerprint: str,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+    ) -> PrincipalAgentEnablement | None:
+        event = await self._store.event_by_idempotency_key(operation_key)
+        if event is None:
+            return None
+        if event.envelope.metadata.get("operation_hash") != fingerprint or event.envelope.metadata.get(
+            "definition_id"
+        ) != str(definition_id):
+            raise WorkshopAgentEnablementConflict("Idempotency key conflicts with another request")
+        return await self._snapshot(principal_id, definition_id)
+
+    @staticmethod
+    def _check_version(snapshot: PrincipalAgentEnablement, expected: object | None) -> None:
+        if snapshot.enablement_id is None:
+            if expected is not None:
+                raise WorkshopAgentEnablementConflict("Agent enablement version changed")
+            return
+        if not isinstance(expected, int) or isinstance(expected, bool) or expected != snapshot.state_version:
+            raise WorkshopAgentEnablementConflict("Agent enablement version changed")
+
+    @staticmethod
+    def _key(value: object) -> str:
+        if not isinstance(value, str) or not _KEY_PATTERN.fullmatch(value):
+            raise WorkshopAgentEnablementValidationError("idempotency_key is invalid")
+        return value
+
+    @staticmethod
+    def _operation_key(workshop_id: WorkshopId, principal_id: PrincipalId, key: str) -> str:
+        digest = hashlib.sha256(f"{workshop_id}:{principal_id}:{key}".encode()).hexdigest()
+        return f"agent-enablement:{digest}"
+
+    @staticmethod
+    def _fingerprint(
+        operation: str,
+        definition_id: AgentDefinitionId,
+        **payload: object,
+    ) -> str:
+        encoded = json.dumps(
+            {"operation": operation, "definition_id": str(definition_id), **payload},
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(encoded.encode()).hexdigest()

--- a/src/kai/workshop/authorization.py
+++ b/src/kai/workshop/authorization.py
@@ -39,8 +39,11 @@ class CanonicalChannelAuthorizer:
             "JOIN channel_agents ca ON ca.channel_id = c.id "
             "JOIN channel_agent_runtime_assignments cara "
             "ON cara.channel_id = ca.channel_id AND cara.agent_id = ca.agent_id "
+            "LEFT JOIN principal_agent_enablements pae ON pae.direct_channel_id = c.id "
+            "AND pae.principal_id = cm.principal_id AND pae.agent_id = ca.agent_id "
             "WHERE cm.principal_id = ? AND cm.channel_id = ? "
             "AND c.kind IN ('direct', 'group') "
+            "AND (c.kind = 'group' OR pae.lifecycle_state = 'enabled') "
             "GROUP BY c.id HAVING COUNT(ca.id) = 1 LIMIT 1",
             (principal_id, channel_id),
         ) as cursor:

--- a/src/kai/workshop/bootstrap.py
+++ b/src/kai/workshop/bootstrap.py
@@ -12,6 +12,7 @@ from typing import Any
 from kai.workshop.domain import (
     AgentDefinitionId,
     AgentDefinitionRevisionId,
+    AgentEnablementId,
     AgentId,
     ChannelAgentId,
     ChannelBindingId,
@@ -248,11 +249,15 @@ async def bootstrap_default_workshop(
         "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'agent_definitions'"
     ) as cursor:
         definitions_supported = await cursor.fetchone() is not None
+    async with store.connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'principal_agent_enablements'"
+    ) as cursor:
+        enablements_supported = await cursor.fetchone() is not None
+    definition_id = AgentDefinitionId.derived(agent_id, "definition")
     # Historical-schema migration tests exercise bootstrap at the simulated
     # old version. The current installer opens/migrates to the latest schema
     # before bootstrap, so production always takes this branch.
     if definitions_supported:
-        definition_id = AgentDefinitionId.derived(agent_id, "definition")
         revision_id = AgentDefinitionRevisionId.derived(definition_id, "revision:1")
         await ensure(
             idempotency_key=_idempotency_key("agent-definition", "kai"),
@@ -420,6 +425,24 @@ async def bootstrap_default_workshop(
                     payload={
                         "channel_id": channel_id,
                         "agent_id": agent_id,
+                        "runtime_profile_id": human.runtime_profile_id,
+                    },
+                )
+            if definitions_supported and enablements_supported:
+                enablement_id = AgentEnablementId.derived(
+                    definition_id,
+                    f"principal:{principal_id}",
+                )
+                await ensure(
+                    idempotency_key=_idempotency_key("agent-enablement", channel_token),
+                    event_type=WorkshopEventType.PRINCIPAL_AGENT_ENABLED,
+                    aggregate_type="agent_enablement",
+                    aggregate_id=enablement_id,
+                    payload={
+                        "principal_id": principal_id,
+                        "agent_definition_id": definition_id,
+                        "agent_id": agent_id,
+                        "direct_channel_id": channel_id,
                         "runtime_profile_id": human.runtime_profile_id,
                     },
                 )

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -19,6 +19,15 @@ from urllib.parse import quote
 
 from aiohttp import BodyPartReader, web
 
+from kai.workshop.agent_enablement import (
+    PrincipalAgentEnablement,
+    WorkshopAgentEnablementAccessDenied,
+    WorkshopAgentEnablementConflict,
+    WorkshopAgentEnablementError,
+    WorkshopAgentEnablementService,
+    WorkshopAgentEnablementStorageError,
+    WorkshopAgentEnablementValidationError,
+)
 from kai.workshop.agent_lifecycle import (
     AgentDefinitionSnapshot,
     WorkshopAgentLifecycleAccessDenied,
@@ -90,6 +99,7 @@ from kai.workshop.domain import (
     MessageReactionSummary,
     PrincipalId,
     RunId,
+    RuntimeProfileId,
     WorkshopEventType,
 )
 from kai.workshop.execution_coordinator import CanonicalCancellationDisposition
@@ -218,6 +228,10 @@ _AGENT_DEFINITION_PATH = "/v1/client/agents/{definition_id}"
 _AGENT_REVISIONS_PATH = "/v1/client/agents/{definition_id}/revisions"
 _AGENT_ACTIVATION_PATH = "/v1/client/agents/{definition_id}/activate"
 _AGENT_ARCHIVAL_PATH = "/v1/client/agents/{definition_id}/archive"
+_AGENT_ENABLEMENTS_PATH = "/v1/client/agent-enablement"
+_AGENT_ENABLEMENT_PATH = "/v1/client/agents/{definition_id}/enablement"
+_AGENT_ENABLE_PATH = "/v1/client/agents/{definition_id}/enable"
+_AGENT_DISABLE_PATH = "/v1/client/agents/{definition_id}/disable"
 _ENROLLMENT_REDEMPTION_PATH = "/v1/client/enrollment/redeem"
 _COMMAND_SUBMISSION_PATH = "/v1/channels/{channel_id}/commands"
 _AGENT_DISMISSAL_PATH = "/v1/channels/{channel_id}/agents/{agent_id}/dismiss"
@@ -660,6 +674,28 @@ def _serialize_agent_definition(snapshot: AgentDefinitionSnapshot) -> dict[str, 
                 "event_position": revision.event_position,
             }
             for revision in snapshot.revisions
+        ],
+    }
+
+
+def _serialize_agent_enablement(snapshot: PrincipalAgentEnablement) -> dict[str, object]:
+    return {
+        "enablement_id": str(snapshot.enablement_id) if snapshot.enablement_id is not None else None,
+        "definition_id": str(snapshot.definition_id),
+        "agent_id": str(snapshot.agent_id),
+        "handle": snapshot.handle,
+        "display_name": snapshot.display_name,
+        "lifecycle_state": snapshot.lifecycle_state,
+        "direct_channel_id": (str(snapshot.direct_channel_id) if snapshot.direct_channel_id is not None else None),
+        "runtime_profile_id": (str(snapshot.runtime_profile_id) if snapshot.runtime_profile_id is not None else None),
+        "state_version": snapshot.state_version,
+        "eligible_runtimes": [
+            {
+                "runtime_profile_id": str(runtime.runtime_profile_id),
+                "display_name": runtime.display_name,
+                "backend_options": list(runtime.backend_options),
+            }
+            for runtime in snapshot.eligible_runtimes
         ],
     }
 
@@ -2996,7 +3032,7 @@ async def _handle_client_navigation(
     async with store.connection.execute(
         "SELECT c.workshop_id, c.id, c.kind, c.name, cm.role, a.id, "
         "a.principal_id, a.name, "
-        "CASE WHEN cara.id IS NULL THEN 0 ELSE 1 END "
+        "CASE WHEN cara.id IS NULL THEN 0 ELSE 1 END, pae.lifecycle_state "
         "FROM channel_memberships cm "
         "JOIN channels c ON c.id = cm.channel_id "
         "JOIN workshop_memberships wm ON wm.workshop_id = c.workshop_id "
@@ -3005,6 +3041,8 @@ async def _handle_client_navigation(
         "LEFT JOIN agents a ON a.id = ca.agent_id AND a.workshop_id = c.workshop_id "
         "LEFT JOIN channel_agent_runtime_assignments cara "
         "ON cara.channel_id = c.id AND cara.agent_id = a.id "
+        "LEFT JOIN principal_agent_enablements pae ON pae.direct_channel_id = c.id "
+        "AND pae.principal_id = cm.principal_id AND pae.agent_id = a.id "
         "WHERE cm.principal_id = ? "
         "ORDER BY c.workshop_id, "
         "CASE c.kind WHEN 'direct' THEN 0 WHEN 'group' THEN 1 "
@@ -3042,6 +3080,7 @@ async def _handle_client_navigation(
                 "agents": [],
                 "participants": [],
                 "_runtime_assignments": [],
+                "_agent_enablement": str(row[9]) if row[9] is not None else None,
             },
         )
         if row[5] is not None:
@@ -3082,6 +3121,7 @@ async def _handle_client_navigation(
         visible_channels: list[dict[str, object]] = []
         for channel in channels_by_workshop.get(workshop_id, {}).values():
             assignments = channel.pop("_runtime_assignments")
+            enablement = channel.pop("_agent_enablement")
             agents = channel["agents"]
             if not isinstance(assignments, list) or not isinstance(agents, list):
                 raise RuntimeError("Workshop navigation capability assembly failed")
@@ -3090,6 +3130,7 @@ async def _handle_client_navigation(
                 and len(agents) >= 1
                 and len(assignments) == len(agents)
                 and all(assignments)
+                and (channel["kind"] == "group" or enablement == "enabled")
             )
             if channel["kind"] == "group":
                 engagement_by_agent = {
@@ -3433,6 +3474,127 @@ async def _handle_agent_archival(
     except WorkshopAgentLifecycleError as exc:
         return _agent_lifecycle_error_response(exc)
     return _json_response({"version": 1, "agent": _serialize_agent_definition(snapshot)}, status=200)
+
+
+def _agent_enablement_error_response(exc: WorkshopAgentEnablementError) -> web.Response:
+    if isinstance(exc, WorkshopAgentEnablementAccessDenied):
+        return _error_response(status=403, code="access_denied", message="Access denied")
+    if isinstance(exc, WorkshopAgentEnablementValidationError):
+        return _error_response(status=400, code="invalid_request", message=str(exc))
+    if isinstance(exc, WorkshopAgentEnablementConflict):
+        return _error_response(
+            status=409,
+            code="agent_enablement_conflict",
+            message=str(exc),
+        )
+    if isinstance(exc, WorkshopAgentEnablementStorageError):
+        return _error_response(
+            status=503,
+            code="agent_enablement_unavailable",
+            message="Agent enablement is temporarily unavailable",
+        )
+    return _error_response(status=500, code="internal_error", message="Internal server error")
+
+
+async def _handle_agent_enablement_list(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentEnablementService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid agent enablement request")
+    try:
+        snapshots = await service.list_for_principal(principal_id)
+    except WorkshopAgentEnablementError as exc:
+        return _agent_enablement_error_response(exc)
+    return _json_response(
+        {"version": 1, "agents": [_serialize_agent_enablement(item) for item in snapshots]},
+        status=200,
+    )
+
+
+async def _handle_agent_enablement_detail(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentEnablementService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid agent enablement request")
+    try:
+        snapshot = await service.inspect(principal_id, _agent_definition_id(request))
+    except WorkshopAgentLifecycleError:
+        return _error_response(status=400, code="invalid_request", message="Invalid agent definition")
+    except WorkshopAgentEnablementError as exc:
+        return _agent_enablement_error_response(exc)
+    return _json_response({"version": 1, "agent": _serialize_agent_enablement(snapshot)}, status=200)
+
+
+async def _handle_agent_enablement_mutation(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentEnablementService,
+    enable: bool,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    if request.query:
+        return _error_response(status=400, code="invalid_request", message="Invalid agent enablement request")
+    try:
+        payload = await request.json()
+        allowed = (
+            {"idempotency_key", "expected_version", "runtime_profile_id"}
+            if enable
+            else {
+                "idempotency_key",
+                "expected_version",
+            }
+        )
+        required = (
+            {"idempotency_key", "runtime_profile_id"}
+            if enable
+            else {
+                "idempotency_key",
+                "expected_version",
+            }
+        )
+        if not isinstance(payload, dict) or not required.issubset(payload) or not set(payload).issubset(allowed):
+            raise WorkshopAgentEnablementValidationError("Invalid agent enablement payload")
+        definition_id = _agent_definition_id(request)
+        if enable:
+            snapshot = await service.enable(
+                principal_id,
+                definition_id,
+                RuntimeProfileId(payload["runtime_profile_id"]),
+                idempotency_key=payload["idempotency_key"],
+                expected_version=payload.get("expected_version"),
+            )
+        else:
+            snapshot = await service.disable(
+                principal_id,
+                definition_id,
+                idempotency_key=payload["idempotency_key"],
+                expected_version=payload["expected_version"],
+            )
+    except (TypeError, ValueError):
+        return _error_response(status=400, code="invalid_request", message="Invalid agent enablement request")
+    except WorkshopAgentLifecycleError:
+        return _error_response(status=400, code="invalid_request", message="Invalid agent definition")
+    except WorkshopAgentEnablementError as exc:
+        return _agent_enablement_error_response(exc)
+    return _json_response({"version": 1, "agent": _serialize_agent_enablement(snapshot)}, status=200)
 
 
 async def _handle_message_reaction(
@@ -4677,6 +4839,7 @@ def register_workshop_read_routes(
     notification_preferences: WorkshopNotificationPreferenceService | None = None,
     client_preferences: WorkshopClientPreferenceService | None = None,
     appearance_preferences: WorkshopAppearancePreferenceService | None = None,
+    agent_enablement: WorkshopAgentEnablementService | None = None,
 ) -> None:
     """Register authenticated Workshop client routes on an application."""
     if event_poll_interval <= 0 or event_heartbeat_interval <= 0 or event_authentication_recheck_interval <= 0:
@@ -4818,6 +4981,46 @@ def register_workshop_read_routes(
     app.router.add_post(_AGENT_REVISIONS_PATH, handle_agent_revision_create)
     app.router.add_post(_AGENT_ACTIVATION_PATH, handle_agent_activation)
     app.router.add_post(_AGENT_ARCHIVAL_PATH, handle_agent_archival)
+    if agent_enablement is not None:
+
+        async def handle_agent_enablement_list(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_agent_enablement_list(
+                    request,
+                    authenticator=authenticator,
+                    service=agent_enablement,
+                )
+
+        async def handle_agent_enablement_detail(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_agent_enablement_detail(
+                    request,
+                    authenticator=authenticator,
+                    service=agent_enablement,
+                )
+
+        async def handle_agent_enable(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_agent_enablement_mutation(
+                    request,
+                    authenticator=authenticator,
+                    service=agent_enablement,
+                    enable=True,
+                )
+
+        async def handle_agent_disable(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_agent_enablement_mutation(
+                    request,
+                    authenticator=authenticator,
+                    service=agent_enablement,
+                    enable=False,
+                )
+
+        app.router.add_get(_AGENT_ENABLEMENTS_PATH, handle_agent_enablement_list)
+        app.router.add_get(_AGENT_ENABLEMENT_PATH, handle_agent_enablement_detail)
+        app.router.add_post(_AGENT_ENABLE_PATH, handle_agent_enable)
+        app.router.add_post(_AGENT_DISABLE_PATH, handle_agent_disable)
     app.router.add_get(_TIMELINE_PATH, handle_channel_timeline)
     app.router.add_get(_THREAD_TIMELINE_PATH, handle_thread_timeline)
     app.router.add_get(_TIMELINE_EVENTS_PATH, handle_channel_event_stream)

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -33,6 +33,9 @@ class WorkshopEventType(StrEnum):
     AGENT_DEFINITION_REVISION_ADDED = "agent_definition.revision_added"
     AGENT_DEFINITION_REVISION_ACTIVATED = "agent_definition.revision_activated"
     AGENT_DEFINITION_ARCHIVED = "agent_definition.archived"
+    PRINCIPAL_AGENT_ENABLED = "principal_agent.enabled"
+    PRINCIPAL_AGENT_DISABLED = "principal_agent.disabled"
+    PRINCIPAL_AGENT_RUNTIME_CHANGED = "principal_agent.runtime_changed"
     CHANNEL_AGENT_ATTACHED = "channel.agent_attached"
     CHANNEL_AGENT_DISMISSED = "channel.agent_dismissed"
     RUNTIME_PROFILE_ASSIGNED = "runtime_profile.assigned"
@@ -139,6 +142,10 @@ class AgentDefinitionRevisionId(OpaqueId):
     prefix = "adr"
 
 
+class AgentEnablementId(OpaqueId):
+    prefix = "aen"
+
+
 class RuntimeProfileId(OpaqueId):
     prefix = "rtp"
 
@@ -240,6 +247,7 @@ _ID_TYPES: dict[str, type[OpaqueId]] = {
         AgentId,
         AgentDefinitionId,
         AgentDefinitionRevisionId,
+        AgentEnablementId,
         ChannelAgentId,
         RuntimeAssignmentId,
         MessageId,

--- a/src/kai/workshop/execution_state.py
+++ b/src/kai/workshop/execution_state.py
@@ -51,28 +51,36 @@ class WorkshopExecutionStateRegistry:
         by_legacy_key: dict[int, WorkshopExecutionStateNamespace] = {}
         by_profile: dict[RuntimeProfileId, WorkshopExecutionStateNamespace] = {}
         by_principal: dict[PrincipalId, WorkshopExecutionStateNamespace | None] = {}
+        by_principal_channel: dict[tuple[PrincipalId, ChannelId], WorkshopExecutionStateNamespace | None] = {}
+        lanes: list[WorkshopExecutionStateNamespace] = []
         for namespace in namespaces:
             if not isinstance(namespace, WorkshopExecutionStateNamespace):
                 raise TypeError("namespaces must contain WorkshopExecutionStateNamespace values")
             if namespace.legacy_runtime_key is not None and namespace.legacy_runtime_key in by_legacy_key:
                 raise WorkshopExecutionStateError("Duplicate archived runtime execution-state key")
-            if namespace.runtime_profile_id in by_profile:
-                raise WorkshopExecutionStateError("Duplicate runtime profile execution-state owner")
+            lane_key = (namespace.principal_id, namespace.channel_id)
+            primary = by_profile.get(namespace.runtime_profile_id)
+            if primary is not None and primary.principal_id != namespace.principal_id:
+                raise WorkshopExecutionStateError("Runtime profile cannot cross canonical human owners")
             if namespace.legacy_runtime_key is not None:
                 by_legacy_key[namespace.legacy_runtime_key] = namespace
-            by_profile[namespace.runtime_profile_id] = namespace
-            # A human may eventually have more than one runtime profile.  A
-            # principal-id lookup is therefore available only while it is
-            # unambiguous; exact protected-runtime lookups remain authoritative.
+            by_profile.setdefault(namespace.runtime_profile_id, namespace)
             if namespace.principal_id in by_principal:
                 by_principal[namespace.principal_id] = None
             else:
                 by_principal[namespace.principal_id] = namespace
+            if lane_key in by_principal_channel:
+                by_principal_channel[lane_key] = None
+            else:
+                by_principal_channel[lane_key] = namespace
+            lanes.append(namespace)
         if not by_profile:
             raise WorkshopExecutionStateError("At least one execution-state namespace is required")
         self._by_legacy_key = by_legacy_key
         self._by_profile = by_profile
         self._by_principal = by_principal
+        self._by_principal_channel = by_principal_channel
+        self._lanes = lanes
 
     @classmethod
     async def from_store(
@@ -82,16 +90,17 @@ class WorkshopExecutionStateRegistry:
     ) -> WorkshopExecutionStateRegistry:
         """Resolve every protected profile through its direct-channel owner."""
         async with store.connection.execute(
-            "SELECT ra.runtime_profile_id, ra.channel_id, ra.agent_id, cm.principal_id "
+            "SELECT ra.runtime_profile_id, ra.channel_id, ra.agent_id, cm.principal_id, "
+            "ra.created_event_position "
             "FROM channel_agent_runtime_assignments ra "
             "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
             "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
             "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
-            "ORDER BY ra.runtime_profile_id, cm.principal_id"
+            "ORDER BY ra.runtime_profile_id, ra.created_event_position, cm.principal_id"
         ) as cursor:
             rows = list(await cursor.fetchall())
 
-        resolved: dict[RuntimeProfileId, set[tuple[ChannelId, AgentId, PrincipalId]]] = {}
+        resolved: dict[RuntimeProfileId, list[tuple[ChannelId, AgentId, PrincipalId]]] = {}
         for row in rows:
             try:
                 profile_id = RuntimeProfileId(str(row[0]))
@@ -100,30 +109,76 @@ class WorkshopExecutionStateRegistry:
                 raise WorkshopExecutionStateError(
                     "Canonical execution-state ownership contains an invalid opaque identifier"
                 ) from exc
-            resolved.setdefault(profile_id, set()).add(identities)
+            if identities not in resolved.setdefault(profile_id, []):
+                resolved[profile_id].append(identities)
 
         namespaces: list[WorkshopExecutionStateNamespace] = []
         for profile in runtime_profiles.profiles:
-            identities = resolved.get(profile.profile_id, set())
-            if len(identities) != 1:
-                raise WorkshopExecutionStateError(
-                    "Protected runtime profile must map to exactly one canonical execution-state owner"
+            identities = resolved.get(profile.profile_id, [])
+            if not identities or len({item[2] for item in identities}) != 1:
+                raise WorkshopExecutionStateError("Protected runtime profile must map to one canonical human owner")
+            for index, (channel_id, agent_id, principal_id) in enumerate(identities):
+                namespaces.append(
+                    WorkshopExecutionStateNamespace(
+                        principal_id=principal_id,
+                        channel_id=channel_id,
+                        agent_id=agent_id,
+                        runtime_profile_id=profile.profile_id,
+                        legacy_runtime_key=(
+                            runtime_profiles.legacy_runtime_key(profile.profile_id) if index == 0 else None
+                        ),
+                    )
                 )
-            channel_id, agent_id, principal_id = next(iter(identities))
-            namespaces.append(
-                WorkshopExecutionStateNamespace(
-                    principal_id=principal_id,
-                    channel_id=channel_id,
-                    agent_id=agent_id,
-                    runtime_profile_id=profile.profile_id,
-                    legacy_runtime_key=runtime_profiles.legacy_runtime_key(profile.profile_id),
-                )
-            )
         return cls(tuple(namespaces))
 
     @property
     def namespaces(self) -> tuple[WorkshopExecutionStateNamespace, ...]:
+        """Return the primary legacy-compatible owner for each protected profile."""
         return tuple(sorted(self._by_profile.values(), key=lambda item: item.runtime_profile_id))
+
+    @property
+    def lanes(self) -> tuple[WorkshopExecutionStateNamespace, ...]:
+        """Return every isolated canonical channel-agent execution lane."""
+        return tuple(self._lanes)
+
+    def register_lane(self, namespace: WorkshopExecutionStateNamespace) -> None:
+        """Register a newly enabled lane without replacing profile-level defaults."""
+        if not isinstance(namespace, WorkshopExecutionStateNamespace):
+            raise TypeError("namespace must be a WorkshopExecutionStateNamespace")
+        key = (namespace.principal_id, namespace.channel_id)
+        existing = self._by_principal_channel.get(key)
+        if existing is not None:
+            if existing != namespace:
+                raise WorkshopExecutionStateError("Canonical execution-state lane conflicts")
+            return
+        primary = self._by_profile.get(namespace.runtime_profile_id)
+        if primary is None or primary.principal_id != namespace.principal_id:
+            raise WorkshopExecutionStateError("Runtime profile is not owned by the canonical principal")
+        if namespace.legacy_runtime_key is not None:
+            raise WorkshopExecutionStateError("New execution lanes cannot claim archived runtime state")
+        self._by_principal_channel[key] = namespace
+        self._lanes.append(namespace)
+
+    def replace_lane(
+        self,
+        prior: WorkshopExecutionStateNamespace,
+        replacement: WorkshopExecutionStateNamespace,
+    ) -> None:
+        """Replace a lane's protected profile without changing its identity."""
+        key = (prior.principal_id, prior.channel_id)
+        if (
+            self._by_principal_channel.get(key) != prior
+            or replacement.principal_id != prior.principal_id
+            or replacement.channel_id != prior.channel_id
+            or replacement.agent_id != prior.agent_id
+            or replacement.legacy_runtime_key is not None
+        ):
+            raise WorkshopExecutionStateError("Canonical execution-state lane replacement conflicts")
+        primary = self._by_profile.get(replacement.runtime_profile_id)
+        if primary is None or primary.principal_id != replacement.principal_id:
+            raise WorkshopExecutionStateError("Replacement runtime profile is not owned by the principal")
+        self._by_principal_channel[key] = replacement
+        self._lanes[self._lanes.index(prior)] = replacement
 
     def maybe_for_legacy_runtime_key(self, legacy_runtime_key: int) -> WorkshopExecutionStateNamespace | None:
         if isinstance(legacy_runtime_key, bool) or not isinstance(legacy_runtime_key, int):
@@ -152,10 +207,7 @@ class WorkshopExecutionStateRegistry:
             canonical_channel = channel_id if isinstance(channel_id, ChannelId) else ChannelId(channel_id)
         except (TypeError, ValueError):
             return None
-        namespace = self._by_principal.get(canonical_principal)
-        if namespace is None or namespace.channel_id != canonical_channel:
-            return None
-        return namespace
+        return self._by_principal_channel.get((canonical_principal, canonical_channel))
 
     def maybe_for_runtime_profile_id(
         self,

--- a/src/kai/workshop/internal_api_contexts.py
+++ b/src/kai/workshop/internal_api_contexts.py
@@ -47,15 +47,25 @@ class WorkshopInternalAPIContextRegistry:
         contexts: tuple[WorkshopInternalAPIExecutionContext, ...],
     ) -> None:
         by_profile: dict[RuntimeProfileId, WorkshopInternalAPIExecutionContext] = {}
+        by_lane: dict[tuple[PrincipalId, ChannelId, AgentId], WorkshopInternalAPIExecutionContext] = {}
+        ordered: list[WorkshopInternalAPIExecutionContext] = []
         for context in contexts:
             if not isinstance(context, WorkshopInternalAPIExecutionContext):
                 raise TypeError("contexts must contain WorkshopInternalAPIExecutionContext values")
-            if context.runtime_profile_id in by_profile:
-                raise WorkshopInternalAPIContextError("Duplicate internal API runtime profile")
-            by_profile[context.runtime_profile_id] = context
+            key = (context.principal_id, context.channel_id, context.agent_id)
+            if key in by_lane:
+                raise WorkshopInternalAPIContextError("Duplicate internal API execution lane")
+            primary = by_profile.get(context.runtime_profile_id)
+            if primary is not None and primary.principal_id != context.principal_id:
+                raise WorkshopInternalAPIContextError("Runtime profile cannot cross internal API principals")
+            by_profile.setdefault(context.runtime_profile_id, context)
+            by_lane[key] = context
+            ordered.append(context)
         if not by_profile:
             raise WorkshopInternalAPIContextError("At least one internal API execution context is required")
         self._by_profile = by_profile
+        self._by_lane = by_lane
+        self._contexts = ordered
 
     @classmethod
     async def from_store(
@@ -65,7 +75,8 @@ class WorkshopInternalAPIContextRegistry:
     ) -> WorkshopInternalAPIContextRegistry:
         """Load complete, same-workshop direct-channel execution contexts."""
         async with store.connection.execute(
-            "SELECT ra.runtime_profile_id, cm.principal_id, ra.channel_id, ra.agent_id "
+            "SELECT ra.runtime_profile_id, cm.principal_id, ra.channel_id, ra.agent_id, "
+            "ra.created_event_position "
             "FROM channel_agent_runtime_assignments ra "
             "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
             "JOIN agents a ON a.id = ra.agent_id AND a.workshop_id = c.workshop_id "
@@ -74,13 +85,13 @@ class WorkshopInternalAPIContextRegistry:
             "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
             "JOIN workshop_memberships wm ON wm.principal_id = p.id "
             "AND wm.workshop_id = c.workshop_id "
-            "ORDER BY ra.runtime_profile_id, cm.principal_id"
+            "ORDER BY ra.runtime_profile_id, ra.created_event_position, cm.principal_id"
         ) as cursor:
             rows = list(await cursor.fetchall())
 
         rows_by_profile: dict[
             RuntimeProfileId,
-            set[tuple[PrincipalId, ChannelId, AgentId]],
+            list[tuple[PrincipalId, ChannelId, AgentId]],
         ] = {}
         for row in rows:
             try:
@@ -94,29 +105,61 @@ class WorkshopInternalAPIContextRegistry:
                 raise WorkshopInternalAPIContextError(
                     "Canonical internal API context contains an invalid opaque identifier"
                 ) from exc
-            rows_by_profile.setdefault(profile_id, set()).add(identity)
+            if identity not in rows_by_profile.setdefault(profile_id, []):
+                rows_by_profile[profile_id].append(identity)
 
         contexts: list[WorkshopInternalAPIExecutionContext] = []
         for profile in runtime_profiles.profiles:
-            identities = rows_by_profile.get(profile.profile_id, set())
-            if len(identities) != 1:
+            identities = rows_by_profile.get(profile.profile_id, [])
+            if not identities or len({item[0] for item in identities}) != 1:
                 raise WorkshopInternalAPIContextError(
-                    "Protected runtime profile must resolve to exactly one canonical internal API context"
+                    "Protected runtime profile must resolve to one canonical human principal"
                 )
-            principal_id, channel_id, agent_id = next(iter(identities))
-            contexts.append(
-                WorkshopInternalAPIExecutionContext(
-                    principal_id=principal_id,
-                    channel_id=channel_id,
-                    agent_id=agent_id,
-                    runtime_profile_id=profile.profile_id,
+            for principal_id, channel_id, agent_id in identities:
+                contexts.append(
+                    WorkshopInternalAPIExecutionContext(
+                        principal_id=principal_id,
+                        channel_id=channel_id,
+                        agent_id=agent_id,
+                        runtime_profile_id=profile.profile_id,
+                    )
                 )
-            )
         return cls(tuple(contexts))
 
     @property
     def contexts(self) -> tuple[WorkshopInternalAPIExecutionContext, ...]:
-        return tuple(sorted(self._by_profile.values(), key=lambda context: context.runtime_profile_id))
+        return tuple(self._contexts)
+
+    def register_context(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        """Register a live principal-agent lane while keeping the profile primary stable."""
+        key = (context.principal_id, context.channel_id, context.agent_id)
+        existing = self._by_lane.get(key)
+        if existing is not None:
+            if existing != context:
+                raise WorkshopInternalAPIContextError("Internal API execution lane conflicts")
+            return
+        primary = self._by_profile.get(context.runtime_profile_id)
+        if primary is None or primary.principal_id != context.principal_id:
+            raise WorkshopInternalAPIContextError("Runtime profile is not owned by this internal API principal")
+        self._by_lane[key] = context
+        self._contexts.append(context)
+
+    def replace_context(
+        self,
+        prior: WorkshopInternalAPIExecutionContext,
+        replacement: WorkshopInternalAPIExecutionContext,
+    ) -> None:
+        """Rebind one live lane to another profile owned by the same human."""
+        key = (prior.principal_id, prior.channel_id, prior.agent_id)
+        if self._by_lane.get(key) != prior or replacement.principal_id != prior.principal_id:
+            raise WorkshopInternalAPIContextError("Internal API context replacement conflicts")
+        if (replacement.principal_id, replacement.channel_id, replacement.agent_id) != key:
+            raise WorkshopInternalAPIContextError("Internal API context identity cannot change")
+        primary = self._by_profile.get(replacement.runtime_profile_id)
+        if primary is None or primary.principal_id != replacement.principal_id:
+            raise WorkshopInternalAPIContextError("Replacement runtime profile is not owned by the principal")
+        self._by_lane[key] = replacement
+        self._contexts[self._contexts.index(prior)] = replacement
 
     def for_runtime_profile(
         self,

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -23,6 +23,7 @@ from kai.workshop.agent_definitions import (
 from kai.workshop.domain import (
     AgentDefinitionId,
     AgentDefinitionRevisionId,
+    AgentEnablementId,
     AgentId,
     ChannelId,
     MessageId,
@@ -608,7 +609,7 @@ class CanonicalConversationProjection:
 
     name = "canonical_conversations"
     # Agent definitions project durable draft, active, and archived lifecycle state.
-    version = 13
+    version = 14
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -624,6 +625,7 @@ class CanonicalConversationProjection:
             "runs",
             "message_reactions",
             "messages",
+            "principal_agent_enablements",
             "channel_agent_dismissals",
             "channel_agent_runtime_assignments",
             "channel_agents",
@@ -907,6 +909,119 @@ class CanonicalConversationProjection:
                 "UPDATE agent_definitions SET lifecycle_state = 'archived' WHERE id = ?",
                 (envelope.aggregate_id,),
             )
+        elif envelope.event_type == WorkshopEventType.PRINCIPAL_AGENT_ENABLED:
+            if not isinstance(envelope.aggregate_id, AgentEnablementId):
+                raise ValueError("Workshop agent enablement requires a typed enablement aggregate")
+            _require_exact_payload(
+                payload,
+                {
+                    "principal_id",
+                    "agent_definition_id",
+                    "agent_id",
+                    "direct_channel_id",
+                    "runtime_profile_id",
+                },
+            )
+            principal_id = _required_text(payload, "principal_id")
+            definition_id = _required_text(payload, "agent_definition_id")
+            agent_id = _required_text(payload, "agent_id")
+            channel_id = _required_text(payload, "direct_channel_id")
+            runtime_profile_id = _required_text(payload, "runtime_profile_id")
+            async with connection.execute(
+                "SELECT d.workshop_id, d.agent_id, d.lifecycle_state, a.principal_id, "
+                "c.workshop_id, c.kind, ra.runtime_profile_id FROM agent_definitions d "
+                "JOIN agents a ON a.id = d.agent_id JOIN channels c ON c.id = ? "
+                "JOIN channel_memberships hm ON hm.channel_id = c.id AND hm.principal_id = ? "
+                "AND hm.role = 'owner' JOIN channel_agents ca ON ca.channel_id = c.id "
+                "AND ca.agent_id = ? JOIN channel_agent_runtime_assignments ra "
+                "ON ra.channel_id = c.id AND ra.agent_id = ca.agent_id WHERE d.id = ?",
+                (channel_id, principal_id, agent_id, definition_id),
+            ) as cursor:
+                authority = await cursor.fetchone()
+            if (
+                authority is None
+                or tuple(authority[:3])
+                != (
+                    envelope.workshop_id,
+                    agent_id,
+                    "active",
+                )
+                or tuple(authority[4:])
+                != (
+                    envelope.workshop_id,
+                    "direct",
+                    runtime_profile_id,
+                )
+            ):
+                raise ValueError("Workshop agent enablement authority is invalid")
+            agent_principal_id = str(authority[3])
+            async with connection.execute(
+                "SELECT COUNT(*), SUM(CASE WHEN principal_id = ? THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN principal_id = ? THEN 1 ELSE 0 END) "
+                "FROM channel_memberships WHERE channel_id = ?",
+                (principal_id, agent_principal_id, channel_id),
+            ) as cursor:
+                membership_counts = await cursor.fetchone()
+            if membership_counts is None or tuple(membership_counts) != (2, 1, 1):
+                raise ValueError("Workshop agent enablement direct channel must have exactly two members")
+            await connection.execute(
+                "INSERT INTO principal_agent_enablements "
+                "(id, workshop_id, principal_id, agent_definition_id, agent_id, "
+                "direct_channel_id, runtime_profile_id, lifecycle_state, created_at, "
+                "updated_at, created_event_position, last_event_position) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, 'enabled', ?, ?, ?, ?) "
+                "ON CONFLICT(principal_id, agent_definition_id) DO UPDATE SET "
+                "lifecycle_state = 'enabled', updated_at = excluded.updated_at, "
+                "last_event_position = excluded.last_event_position",
+                (
+                    envelope.aggregate_id,
+                    envelope.workshop_id,
+                    principal_id,
+                    definition_id,
+                    agent_id,
+                    channel_id,
+                    runtime_profile_id,
+                    occurred_at,
+                    occurred_at,
+                    event.position,
+                    event.position,
+                ),
+            )
+        elif envelope.event_type == WorkshopEventType.PRINCIPAL_AGENT_DISABLED:
+            if not isinstance(envelope.aggregate_id, AgentEnablementId):
+                raise ValueError("Workshop agent disablement requires a typed enablement aggregate")
+            _require_exact_payload(payload, set())
+            cursor = await connection.execute(
+                "UPDATE principal_agent_enablements SET lifecycle_state = 'disabled', "
+                "updated_at = ?, last_event_position = ? WHERE id = ? "
+                "AND workshop_id = ? AND lifecycle_state = 'enabled'",
+                (occurred_at, event.position, envelope.aggregate_id, envelope.workshop_id),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError("Workshop agent disablement has no enabled principal agent")
+        elif envelope.event_type == WorkshopEventType.PRINCIPAL_AGENT_RUNTIME_CHANGED:
+            if not isinstance(envelope.aggregate_id, AgentEnablementId):
+                raise ValueError("Workshop agent runtime change requires a typed enablement aggregate")
+            _require_exact_payload(payload, {"runtime_profile_id"})
+            runtime_profile_id = _required_text(payload, "runtime_profile_id")
+            async with connection.execute(
+                "SELECT e.direct_channel_id, e.agent_id, ra.runtime_profile_id "
+                "FROM principal_agent_enablements e "
+                "JOIN channel_agent_runtime_assignments ra "
+                "ON ra.channel_id = e.direct_channel_id AND ra.agent_id = e.agent_id "
+                "WHERE e.id = ? AND e.workshop_id = ?",
+                (envelope.aggregate_id, envelope.workshop_id),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None or str(row[2]) != runtime_profile_id:
+                raise ValueError("Workshop agent runtime change does not match its channel assignment")
+            cursor = await connection.execute(
+                "UPDATE principal_agent_enablements SET runtime_profile_id = ?, "
+                "updated_at = ?, last_event_position = ? WHERE id = ?",
+                (runtime_profile_id, occurred_at, event.position, envelope.aggregate_id),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError("Workshop agent runtime change has no principal agent")
         elif envelope.event_type == WorkshopEventType.CHANNEL_AGENT_ATTACHED:
             await connection.execute(
                 "INSERT INTO channel_agents (id, channel_id, agent_id, created_at) VALUES (?, ?, ?, ?)",

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -11,6 +11,7 @@ from kai.backend import StreamEvent
 from kai.config import VALID_BACKENDS, validate_model_for_backend
 from kai.workshop.conversation_runs import resolve_canonical_conversation_run
 from kai.workshop.domain import RunId, RuntimeProfileId
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.routing_policy import RunRoutingDecision, WorkshopRoutingPolicyService
 from kai.workshop.run_execution_authority import RunExecutionSelection
 from kai.workshop.run_lifecycle import DurableRun, RunStatus, WorkshopRunLifecycle
@@ -113,8 +114,14 @@ class WorkshopProtectedExecutionPreparationService:
         )
         if decision.rejected or decision.selected_backend_option_id is None:
             raise ProtectedExecutionRoutingRejected(run, decision)
+        runtime_authority = WorkshopInternalAPIExecutionContext(
+            principal_id=target.requested_by_principal_id,
+            channel_id=target.channel_id,
+            agent_id=target.agent_id,
+            runtime_profile_id=resolution.runtime_profile_id,
+        )
         runtime = await self._pool.prepare_routed_execution(
-            resolution.runtime_profile_id,
+            runtime_authority,
             decision.selected_backend_option_id,
             decision.selection.model,
         )

--- a/src/kai/workshop/routing_eligibility.py
+++ b/src/kai/workshop/routing_eligibility.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from kai.backend import AgentBackend
 from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.model_catalogue import (
     ModelCatalogueEntry,
     ModelCatalogueEntryStatus,
@@ -172,7 +173,10 @@ class WorkshopRoutingEligibilityService:
         additional_required: tuple[RuntimeCapability, ...] = (),
     ) -> RuntimeEligibilityReport:
         canonical_task = _task_class(task_class)
-        namespace = self._execution_state.maybe_for_runtime_profile_id(authority.runtime_profile_id)
+        namespace = self._execution_state.maybe_for_principal_channel(
+            authority.principal_id,
+            authority.channel_id,
+        )
         if (
             namespace is None
             or namespace.principal_id != authority.principal_id
@@ -185,15 +189,17 @@ class WorkshopRoutingEligibilityService:
             (item for item in profiles if item.runtime_profile_id == authority.runtime_profile_id),
             None,
         )
-        if (
-            profile is None
-            or profile.channel_id != str(authority.channel_id)
-            or profile.agent_id != str(authority.agent_id)
-        ):
+        if profile is None:
             raise RoutingEligibilityAccessDenied("Routing eligibility access denied")
 
-        workspace = await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)
-        selected_model = await self._runtime_pool.get_effective_model(authority.runtime_profile_id)
+        runtime_authority = WorkshopInternalAPIExecutionContext(
+            authority.principal_id,
+            authority.channel_id,
+            authority.agent_id,
+            authority.runtime_profile_id,
+        )
+        workspace = await self._runtime_pool.get_effective_workspace(runtime_authority)
+        selected_model = await self._runtime_pool.get_effective_model(runtime_authority)
         allowed_services = self._runtime_pool.runtime_profile(authority.runtime_profile_id).allowed_services
         catalogue_authority = self._catalogue.authority_for_principal(authority.principal_id)
         if any(not isinstance(capability, RuntimeCapability) for capability in additional_required):

--- a/src/kai/workshop/runtime_pool.py
+++ b/src/kai/workshop/runtime_pool.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from kai.backend import StreamEvent
 from kai.config import ModelRole, WorkspaceConfig
 from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.runtime_profiles import (
     ProtectedRuntimeBackend,
     ProtectedRuntimeProfile,
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from kai.pool import PreparedBackendExecution, SubprocessPool
 
 type AgentPrompt = str | list[dict[str, str]]
+type RuntimeAuthority = str | RuntimeProfileId | WorkshopInternalAPIExecutionContext
 
 
 class WorkshopRuntimePool:
@@ -37,10 +39,33 @@ class WorkshopRuntimePool:
 
     def runtime_profile(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
     ) -> ProtectedRuntimeProfile:
         """Resolve the protected profile without exposing compatibility lookup."""
-        return self._profiles.resolve(runtime_profile_id)
+        return self._profiles.resolve(
+            runtime_profile_id.runtime_profile_id
+            if isinstance(runtime_profile_id, WorkshopInternalAPIExecutionContext)
+            else runtime_profile_id
+        )
+
+    def _selector(self, authority: RuntimeAuthority):
+        profile = self.runtime_profile(authority)
+        return authority if isinstance(authority, WorkshopInternalAPIExecutionContext) else profile.profile_id
+
+    def register_canonical_lane(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        self.runtime_profile(context)
+        self._pool.register_canonical_lane(context)
+
+    async def rebind_canonical_lane(
+        self,
+        prior: WorkshopInternalAPIExecutionContext,
+        replacement: WorkshopInternalAPIExecutionContext,
+    ) -> None:
+        self.runtime_profile(replacement)
+        await self._pool.rebind_canonical_lane(prior, replacement)
+
+    async def suspend_canonical_lane(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        await self._pool.suspend_canonical_lane(context)
 
     def legacy_runtime_key(self, runtime_profile_id: str | RuntimeProfileId) -> int | None:
         """Return migration-only state for the temporary cutover coordinator."""
@@ -48,134 +73,119 @@ class WorkshopRuntimePool:
 
     async def prepare_execution(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
     ) -> PreparedBackendExecution:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return await self._pool.prepare_execution(profile_id)
+        return await self._pool.prepare_execution(self._selector(runtime_profile_id))
 
     async def prepare_routed_execution(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
         backend_option_id: str,
         model: str,
     ) -> PreparedBackendExecution:
         """Prepare an authorized per-option runtime without changing the default."""
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
         return await self._pool.prepare_routed_execution(
-            profile_id,
+            self._selector(runtime_profile_id),
             backend_option_id,
             model,
         )
 
-    def get_model(self, runtime_profile_id: str | RuntimeProfileId) -> str:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return self._pool.get_model(profile_id)
+    def get_model(self, runtime_profile_id: RuntimeAuthority) -> str:
+        return self._pool.get_model(self._selector(runtime_profile_id))
 
-    async def get_effective_model(self, runtime_profile_id: str | RuntimeProfileId) -> str:
+    async def get_effective_model(self, runtime_profile_id: RuntimeAuthority) -> str:
         """Return canonical persisted selection without starting a backend."""
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return await self._pool.get_effective_model(profile_id)
+        return await self._pool.get_effective_model(self._selector(runtime_profile_id))
 
     def get_backend_provider(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
     ) -> tuple[str, str]:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return self._pool.get_backend_provider(profile_id)
+        return self._pool.get_backend_provider(self._selector(runtime_profile_id))
 
     def backend_option(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
         backend: str,
     ) -> ProtectedRuntimeBackend:
-        return self._profiles.resolve(runtime_profile_id).backend_option(backend)
+        return self.runtime_profile(runtime_profile_id).backend_option(backend)
 
-    def is_in_flight(self, runtime_profile_id: str | RuntimeProfileId) -> bool:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return self._pool.is_in_flight(profile_id)
+    def is_in_flight(self, runtime_profile_id: RuntimeAuthority) -> bool:
+        return self._pool.is_in_flight(self._selector(runtime_profile_id))
 
     async def select_backend(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
         backend_option_id: str,
         *,
         commit_selection: Callable[[], Awaitable[None]] | None = None,
     ) -> bool:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
         return await self._pool.select_backend(
-            profile_id,
+            self._selector(runtime_profile_id),
             backend_option_id,
             commit_selection=commit_selection,
         )
 
-    def is_running(self, runtime_profile_id: str | RuntimeProfileId) -> bool:
+    def is_running(self, runtime_profile_id: RuntimeAuthority) -> bool:
         """Return whether this protected profile currently has a live backend."""
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return self._pool.get_if_exists(profile_id) is not None
+        return self._pool.get_if_exists(self._selector(runtime_profile_id)) is not None
 
     def get_role_model(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
         role: ModelRole,
     ) -> str:
         """Resolve a role model through one protected canonical profile."""
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return self._pool.get_role_model(profile_id, role)
+        return self._pool.get_role_model(self._selector(runtime_profile_id), role)
 
     async def send(
         self,
         prompt: AgentPrompt,
         *,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
     ) -> AsyncIterator[StreamEvent]:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        async for event in self._pool.send(prompt, runtime=profile_id):
+        async for event in self._pool.send(prompt, runtime=self._selector(runtime_profile_id)):
             yield event
 
     async def get_effective_workspace(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
     ) -> Path:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return await self._pool.get_effective_workspace(profile_id)
+        return await self._pool.get_effective_workspace(self._selector(runtime_profile_id))
 
     def get_home_workspace(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
     ) -> Path:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return self._pool.get_home_workspace(profile_id)
+        return self._pool.get_home_workspace(self._selector(runtime_profile_id))
 
     async def resolve_workspace_access(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
     ) -> tuple[Path | None, list[Path]]:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        return await self._pool.resolve_workspace_access(profile_id)
+        return await self._pool.resolve_workspace_access(self._selector(runtime_profile_id))
 
     def set_model_if_running(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
         model: str,
     ) -> None:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        instance = self._pool.get_if_exists(profile_id)
+        instance = self._pool.get_if_exists(self._selector(runtime_profile_id))
         if instance is not None:
             instance.model = model
 
     def set_timeout_if_running(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
         timeout_seconds: int,
     ) -> None:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        instance = self._pool.get_if_exists(profile_id)
+        instance = self._pool.get_if_exists(self._selector(runtime_profile_id))
         if instance is not None:
             instance.timeout_seconds = timeout_seconds
 
     async def apply_workspace_config_if_running(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
         workspace: Path,
         *,
         workspace_config: WorkspaceConfig | None,
@@ -189,8 +199,7 @@ class WorkshopRuntimePool:
         second explicit restart would therefore be redundant and can add a
         second shutdown delay.
         """
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        instance = self._pool.get_if_exists(profile_id)
+        instance = self._pool.get_if_exists(self._selector(runtime_profile_id))
         if instance is None:
             return
         await instance.change_workspace(
@@ -206,18 +215,16 @@ class WorkshopRuntimePool:
 
     async def change_workspace(
         self,
-        runtime_profile_id: str | RuntimeProfileId,
+        runtime_profile_id: RuntimeAuthority,
         workspace: Path,
         *,
         workspace_config: WorkspaceConfig | None,
     ) -> None:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
         await self._pool.change_workspace(
-            profile_id,
+            self._selector(runtime_profile_id),
             workspace,
             workspace_config=workspace_config,
         )
 
-    async def restart(self, runtime_profile_id: str | RuntimeProfileId) -> None:
-        profile_id = self._profiles.resolve(runtime_profile_id).profile_id
-        await self._pool.restart(profile_id)
+    async def restart(self, runtime_profile_id: RuntimeAuthority) -> None:
+        await self._pool.restart(self._selector(runtime_profile_id))

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 46
+WORKSHOP_SCHEMA_VERSION = 47
 
 
 @dataclass(frozen=True, slots=True)
@@ -2242,6 +2242,38 @@ _VERSIONED_AGENT_DEFINITION_SCHEMA = SchemaMigration(
     ),
 )
 
+_PRINCIPAL_AGENT_ENABLEMENT_SCHEMA = SchemaMigration(
+    version=47,
+    name="principal_agent_enablement",
+    statements=(
+        """
+        CREATE TABLE principal_agent_enablements (
+            id TEXT PRIMARY KEY,
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+            agent_definition_id TEXT NOT NULL
+                REFERENCES agent_definitions(id) ON DELETE CASCADE,
+            agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+            direct_channel_id TEXT NOT NULL UNIQUE
+                REFERENCES channels(id) ON DELETE RESTRICT,
+            runtime_profile_id TEXT NOT NULL,
+            lifecycle_state TEXT NOT NULL CHECK (
+                lifecycle_state IN ('enabled', 'disabled')
+            ),
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            created_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            last_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            UNIQUE (principal_id, agent_definition_id)
+        )
+        """,
+        "CREATE INDEX principal_agent_enablements_runtime_idx "
+        "ON principal_agent_enablements (runtime_profile_id, principal_id)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -2289,6 +2321,7 @@ _MIGRATIONS = (
     _EXPLICIT_TASK_ROUTING_SCHEMA,
     _MESSAGE_REACTIONS_SCHEMA,
     _VERSIONED_AGENT_DEFINITION_SCHEMA,
+    _PRINCIPAL_AGENT_ENABLEMENT_SCHEMA,
 )
 
 

--- a/src/kai/workshop/settings_workspaces.py
+++ b/src/kai/workshop/settings_workspaces.py
@@ -21,6 +21,7 @@ from kai.workshop.execution_state import (
     WorkshopExecutionStateNamespace,
     WorkshopExecutionStateRegistry,
 )
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.model_catalogue import (
     ModelCatalogueEntryStatus,
     ModelCatalogueRefreshResult,
@@ -185,7 +186,7 @@ class WorkshopSettingsWorkspaceService:
         self._runtime_pool = runtime_pool
         self._execution_state = execution_state
         self._model_catalogue = model_catalogue
-        self._locks: dict[RuntimeProfileId, asyncio.Lock] = {}
+        self._locks: dict[tuple[ChannelId, AgentId], asyncio.Lock] = {}
 
     def authority_for_principal_channel(
         self,
@@ -218,7 +219,10 @@ class WorkshopSettingsWorkspaceService:
         self,
         authority: SettingsWorkspaceAuthority,
     ) -> WorkshopExecutionStateNamespace:
-        namespace = self._execution_state.maybe_for_runtime_profile_id(authority.runtime_profile_id)
+        namespace = self._execution_state.maybe_for_principal_channel(
+            authority.principal_id,
+            authority.channel_id,
+        )
         if namespace is None:
             raise WorkshopSettingsWorkspaceAccessDenied("Runtime profile has no canonical execution state")
         if (
@@ -230,7 +234,18 @@ class WorkshopSettingsWorkspaceService:
         return namespace
 
     def _lock(self, authority: SettingsWorkspaceAuthority) -> asyncio.Lock:
-        return self._locks.setdefault(authority.runtime_profile_id, asyncio.Lock())
+        return self._locks.setdefault((authority.channel_id, authority.agent_id), asyncio.Lock())
+
+    @staticmethod
+    def _runtime_authority(
+        authority: SettingsWorkspaceAuthority,
+    ) -> WorkshopInternalAPIExecutionContext:
+        return WorkshopInternalAPIExecutionContext(
+            authority.principal_id,
+            authority.channel_id,
+            authority.agent_id,
+            authority.runtime_profile_id,
+        )
 
     async def inspect(
         self,
@@ -246,8 +261,9 @@ class WorkshopSettingsWorkspaceService:
     ) -> ModelCatalogueSnapshot:
         """Inspect one principal-owned backend lane through canonical authority."""
         catalogue = self._require_model_catalogue()
-        profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
-        requested = option_id or self._runtime_pool.get_backend_provider(authority.runtime_profile_id)
+        runtime = self._runtime_authority(authority)
+        profile = self._runtime_pool.runtime_profile(runtime)
+        requested = option_id or self._runtime_pool.get_backend_provider(runtime)
         resolved_option_id = f"{requested[0]}:{requested[1]}" if isinstance(requested, tuple) else requested
         try:
             profile.backend_option(resolved_option_id)
@@ -338,18 +354,19 @@ class WorkshopSettingsWorkspaceService:
         *,
         mutation: SettingsMutationOutcome | None = None,
     ) -> SettingsWorkspaceSnapshot:
-        profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
-        effective_backend, effective_provider = self._runtime_pool.get_backend_provider(authority.runtime_profile_id)
+        runtime = self._runtime_authority(authority)
+        profile = self._runtime_pool.runtime_profile(runtime)
+        effective_backend, effective_provider = self._runtime_pool.get_backend_provider(runtime)
         effective_option = profile.backend_option(f"{effective_backend}:{effective_provider}")
         namespace = self._namespace(authority)
-        workspace = await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)
+        workspace = await self._runtime_pool.get_effective_workspace(runtime)
         model, timeout_value = await self._effective_values(
             authority,
             workspace,
         )
-        home = self._runtime_pool.get_home_workspace(authority.runtime_profile_id)
+        home = self._runtime_pool.get_home_workspace(runtime)
         home_resolved = home.resolve()
-        base, allowed = await self._runtime_pool.resolve_workspace_access(authority.runtime_profile_id)
+        base, allowed = await self._runtime_pool.resolve_workspace_access(runtime)
         history = await sessions.get_canonical_workspace_history(namespace)
         candidates: list[Path] = [home, workspace, *allowed]
         candidates.extend(Path(str(item["path"])) for item in history)
@@ -444,8 +461,8 @@ class WorkshopSettingsWorkspaceService:
         expected_revision: str | None = None,
         clear_workspace_override: bool = True,
     ) -> SettingsWorkspaceSnapshot:
-        profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
-        backend, _provider = self._runtime_pool.get_backend_provider(authority.runtime_profile_id)
+        profile = self._runtime_pool.runtime_profile(self._runtime_authority(authority))
+        backend, _provider = self._runtime_pool.get_backend_provider(self._runtime_authority(authority))
         option = profile.backend_option(f"{backend}:{_provider}")
         normalized = canonicalize_model_for_backend(model.strip(), option.backend)
         if not normalized or not await self._model_is_selectable(
@@ -474,7 +491,7 @@ class WorkshopSettingsWorkspaceService:
         expected_revision: str | None = None,
     ) -> SettingsWorkspaceSnapshot:
         requested = backend_option_id.strip().lower()
-        profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
+        profile = self._runtime_pool.runtime_profile(self._runtime_authority(authority))
         try:
             requested_option = profile.backend_option(requested)
         except WorkshopRuntimeProfileError as exc:
@@ -494,7 +511,7 @@ class WorkshopSettingsWorkspaceService:
                         provider_session_invalidated=False,
                     ),
                 )
-            if self._runtime_pool.is_in_flight(authority.runtime_profile_id):
+            if self._runtime_pool.is_in_flight(self._runtime_authority(authority)):
                 raise WorkshopSettingsWorkspaceBusy(
                     "The backend cannot be changed while this runtime has an active run"
                 )
@@ -506,7 +523,7 @@ class WorkshopSettingsWorkspaceService:
             # valid for the selected backend.  This neither carries an
             # incompatible model into the new process nor discards a useful
             # choice when the principal later switches back.
-            was_running = self._runtime_pool.is_running(authority.runtime_profile_id)
+            was_running = self._runtime_pool.is_running(self._runtime_authority(authority))
 
             async def commit_selection() -> None:
                 await sessions.replace_canonical_settings_state(namespace, desired_settings)
@@ -514,7 +531,7 @@ class WorkshopSettingsWorkspaceService:
 
             try:
                 selected = await self._runtime_pool.select_backend(
-                    authority.runtime_profile_id,
+                    self._runtime_authority(authority),
                     requested_option.option_id,
                     commit_selection=commit_selection,
                 )
@@ -522,11 +539,11 @@ class WorkshopSettingsWorkspaceService:
                 try:
                     await sessions.replace_canonical_settings_state(namespace, prior_settings)
                     active_backend, active_provider = self._runtime_pool.get_backend_provider(
-                        authority.runtime_profile_id
+                        self._runtime_authority(authority)
                     )
                     if f"{active_backend}:{active_provider}" != current.backend_option_id:
                         await self._runtime_pool.select_backend(
-                            authority.runtime_profile_id,
+                            self._runtime_authority(authority),
                             current.backend_option_id,
                         )
                 except BaseException as rollback_exc:
@@ -557,7 +574,7 @@ class WorkshopSettingsWorkspaceService:
     ) -> SettingsWorkspaceSnapshot:
         if isinstance(timeout_seconds, bool) or not isinstance(timeout_seconds, int):
             raise WorkshopSettingsWorkspaceValidationError("Timeout must be a whole number of seconds")
-        profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
+        profile = self._runtime_pool.runtime_profile(self._runtime_authority(authority))
         maximum_timeout = profile.maximum_timeout_seconds
         if not MIN_SELF_SERVICE_TIMEOUT_SECONDS <= timeout_seconds <= maximum_timeout:
             raise WorkshopSettingsWorkspaceValidationError(
@@ -599,8 +616,8 @@ class WorkshopSettingsWorkspaceService:
             raise WorkshopSettingsWorkspaceValidationError("Workspace path must be absolute")
         requested = Path(workspace_path).expanduser().resolve()
         async with self._lock(authority):
-            home = self._runtime_pool.get_home_workspace(authority.runtime_profile_id).resolve()
-            base, allowed = await self._runtime_pool.resolve_workspace_access(authority.runtime_profile_id)
+            home = self._runtime_pool.get_home_workspace(self._runtime_authority(authority)).resolve()
+            base, allowed = await self._runtime_pool.resolve_workspace_access(self._runtime_authority(authority))
             if not requested.is_dir():
                 raise WorkshopSettingsWorkspaceValidationError("Workspace directory is unavailable")
             if requested != home and not is_workspace_allowed(
@@ -611,10 +628,10 @@ class WorkshopSettingsWorkspaceService:
                 raise WorkshopSettingsWorkspaceAccessDenied("Workspace is outside this runtime profile's grants")
             current = await self._inspect_locked(authority)
             self._check_revision(current.revision, expected_revision)
-            was_running = self._runtime_pool.is_running(authority.runtime_profile_id)
+            was_running = self._runtime_pool.is_running(self._runtime_authority(authority))
             namespace = self._namespace(authority)
             prior_settings = await sessions.get_canonical_execution_settings(namespace)
-            prior_workspace = await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)
+            prior_workspace = await self._runtime_pool.get_effective_workspace(self._runtime_authority(authority))
             desired_settings = dict(prior_settings)
             if requested == home:
                 desired_settings.pop("workspace", None)
@@ -674,8 +691,8 @@ class WorkshopSettingsWorkspaceService:
         mutation: SettingsMutationOutcome | None = None,
     ) -> WorkspaceConfigSnapshot:
         namespace = self._namespace(authority)
-        profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
-        backend, _provider = self._runtime_pool.get_backend_provider(authority.runtime_profile_id)
+        profile = self._runtime_pool.runtime_profile(self._runtime_authority(authority))
+        backend, _provider = self._runtime_pool.get_backend_provider(self._runtime_authority(authority))
         backend_option = profile.backend_option(f"{backend}:{_provider}")
         workspace = await self._authorized_workspace(authority, workspace_path)
         yaml_config = self._config.get_workspace_config(workspace)
@@ -762,8 +779,8 @@ class WorkshopSettingsWorkspaceService:
     ) -> WorkspaceConfigSnapshot:
         if field not in {"model", "timeout", "env", "prompt"}:
             raise WorkshopSettingsWorkspaceValidationError("Unsupported workspace setting")
-        profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
-        backend, _provider = self._runtime_pool.get_backend_provider(authority.runtime_profile_id)
+        profile = self._runtime_pool.runtime_profile(self._runtime_authority(authority))
+        backend, _provider = self._runtime_pool.get_backend_provider(self._runtime_authority(authority))
         backend_option = profile.backend_option(f"{backend}:{_provider}")
         if field == "model":
             value = canonicalize_model_for_backend(value.strip(), backend_option.backend)
@@ -814,7 +831,7 @@ class WorkshopSettingsWorkspaceService:
                 self._namespace(authority),
                 str(workspace),
             )
-            was_running = self._runtime_pool.is_running(authority.runtime_profile_id)
+            was_running = self._runtime_pool.is_running(self._runtime_authority(authority))
             if prior.get(field) == value:
                 return await self._workspace_config_locked(
                     authority,
@@ -864,7 +881,7 @@ class WorkshopSettingsWorkspaceService:
                 self._namespace(authority),
                 str(workspace),
             )
-            was_running = self._runtime_pool.is_running(authority.runtime_profile_id)
+            was_running = self._runtime_pool.is_running(self._runtime_authority(authority))
             reset_fields = set(prior) if field is None else {field} & set(prior)
             if not reset_fields:
                 return await self._workspace_config_locked(
@@ -1018,7 +1035,7 @@ class WorkshopSettingsWorkspaceService:
             str(workspace),
         )
         prior_execution = await sessions.get_canonical_execution_settings(namespace)
-        active = await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)
+        active = await self._runtime_pool.get_effective_workspace(self._runtime_authority(authority))
         desired = dict(prior)
         desired[field] = value
         await sessions.replace_canonical_settings_state(
@@ -1056,7 +1073,7 @@ class WorkshopSettingsWorkspaceService:
             str(workspace),
         )
         prior_execution = await sessions.get_canonical_execution_settings(namespace)
-        active = await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)
+        active = await self._runtime_pool.get_effective_workspace(self._runtime_authority(authority))
         desired = {} if field is None else {key: value for key, value in prior.items() if key != field}
         await sessions.replace_canonical_settings_state(
             namespace,
@@ -1093,7 +1110,7 @@ class WorkshopSettingsWorkspaceService:
             self._check_revision(current.revision, expected_revision)
             namespace = self._namespace(authority)
             prior = await sessions.get_canonical_workspace_config_settings(namespace, str(workspace))
-            was_running = self._runtime_pool.is_running(authority.runtime_profile_id)
+            was_running = self._runtime_pool.is_running(self._runtime_authority(authority))
             desired = {field: value for field, value in prior.items() if field not in {"model", "timeout", "prompt"}}
             if desired == prior:
                 return await self._workspace_config_locked(
@@ -1107,7 +1124,7 @@ class WorkshopSettingsWorkspaceService:
                     ),
                 )
             prior_execution = await sessions.get_canonical_execution_settings(namespace)
-            active = await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)
+            active = await self._runtime_pool.get_effective_workspace(self._runtime_authority(authority))
             await sessions.replace_canonical_settings_state(
                 namespace,
                 prior_execution,
@@ -1150,14 +1167,14 @@ class WorkshopSettingsWorkspaceService:
             # returning it. Reapplying the static grant check here creates a
             # second, subtly different authority path for protected homes
             # owned by another OS user (for example Scott's installed runtime).
-            workspace = (await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)).resolve()
+            workspace = (await self._runtime_pool.get_effective_workspace(self._runtime_authority(authority))).resolve()
             if not workspace.is_dir():
                 raise WorkshopSettingsWorkspaceValidationError("Workspace directory is unavailable")
             return workspace
 
         workspace = Path(workspace_path).expanduser().resolve()
-        home = self._runtime_pool.get_home_workspace(authority.runtime_profile_id).resolve()
-        base, allowed = await self._runtime_pool.resolve_workspace_access(authority.runtime_profile_id)
+        home = self._runtime_pool.get_home_workspace(self._runtime_authority(authority)).resolve()
+        base, allowed = await self._runtime_pool.resolve_workspace_access(self._runtime_authority(authority))
         if not workspace.is_dir():
             raise WorkshopSettingsWorkspaceValidationError("Workspace directory is unavailable")
         if workspace != home and not is_workspace_allowed(workspace, base, allowed):
@@ -1176,9 +1193,9 @@ class WorkshopSettingsWorkspaceService:
     ) -> SettingsWorkspaceSnapshot:
         current = await self._inspect_locked(authority)
         self._check_revision(current.revision, expected_revision)
-        was_running = self._runtime_pool.is_running(authority.runtime_profile_id)
+        was_running = self._runtime_pool.is_running(self._runtime_authority(authority))
         namespace = self._namespace(authority)
-        workspace = await self._runtime_pool.get_effective_workspace(authority.runtime_profile_id)
+        workspace = await self._runtime_pool.get_effective_workspace(self._runtime_authority(authority))
         prior_execution = await sessions.get_canonical_execution_settings(namespace)
         prior_workspace = await sessions.get_canonical_workspace_config_settings(namespace, str(workspace))
         desired_execution = dict(prior_execution)
@@ -1240,7 +1257,7 @@ class WorkshopSettingsWorkspaceService:
         )
         model, timeout = await self._effective_values(authority, workspace)
         await self._runtime_pool.apply_workspace_config_if_running(
-            authority.runtime_profile_id,
+            self._runtime_authority(authority),
             workspace,
             workspace_config=config,
             model=str(model.value),
@@ -1436,8 +1453,8 @@ class WorkshopSettingsWorkspaceService:
         authority: SettingsWorkspaceAuthority,
         workspace: Path,
     ) -> tuple[EffectiveValue, EffectiveValue]:
-        profile = self._runtime_pool.runtime_profile(authority.runtime_profile_id)
-        backend, _provider = self._runtime_pool.get_backend_provider(authority.runtime_profile_id)
+        profile = self._runtime_pool.runtime_profile(self._runtime_authority(authority))
+        backend, _provider = self._runtime_pool.get_backend_provider(self._runtime_authority(authority))
         backend_option = profile.backend_option(f"{backend}:{_provider}")
         namespace = self._namespace(authority)
         user = await sessions.get_canonical_execution_settings(namespace)

--- a/src/kai/workshop/storage_namespaces.py
+++ b/src/kai/workshop/storage_namespaces.py
@@ -77,11 +77,11 @@ class WorkshopChannelHistoryRegistry:
     ) -> WorkshopChannelHistoryRegistry:
         """Resolve protected runtime assignments to canonical channels."""
         async with store.connection.execute(
-            "SELECT ra.runtime_profile_id, ra.channel_id, c.kind "
+            "SELECT ra.runtime_profile_id, ra.channel_id, c.kind, ra.created_event_position "
             "FROM channel_agent_runtime_assignments ra "
             "JOIN channels c ON c.id = ra.channel_id "
             "ORDER BY ra.runtime_profile_id, "
-            "CASE c.kind WHEN 'direct' THEN 0 ELSE 1 END, ra.channel_id"
+            "CASE c.kind WHEN 'direct' THEN 0 ELSE 1 END, ra.created_event_position, ra.channel_id"
         ) as cursor:
             assignment_rows = list(await cursor.fetchall())
         channels_by_profile: dict[RuntimeProfileId, list[tuple[ChannelId, str]]] = {}
@@ -99,10 +99,12 @@ class WorkshopChannelHistoryRegistry:
         legacy_key_by_channel: dict[ChannelId, int | None] = {}
         for profile in runtime_profiles.profiles:
             assignments = channels_by_profile.get(profile.profile_id, [])
-            direct_channels = {channel_id for channel_id, kind in assignments if kind == "direct"}
-            if len(direct_channels) != 1:
+            direct_channels = [channel_id for channel_id, kind in assignments if kind == "direct"]
+            if not direct_channels:
                 raise WorkshopStorageNamespaceError("Protected runtime profile has no canonical history channel")
-            direct_channel_id = next(iter(direct_channels))
+            # The oldest direct lane is the sole compatibility-history alias.
+            # Additional enabled agents are independent canonical histories.
+            direct_channel_id = direct_channels[0]
             legacy_runtime_key = runtime_profiles.legacy_runtime_key(profile.profile_id)
             if legacy_runtime_key is not None:
                 runtime_aliases[legacy_runtime_key] = direct_channel_id

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -23,6 +23,7 @@ from kai.config import Config, ModelRole, UserConfig, WorkspaceConfig, get_model
 from kai.goose import GooseBackend
 from kai.internal_api_auth import InternalAPIScope
 from kai.pool import SubprocessPool
+from kai.workshop.domain import AgentId, ChannelId
 from kai.workshop.internal_api_contexts import (
     WorkshopInternalAPIContextRegistry,
     WorkshopInternalAPIExecutionContext,
@@ -106,6 +107,50 @@ class TestInstanceCreation:
         b = pool.get(222)
         assert a is not b
         assert a._api_context.webhook_secret != b._api_context.webhook_secret
+
+    def test_same_profile_uses_distinct_channel_agent_runtime_lanes(self, tmp_path):
+        runtime_id = profile_id(111)
+        primary = WorkshopInternalAPIExecutionContext.for_unprotected_runtime(111, runtime_id)
+        secondary = WorkshopInternalAPIExecutionContext(
+            primary.principal_id,
+            ChannelId("chn_" + "a" * 32),
+            AgentId("agt_" + "b" * 32),
+            runtime_id,
+        )
+        profiles = WorkshopRuntimeProfileRegistry(
+            (
+                ProtectedRuntimeProfile(
+                    profile_id=runtime_id,
+                    display_name="shared policy",
+                    os_user=None,
+                    backend="codex",
+                    provider="openai",
+                    model="gpt-5.6-sol",
+                    timeout_seconds=120,
+                    allowed_services=(),
+                    home_workspace=tmp_path,
+                    workspace_base=None,
+                    allowed_workspaces=(),
+                ),
+            ),
+            legacy_runtime_keys={runtime_id: 111},
+        )
+        pool = SubprocessPool(
+            config=_make_config(allowed_user_ids={111}),
+            services_info=[],
+            runtime_profiles=profiles,
+            internal_api_contexts=WorkshopInternalAPIContextRegistry((primary, secondary)),
+        )
+
+        first = pool.get(primary)
+        second = pool.get(secondary)
+
+        assert first is not second
+        assert first._api_context.webhook_secret != second._api_context.webhook_secret
+        assert pool.internal_api_auth.authenticate(first._api_context.webhook_secret).channel_id == primary.channel_id
+        assert (
+            pool.internal_api_auth.authenticate(second._api_context.webhook_secret).channel_id == secondary.channel_id
+        )
 
     def test_internal_api_credential_exists_without_external_webhooks(self):
         """Disabling public ingress must not remove the agent's scoped API."""

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -656,7 +656,7 @@ class TestSendFile:
         assert body["status"] == "recorded"
         send_file_request.app[CORE_HOST_KEY].services.proactive_publication.publish_file.assert_awaited_once()
         send_file_request.app[CORE_HOST_KEY].services.runtime_pool.get_effective_workspace.assert_awaited_once_with(
-            profile_id(123)
+            _internal_api_context(123)
         )
 
     async def test_caption_forwarded_to_canonical_publication(self, tmp_path, send_file_request):
@@ -2704,7 +2704,7 @@ class TestMemoryAdd:
         body = json.loads(resp.body.decode())
         assert body == {"id": "mem-uuid-123"}
         mock_request.app[CORE_HOST_KEY].services.runtime_pool.get_effective_workspace.assert_awaited_once_with(
-            profile_id(123)
+            _internal_api_context(123)
         )
 
     async def test_returns_503_when_memory_disabled(self, mock_request):

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -1,0 +1,207 @@
+"""Principal-agent enablement, isolation, and continuity contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.agent_enablement import (
+    WorkshopAgentEnablementAccessDenied,
+    WorkshopAgentEnablementService,
+)
+from kai.workshop.agent_lifecycle import WorkshopAgentLifecycleService
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.domain import AgentDefinitionId, PrincipalId
+from kai.workshop.execution_state import WorkshopExecutionStateRegistry
+from kai.workshop.internal_api_contexts import (
+    WorkshopInternalAPIContextRegistry,
+    WorkshopInternalAPIExecutionContext,
+)
+from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
+
+
+@dataclass
+class _RuntimePool:
+    registered: list[WorkshopInternalAPIExecutionContext] = field(default_factory=list)
+    suspended: list[WorkshopInternalAPIExecutionContext] = field(default_factory=list)
+    rebound: list[tuple[WorkshopInternalAPIExecutionContext, WorkshopInternalAPIExecutionContext]] = field(
+        default_factory=list
+    )
+
+    def register_canonical_lane(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        self.registered.append(context)
+
+    async def suspend_canonical_lane(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        self.suspended.append(context)
+
+    async def rebind_canonical_lane(
+        self,
+        prior: WorkshopInternalAPIExecutionContext,
+        replacement: WorkshopInternalAPIExecutionContext,
+    ) -> None:
+        self.rebound.append((prior, replacement))
+
+
+async def _principal(store: WorkshopEventStore, external_subject: str) -> PrincipalId:
+    async with store.connection.execute(
+        "SELECT principal_id FROM external_identities WHERE provider = 'telegram' AND external_subject = ?",
+        (external_subject,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return PrincipalId(str(row[0]))
+
+
+async def _active_specialist(
+    store: WorkshopEventStore,
+    principal_id: PrincipalId,
+) -> AgentDefinitionId:
+    lifecycle = WorkshopAgentLifecycleService(store)
+    draft = await lifecycle.create_draft(
+        principal_id,
+        idempotency_key="specialist-create",
+        handle="specialist",
+        display_name="Specialist",
+        description="An isolated specialist.",
+        presentation={"avatar": "S"},
+        purpose="Qualify reusable agents.",
+        instructions="Work only in the current canonical conversation.",
+        capabilities=["text_generation"],
+    )
+    active = await lifecycle.activate_revision(
+        principal_id,
+        draft.definition_id,
+        revision_id=draft.revisions[0].revision_id,
+        idempotency_key="specialist-activate",
+        expected_version=draft.state_version,
+    )
+    return active.definition_id
+
+
+async def _service(path: Path):
+    store = await WorkshopEventStore.open(path)
+    profiles = profile_registry(101, 202)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman("Daniel", "admin", "telegram", "101", "101", profile_id(101)),
+            BootstrapHuman("Scott", "member", "telegram", "202", "202", profile_id(202)),
+        ),
+    )
+    execution = await WorkshopExecutionStateRegistry.from_store(store, profiles)
+    contexts = await WorkshopInternalAPIContextRegistry.from_store(store, profiles)
+    runtime_pool = _RuntimePool()
+    return (
+        store,
+        WorkshopAgentEnablementService(
+            store,
+            profiles,
+            execution,
+            contexts,
+            runtime_pool,  # type: ignore[arg-type]
+        ),
+        execution,
+        contexts,
+        runtime_pool,
+    )
+
+
+async def test_two_principals_enable_same_definition_in_isolated_direct_lanes(tmp_path: Path) -> None:
+    store, service, execution, contexts, runtime_pool = await _service(tmp_path / "kai.db")
+    try:
+        daniel = await _principal(store, "101")
+        scott = await _principal(store, "202")
+        definition_id = await _active_specialist(store, daniel)
+
+        daniel_enabled = await service.enable(
+            daniel,
+            definition_id,
+            profile_id(101),
+            idempotency_key="daniel-enable",
+        )
+        scott_enabled = await service.enable(
+            scott,
+            definition_id,
+            profile_id(202),
+            idempotency_key="scott-enable",
+        )
+
+        assert daniel_enabled.lifecycle_state == scott_enabled.lifecycle_state == "enabled"
+        assert daniel_enabled.agent_id == scott_enabled.agent_id
+        assert daniel_enabled.direct_channel_id != scott_enabled.direct_channel_id
+        assert daniel_enabled.runtime_profile_id == profile_id(101)
+        assert scott_enabled.runtime_profile_id == profile_id(202)
+        assert len(runtime_pool.registered) == 2
+        assert execution.maybe_for_principal_channel(daniel, daniel_enabled.direct_channel_id) is not None
+        assert execution.maybe_for_principal_channel(scott, scott_enabled.direct_channel_id) is not None
+        assert len(contexts.contexts) == 4
+        async with store.connection.execute(
+            "SELECT direct_channel_id, COUNT(*) FROM principal_agent_enablements "
+            "WHERE agent_definition_id = ? GROUP BY direct_channel_id ORDER BY direct_channel_id",
+            (definition_id,),
+        ) as cursor:
+            assert [int(row[1]) for row in await cursor.fetchall()] == [1, 1]
+    finally:
+        await store.close()
+
+
+async def test_runtime_authority_cannot_cross_principals(tmp_path: Path) -> None:
+    store, service, _execution, _contexts, _runtime_pool = await _service(tmp_path / "kai.db")
+    try:
+        daniel = await _principal(store, "101")
+        definition_id = await _active_specialist(store, daniel)
+        with pytest.raises(WorkshopAgentEnablementAccessDenied, match="not owned"):
+            await service.enable(
+                daniel,
+                definition_id,
+                profile_id(202),
+                idempotency_key="cross-principal-runtime",
+            )
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM principal_agent_enablements WHERE agent_definition_id = ?",
+            (definition_id,),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 0
+    finally:
+        await store.close()
+
+
+async def test_disable_and_reenable_preserve_direct_channel(tmp_path: Path) -> None:
+    store, service, _execution, _contexts, runtime_pool = await _service(tmp_path / "kai.db")
+    try:
+        daniel = await _principal(store, "101")
+        definition_id = await _active_specialist(store, daniel)
+        enabled = await service.enable(
+            daniel,
+            definition_id,
+            profile_id(101),
+            idempotency_key="enable-once",
+        )
+        disabled = await service.disable(
+            daniel,
+            definition_id,
+            idempotency_key="disable-once",
+            expected_version=enabled.state_version,
+        )
+        restored = await service.enable(
+            daniel,
+            definition_id,
+            profile_id(101),
+            idempotency_key="enable-again",
+            expected_version=disabled.state_version,
+        )
+
+        assert disabled.lifecycle_state == "disabled"
+        assert restored.lifecycle_state == "enabled"
+        assert restored.direct_channel_id == enabled.direct_channel_id
+        assert runtime_pool.suspended[0].channel_id == enabled.direct_channel_id
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM channels WHERE id = ?",
+            (enabled.direct_channel_id,),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 1
+    finally:
+        await store.close()

--- a/tests/test_workshop_appearance_preferences.py
+++ b/tests/test_workshop_appearance_preferences.py
@@ -70,7 +70,7 @@ async def test_version_thirty_seven_preferences_upgrade_without_data_loss(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 46
+        assert await upgraded.schema_version() == 47
         async with upgraded.connection.execute(
             "SELECT principal_id, theme_id, created_at, updated_at FROM principal_appearance_preferences"
         ) as cursor:

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -529,7 +529,7 @@ class TestArtifactShadowRecordingAfterRestart:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 13
+            assert checkpoint.version == 14
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_bootstrap.py
+++ b/tests/test_workshop_bootstrap.py
@@ -251,7 +251,7 @@ class TestDefaultWorkshopBootstrap:
         )
 
         assert first.created_events == 15
-        assert upgraded.created_events == 1
+        assert upgraded.created_events == 2
         assert upgraded.existing_events == 15
         async with store.connection.execute(
             "SELECT provider, external_subject FROM external_identities ORDER BY provider"
@@ -306,8 +306,9 @@ class TestDefaultWorkshopBootstrap:
             ],
         )
 
-        assert migrated.created_events == 1
-        assert (await store.read_events())[-1].envelope.event_type == WorkshopEventType.RUNTIME_PROFILE_REASSIGNED
+        assert migrated.created_events == 2
+        assert (await store.read_events())[-2].envelope.event_type == WorkshopEventType.RUNTIME_PROFILE_REASSIGNED
+        assert (await store.read_events())[-1].envelope.event_type == WorkshopEventType.PRINCIPAL_AGENT_ENABLED
         async with store.connection.execute(
             "SELECT runtime_profile_id FROM channel_agent_runtime_assignments"
         ) as cursor:

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -13,6 +13,7 @@ import pytest
 from aiohttp import FormData, web
 from aiohttp.test_utils import TestClient, TestServer
 
+from kai.workshop.agent_enablement import EligibleAgentRuntime, PrincipalAgentEnablement
 from kai.workshop.appearance_preferences import (
     WORKSHOP_APPEARANCE_THEMES,
     WorkshopAppearancePreferenceService,
@@ -672,6 +673,59 @@ class _GitHubSettings:
         return self._snapshot(GitHubSettingsMutation("replace_github_token", True))
 
 
+@dataclass
+class _AgentEnablement:
+    principal_id: PrincipalId
+    definition_id: AgentDefinitionId = field(default_factory=lambda: AgentDefinitionId("adf_" + "a" * 32))
+    calls: list[tuple[str, object]] = field(default_factory=list)
+
+    def _snapshot(self, state: str = "available") -> PrincipalAgentEnablement:
+        enabled = state in {"enabled", "disabled"}
+        return PrincipalAgentEnablement(
+            None,
+            self.definition_id,
+            AgentId("agt_" + "b" * 32),
+            "specialist",
+            "Specialist",
+            state,
+            ChannelId("chn_" + "c" * 32) if enabled else None,
+            profile_id(101) if enabled else None,
+            42 if enabled else None,
+            (EligibleAgentRuntime(profile_id(101), "Daniel", ("claude:anthropic",)),),
+        )
+
+    async def list_for_principal(self, principal_id):
+        assert principal_id == self.principal_id
+        self.calls.append(("list", principal_id))
+        return (self._snapshot(),)
+
+    async def inspect(self, principal_id, definition_id):
+        assert principal_id == self.principal_id
+        assert definition_id == self.definition_id
+        self.calls.append(("inspect", definition_id))
+        return self._snapshot()
+
+    async def enable(
+        self,
+        principal_id,
+        definition_id,
+        runtime_profile_id,
+        *,
+        idempotency_key,
+        expected_version=None,
+    ):
+        assert principal_id == self.principal_id
+        assert definition_id == self.definition_id
+        self.calls.append(("enable", (runtime_profile_id, idempotency_key, expected_version)))
+        return self._snapshot("enabled")
+
+    async def disable(self, principal_id, definition_id, *, idempotency_key, expected_version):
+        assert principal_id == self.principal_id
+        assert definition_id == self.definition_id
+        self.calls.append(("disable", (idempotency_key, expected_version)))
+        return self._snapshot("disabled")
+
+
 async def _identity_for(store: WorkshopEventStore, subject: str) -> tuple[PrincipalId, ChannelId]:
     async with store.connection.execute(
         "SELECT e.principal_id, b.channel_id FROM external_identities e "
@@ -797,6 +851,7 @@ async def _open_client(
     notification_preferences=None,
     client_preferences=None,
     appearance_preferences=None,
+    agent_enablement=None,
 ) -> TestClient:
     app = web.Application()
     register_workshop_read_routes(
@@ -818,6 +873,7 @@ async def _open_client(
         notification_preferences=notification_preferences,
         client_preferences=client_preferences,
         appearance_preferences=appearance_preferences,
+        agent_enablement=agent_enablement,
     )
     client = TestClient(TestServer(app))
     await client.start_server()
@@ -1603,6 +1659,81 @@ class TestWorkshopAgentLifecycleHTTPContract:
                 first_revision_id,
                 second_revision_id,
             }
+        finally:
+            await client.close()
+            await store.close()
+
+
+class TestWorkshopAgentEnablementHTTPContract:
+    async def test_authenticated_principal_lists_enables_and_disables_agent(self, tmp_path: Path) -> None:
+        store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+        service = _AgentEnablement(alice_id)
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id}),
+            agent_enablement=service,
+        )
+        try:
+            listed = await client.get(
+                "/v1/client/agent-enablement",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert listed.status == 200
+            listing = await listed.json()
+            assert listing["agents"][0]["lifecycle_state"] == "available"
+            assert listing["agents"][0]["eligible_runtimes"] == [
+                {
+                    "runtime_profile_id": str(profile_id(101)),
+                    "display_name": "Daniel",
+                    "backend_options": ["claude:anthropic"],
+                }
+            ]
+
+            enabled = await client.post(
+                f"/v1/client/agents/{service.definition_id}/enable",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "idempotency_key": "enable-specialist",
+                    "runtime_profile_id": str(profile_id(101)),
+                },
+            )
+            assert enabled.status == 200
+            assert (await enabled.json())["agent"]["lifecycle_state"] == "enabled"
+
+            disabled = await client.post(
+                f"/v1/client/agents/{service.definition_id}/disable",
+                headers={"Authorization": "Bearer alice"},
+                json={"idempotency_key": "disable-specialist", "expected_version": 42},
+            )
+            assert disabled.status == 200
+            assert (await disabled.json())["agent"]["lifecycle_state"] == "disabled"
+            assert [item[0] for item in service.calls] == ["list", "enable", "disable"]
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_enablement_routes_require_authentication_and_exact_payloads(self, tmp_path: Path) -> None:
+        store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+        service = _AgentEnablement(alice_id)
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id}),
+            agent_enablement=service,
+        )
+        try:
+            unauthenticated = await client.get("/v1/client/agent-enablement")
+            assert unauthenticated.status == 401
+            malformed = await client.post(
+                f"/v1/client/agents/{service.definition_id}/enable",
+                headers={"Authorization": "Bearer alice"},
+                json={
+                    "idempotency_key": "bad-extra",
+                    "runtime_profile_id": str(profile_id(101)),
+                    "principal_id": str(alice_id),
+                },
+            )
+            assert malformed.status == 400
+            assert service.calls == []
         finally:
             await client.close()
             await store.close()

--- a/tests/test_workshop_client_enrollment.py
+++ b/tests/test_workshop_client_enrollment.py
@@ -313,7 +313,7 @@ class TestWorkshopClientSecurityStateIsolation:
             await upgraded.rebuild_projection(CanonicalConversationProjection())
             after = {table: await security_rows(table) for table in before}
 
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert after == before
             async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
                 assert await cursor.fetchall() == []

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -389,7 +389,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 13
+            assert checkpoint.version == 14
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -92,7 +92,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             tables = await upgraded.schema_tables()
             assert {
                 "channel_agent_execution_settings",
@@ -129,7 +129,7 @@ class TestCanonicalExecutionStateMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             async with upgraded.connection.execute(
                 "SELECT field, value FROM channel_agent_execution_settings"
             ) as cursor:

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -98,6 +98,9 @@ class TestEventEnvelope:
             "agent_definition.revision_added",
             "agent_definition.revision_activated",
             "agent_definition.archived",
+            "principal_agent.enabled",
+            "principal_agent.disabled",
+            "principal_agent.runtime_changed",
             "channel.agent_attached",
             "channel.agent_dismissed",
             "runtime_profile.assigned",
@@ -189,6 +192,7 @@ class TestWorkshopSchema:
             "agents",
             "agent_definitions",
             "agent_definition_revisions",
+            "principal_agent_enablements",
             "channel_agents",
             "channel_agent_runtime_assignments",
             "channel_agent_runtime_sessions",
@@ -218,7 +222,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 46
+        assert await workshop_store.schema_version() == 47
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -254,7 +258,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 46
+        assert await second.schema_version() == 47
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -286,7 +290,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -314,7 +318,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -378,6 +382,7 @@ class TestWorkshopSchema:
                     44,
                     45,
                     46,
+                    47,
                 ]
         finally:
             await upgraded.close()
@@ -400,7 +405,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -441,7 +446,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -494,7 +499,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -538,7 +543,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -582,7 +587,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -626,7 +631,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -730,7 +735,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -857,7 +862,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_internal_api_contexts.py
+++ b/tests/test_workshop_internal_api_contexts.py
@@ -52,7 +52,7 @@ async def test_missing_profile_assignment_fails_closed(tmp_path: Path) -> None:
     try:
         with pytest.raises(
             WorkshopInternalAPIContextError,
-            match="exactly one canonical internal API context",
+            match="one canonical human principal",
         ):
             await WorkshopInternalAPIContextRegistry.from_store(
                 store,
@@ -73,7 +73,7 @@ async def test_missing_channel_agent_attachment_fails_closed(tmp_path: Path) -> 
         await store.connection.commit()
         with pytest.raises(
             WorkshopInternalAPIContextError,
-            match="exactly one canonical internal API context",
+            match="one canonical human principal",
         ):
             await WorkshopInternalAPIContextRegistry.from_store(
                 store,
@@ -112,7 +112,7 @@ async def test_ambiguous_direct_channel_ownership_fails_closed(tmp_path: Path) -
 
         with pytest.raises(
             WorkshopInternalAPIContextError,
-            match="exactly one canonical internal API context",
+            match="one canonical human principal",
         ):
             await WorkshopInternalAPIContextRegistry.from_store(
                 store,
@@ -139,7 +139,7 @@ async def test_cross_workshop_agent_assignment_fails_closed(tmp_path: Path) -> N
 
         with pytest.raises(
             WorkshopInternalAPIContextError,
-            match="exactly one canonical internal API context",
+            match="one canonical human principal",
         ):
             await WorkshopInternalAPIContextRegistry.from_store(
                 store,
@@ -161,6 +161,6 @@ def test_duplicate_runtime_profile_contexts_are_rejected() -> None:
 
     with pytest.raises(
         WorkshopInternalAPIContextError,
-        match="Duplicate internal API runtime profile",
+        match="cannot cross internal API principals",
     ):
         WorkshopInternalAPIContextRegistry((context, duplicate_assignment))

--- a/tests/test_workshop_memory_authority.py
+++ b/tests/test_workshop_memory_authority.py
@@ -521,7 +521,7 @@ class TestCanonicalMemoryAuthorityMigration:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert "workshop_memory_authority_migrations" in await upgraded.schema_tables()
         finally:
             await upgraded.close()

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -18,6 +18,7 @@ from kai.workshop.execution_coordinator import (
     CanonicalExecutionDisposition,
 )
 from kai.workshop.inbound import ClientInboundMessage, InboundMessage
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.private_text_execution import (
     RecoverableClientRun,
     WorkshopPrivateTextExecutionService,
@@ -201,7 +202,12 @@ async def test_owner_accepts_executes_and_atomically_enqueues_terminal_reply(tmp
         assert "canonical-transcript.ndjson" in runtime.canonical_histories[0]
         assert "untrusted conversation data" in runtime.canonical_histories[0]
         pool.prepare_routed_execution.assert_awaited_once_with(
-            profile_id(101),
+            WorkshopInternalAPIExecutionContext(
+                accepted.run.requested_by_principal_id,
+                accepted.run.channel_id,
+                accepted.run.agent_id,
+                profile_id(101),
+            ),
             "codex:openai",
             "gpt-5.6-sol",
         )

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -13,6 +13,7 @@ from kai.pool import SubprocessPool
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.inbound import InboundMessage
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.protected_execution import (
     ProtectedExecutionPreparationError,
     WorkshopProtectedExecutionPreparationService,
@@ -93,10 +94,16 @@ async def _accepted_run(path: Path, home: Path):
         },
     )
     profiles = profile_registry(101)
+    internal_api_contexts = await WorkshopInternalAPIContextRegistry.from_store(store, profiles)
     return (
         store,
         accepted.run,
-        SubprocessPool(config=config, services_info=[], runtime_profiles=profiles),
+        SubprocessPool(
+            config=config,
+            services_info=[],
+            runtime_profiles=profiles,
+            internal_api_contexts=internal_api_contexts,
+        ),
         profiles,
     )
 

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -391,7 +391,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 13
+            assert checkpoint.version == 14
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:
@@ -411,7 +411,7 @@ class TestRunExecutionMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("PRAGMA table_info(runs)") as cursor:
                 columns = {str(row[1]) for row in await cursor.fetchall()}

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -166,7 +166,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 13
+            assert checkpoint.version == 14
             assert after == before
         finally:
             await store.close()
@@ -221,7 +221,7 @@ class TestDurableRunMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert "runs" in await upgraded.schema_tables()
             assert "run_attempts" in await upgraded.schema_tables()
             async with upgraded.connection.execute("SELECT name FROM workshops") as cursor:

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -178,7 +178,7 @@ class TestRuntimeAssignmentPolicy:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 13
+            assert checkpoint.version == 14
             assert await resolve_channel_runtime_profile(store, human.channel_id) == (
                 assigned.agent_id,
                 profile_id(202),

--- a/tests/test_workshop_streaming_finalization.py
+++ b/tests/test_workshop_streaming_finalization.py
@@ -524,7 +524,7 @@ class TestStreamingFinalizationMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             async with upgraded.connection.execute(
                 "SELECT execution_contract FROM delivery_outbox WHERE id = ?", (delivery_id,)
             ) as cursor:

--- a/tests/test_workshop_streaming_preview.py
+++ b/tests/test_workshop_streaming_preview.py
@@ -417,7 +417,7 @@ class TestTelegramStreamingPreviewMigration:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert "telegram_streaming_previews" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT name FROM workshop_schema_migrations WHERE version = 12"

--- a/tests/test_workshop_terminal_transactions.py
+++ b/tests/test_workshop_terminal_transactions.py
@@ -382,7 +382,7 @@ class TestAtomicTerminalTransactions:
 
         upgraded = await WorkshopEventStore.open(database)
         try:
-            assert await upgraded.schema_version() == 46
+            assert await upgraded.schema_version() == 47
             assert await _post_run_effect_count(upgraded) == 1
             async with upgraded.connection.execute(
                 "SELECT status, source_message_id, result_message_id FROM workshop_post_run_effects WHERE run_id = ?",


### PR DESCRIPTION
Closes #1230.

## Summary

- add canonical per-principal agent enablement lifecycle state and replayable projections
- provision isolated direct channels and exact runtime namespaces without restarting Kai
- preserve channel history across disable/re-enable and support live runtime rebinding
- expose authenticated enablement APIs without leaking runtime credentials or OS-user details
- reconcile existing Kai direct channels into enablements during bootstrap

## Security

- require the selected runtime profile to belong to the authenticated human principal
- keep processes, credentials, settings, workspaces, history, and memory scoped to the exact principal/channel/agent/runtime context
- revoke lane credentials before terminating or rebinding protected processes
- reject disabled lanes and cross-principal profiles before execution or mutation

## Validation

- `make check`
- `make typecheck`
- `make test` — 6,310 passed
- `make client-check` — 121 passed; generated assets verified
- `make check-install-constraints`
- `make audit-deps` — no known vulnerabilities
