### PR TITLE
Fix sponsored channel agent execution

### DIFF
--- a/src/kai/workshop/routing_eligibility.py
+++ b/src/kai/workshop/routing_eligibility.py
@@ -165,6 +165,35 @@ class WorkshopRoutingEligibilityService:
             namespace.runtime_profile_id,
         )
 
+    def authority_for_sponsored_channel(
+        self,
+        principal_id: str | PrincipalId,
+        channel_id: str | ChannelId,
+        agent_id: str | AgentId,
+        runtime_profile_id: str | RuntimeProfileId,
+    ) -> RoutingEligibilityAuthority:
+        """Bind a durable shared-channel sponsorship to its protected owner."""
+        try:
+            canonical_principal = principal_id if isinstance(principal_id, PrincipalId) else PrincipalId(principal_id)
+            canonical_channel = channel_id if isinstance(channel_id, ChannelId) else ChannelId(channel_id)
+            canonical_agent = agent_id if isinstance(agent_id, AgentId) else AgentId(agent_id)
+            canonical_profile = (
+                runtime_profile_id
+                if isinstance(runtime_profile_id, RuntimeProfileId)
+                else RuntimeProfileId(runtime_profile_id)
+            )
+        except (TypeError, ValueError) as exc:
+            raise RoutingEligibilityAccessDenied("Routing eligibility access denied") from exc
+        namespace = self._execution_state.maybe_for_runtime_profile_id(canonical_profile)
+        if namespace is None or namespace.principal_id != canonical_principal:
+            raise RoutingEligibilityAccessDenied("Routing eligibility access denied")
+        return RoutingEligibilityAuthority(
+            canonical_principal,
+            canonical_channel,
+            canonical_agent,
+            canonical_profile,
+        )
+
     async def inspect(
         self,
         authority: RoutingEligibilityAuthority,
@@ -172,17 +201,55 @@ class WorkshopRoutingEligibilityService:
         *,
         additional_required: tuple[RuntimeCapability, ...] = (),
     ) -> RuntimeEligibilityReport:
+        return await self._inspect(
+            authority,
+            task_class,
+            additional_required=additional_required,
+            sponsored_channel=False,
+        )
+
+    async def inspect_sponsored_channel(
+        self,
+        authority: RoutingEligibilityAuthority,
+        task_class: str | RoutingTaskClass,
+        *,
+        additional_required: tuple[RuntimeCapability, ...] = (),
+    ) -> RuntimeEligibilityReport:
+        """Inspect an already accepted shared-channel sponsorship without private state."""
+        return await self._inspect(
+            authority,
+            task_class,
+            additional_required=additional_required,
+            sponsored_channel=True,
+        )
+
+    async def _inspect(
+        self,
+        authority: RoutingEligibilityAuthority,
+        task_class: str | RoutingTaskClass,
+        *,
+        additional_required: tuple[RuntimeCapability, ...],
+        sponsored_channel: bool,
+    ) -> RuntimeEligibilityReport:
         canonical_task = _task_class(task_class)
         namespace = self._execution_state.maybe_for_principal_channel(
             authority.principal_id,
             authority.channel_id,
         )
-        if (
-            namespace is None
-            or namespace.principal_id != authority.principal_id
-            or namespace.channel_id != authority.channel_id
-            or namespace.agent_id != authority.agent_id
-        ):
+        profile_owner = self._execution_state.maybe_for_runtime_profile_id(
+            authority.runtime_profile_id,
+        )
+        exact_private_lane = (
+            namespace is not None
+            and namespace.principal_id == authority.principal_id
+            and namespace.channel_id == authority.channel_id
+            and namespace.agent_id == authority.agent_id
+            and namespace.runtime_profile_id == authority.runtime_profile_id
+        )
+        exact_sponsor = (
+            sponsored_channel and profile_owner is not None and profile_owner.principal_id == authority.principal_id
+        )
+        if not exact_private_lane and not exact_sponsor:
             raise RoutingEligibilityAccessDenied("Routing eligibility access denied")
         profiles = self._inventory.for_principal(authority.principal_id)
         profile = next(
@@ -197,6 +264,7 @@ class WorkshopRoutingEligibilityService:
             authority.channel_id,
             authority.agent_id,
             authority.runtime_profile_id,
+            private_context=not sponsored_channel,
         )
         workspace = await self._runtime_pool.get_effective_workspace(runtime_authority)
         selected_backend, selected_provider = self._runtime_pool.get_backend_provider(runtime_authority)

--- a/src/kai/workshop/routing_policy.py
+++ b/src/kai/workshop/routing_policy.py
@@ -184,10 +184,28 @@ class WorkshopRoutingPolicyService:
             return existing
 
         requested_task = await self._requested_task_class(run)
