### PR TITLE
fix: dispatch enabled Workshop agents

### DIFF
--- a/src/kai/workshop/routing_policy.py
+++ b/src/kai/workshop/routing_policy.py
@@ -184,10 +184,12 @@ class WorkshopRoutingPolicyService:
             return existing
 
         requested_task = await self._requested_task_class(run)
-        authority = self._eligibility.authority_for_principal_runtime(
+        authority = self._eligibility.authority_for_principal_channel(
             run.requested_by_principal_id,
-            runtime_profile_id,
+            run.channel_id,
         )
+        if authority.runtime_profile_id != runtime_profile_id:
+            raise RoutingPolicyError("Run does not match canonical routing profile")
         if authority.agent_id != run.agent_id:
             raise RoutingPolicyError("Run does not match canonical routing authority")
         agent_requirements: tuple[RuntimeCapability, ...] = ()

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -89,9 +89,7 @@ class _Eligibility:
         return self.authority
 
     def authority_for_principal_runtime(self, principal_id, runtime_profile_id):
-        assert principal_id == self.authority.principal_id
-        assert runtime_profile_id == self.authority.runtime_profile_id
-        return self.authority
+        raise AssertionError("Run routing must resolve the exact channel lane")
 
     async def inspect(self, authority, task_class, *, additional_required=()):
         assert not additional_required or additional_required[0].value == "text_generation"

--- a/tests/test_workshop_routing_policy.py
+++ b/tests/test_workshop_routing_policy.py
@@ -73,9 +73,7 @@ class _Eligibility:
         return self.authority
 
     def authority_for_principal_runtime(self, principal_id, runtime_profile_id):
-        if principal_id != self.authority.principal_id or runtime_profile_id != self.authority.runtime_profile_id:
-            raise RuntimeError("access denied")
-        return self.authority
+        raise AssertionError("Run routing must resolve the exact channel lane")
 
     async def inspect(self, authority, task_class, *, additional_required=()):
         assert not additional_required or additional_required[0].value == "text_generation"

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -136,9 +136,9 @@ class _CanonicalRoutingEligibility:
     def __init__(self, authority: RoutingEligibilityAuthority) -> None:
         self.authority = authority
 
-    def authority_for_principal_runtime(self, principal_id, runtime_profile_id):
+    def authority_for_principal_channel(self, principal_id, channel_id):
         assert principal_id == self.authority.principal_id
-        assert runtime_profile_id == self.authority.runtime_profile_id
+        assert channel_id == self.authority.channel_id
         return self.authority
 
     async def inspect(self, authority, task_class, *, additional_required=()):


### PR DESCRIPTION
Follow-up to #1235.

## Summary
- resolve run routing from the exact principal/channel execution lane
- verify that the resolved lane still matches the accepted runtime profile and agent
- cover browser, private-text, and scheduled coordinator paths with exact-lane fixtures

## Cause
Newly enabled agents reuse a principal-owned protected runtime profile in a separate canonical channel/agent lane. Routing still looked up the profile-level primary lane, which belongs to Kai, so the agent identity check deferred the new agent run before dispatch.

## Validation
- 6311 Python tests
- 125 Workshop client tests
- ruff lint and formatting
- TypeScript typecheck and generated-asset verification