### PR TITLE
fix: route exact Workshop agent lane selection

### DIFF
--- a/src/kai/workshop/routing_eligibility.py
+++ b/src/kai/workshop/routing_eligibility.py
@@ -199,6 +199,8 @@ class WorkshopRoutingEligibilityService:
             authority.runtime_profile_id,
         )
         workspace = await self._runtime_pool.get_effective_workspace(runtime_authority)
+        selected_backend, selected_provider = self._runtime_pool.get_backend_provider(runtime_authority)
+        selected_option_id = f"{selected_backend}:{selected_provider}"
         selected_model = await self._runtime_pool.get_effective_model(runtime_authority)
         allowed_services = self._runtime_pool.runtime_profile(authority.runtime_profile_id).allowed_services
         catalogue_authority = self._catalogue.authority_for_principal(authority.principal_id)
@@ -207,8 +209,9 @@ class WorkshopRoutingEligibilityService:
         required = tuple(dict.fromkeys((*_TASK_REQUIREMENTS[canonical_task], *additional_required)))
         candidates: list[RuntimeEligibilityCandidate] = []
         for lane in profile.backends:
-            model_id = selected_model if lane.selected else lane.default_model
-            model_source = "current_selection" if lane.selected else "protected_default"
+            selected = lane.option_id == selected_option_id
+            model_id = selected_model if selected else lane.default_model
+            model_source = "current_selection" if selected else "protected_default"
             snapshot: ModelCatalogueSnapshot | None
             try:
                 snapshot = await self._catalogue.inspect(
@@ -223,6 +226,7 @@ class WorkshopRoutingEligibilityService:
                     lane,
                     model_id=model_id,
                     model_source=model_source,
+                    selected=selected,
                     allowed_services=allowed_services,
                     workspace=workspace,
                     required=required,
@@ -247,6 +251,7 @@ class WorkshopRoutingEligibilityService:
         *,
         model_id: str,
         model_source: str,
+        selected: bool,
         allowed_services: tuple[str, ...],
         workspace: Path,
         required: tuple[RuntimeCapability, ...],
@@ -305,7 +310,7 @@ class WorkshopRoutingEligibilityService:
             allowed_services=allowed_services,
             model_id=model_id,
             model_source=model_source,
-            selected=lane.selected,
+            selected=selected,
             eligible=not blocked,
             capabilities=assessments,
             reasons=tuple(reasons),

--- a/tests/test_workshop_routing_eligibility.py
+++ b/tests/test_workshop_routing_eligibility.py
@@ -158,6 +158,7 @@ class _RuntimePool:
     def __init__(self, workspace: Path) -> None:
         self.workspace = workspace
         self.selection_reads = 0
+        self.selected_backend = ("claude", "anthropic")
 
     async def get_effective_workspace(self, _runtime_profile_id):
         return self.workspace
@@ -165,6 +166,9 @@ class _RuntimePool:
     async def get_effective_model(self, _runtime_profile_id):
         self.selection_reads += 1
         return "selected-model"
+
+    def get_backend_provider(self, _runtime_profile_id):
+        return self.selected_backend
 
     def runtime_profile(self, _runtime_profile_id):
         return SimpleNamespace(allowed_services=("perplexity",))
@@ -221,6 +225,27 @@ async def test_report_explains_all_five_authorized_backends_without_switching(tm
     assert len(catalogue.inspected) == 5
     assert all(option_id != ungranted.option_id for _, _, option_id in catalogue.inspected)
     assert not hasattr(pool, "select_backend")
+
+
+@pytest.mark.asyncio
+async def test_report_uses_exact_lane_selection_instead_of_profile_inventory(tmp_path: Path) -> None:
+    namespace = _namespace(1)
+    claude = _lane("claude", "anthropic")
+    codex = _lane("codex", "openai", selected=True)
+    lanes = (claude, codex)
+    snapshots = {lane.option_id: _snapshot(namespace, lane, image_input=True) for lane in lanes}
+    service, authority, pool, *_ = _service(tmp_path, lanes, snapshots)
+    pool.selected_backend = ("claude", "anthropic")
+
+    report = await service.inspect(authority, RoutingTaskClass.CONVERSATION)
+
+    by_option = {candidate.option_id: candidate for candidate in report.candidates}
+    assert by_option["claude:anthropic"].selected is True
+    assert by_option["claude:anthropic"].model_id == "selected-model"
+    assert by_option["claude:anthropic"].model_source == "current_selection"
+    assert by_option["codex:openai"].selected is False
+    assert by_option["codex:openai"].model_id == "codex-default"
+    assert by_option["codex:openai"].model_source == "protected_default"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- derive routing selection from the exact principal/channel/agent lane
- keep the selected backend and selected model from the same canonical authority
- cover the enabled-agent regression where profile inventory and lane selection differ

## Verification
- make check
- make typecheck
- .venv/bin/python -m pytest tests/ -q (6312 passed)
- make client-check (125 passed; generated bundle verified)