### PR TITLE
feat: add Workshop agent integrity diagnostics

### DIFF
--- a/home/docs/specs/workshop-agent-security-audit.md
+++ b/home/docs/specs/workshop-agent-security-audit.md
@@ -1,0 +1,116 @@
+# Workshop agent security and qualification audit
+
+## Scope
+
+This audit covers canonical Workshop agent definitions, per-principal
+enablement, direct and shared-channel execution, runtime sponsorship,
+delegation, client and internal APIs, memory, workspaces, services, restart,
+replay, and operator diagnostics. It treats Telegram and Workshop as clients;
+neither client supplies execution authority.
+
+The audit does not claim hostile local multi-user isolation for trusted-host
+backend processes. That remains the responsibility of a future isolated worker
+boundary. It also does not claim installed live-account coverage for backends
+that are not configured on the qualification host.
+
+## Authority boundaries
+
+- An agent definition is immutable, versioned behavior metadata. Its rendered
+  instructions explicitly confer no tools, credentials, identity, data access,
+  workspace access, or policy authority.
+- A human may use an active definition only through a canonical
+  `principal_agent_enablement`. The enablement binds exactly one human, agent,
+  direct channel, and protected runtime profile.
+- A shared-channel attachment records its human sponsor and sponsored runtime
+  profile. It is valid only while the sponsor owns the channel and retains a
+  matching enabled direct-agent lane.
+- Runtime profiles, backend credentials, service names, workspace grants, and
+  memory namespaces are resolved by the server from canonical context. Agent
+  text cannot broaden them.
+- Delegation carries exact caller and target definition revisions, sponsor and
+  runtime bindings, a bounded shared-context summary, depth, parentage, and an
+  idempotency receipt. Cycles and unbounded depth are rejected before child
+  state is created.
+- Workshop client sessions bind a human principal. Internal API credentials
+  bind a complete canonical execution context and reject caller-supplied
+  identity selectors.
+- Canonical event, run, message, memory, and delegation records survive restart
+  and projection replay. Definition revisions and archive provenance are not
+  rewritten when later revisions are activated or definitions are archived.
+
+## Automated evidence
+
+The following suites are the focused security and recovery evidence for this
+boundary:
+
+- `tests/test_workshop_agent_definitions.py`: strict definition payloads and
+  handles, immutable revisions, exact run provenance, archive behavior,
+  replay, and the explicit no-authority instruction contract.
+- `tests/test_workshop_agent_enablement.py`: two-human direct-lane isolation,
+  cross-principal runtime denial, enable/disable/rebind continuity, and scoped
+  event delivery.
+- `tests/test_workshop_agent_delegation.py`: explicit delegation, idempotency,
+  bounded shared context, cycle rejection, cancellation, terminal settlement,
+  restart recovery, and replay.
+- `tests/test_workshop_wake_policy.py` and
+  `tests/test_workshop_conversation_commands.py`: exact mention routing,
+  multi-agent acceptance, detached/unavailable agents, and mutation-free
+  rejection.
+- `tests/test_workshop_internal_api_contexts.py` and
+  `tests/test_internal_api_auth.py`: complete server-bound contexts,
+  fail-closed ambiguity, unique credentials, named service scopes, and denial
+  of personal memory to shared-channel credentials.
+- `tests/test_workshop_settings_workspaces.py` and
+  `tests/test_workshop_runtime_pool.py`: protected runtime policy, targeted
+  backend changes, runtime-busy rejection, workspace grants, OS-user
+  boundaries, named service scopes, and fail-closed unavailable resources.
+- `tests/test_workshop_memory_authority.py` and
+  `tests/test_workshop_memory_queries.py`: disjoint principal/profile memory
+  namespaces, exact provenance, scope enforcement, and fail-closed ambiguous
+  legacy state.
+- `tests/test_workshop_client_api.py`: authentication before parsing,
+  principal/channel non-enumerability, strict mutation schemas, cross-principal
+  run/trace/thread/artifact/settings denial, session revocation, and canonical
+  SSE replay.
+
+The full test suite, lint/format checks, type checks, dependency audit, and the
+Telegram-free core gate remain required CI evidence. The installed
+qualification must additionally exercise the lifecycle with two human
+principals, at least two agent definitions, and each backend that is actually
+available on the host.
+
+## Operator diagnostic
+
+`make install-status` reports one aggregate `Workshop agent authority` line.
+It includes definition lifecycle and revision counts, enablements, direct
+channels, active and detached shared-channel attachments, runtime sponsorship,
+delegation trees, and nonterminal delegation work.
+
+The line becomes `INCOMPLETE` for any of these integrity failures:
+
+- an agent without a definition, or a definition bound across workshops;
+- a missing, invalid active, or non-sequential revision history;
+- an orphaned/non-agent principal or invalid handle;
+- an invalid enabled direct lane or cross-principal runtime binding;
+- one runtime namespace owned by more than one human principal;
+- a dangling or unsponsored active shared-channel attachment; or
+- a delegation whose run parentage, agents, revisions, sponsors, runtimes, or
+  tree depth no longer match its durable receipt.
+
+Normal draft or archived definitions, detached historical attachments, and
+currently requested/executing delegations are reported but are not themselves
+integrity failures.
+
+## Installed qualification limits
+
+Installed completion is evidence for configured accounts, not a claim that
+every supported provider account exists. The qualification records which
+backends were exercised and why any supported backend was unavailable. Backend
+harness tests still cover adapters that cannot be exercised with a live account
+on the host.
+
+The trusted-host compatibility runtime warning remains material: a backend
+executable writable by its OS user is not a hostile multi-user security
+boundary. Canonical principal isolation prevents one Workshop user from
+selecting another user's runtime, memory, workspace, or credential context, but
+strong containment of a malicious local process requires isolated workers.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -78,7 +78,7 @@ from kai.protected_config import ProtectedConfigError, validate_protected_file_m
 from kai.user_isolation import validate_protected_user_isolation
 from kai.workshop.bootstrap import bootstrap_human_principal_id
 from kai.workshop.diagnostics import (
-    workshop_agent_definition_status,
+    workshop_agent_authority_status,
     workshop_appearance_preference_status,
     workshop_bootstrap_status,
     workshop_canonical_message_integrity_status,
@@ -9553,7 +9553,7 @@ def _cmd_status() -> None:
             expected_humans=expected_humans,
         )
     )
