### PR TITLE
fix: retain principal authority across agent lanes

### DIFF
--- a/src/kai/workshop/execution_state.py
+++ b/src/kai/workshop/execution_state.py
@@ -65,10 +65,12 @@ class WorkshopExecutionStateRegistry:
             if namespace.legacy_runtime_key is not None:
                 by_legacy_key[namespace.legacy_runtime_key] = namespace
             by_profile.setdefault(namespace.runtime_profile_id, namespace)
-            if namespace.principal_id in by_principal:
-                by_principal[namespace.principal_id] = None
-            else:
+            if namespace.principal_id not in by_principal:
                 by_principal[namespace.principal_id] = namespace
+            else:
+                principal_owner = by_principal[namespace.principal_id]
+                if principal_owner is not None and principal_owner.runtime_profile_id != namespace.runtime_profile_id:
+                    by_principal[namespace.principal_id] = None
             if lane_key in by_principal_channel:
                 by_principal_channel[lane_key] = None
             else:
@@ -190,6 +192,7 @@ class WorkshopExecutionStateRegistry:
         return self.maybe_for_legacy_runtime_key(runtime_config_id)
 
     def maybe_for_principal_id(self, principal_id: str) -> WorkshopExecutionStateNamespace | None:
+        """Resolve the principal's one protected profile across any number of lanes."""
         try:
             canonical_id = PrincipalId(principal_id)
         except (TypeError, ValueError):

--- a/tests/test_workshop_execution_state.py
+++ b/tests/test_workshop_execution_state.py
@@ -9,7 +9,12 @@ import pytest
 from kai import sessions
 from kai.workshop.bootstrap import BootstrapHuman
 from kai.workshop.diagnostics import workshop_execution_state_status
-from kai.workshop.execution_state import WorkshopExecutionStateError
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId
+from kai.workshop.execution_state import (
+    WorkshopExecutionStateError,
+    WorkshopExecutionStateNamespace,
+    WorkshopExecutionStateRegistry,
+)
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id, profile_registry
 
@@ -40,6 +45,55 @@ async def database(tmp_path: Path):
 
 
 class TestCanonicalExecutionStateMigration:
+    def test_principal_authority_survives_multiple_lanes_on_one_profile(self) -> None:
+        principal_id = PrincipalId.new()
+        primary = WorkshopExecutionStateNamespace(
+            principal_id,
+            ChannelId.new(),
+            AgentId.new(),
+            profile_id(101),
+            101,
+        )
+        enabled_agent = WorkshopExecutionStateNamespace(
+            principal_id,
+            ChannelId.new(),
+            AgentId.new(),
+            profile_id(101),
+            None,
+        )
+
+        registry = WorkshopExecutionStateRegistry((primary, enabled_agent))
+
+        assert registry.maybe_for_principal_id(str(principal_id)) == primary
+        assert (
+            registry.maybe_for_principal_channel(
+                principal_id,
+                enabled_agent.channel_id,
+            )
+            == enabled_agent
+        )
+
+    def test_principal_authority_remains_ambiguous_across_profiles(self) -> None:
+        principal_id = PrincipalId.new()
+        first = WorkshopExecutionStateNamespace(
+            principal_id,
+            ChannelId.new(),
+            AgentId.new(),
+            profile_id(101),
+            101,
+        )
+        second = WorkshopExecutionStateNamespace(
+            principal_id,
+            ChannelId.new(),
+            AgentId.new(),
+            profile_id(202),
+            202,
+        )
+
+        registry = WorkshopExecutionStateRegistry((first, second))
+
+        assert registry.maybe_for_principal_id(str(principal_id)) is None
+
     async def test_replaces_execution_and_workspace_settings_in_one_canonical_transaction(
         self,
         database: Path,


### PR DESCRIPTION
## Summary
- keep principal-scoped settings authority when one runtime profile serves multiple agent lanes
- preserve fail-closed ambiguity when a principal actually spans multiple runtime profiles
- cover both same-profile multi-lane and multi-profile cases

## Regression fixed
After enabling a second agent and restarting Kai, Runtime settings could remain on 'Loading runtime policy…' indefinitely. The same authority loss also broke canonical GitHub subscriber resolution.

## Verification
- make check
- make typecheck
- make test (6314 passed)
- make client-check (125 passed; generated bundle verified)