### PR TITLE
Add fast Workshop UI development and CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,23 +8,53 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      client: ${{ steps.scope.outputs.client }}
+      full: ${{ steps.scope.outputs.full }}
+      dependency: ${{ steps.scope.outputs.dependency }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Select validation scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" |
+              python3 scripts/ci_change_scope.py
+          else
+            python3 scripts/ci_change_scope.py --force-full
+          fi
+
   check:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        if: needs.changes.outputs.client == 'true'
 
       - uses: actions/setup-node@v7
+        if: needs.changes.outputs.client == 'true'
         with:
           node-version: "22"
           cache: npm
           cache-dependency-path: workshop-client/package-lock.json
 
       - uses: actions/setup-python@v7
+        if: needs.changes.outputs.full == 'true'
         with:
           python-version: "3.13"
           cache: pip
 
       - name: Install dependencies
+        if: needs.changes.outputs.full == 'true'
         run: |
           python -m pip install --upgrade \
             --constraint requirements/constraints.txt pip setuptools
@@ -32,34 +62,48 @@ jobs:
             --constraint requirements/constraints.txt -e '.[dev,telegram,totp]'
 
       - name: Install Workshop client dependencies
+        if: needs.changes.outputs.client == 'true'
         run: npm ci --prefix workshop-client
 
       - name: Check Workshop client
+        if: needs.changes.outputs.client == 'true'
         run: make client-check
 
       - name: Validate install constraints
+        if: needs.changes.outputs.full == 'true'
         run: make BIN= check-install-constraints
 
       - name: Lint and format check
+        if: needs.changes.outputs.full == 'true'
         run: make BIN= check
 
       - name: Type check
+        if: needs.changes.outputs.full == 'true'
         run: make BIN= typecheck
 
       - name: Run tests
+        if: needs.changes.outputs.full == 'true'
         run: make BIN= test
 
+      - name: Confirm documentation-only fast path
+        if: needs.changes.outputs.client != 'true' && needs.changes.outputs.full != 'true'
+        run: echo "No runtime validation is required for documentation-only changes."
+
   core-workshop:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        if: needs.changes.outputs.full == 'true'
 
       - uses: actions/setup-python@v7
+        if: needs.changes.outputs.full == 'true'
         with:
           python-version: "3.13"
           cache: pip
 
       - name: Install base without Telegram
+        if: needs.changes.outputs.full == 'true'
         run: |
           python -m pip install --upgrade \
             --constraint requirements/constraints.txt pip setuptools
@@ -67,6 +111,7 @@ jobs:
             --constraint requirements/constraints.txt -e '.[dev,totp]'
 
       - name: Prove the Telegram-free architecture and runtime boundary
+        if: needs.changes.outputs.full == 'true'
         run: |
           python -m pytest -v \
             tests/test_adapter_architecture.py \
@@ -84,3 +129,7 @@ jobs:
             tests/test_workshop_scheduler.py::test_workshop_only_agent_job_uses_canonical_execution \
             tests/test_workshop_scheduler.py::test_disabled_telegram_adapter_does_not_enqueue_retained_reminder_binding \
             tests/test_workshop_github_notifications.py::TestWorkshopIntegrationNotificationService::test_route_records_without_resolving_any_transport_binding
+
+      - name: Confirm non-backend fast path
+        if: needs.changes.outputs.full != 'true'
+        run: echo "No backend architecture validation is required for this change scope."

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -19,13 +19,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Select dependency-audit scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+          PUSH_HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "schedule" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            python3 scripts/ci_change_scope.py --force-full
+          elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" |
+              python3 scripts/ci_change_scope.py
+          elif [[ -z "$PUSH_BASE_SHA" || "$PUSH_BASE_SHA" =~ ^0+$ ]]; then
+            python3 scripts/ci_change_scope.py --force-full
+          else
+            git diff --name-only "$PUSH_BASE_SHA" "$PUSH_HEAD_SHA" |
+              python3 scripts/ci_change_scope.py
+          fi
 
       - uses: actions/setup-python@v7
+        if: steps.scope.outputs.dependency == 'true'
         with:
           python-version: "3.13"
           cache: pip
 
       - name: Install dependencies
+        if: steps.scope.outputs.dependency == 'true'
         run: |
           python -m pip install --upgrade \
             --constraint requirements/constraints.txt pip setuptools
@@ -33,4 +58,9 @@ jobs:
             --constraint requirements/constraints.txt -e '.[dev,memory,telegram,totp,tts]'
 
       - name: Run dependency audit
+        if: steps.scope.outputs.dependency == 'true'
         run: make BIN= audit-deps
+
+      - name: Confirm dependency-audit fast path
+        if: steps.scope.outputs.dependency != 'true'
+        run: echo "Python dependency inputs are unchanged; scheduled audit remains authoritative."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,9 @@ Personal AI assistant accessed via Telegram. Python package at src/kai/.
 ## Development
 
 - Run: `make run` or `python -m kai`
-- Test: `make test` (pytest, ~1200 tests)
+- Full backend/integration test: `make test` (pytest, more than 6000 tests)
+- Workshop-only validation: `make client-check`
+- Workshop live preview: `make workshop-dev` (foreground only; stop after review)
 - Lint: `make check` (ruff check + ruff format)
 - Config wizard: `make config`
 - Install: `make install` (the Makefile invokes `sudo`; never prefix this command with `sudo`)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # where tools are installed globally (no .venv).
 BIN = .venv/bin/
 
-.PHONY: run lint format check typecheck client-check audit-deps check-install-constraints module-sizes test setup config install install-status runtime-access tts-model refresh-models
+.PHONY: run lint format check typecheck client-check workshop-dev audit-deps check-install-constraints module-sizes test setup config install install-status runtime-access tts-model refresh-models
 
 run:
 	$(BIN)python -m kai
@@ -21,6 +21,9 @@ typecheck:
 
 client-check:
 	cd workshop-client && npm run check
+
+workshop-dev:
+	cd workshop-client && npm run dev -- --host 0.0.0.0 --port 5173
 
 audit-deps:
 	$(BIN)pip-audit --local --skip-editable

--- a/README.md
+++ b/README.md
@@ -222,12 +222,27 @@ make format     # Format with ruff
 make check      # Lint and format check
 make typecheck  # Run Pyright on the maintained typed baseline
 make client-check # Type-check/test React and verify its packaged assets
+make workshop-dev # Serve Workshop with hot reload and proxy the installed API
 make audit-deps # Report known vulnerabilities in installed dependencies
 make check-install-constraints # Dry-run install dependency resolution with constraints
 make module-sizes # Report large Python modules for decomposition planning
 make test       # Run pytest
 make run        # Start Kai locally
 ```
+
+For rapid Workshop UI iteration, leave the installed Kai service running and
+start `make workshop-dev` in the foreground. Open
+`http://<kai-host>:5173/workshop/` and enroll that development origin once.
+Vite serves only the Workshop client and proxies `/v1` to
+`http://127.0.0.1:8080`; browser credentials remain isolated from the installed
+Workshop origin. The server binds to the LAN only while this command is running.
+Stop it with Control-C immediately after visual review and verify that no Vite
+process remains.
+
+Client-only pull requests run the client typecheck, tests, build, and generated
+asset verification. Backend or mixed changes retain the complete Python and
+client validation, and every push to `main` runs the full suite. Unknown paths
+fail closed to the full lane.
 
 Pull requests are currently restricted to collaborators while the architecture is moving quickly. Issues, bug reports, design feedback, and focused proposals are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -1,0 +1,111 @@
+"""Conservatively classify changed paths for Kai CI."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+_CLIENT_PREFIXES = ("workshop-client/", "src/kai/workshop/static/")
+_DOCUMENTATION_PREFIXES = ("docs/", "home/docs/", ".github/ISSUE_TEMPLATE/")
+_DOCUMENTATION_FILES = {
+    "AGENTS.md",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "README.md",
+    "SECURITY.md",
+}
+_DEPENDENCY_FILES = {
+    "Makefile",
+    "pyproject.toml",
+    ".github/workflows/dependency-audit.yml",
+    "scripts/ci_change_scope.py",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ChangeScope:
+    client: bool
+    full: bool
+    dependency: bool
+
+
+def _normalized_path(raw_path: str) -> str:
+    path = raw_path.strip().replace("\\", "/")
+    if not path:
+        return ""
+    normalized = str(PurePosixPath(path))
+    if normalized == "." or normalized.startswith("../") or normalized.startswith("/"):
+        return ""
+    return normalized
+
+
+def _is_documentation(path: str) -> bool:
+    return path in _DOCUMENTATION_FILES or path.startswith(_DOCUMENTATION_PREFIXES)
+
+
+def _is_dependency_input(path: str) -> bool:
+    return path in _DEPENDENCY_FILES or path.startswith("requirements/")
+
+
+def classify_paths(paths: Iterable[str], *, force_full: bool = False) -> ChangeScope:
+    """Return a fail-closed CI scope for the supplied repository paths."""
+    if force_full:
+        return ChangeScope(client=True, full=True, dependency=True)
+
+    client = False
+    full = False
+    dependency = False
+    saw_path = False
+    for raw_path in paths:
+        path = _normalized_path(raw_path)
+        if not path:
+            continue
+        saw_path = True
+        if _is_dependency_input(path):
+            dependency = True
+        if path.startswith(_CLIENT_PREFIXES):
+            client = True
+        elif not _is_documentation(path):
+            full = True
+
+    if not saw_path:
+        full = True
+    if full:
+        client = True
+    return ChangeScope(client=client, full=full, dependency=dependency)
+
+
+def _write_outputs(scope: ChangeScope, output_path: str | None) -> None:
+    lines = (
+        f"client={str(scope.client).lower()}",
+        f"full={str(scope.full).lower()}",
+        f"dependency={str(scope.dependency).lower()}",
+    )
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as output:
+            output.write("\n".join(lines) + "\n")
+    for line in lines:
+        print(line)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Changed repository paths; stdin is used when omitted")
+    parser.add_argument("--force-full", action="store_true", help="Select every validation lane")
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="Optional GitHub Actions output file",
+    )
+    args = parser.parse_args(argv)
+    paths = args.paths if args.paths else sys.stdin.read().splitlines()
+    _write_outputs(classify_paths(paths, force_full=args.force_full), args.github_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_change_scope.py
+++ b/tests/test_ci_change_scope.py
@@ -1,0 +1,60 @@
+from scripts.ci_change_scope import ChangeScope, classify_paths
+
+
+def test_client_sources_and_generated_assets_use_only_client_lane() -> None:
+    assert classify_paths(
+        [
+            "workshop-client/src/App.tsx",
+            "workshop-client/src/styles.css",
+            "src/kai/workshop/static/app.js",
+            "src/kai/workshop/static/app.css",
+        ]
+    ) == ChangeScope(client=True, full=False, dependency=False)
+
+
+def test_documentation_only_change_needs_no_runtime_lane() -> None:
+    assert classify_paths(["README.md", "docs/design.md", "home/docs/specs/workshop.md"]) == ChangeScope(
+        client=False,
+        full=False,
+        dependency=False,
+    )
+
+
+def test_unknown_and_mixed_paths_fail_closed_to_complete_validation() -> None:
+    assert classify_paths(["workshop-client/src/App.tsx", "mystery/new-input.dat"]) == ChangeScope(
+        client=True,
+        full=True,
+        dependency=False,
+    )
+
+
+def test_backend_and_test_changes_retain_client_and_full_validation() -> None:
+    assert classify_paths(["src/kai/workshop/client_api.py", "tests/test_bot.py"]) == ChangeScope(
+        client=True,
+        full=True,
+        dependency=False,
+    )
+
+
+def test_python_dependency_inputs_select_full_and_audit_lanes() -> None:
+    for path in (
+        "pyproject.toml",
+        "requirements/constraints.txt",
+        ".github/workflows/dependency-audit.yml",
+        "scripts/ci_change_scope.py",
+        "Makefile",
+    ):
+        assert classify_paths([path]) == ChangeScope(client=True, full=True, dependency=True)
+
+
+def test_empty_or_invalid_input_fails_closed() -> None:
+    assert classify_paths([]) == ChangeScope(client=True, full=True, dependency=False)
+    assert classify_paths(["../outside"]) == ChangeScope(client=True, full=True, dependency=False)
+
+
+def test_force_full_selects_every_lane() -> None:
+    assert classify_paths(["README.md"], force_full=True) == ChangeScope(
+        client=True,
+        full=True,
+        dependency=True,
+    )

--- a/workshop-client/package.json
+++ b/workshop-client/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "vite build",
     "check": "npm run typecheck && npm run test && npm run verify-generated",
+    "dev": "vite",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "verify-generated": "npm run build && git diff --exit-code -- ../src/kai/workshop/static"

--- a/workshop-client/vite.config.ts
+++ b/workshop-client/vite.config.ts
@@ -4,6 +4,14 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   base: "/workshop/",
   plugins: [react()],
+  server: {
+    proxy: {
+      "/v1": {
+        target: "http://127.0.0.1:8080",
+      },
+    },
+    strictPort: true,
+  },
   build: {
     assetsInlineLimit: 0,
     emptyOutDir: true,


### PR DESCRIPTION
Closes #1285

Adds an opt-in Vite development server that proxies the installed Kai API, plus a conservative path classifier for pull-request validation. Client-only PRs keep the required check result while running only the Workshop client checks; backend, mixed, workflow, test, unknown-path, and every main-push change retain full validation. Dependency audit now runs on dependency inputs plus scheduled/manual execution.

Validated locally:
- classifier tests: 7 passed
- Workshop client: 146 passed; typecheck/build/generated assets clean
- ruff and formatting
- Pyright
- install constraints
- pip-audit: no known vulnerabilities
- full pytest: 6375 passed
- live Vite LAN origin and installed-API proxy; preview process stopped