-    print(workshop_agent_definition_status(Path(data_dir) / "kai.db"))
+    print(workshop_agent_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_delivery_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_runtime_session_status(Path(data_dir) / "kai.db"))
     print(_runtime_key_cutover_status(Path(data_dir) / "kai.db", RUNTIME_PROFILES_YAML))

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -83,6 +83,21 @@ _OPERATIONAL_STATE_TABLES = {
     "workshop_scheduled_job_migrations",
     "workshop_scheduled_jobs",
 }
+_AGENT_AUTHORITY_TABLES = {
+    "agent_definitions",
+    "agent_definition_revisions",
+    "agent_delegations",
+    "agents",
+    "channel_agent_runtime_assignments",
+    "channel_agents",
+    "channel_memberships",
+    "channels",
+    "principal_agent_enablements",
+    "principals",
+    "runs",
+    "workshop_memberships",
+}
+_AGENT_HANDLE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
 _TELEGRAM_SUBJECT_PATTERN = re.compile(r"^-?[0-9]+$")
 _SYNTHETIC_ASSISTANT_PATTERN = re.compile(
     r"\[(stopped by user|no response|error: .+)\]",
@@ -188,39 +203,249 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
     )
 
 
-def workshop_agent_definition_status(db_path: Path) -> str:
-    """Describe versioned agent-definition completeness without exposing content."""
-    prefix = "Workshop agent definitions:"
+def workshop_agent_authority_status(db_path: Path) -> str:
+    """Describe canonical multi-agent authority and integrity without exposing content."""
+    prefix = "Workshop agent authority:"
     if not db_path.is_file():
         return f"{prefix} pending; canonical schema unavailable"
     try:
         connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
         try:
+            connection.execute("PRAGMA query_only=ON")
+            connection.execute("BEGIN")
             tables = {
                 str(row[0])
                 for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
             }