-        authority = self._eligibility.authority_for_principal_channel(
-            run.requested_by_principal_id,
-            run.channel_id,
-        )
+        async with self._store.connection.execute(
+            "SELECT kind FROM channels WHERE id = ? AND workshop_id = ?",
+            (run.channel_id, run.workshop_id),
+        ) as cursor:
+            channel_row = await cursor.fetchone()
+        if channel_row is None:
+            raise RoutingPolicyError("Run channel is unavailable")
+        shared_channel = str(channel_row[0]) == "group"
+        if shared_channel:
+            if run.sponsor_principal_id is None:
+                raise RoutingPolicyError("Shared-channel run has no runtime sponsor")
+            authority = self._eligibility.authority_for_sponsored_channel(
+                run.sponsor_principal_id,
+                run.channel_id,
+                run.agent_id,
+                runtime_profile_id,
+            )
+        else:
+            authority = self._eligibility.authority_for_principal_channel(
+                run.requested_by_principal_id,
+                run.channel_id,
+            )
         if authority.runtime_profile_id != runtime_profile_id:
             raise RoutingPolicyError("Run does not match canonical routing profile")
         if authority.agent_id != run.agent_id:
@@ -200,10 +218,11 @@ class WorkshopRoutingPolicyService:
             agent_requirements = tuple(RuntimeCapability(value) for value in revision.capabilities)
 
         if requested_task is None:
-            report = await self._eligibility.inspect(
+            report = await self._inspect_run_authority(
                 authority,
                 RoutingTaskClass.CONVERSATION,
                 additional_required=agent_requirements,
+                shared_channel=shared_channel,
             )
             selected = self._selected_candidate(report)
             decision = self._decision(
@@ -220,10 +239,11 @@ class WorkshopRoutingPolicyService:
             )
             return await self._store_decision(decision)
 
-        report = await self._eligibility.inspect(
+        report = await self._inspect_run_authority(
             authority,
             requested_task,
             additional_required=agent_requirements,
+            shared_channel=shared_channel,
         )
         policy = (await self._load_policy_entries(runtime_profile_id)).get(requested_task)
         if policy is None or policy.backend_option_id is None:
@@ -295,6 +315,26 @@ class WorkshopRoutingPolicyService:
             evidence_version=report.version,
         )
         return await self._store_decision(decision)
+
+    async def _inspect_run_authority(
+        self,
+        authority: RoutingEligibilityAuthority,
+        task_class: RoutingTaskClass,
+        *,
+        additional_required: tuple[RuntimeCapability, ...],
+        shared_channel: bool,
+    ) -> RuntimeEligibilityReport:
+        if shared_channel:
+            return await self._eligibility.inspect_sponsored_channel(
+                authority,
+                task_class,
+                additional_required=additional_required,
+            )
+        return await self._eligibility.inspect(
+            authority,
+            task_class,
+            additional_required=additional_required,
+        )
 
     async def load_decision(self, run_id: RunId) -> RunRoutingDecision | None:
         async with self._store.connection.execute(

--- a/tests/test_workshop_routing_eligibility.py
+++ b/tests/test_workshop_routing_eligibility.py
@@ -159,15 +159,19 @@ class _RuntimePool:
         self.workspace = workspace
         self.selection_reads = 0
         self.selected_backend = ("claude", "anthropic")
+        self.authorities: list[object] = []
 
-    async def get_effective_workspace(self, _runtime_profile_id):
+    async def get_effective_workspace(self, runtime_authority):
+        self.authorities.append(runtime_authority)
         return self.workspace
 
-    async def get_effective_model(self, _runtime_profile_id):
+    async def get_effective_model(self, runtime_authority):
+        self.authorities.append(runtime_authority)
         self.selection_reads += 1
         return "selected-model"
 
-    def get_backend_provider(self, _runtime_profile_id):
+    def get_backend_provider(self, runtime_authority):
+        self.authorities.append(runtime_authority)
         return self.selected_backend
 
     def runtime_profile(self, _runtime_profile_id):
@@ -341,6 +345,48 @@ async def test_cross_principal_authority_and_unknown_task_fail_closed(tmp_path: 
         service.authority_for_principal_channel(_id(PrincipalId, 2), namespace.channel_id)
     with pytest.raises(RoutingEligibilityError, match="Unsupported task class"):
         await service.inspect(authority, "best")
+
+
+@pytest.mark.asyncio
+async def test_sponsored_channel_uses_profile_owner_without_private_lane_access(
+    tmp_path: Path,
+) -> None:
+    namespace = _namespace(1)
+    lane = _lane("claude", "anthropic", selected=True)
+    service, _, pool, _, _ = _service(
+        tmp_path,
+        (lane,),
+        {lane.option_id: _snapshot(namespace, lane, image_input=True)},
+    )
+    group_channel = _id(ChannelId, 20)
+    group_agent = _id(AgentId, 21)
+    authority = service.authority_for_sponsored_channel(
+        namespace.principal_id,
+        group_channel,
+        group_agent,
+        namespace.runtime_profile_id,
+    )
+
+    report = await service.inspect_sponsored_channel(
+        authority,
+        RoutingTaskClass.CONVERSATION,
+    )
+
+    assert report.principal_id == namespace.principal_id
+    assert report.channel_id == group_channel
+    assert report.agent_id == group_agent
+    assert report.runtime_profile_id == namespace.runtime_profile_id
+    assert pool.authorities
+    assert all(getattr(item, "private_context", None) is False for item in pool.authorities)
+    with pytest.raises(RoutingEligibilityAccessDenied):
+        await service.inspect(authority, RoutingTaskClass.CONVERSATION)
+    with pytest.raises(RoutingEligibilityAccessDenied):
+        service.authority_for_sponsored_channel(
+            _id(PrincipalId, 2),
+            group_channel,
+            group_agent,
+            namespace.runtime_profile_id,
+        )
 
 
 def test_image_capability_normalization_accepts_only_explicit_evidence() -> None:

--- a/tests/test_workshop_routing_policy.py
+++ b/tests/test_workshop_routing_policy.py
@@ -12,6 +12,7 @@ from kai.workshop.bootstrap import (
     bootstrap_default_workshop,
     bootstrap_human_principal_id,
 )
+from kai.workshop.channel_lifecycle import WorkshopChannelLifecycleService
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.domain import ChannelId
 from kai.workshop.inbound import ClientInboundMessage
@@ -66,6 +67,7 @@ class _Eligibility:
             _candidate("claude:anthropic", selected=True, eligible=True),
             _candidate("codex:openai", selected=False, eligible=True),
         )
+        self.sponsored_inspections = 0
 
     def authority_for_principal_channel(self, principal_id, channel_id):
         if principal_id != self.authority.principal_id or channel_id != self.authority.channel_id:
@@ -74,6 +76,19 @@ class _Eligibility:
 
     def authority_for_principal_runtime(self, principal_id, runtime_profile_id):
         raise AssertionError("Run routing must resolve the exact channel lane")
+
+    def authority_for_sponsored_channel(
+        self,
+        principal_id,
+        channel_id,
+        agent_id,
+        runtime_profile_id,
+    ):
+        assert principal_id == self.authority.principal_id
+        assert channel_id == self.authority.channel_id
+        assert agent_id == self.authority.agent_id
+        assert runtime_profile_id == self.authority.runtime_profile_id
+        return self.authority
 
     async def inspect(self, authority, task_class, *, additional_required=()):
         assert not additional_required or additional_required[0].value == "text_generation"
@@ -89,6 +104,20 @@ class _Eligibility:
             runtime_profile_id=authority.runtime_profile_id,
             workspace="/workspace",
             candidates=self.candidates,
+        )
+
+    async def inspect_sponsored_channel(
+        self,
+        authority,
+        task_class,
+        *,
+        additional_required=(),
+    ):
+        self.sponsored_inspections += 1
+        return await self.inspect(
+            authority,
+            task_class,
+            additional_required=additional_required,
         )
 
 
@@ -240,5 +269,51 @@ async def test_policy_revision_conflicts_and_default_messages_preserve_selection
         decision = await service.decide_for_run(run, profile_id(101))
         assert decision.disposition == RoutingDecisionDisposition.SELECTED_DEFAULT
         assert decision.selected_backend_option_id == "claude:anthropic"
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_group_run_routes_through_immutable_sponsor_authority(tmp_path: Path) -> None:
+    store, _, direct_authority, _, _ = await _fixture(
+        tmp_path / "kai.db",
+        task_class=None,
+    )
+    try:
+        group = await WorkshopChannelLifecycleService(store).create_group(
+            direct_authority.principal_id,
+            name="Sponsored routing",
+            agent_ids=[direct_authority.agent_id],
+            origin_channel_id=direct_authority.channel_id,
+        )
+        accepted = await WorkshopConversationCommandService(store).accept_client(
+            ClientInboundMessage(
+                principal_id=direct_authority.principal_id,
+                channel_id=group.channel_id,
+                client_message_id="sponsored-routing-policy-test",
+                body="@Kai run through the sponsor",
+                occurred_at=_NOW,
+            )
+        )
+        run = accepted.command.runs[0]
+        authority = RoutingEligibilityAuthority(
+            direct_authority.principal_id,
+            group.channel_id,
+            direct_authority.agent_id,
+            profile_id(101),
+        )
+        eligibility = _Eligibility(authority)
+        service = WorkshopRoutingPolicyService(
+            store,
+            eligibility,  # type: ignore[arg-type]
+            asyncio.Lock(),
+        )
+
+        decision = await service.decide_for_run(run, profile_id(101))
+
+        assert run.sponsor_principal_id == direct_authority.principal_id
+        assert decision.disposition == RoutingDecisionDisposition.SELECTED_DEFAULT
+        assert decision.selected_backend_option_id == "claude:anthropic"
+        assert eligibility.sponsored_inspections == 1
     finally:
         await store.close()


### PR DESCRIPTION
## Summary

- route group-channel agent runs through their immutable sponsor/profile snapshot
- keep sponsored shared-channel runtime contexts explicitly non-private
- preserve the existing private direct-message eligibility path unchanged
- cover the real sponsored authority and group-run routing paths with regressions

## Validation

- `make check typecheck client-check`
- focused routing and protected-execution tests: 18 passed
- `make test`: 6,322 passed

Closes #1229