-            if not {"agents", "agent_definitions", "agent_definition_revisions"} <= tables:
+            if not tables >= _AGENT_AUTHORITY_TABLES:
                 return f"{prefix} pending; canonical schema unavailable"
-            agents = _scalar(connection, "SELECT COUNT(*) FROM agents")
             definitions = _scalar(connection, "SELECT COUNT(*) FROM agent_definitions")
             revisions = _scalar(connection, "SELECT COUNT(*) FROM agent_definition_revisions")
             active = _scalar(
                 connection,
-                "SELECT COUNT(*) FROM agent_definitions d "
-                "JOIN agent_definition_revisions r ON r.id = d.active_revision_id "
-                "AND r.agent_definition_id = d.id WHERE d.lifecycle_state = 'active'",
+                "SELECT COUNT(*) FROM agent_definitions WHERE lifecycle_state = 'active'",
+            )
+            drafts = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agent_definitions WHERE lifecycle_state = 'draft'",
+            )
+            archived = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agent_definitions WHERE lifecycle_state = 'archived'",
+            )
+            missing_definitions = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agents a LEFT JOIN agent_definitions d ON d.agent_id = a.id WHERE d.id IS NULL",
+            )
+            missing_revisions = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agent_definitions d WHERE NOT EXISTS ("
+                "SELECT 1 FROM agent_definition_revisions r WHERE r.agent_definition_id = d.id)",
+            )
+            stale_active_revisions = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agent_definitions d LEFT JOIN agent_definition_revisions r "
+                "ON r.id = d.active_revision_id AND r.agent_definition_id = d.id WHERE "
+                "(d.lifecycle_state = 'active' AND r.id IS NULL) OR "
+                "(d.lifecycle_state = 'draft' AND d.active_revision_id IS NOT NULL)",
+            )
+            ambiguous_revisions = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM (SELECT d.id, COUNT(r.id) AS revision_count, "
+                "COALESCE(MIN(r.revision_number), 0) AS minimum_revision, "
+                "COALESCE(MAX(r.revision_number), 0) AS maximum_revision "
+                "FROM agent_definitions d LEFT JOIN agent_definition_revisions r "
+                "ON r.agent_definition_id = d.id GROUP BY d.id "
+                "HAVING revision_count > 0 AND "
+                "(minimum_revision != 1 OR maximum_revision != revision_count))",
+            )
+            orphaned_principals = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agents a LEFT JOIN principals p ON p.id = a.principal_id "
+                "LEFT JOIN workshop_memberships wm ON wm.principal_id = a.principal_id "
+                "AND wm.workshop_id = a.workshop_id WHERE p.kind IS NULL OR p.kind != 'agent' "
+                "OR wm.id IS NULL",
+            )
+            definition_mismatches = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agent_definitions d LEFT JOIN agents a ON a.id = d.agent_id "
+                "WHERE a.id IS NULL OR a.workshop_id != d.workshop_id",
+            )
+            handles = [str(row[0]) for row in connection.execute("SELECT handle FROM agent_definitions").fetchall()]
+            invalid_handles = sum(not _AGENT_HANDLE_PATTERN.fullmatch(handle) for handle in handles)
+
+            enablements = _scalar(connection, "SELECT COUNT(*) FROM principal_agent_enablements")
+            enabled = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM principal_agent_enablements WHERE lifecycle_state = 'enabled'",
+            )
+            direct_channels = _scalar(
+                connection,
+                "SELECT COUNT(DISTINCT direct_channel_id) FROM principal_agent_enablements "
+                "WHERE lifecycle_state = 'enabled'",
+            )
+            invalid_enablements = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM principal_agent_enablements e "
+                "LEFT JOIN principals hp ON hp.id = e.principal_id "
+                "LEFT JOIN workshop_memberships hwm ON hwm.principal_id = e.principal_id "
+                "AND hwm.workshop_id = e.workshop_id "
+                "LEFT JOIN agent_definitions d ON d.id = e.agent_definition_id "
+                "LEFT JOIN agents a ON a.id = e.agent_id "
+                "LEFT JOIN principals ap ON ap.id = a.principal_id "
+                "LEFT JOIN channels c ON c.id = e.direct_channel_id WHERE "
+                "e.lifecycle_state = 'enabled' AND (hp.kind IS NULL OR hp.kind != 'human' "
+                "OR hwm.id IS NULL OR d.id IS NULL OR d.lifecycle_state != 'active' "
+                "OR d.active_revision_id IS NULL OR d.agent_id != e.agent_id "
+                "OR d.workshop_id != e.workshop_id OR a.workshop_id != e.workshop_id "
+                "OR ap.kind IS NULL OR ap.kind != 'agent' OR c.kind IS NULL OR c.kind != 'direct' "
+                "OR c.workshop_id != e.workshop_id OR (SELECT COUNT(*) FROM channel_memberships cm "
+                "WHERE cm.channel_id = e.direct_channel_id) != 2 "
+                "OR NOT EXISTS (SELECT 1 FROM channel_memberships cm WHERE "
+                "cm.channel_id = e.direct_channel_id AND cm.principal_id = e.principal_id "
+                "AND cm.role = 'owner') OR NOT EXISTS (SELECT 1 FROM channel_memberships cm "
+                "WHERE cm.channel_id = e.direct_channel_id AND cm.principal_id = a.principal_id) "
+                "OR NOT EXISTS (SELECT 1 FROM channel_agents ca WHERE "
+                "ca.channel_id = e.direct_channel_id AND ca.agent_id = e.agent_id "
+                "AND ca.detached_at IS NULL) OR NOT EXISTS (SELECT 1 FROM "
+                "channel_agent_runtime_assignments ra WHERE ra.channel_id = e.direct_channel_id "
+                "AND ra.agent_id = e.agent_id AND ra.runtime_profile_id = e.runtime_profile_id))",
+            )
+            unauthorized_runtime_bindings = _scalar(
+                connection,
+                "WITH runtime_owners AS (SELECT ra.runtime_profile_id, "
+                "COUNT(DISTINCT owner.principal_id) AS owner_count, "
+                "MIN(owner.principal_id) AS owner_id FROM channel_agent_runtime_assignments ra "
+                "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+                "JOIN channel_memberships owner ON owner.channel_id = c.id AND owner.role = 'owner' "
+                "JOIN principals p ON p.id = owner.principal_id AND p.kind = 'human' "
+                "GROUP BY ra.runtime_profile_id) SELECT COUNT(*) "
+                "FROM principal_agent_enablements e LEFT JOIN runtime_owners ro "
+                "ON ro.runtime_profile_id = e.runtime_profile_id WHERE e.lifecycle_state = 'enabled' "
+                "AND (ro.owner_count IS NULL OR ro.owner_count != 1 OR ro.owner_id != e.principal_id)",
+            )
+            namespace_conflicts = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM (SELECT ra.runtime_profile_id FROM "
+                "channel_agent_runtime_assignments ra JOIN channels c ON c.id = ra.channel_id "
+                "AND c.kind = 'direct' JOIN channel_memberships owner ON owner.channel_id = c.id "
+                "AND owner.role = 'owner' JOIN principals p ON p.id = owner.principal_id "
+                "AND p.kind = 'human' GROUP BY ra.runtime_profile_id "
+                "HAVING COUNT(DISTINCT owner.principal_id) > 1)",
+            )
+
+            attachments = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM channel_agents ca JOIN channels c ON c.id = ca.channel_id "
+                "WHERE c.kind = 'group' AND ca.detached_at IS NULL",
+            )
+            detached_attachments = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM channel_agents ca JOIN channels c ON c.id = ca.channel_id "
+                "WHERE c.kind = 'group' AND ca.detached_at IS NOT NULL",
+            )
+            runtime_sponsorships = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM channel_agents WHERE detached_at IS NULL "
+                "AND sponsor_principal_id IS NOT NULL AND sponsored_runtime_profile_id IS NOT NULL",
+            )
+            dangling_attachments = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM channel_agents ca JOIN channels c ON c.id = ca.channel_id "
+                "LEFT JOIN agent_definitions d ON d.agent_id = ca.agent_id "
+                "WHERE c.kind = 'group' AND ca.detached_at IS NULL AND ("
+                "d.id IS NULL OR d.workshop_id != c.workshop_id OR d.lifecycle_state != 'active' "
+                "OR ca.sponsor_principal_id IS NULL OR ca.sponsored_runtime_profile_id IS NULL "
+                "OR NOT EXISTS (SELECT 1 FROM principals p WHERE p.id = ca.sponsor_principal_id "
+                "AND p.kind = 'human') OR NOT EXISTS (SELECT 1 FROM channel_memberships owner "
+                "WHERE owner.channel_id = ca.channel_id AND owner.principal_id = ca.sponsor_principal_id "
+                "AND owner.role = 'owner') OR NOT EXISTS (SELECT 1 FROM "
+                "principal_agent_enablements e WHERE e.principal_id = ca.sponsor_principal_id "
+                "AND e.agent_id = ca.agent_id AND e.runtime_profile_id = "
+                "ca.sponsored_runtime_profile_id AND e.lifecycle_state = 'enabled') "
+                "OR NOT EXISTS (SELECT 1 FROM channel_agent_runtime_assignments ra "
+                "WHERE ra.channel_id = ca.channel_id AND ra.agent_id = ca.agent_id "
+                "AND ra.runtime_profile_id = ca.sponsored_runtime_profile_id))",
+            )
+
+            delegations = _scalar(connection, "SELECT COUNT(*) FROM agent_delegations")
+            delegation_trees = _scalar(
+                connection,
+                "SELECT COUNT(DISTINCT root_run_id) FROM agent_delegations",
+            )
+            nonterminal_delegations = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agent_delegations WHERE status IN ('requested', 'executing')",
+            )
+            delegation_gaps = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agent_delegations d "
+                "LEFT JOIN channels c ON c.id = d.channel_id "
+                "LEFT JOIN runs root ON root.id = d.root_run_id "
+                "LEFT JOIN runs parent ON parent.id = d.parent_run_id "
+                "LEFT JOIN runs child ON child.id = d.child_run_id "
+                "LEFT JOIN agent_definition_revisions caller_revision "
+                "ON caller_revision.id = d.caller_definition_revision_id "
+                "LEFT JOIN agent_definitions caller_definition "
+                "ON caller_definition.id = caller_revision.agent_definition_id "
+                "LEFT JOIN agent_definition_revisions target_revision "
+                "ON target_revision.id = d.target_definition_revision_id "
+                "LEFT JOIN agent_definitions target_definition "
+                "ON target_definition.id = target_revision.agent_definition_id "
+                "LEFT JOIN agent_delegations prior ON prior.id = d.parent_delegation_id WHERE "
+                "c.workshop_id IS NULL OR c.workshop_id != d.workshop_id "
+                "OR root.workshop_id IS NULL OR root.workshop_id != d.workshop_id "
+                "OR parent.workshop_id IS NULL OR parent.workshop_id != d.workshop_id "
+                "OR child.workshop_id IS NULL OR child.workshop_id != d.workshop_id "
+                "OR parent.channel_id IS NOT d.channel_id OR child.channel_id IS NOT d.channel_id "
+                "OR parent.agent_id IS NOT d.caller_agent_id OR child.agent_id IS NOT d.target_agent_id "
+                "OR child.parent_run_id IS NOT d.parent_run_id OR child.delegation_id IS NOT d.id "
+                "OR parent.sponsor_principal_id IS NOT d.caller_sponsor_principal_id "
+                "OR parent.runtime_profile_id IS NOT d.caller_runtime_profile_id "
+                "OR child.sponsor_principal_id IS NOT d.target_sponsor_principal_id "
+                "OR child.runtime_profile_id IS NOT d.target_runtime_profile_id "
+                "OR caller_definition.agent_id IS NULL "
+                "OR caller_definition.agent_id != d.caller_agent_id "
+                "OR target_definition.agent_id IS NULL "
+                "OR target_definition.agent_id != d.target_agent_id "
+                "OR (d.depth = 1 AND d.parent_delegation_id IS NOT NULL) "
+                "OR (d.depth > 1 AND (prior.id IS NULL OR prior.child_run_id != d.parent_run_id "
+                "OR prior.depth + 1 != d.depth))",
             )
         finally:
             connection.close()
     except (OSError, sqlite3.Error) as exc:
         return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
-    missing = max(agents - definitions, 0)
-    invalid_active = max(definitions - active, 0)
-    state = "active" if agents > 0 and missing == 0 and invalid_active == 0 else "INCOMPLETE"
+    integrity_gaps = sum(
+        (
+            missing_definitions,
+            missing_revisions,
+            stale_active_revisions,
+            ambiguous_revisions,
+            orphaned_principals,
+            definition_mismatches,
+            invalid_handles,
+            invalid_enablements,
+            unauthorized_runtime_bindings,
+            namespace_conflicts,
+            dangling_attachments,
+            delegation_gaps,
+        )
+    )
+    state = "active" if definitions > 0 and integrity_gaps == 0 else "INCOMPLETE"
     return (
-        f"{prefix} {state}; agents={agents}, definitions={definitions}, revisions={revisions}, "
-        f"active={active}, missing={missing}, invalid active={invalid_active}; authority=versioned"
+        f"{prefix} {state}; definitions={definitions} "
+        f"(active={active}, draft={drafts}, archived={archived}), revisions={revisions}, "
+        f"enablements={enablements} (enabled={enabled}), direct channels={direct_channels}, "
+        f"attachments={attachments} (detached={detached_attachments}), "
+        f"runtime sponsorships={runtime_sponsorships}, delegation trees={delegation_trees}, "
+        f"delegations={delegations} (nonterminal={nonterminal_delegations}); "
+        f"integrity gaps={integrity_gaps} (definitions={missing_definitions + definition_mismatches}, "
+        f"missing revisions={missing_revisions}, stale revisions={stale_active_revisions}, "
+        f"ambiguous revisions={ambiguous_revisions}, principals={orphaned_principals}, "
+        f"handles={invalid_handles}, enablements={invalid_enablements}, "
+        f"runtime bindings={unauthorized_runtime_bindings}, namespaces={namespace_conflicts}, "
+        f"attachments={dangling_attachments}, delegations={delegation_gaps}); authority=canonical"
     )
 
 

--- a/tests/test_workshop_agent_definitions.py
+++ b/tests/test_workshop_agent_definitions.py
@@ -15,7 +15,7 @@ from kai.workshop.agent_definitions import (
 )
 from kai.workshop.agent_lifecycle import WorkshopAgentLifecycleService
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
-from kai.workshop.diagnostics import workshop_agent_definition_status
+from kai.workshop.diagnostics import workshop_agent_authority_status
 from kai.workshop.domain import (
     AgentDefinitionId,
     AgentDefinitionRevisionId,
@@ -86,10 +86,35 @@ class TestAgentDefinitionBootstrap:
 
             await store.rebuild_projection(CanonicalConversationProjection())
             assert await active_agent_definition_revision(store, agent_id) == revision
-            assert workshop_agent_definition_status(tmp_path / "kai.db") == (
-                "Workshop agent definitions: active; agents=1, definitions=1, revisions=2, "
-                "active=1, missing=0, invalid active=0; authority=versioned"
+            assert workshop_agent_authority_status(tmp_path / "kai.db") == (
+                "Workshop agent authority: active; definitions=1 (active=1, draft=0, archived=0), "
+                "revisions=2, enablements=0 (enabled=0), direct channels=0, attachments=0 "
+                "(detached=0), runtime sponsorships=0, delegation trees=0, delegations=0 "
+                "(nonterminal=0); integrity gaps=0 (definitions=0, missing revisions=0, "
+                "stale revisions=0, ambiguous revisions=0, principals=0, handles=0, "
+                "enablements=0, runtime bindings=0, namespaces=0, attachments=0, "
+                "delegations=0); authority=canonical"
             )
+        finally:
+            await store.close()
+
+    async def test_diagnostics_fail_closed_for_invalid_handle_and_active_revision(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, agent_id = await _open(tmp_path / "kai.db")
+        try:
+            await store.connection.execute(
+                "UPDATE agent_definitions SET handle = 'Kai', active_revision_id = NULL WHERE agent_id = ?",
+                (agent_id,),
+            )
+            await store.connection.commit()
+
+            status = workshop_agent_authority_status(tmp_path / "kai.db")
+
+            assert status.startswith("Workshop agent authority: INCOMPLETE;")
+            assert "stale revisions=1" in status
+            assert "handles=1" in status
         finally:
             await store.close()
 

--- a/tests/test_workshop_agent_delegation.py
+++ b/tests/test_workshop_agent_delegation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -10,10 +11,12 @@ import pytest
 
 from kai.workshop.agent_delegation import (
     AgentDelegationAuthority,
+    AgentDelegationContext,
     AgentDelegationDenied,
     WorkshopAgentDelegationService,
 )
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
+from kai.workshop.diagnostics import workshop_agent_authority_status
 from kai.workshop.domain import (
     MessageId,
     PrincipalId,
@@ -84,6 +87,35 @@ class _CompletingExecution:
         run_id: RunId,
     ) -> CanonicalCancellationDisposition:
         return CanonicalCancellationDisposition.ALREADY_TERMINAL
+
+
+class _CancellableExecution:
+    def __init__(self, authority: WorkshopRunExecutionAuthority) -> None:
+        self._authority = authority
+        self._store = authority.event_store
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+
+    async def execute(self, run_id: RunId) -> CanonicalExecutionResult:
+        self.started.set()
+        await self.cancelled.wait()
+        run = await WorkshopRunLifecycle(self._store).state(run_id)
+        return CanonicalExecutionResult(CanonicalExecutionDisposition.CANCELLED, run)
+
+    async def run_state(self, run_id: RunId) -> DurableRun:
+        return await WorkshopRunLifecycle(self._store).state(run_id)
+
+    async def request_run_cancellation(
+        self,
+        run_id: RunId,
+    ) -> CanonicalCancellationDisposition:
+        await self._authority.cancel_before_dispatch(
+            run_id,
+            cancellation_code="service_shutdown",
+            occurred_at=datetime.now(UTC),
+        )
+        self.cancelled.set()
+        return CanonicalCancellationDisposition.REQUESTED
 
 
 async def _running_parent(path: Path):
@@ -216,6 +248,19 @@ async def test_explicit_delegation_is_visible_durable_bounded_and_idempotent(
         await store.connection.commit()
 
         assert await service.snapshot(result.delegation.delegation_id) == result.delegation
+        clean = workshop_agent_authority_status(tmp_path / "kai.db")
+        assert clean.startswith("Workshop agent authority: active;")
+        assert "delegation trees=1, delegations=1 (nonterminal=0)" in clean
+        assert "delegations=0); authority=canonical" in clean
+
+        await store.connection.execute(
+            "UPDATE runs SET parent_run_id = NULL WHERE id = ?",
+            (result.delegation.child_run_id,),
+        )
+        await store.connection.commit()
+        damaged = workshop_agent_authority_status(tmp_path / "kai.db")
+        assert damaged.startswith("Workshop agent authority: INCOMPLETE;")
+        assert "delegations=1); authority=canonical" in damaged
     finally:
         await service.stop()
         await store.close()
@@ -241,6 +286,61 @@ async def test_delegation_rejects_cycles_before_creating_any_child_state(
         assert denied.value.code == "cycle"
         async with store.connection.execute("SELECT COUNT(*) FROM agent_delegations") as cursor:
             assert int((await cursor.fetchone())[0]) == 0
+    finally:
+        await service.stop()
+        await store.close()
+
+
+async def test_requested_delegation_resumes_after_service_restart(tmp_path: Path) -> None:
+    store, authority, caller, _parent, _target_agent_id = await _running_parent(tmp_path / "kai.db")
+    execution = _CompletingExecution(authority)
+    seed = WorkshopAgentDelegationService(store, execution)  # type: ignore[arg-type]
+    # Call the acceptance seam directly to simulate a crash after its durable commit.
+    delegation = await seed._accept(
+        caller,
+        target_handle="nova",
+        task="Complete after restart.",
+        context=AgentDelegationContext(),
+        idempotency_key="restart-recovery",
+    )
+    assert delegation.status == "requested"
+
+    recovered = WorkshopAgentDelegationService(store, execution)  # type: ignore[arg-type]
+    await recovered.start()
+    try:
+        for _ in range(100):
+            snapshot = await recovered.snapshot(delegation.delegation_id)
+            if snapshot.status == "completed":
+                break
+            await asyncio.sleep(0.01)
+        assert snapshot.status == "completed"
+        assert execution.executed == [delegation.child_run_id]
+    finally:
+        await recovered.stop()
+        await store.close()
+
+
+async def test_service_shutdown_cancels_the_delegated_child_tree(tmp_path: Path) -> None:
+    store, authority, caller, _parent, _target_agent_id = await _running_parent(tmp_path / "kai.db")
+    execution = _CancellableExecution(authority)
+    service = WorkshopAgentDelegationService(store, execution)  # type: ignore[arg-type]
+    # Seed the durable pre-dispatch boundary before the worker starts.
+    delegation = await service._accept(
+        caller,
+        target_handle="nova",
+        task="Remain active until shutdown.",
+        context=AgentDelegationContext(),
+        idempotency_key="shutdown-cancellation",
+    )
+    await service.start()
+    try:
+        await asyncio.wait_for(execution.started.wait(), timeout=1)
+        await service.stop()
+        snapshot = await service.snapshot(delegation.delegation_id)
+        child = await WorkshopRunLifecycle(store).state(delegation.child_run_id)
+        assert snapshot.status == "cancelled"
+        assert child.status.value == "cancelled"
+        assert execution.cancelled.is_set()
     finally:
         await service.stop()
         await store.close()

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -14,6 +14,7 @@ from kai.workshop.agent_enablement import (
 from kai.workshop.agent_lifecycle import WorkshopAgentLifecycleService
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.client_api import _read_agent_lifecycle_events
+from kai.workshop.diagnostics import workshop_agent_authority_status
 from kai.workshop.domain import AgentDefinitionId, PrincipalId
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.internal_api_contexts import (
@@ -166,6 +167,31 @@ async def test_runtime_authority_cannot_cross_principals(tmp_path: Path) -> None
             (definition_id,),
         ) as cursor:
             assert int((await cursor.fetchone())[0]) == 0
+    finally:
+        await store.close()
+
+
+async def test_diagnostics_detect_cross_principal_runtime_binding(tmp_path: Path) -> None:
+    store, _service_instance, _execution, _contexts, _runtime_pool = await _service(tmp_path / "kai.db")
+    try:
+        daniel = await _principal(store, "101")
+        scott = await _principal(store, "202")
+        clean = workshop_agent_authority_status(tmp_path / "kai.db")
+        assert clean.startswith("Workshop agent authority: active;")
+        assert "integrity gaps=0" in clean
+
+        await store.connection.execute(
+            "UPDATE principal_agent_enablements SET runtime_profile_id = ? WHERE principal_id = ?",
+            (profile_id(101), scott),
+        )
+        await store.connection.commit()
+
+        status = workshop_agent_authority_status(tmp_path / "kai.db")
+        assert status.startswith("Workshop agent authority: INCOMPLETE;")
+        assert "enablements=1" in status.split("integrity gaps=", 1)[1]
+        assert "runtime bindings=1" in status
+        assert str(daniel) not in status
+        assert str(scott) not in status
     finally:
         await store.close()
 


### PR DESCRIPTION
Implements #1226. Keep #1226 open through installed qualification and final evidence reconciliation.

## Summary
- replace the narrow agent-definition status line with a canonical multi-agent authority diagnostic
- detect broken definition, revision, principal, handle, enablement, runtime ownership, attachment, and delegation records without exposing identifiers
- add restart recovery and shutdown cancellation coverage for durable delegation trees
- document the focused agent security audit, authority boundaries, automated evidence, and live-account qualification limits

## Validation
- make check
- make typecheck
- full pytest suite: 6337 passed
- make client-check: 129 tests passed and generated static client verified
- make module-sizes
- git diff --check

## Installed follow-up
After merge and installation, qualify two human principals and two agent definitions across the available Claude and Codex contexts, direct and shared-channel routing, attachment/detachment, delegation and cancellation, restart continuity, replay/archive provenance, and confirm Workshop agent authority reports active with zero integrity gaps.