### PR TITLE
Publish canonical human notifications through delivery adapters

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -163,6 +163,7 @@ def _delivery_policy(config, telegram_adapter_module: ModuleType | None) -> Work
     return WorkshopDeliveryBindingPolicy(
         frozenset(item.transport for item in capabilities),
         capabilities,
+        (f"http://{config.workshop_lan_host}:{config.webhook_port}/workshop/" if config.workshop_lan_host else None),
     )
 
 

--- a/src/kai/workshop/conversation_commands.py
+++ b/src/kai/workshop/conversation_commands.py
@@ -111,6 +111,7 @@ class WorkshopConversationCommandService:
         self._store = store
         self._artifact_storage_root = artifact_storage_root
         effective_policy = delivery_policy or WorkshopDeliveryBindingPolicy.disabled()
+        self._delivery_policy = effective_policy
         self._delivery_planner = WorkshopDeliveryPlanner(self._store, effective_policy)
 
     async def accept(
@@ -124,7 +125,11 @@ class WorkshopConversationCommandService:
         connection = self._store.connection
         try:
             await connection.execute("BEGIN IMMEDIATE")
-            inbound = await record_inbound_message_in_transaction(self._store, message)
+            inbound = await record_inbound_message_in_transaction(
+                self._store,
+                message,
+                delivery_policy=self._delivery_policy,
+            )
             inbound_message_id = inbound.event.envelope.aggregate_id
             if not isinstance(inbound_message_id, MessageId):
                 raise ConversationCommandStateConflictError("Canonical inbound event did not identify a message")
@@ -173,7 +178,11 @@ class WorkshopConversationCommandService:
         connection = self._store.connection
         try:
             await connection.execute("BEGIN IMMEDIATE")
-            inbound = await record_client_inbound_message_in_transaction(self._store, message)
+            inbound = await record_client_inbound_message_in_transaction(
+                self._store,
+                message,
+                delivery_policy=self._delivery_policy,
+            )
             inbound_message_id = inbound.event.envelope.aggregate_id
             if not isinstance(inbound_message_id, MessageId):
                 raise ConversationCommandStateConflictError("Canonical inbound event did not identify a message")
@@ -238,7 +247,11 @@ class WorkshopConversationCommandService:
         connection = self._store.connection
         try:
             await connection.execute("BEGIN IMMEDIATE")
-            inbound = await record_scheduled_inbound_message_in_transaction(self._store, message)
+            inbound = await record_scheduled_inbound_message_in_transaction(
+                self._store,
+                message,
+                delivery_policy=self._delivery_policy,
+            )
             inbound_message_id = inbound.event.envelope.aggregate_id
             if not isinstance(inbound_message_id, MessageId):
                 raise ConversationCommandStateConflictError("Scheduled inbound event did not identify a message")

--- a/src/kai/workshop/delivery_outbox.py
+++ b/src/kai/workshop/delivery_outbox.py
@@ -18,6 +18,7 @@ from kai.workshop.domain import (
     DeliveryId,
     EventEnvelope,
     EventId,
+    HumanNotificationId,
     MessageId,
     PrincipalId,
     WorkshopEventType,
@@ -79,6 +80,7 @@ class DeliveryRequest:
     occurred_at: datetime
     execution_contract: DeliveryExecutionContract = SEND_FRAGMENTS_CONTRACT
     authority_epoch_id: DeliveryAuthorityEpochId | None = None
+    human_notification_id: HumanNotificationId | None = None
     max_attempts: int = 5
 
     def __post_init__(self) -> None:
@@ -97,6 +99,11 @@ class DeliveryRequest:
             raise ValueError("streaming conversation delivery requires a DeliveryAuthorityEpochId")
         if not requires_epoch and self.authority_epoch_id is not None:
             raise ValueError("authority_epoch_id is only valid for streaming conversation delivery")
+        if self.human_notification_id is not None:
+            if not isinstance(self.human_notification_id, HumanNotificationId):
+                raise ValueError("human_notification_id must be a HumanNotificationId when supplied")
+            if self.purpose != NOTIFICATION_PURPOSE or self.execution_contract != SEND_FRAGMENTS_CONTRACT:
+                raise ValueError("human notifications require send-fragments notification delivery")
         if self.occurred_at.tzinfo is None or self.occurred_at.utcoffset() is None:
             raise ValueError("occurred_at must be timezone-aware")
         if (
@@ -118,6 +125,7 @@ class DeliveryState:
     purpose: DeliveryPurpose
     execution_contract: DeliveryExecutionContract
     authority_epoch_id: DeliveryAuthorityEpochId | None
+    human_notification_id: HumanNotificationId | None
     status: str
     max_attempts: int
     attempt_count: int
@@ -151,6 +159,8 @@ class DeliveryClaim:
     author_display_name: str
     body: str
     lease_expires_at: datetime
+    human_notification_id: HumanNotificationId | None = None
+    recipient_binding_current: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -268,6 +278,9 @@ class WorkshopDeliveryOutbox:
         if not connection.in_transaction:
             raise RuntimeError("request_delivery_in_transaction requires an active transaction")
 
+        has_human_notification_column = await self._has_human_notification_column()
+        if request.human_notification_id is not None and not has_human_notification_column:
+            raise DeliveryTargetNotFoundError("Canonical human notification publication schema is unavailable")
         resolved = await self._resolve_target(request)
         workshop_id, channel_id, author_principal_id, transport = resolved
         if request.authority_epoch_id is not None:
@@ -299,6 +312,7 @@ class WorkshopDeliveryOutbox:
                 or existing.purpose != request.purpose
                 or existing.execution_contract != request.execution_contract
                 or existing.authority_epoch_id != request.authority_epoch_id
+                or existing.human_notification_id != request.human_notification_id
             ):
                 raise DeliveryRequestConflictError("Delivery request identity has different semantics")
             return DeliveryRequestResult(delivery=existing, inserted=False)
@@ -319,6 +333,8 @@ class WorkshopDeliveryOutbox:
         if streaming_finalization:
             payload["execution_contract"] = request.execution_contract
             payload["authority_epoch_id"] = request.authority_epoch_id
+        if request.human_notification_id is not None:
+            payload["human_notification_id"] = request.human_notification_id
         event = EventEnvelope.create(
             event_id=EventId.derived(
                 workshop_id,
@@ -344,30 +360,57 @@ class WorkshopDeliveryOutbox:
             raise DeliveryRequestConflictError("Delivery request event exists without outbox state")
 
         timestamp = _format_timestamp(occurred_at)
-        await connection.execute(
-            "INSERT INTO delivery_outbox "
-            "(id, workshop_id, channel_id, channel_binding_id, message_id, transport, mode, purpose, "
-            "execution_contract, authority_epoch_id, "
-            "status, max_attempts, attempt_count, available_at, requested_event_position, "
-            "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, 0, ?, ?, ?, ?)",
-            (
-                delivery_id,
-                workshop_id,
-                channel_id,
-                request.channel_binding_id,
-                request.message_id,
-                transport,
-                request.mode,
-                request.purpose,
-                request.execution_contract,
-                request.authority_epoch_id,
-                request.max_attempts,
-                timestamp,
-                appended.event.position,
-                timestamp,
-                timestamp,
-            ),
-        )
+        if has_human_notification_column:
+            await connection.execute(
+                "INSERT INTO delivery_outbox "
+                "(id, workshop_id, channel_id, channel_binding_id, message_id, transport, mode, purpose, "
+                "execution_contract, authority_epoch_id, human_notification_id, status, max_attempts, "
+                "attempt_count, available_at, requested_event_position, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, 0, ?, ?, ?, ?)",
+                (
+                    delivery_id,
+                    workshop_id,
+                    channel_id,
+                    request.channel_binding_id,
+                    request.message_id,
+                    transport,
+                    request.mode,
+                    request.purpose,
+                    request.execution_contract,
+                    request.authority_epoch_id,
+                    request.human_notification_id,
+                    request.max_attempts,
+                    timestamp,
+                    appended.event.position,
+                    timestamp,
+                    timestamp,
+                ),
+            )
+        else:
+            await connection.execute(
+                "INSERT INTO delivery_outbox "
+                "(id, workshop_id, channel_id, channel_binding_id, message_id, transport, mode, purpose, "
+                "execution_contract, authority_epoch_id, status, max_attempts, attempt_count, available_at, "
+                "requested_event_position, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, 0, ?, ?, ?, ?)",
+                (
+                    delivery_id,
+                    workshop_id,
+                    channel_id,
+                    request.channel_binding_id,
+                    request.message_id,
+                    transport,
+                    request.mode,
+                    request.purpose,
+                    request.execution_contract,
+                    request.authority_epoch_id,
+                    request.max_attempts,
+                    timestamp,
+                    appended.event.position,
+                    timestamp,
+                    timestamp,
+                ),
+            )
         state = await self._state_by_id(delivery_id)
         return DeliveryRequestResult(delivery=state, inserted=True)
 
@@ -404,6 +447,7 @@ class WorkshopDeliveryOutbox:
         now = self._now()
         try:
             await connection.execute("BEGIN IMMEDIATE")
+            has_human_notification_column = await self._has_human_notification_column()
             await self._recover_expired_in_transaction(
                 now,
                 purposes=purposes,
@@ -456,15 +500,46 @@ class WorkshopDeliveryOutbox:
                 placeholders = ", ".join("?" for _ in modes)
                 filters.append(f"o.mode IN ({placeholders})")
                 parameters.extend(modes)
+            publication_body = "COALESCE(np.alert_body, m.body)" if has_human_notification_column else "m.body"
+            publication_join = (
+                "LEFT JOIN human_notification_publications np ON np.notification_id = o.human_notification_id "
+                if has_human_notification_column
+                else ""
+            )
+            binding_scope = (
+                "AND (o.human_notification_id IS NOT NULL OR cb.channel_id = o.channel_id) "
+                if has_human_notification_column
+                else "AND cb.channel_id = o.channel_id "
+            )
+            notification_identity = "o.human_notification_id" if has_human_notification_column else "NULL"
+            binding_current = (
+                "CASE WHEN o.human_notification_id IS NULL THEN 1 ELSE EXISTS ("
+                "SELECT 1 FROM human_notification_publications current_np "
+                "JOIN external_identities current_ei "
+                "ON current_ei.principal_id = current_np.recipient_principal_id "
+                "AND current_ei.provider = o.transport "
+                "AND current_ei.external_subject = cb.external_channel_id "
+                "JOIN channels current_channel ON current_channel.id = cb.channel_id "
+                "AND current_channel.kind = 'direct' "
+                "AND current_channel.workshop_id = current_np.workshop_id "
+                "JOIN channel_memberships current_cm ON current_cm.channel_id = current_channel.id "
+                "AND current_cm.principal_id = current_np.recipient_principal_id "
+                "WHERE current_np.notification_id = o.human_notification_id) END"
+                if has_human_notification_column
+                else "1"
+            )
             async with connection.execute(
                 "SELECT o.id, o.workshop_id, o.channel_id, o.channel_binding_id, o.message_id, "
                 "o.transport, o.mode, o.purpose, o.execution_contract, o.authority_epoch_id, o.attempt_count, "
-                "m.body, cb.external_channel_id, p.display_name "
+                f"{publication_body}, cb.external_channel_id, p.display_name, {notification_identity}, "
+                f"{binding_current} "
                 "FROM delivery_outbox o "
                 "JOIN messages m ON m.id = o.message_id AND m.channel_id = o.channel_id "
                 "JOIN principals p ON p.id = m.author_principal_id "
+                f"{publication_join}"
                 "JOIN channel_bindings cb ON cb.id = o.channel_binding_id "
-                "AND cb.channel_id = o.channel_id AND cb.transport = o.transport "
+                "AND cb.transport = o.transport "
+                f"{binding_scope}"
                 f"WHERE {' AND '.join(filters)} "
                 "ORDER BY o.requested_event_position LIMIT 1",
                 parameters,
@@ -515,6 +590,8 @@ class WorkshopDeliveryOutbox:
                 purpose=_delivery_purpose(row[7]),
                 execution_contract=_delivery_execution_contract(row[8]),
                 authority_epoch_id=(DeliveryAuthorityEpochId(str(row[9])) if row[9] is not None else None),
+                human_notification_id=(HumanNotificationId(str(row[14])) if row[14] is not None else None),
+                recipient_binding_current=bool(row[15]),
                 author_display_name=str(row[13]),
                 body=str(row[11]),
                 external_channel_id=str(row[12]),
@@ -635,6 +712,7 @@ class WorkshopDeliveryOutbox:
                         transport=str(row[12]),
                         mode=str(row[13]),
                         authority_epoch_id=persisted_epoch,
+                        human_notification_id=claim.human_notification_id,
                         attempt_number=int(row[1]),
                         status="succeeded",
                         error_code=None,
@@ -726,6 +804,7 @@ class WorkshopDeliveryOutbox:
                     transport=str(row[12]),
                     mode=str(row[13]),
                     authority_epoch_id=persisted_epoch,
+                    human_notification_id=claim.human_notification_id,
                     attempt_number=attempt_count,
                     status=status,
                     error_code=error_code,
@@ -766,9 +845,12 @@ class WorkshopDeliveryOutbox:
             parameters = (*parameters, authority_epoch_id)
         if delivery_id is not None:
             parameters = (*parameters, delivery_id)
+        has_human_notification_column = await self._has_human_notification_column()
+        notification_identity = "human_notification_id" if has_human_notification_column else "NULL"
         async with connection.execute(
             "SELECT id, lease_id, attempt_count, max_attempts, workshop_id, channel_id, "
-            "channel_binding_id, message_id, transport, mode, authority_epoch_id FROM delivery_outbox "
+            f"channel_binding_id, message_id, transport, mode, authority_epoch_id, {notification_identity} "
+            "FROM delivery_outbox "
             f"WHERE status = 'leased' AND lease_expires_at <= ? "
             f"AND purpose IN ({purpose_placeholders}) "
             f"AND execution_contract IN ({contract_placeholders}){authority_filter}"
@@ -828,6 +910,7 @@ class WorkshopDeliveryOutbox:
                     transport=str(row[8]),
                     mode=str(row[9]),
                     authority_epoch_id=(DeliveryAuthorityEpochId(str(row[10])) if row[10] is not None else None),
+                    human_notification_id=(HumanNotificationId(str(row[11])) if row[11] is not None else None),
                     attempt_number=int(row[2]),
                     status="failed",
                     error_code=error_code,
@@ -849,6 +932,7 @@ class WorkshopDeliveryOutbox:
         transport: str,
         mode: str,
         authority_epoch_id: DeliveryAuthorityEpochId | None,
+        human_notification_id: HumanNotificationId | None,
         attempt_number: int,
         status: str,
         error_code: str | None,
@@ -868,8 +952,10 @@ class WorkshopDeliveryOutbox:
             payload["error_code"] = error_code
         if authority_epoch_id is not None:
             payload["authority_epoch_id"] = authority_epoch_id
-        event_identity_version = "v3" if authority_epoch_id is not None else "v2"
-        event_version = 3 if authority_epoch_id is not None else 2
+        if human_notification_id is not None:
+            payload["human_notification_id"] = human_notification_id
+        event_identity_version = "v4" if human_notification_id is not None else "v3" if authority_epoch_id else "v2"
+        event_version = 4 if human_notification_id is not None else 3 if authority_epoch_id else 2
         event_type = (
             WorkshopEventType.DELIVERY_SUCCEEDED if status == "succeeded" else WorkshopEventType.DELIVERY_FAILED
         )
@@ -894,13 +980,36 @@ class WorkshopDeliveryOutbox:
         self,
         request: DeliveryRequest,
     ) -> tuple[WorkshopId, ChannelId, PrincipalId, str]:
-        async with self._store.connection.execute(
-            "SELECT c.workshop_id, m.channel_id, m.author_principal_id, cb.transport "
-            "FROM messages m JOIN channels c ON c.id = m.channel_id "
-            "JOIN channel_bindings cb ON cb.channel_id = m.channel_id "
-            "WHERE m.id = ? AND cb.id = ?",
-            (request.message_id, request.channel_binding_id),
-        ) as cursor:
+        if request.human_notification_id is None:
+            query = (
+                "SELECT c.workshop_id, m.channel_id, m.author_principal_id, cb.transport "
+                "FROM messages m JOIN channels c ON c.id = m.channel_id "
+                "JOIN channel_bindings cb ON cb.channel_id = m.channel_id "
+                "WHERE m.id = ? AND cb.id = ?"
+            )
+            parameters: tuple[object, ...] = (request.message_id, request.channel_binding_id)
+        else:
+            query = (
+                "SELECT np.workshop_id, np.source_channel_id, m.author_principal_id, cb.transport "
+                "FROM human_notification_publications np "
+                "JOIN messages m ON m.id = np.source_message_id "
+                "AND m.channel_id = np.source_channel_id "
+                "JOIN external_identities ei ON ei.principal_id = np.recipient_principal_id "
+                "JOIN channel_bindings cb ON cb.id = ? AND cb.transport = ei.provider "
+                "AND cb.external_channel_id = ei.external_subject "
+                "JOIN channels target ON target.id = cb.channel_id AND target.kind = 'direct' "
+                "AND target.workshop_id = np.workshop_id "
+                "JOIN channel_memberships cm ON cm.channel_id = target.id "
+                "AND cm.principal_id = np.recipient_principal_id "
+                "WHERE np.notification_id = ? AND np.source_message_id = ? "
+                "AND np.policy_result = 'eligible'"
+            )
+            parameters = (
+                request.channel_binding_id,
+                request.human_notification_id,
+                request.message_id,
+            )
+        async with self._store.connection.execute(query, parameters) as cursor:
             row = await cursor.fetchone()
         if row is None:
             raise DeliveryTargetNotFoundError("Canonical message and channel binding were not found together")
@@ -927,6 +1036,12 @@ class WorkshopDeliveryOutbox:
             row = await cursor.fetchone()
         return self._state_from_row(row) if row is not None else None
 
+    async def _has_human_notification_column(self) -> bool:
+        async with self._store.connection.execute(
+            "SELECT 1 FROM pragma_table_info('delivery_outbox') WHERE name = 'human_notification_id'"
+        ) as cursor:
+            return await cursor.fetchone() is not None
+
     async def _state_by_id(self, delivery_id: DeliveryId) -> DeliveryState:
         async with self._store.connection.execute(
             "SELECT * FROM delivery_outbox WHERE id = ?",
@@ -939,6 +1054,10 @@ class WorkshopDeliveryOutbox:
 
     @staticmethod
     def _state_from_row(row: aiosqlite.Row) -> DeliveryState:
+        try:
+            raw_human_notification_id = row["human_notification_id"]
+        except IndexError:
+            raw_human_notification_id = None
         return DeliveryState(
             delivery_id=DeliveryId(str(row["id"])),
             message_id=MessageId(str(row["message_id"])),
@@ -952,6 +1071,9 @@ class WorkshopDeliveryOutbox:
                 DeliveryAuthorityEpochId(str(row["authority_epoch_id"]))
                 if row["authority_epoch_id"] is not None
                 else None
+            ),
+            human_notification_id=(
+                HumanNotificationId(str(raw_human_notification_id)) if raw_human_notification_id is not None else None
             ),
             status=str(row["status"]),
             max_attempts=int(row["max_attempts"]),

--- a/src/kai/workshop/delivery_planning.py
+++ b/src/kai/workshop/delivery_planning.py
@@ -17,7 +17,7 @@ from kai.workshop.delivery_outbox import (
     WorkshopDeliveryOutbox,
 )
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
-from kai.workshop.domain import ChannelId, MessageId, PrincipalId
+from kai.workshop.domain import ChannelId, HumanNotificationId, MessageId, PrincipalId, WorkshopId
 from kai.workshop.store import WorkshopEventStore
 
 DeliveryContentKind = Literal["text", "attachment"]
@@ -36,6 +36,8 @@ class CanonicalDeliveryIntent:
     recipient_principal_id: PrincipalId | None = None
     preview_eligible: bool = False
     max_attempts: int = 5
+    human_notification_id: HumanNotificationId | None = None
+    workshop_id: WorkshopId | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.message_id, MessageId):
@@ -51,6 +53,15 @@ class CanonicalDeliveryIntent:
             raise ValueError("recipient_principal_id must be a PrincipalId when supplied")
         if not isinstance(self.preview_eligible, bool):
             raise ValueError("preview_eligible must be a boolean")
+        if self.human_notification_id is not None:
+            if not isinstance(self.human_notification_id, HumanNotificationId):
+                raise ValueError("human_notification_id must be a HumanNotificationId when supplied")
+            if not isinstance(self.workshop_id, WorkshopId):
+                raise ValueError("human notification delivery requires a WorkshopId")
+            if self.recipient_principal_id is None:
+                raise ValueError("human notification delivery requires a recipient principal")
+        elif self.workshop_id is not None:
+            raise ValueError("workshop_id is only accepted for human notification delivery")
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,11 +89,20 @@ class WorkshopDeliveryPlanner:
     ) -> DeliveryPlanningResult:
         if not self._store.connection.in_transaction:
             raise RuntimeError("plan_in_transaction requires an active transaction")
-        bindings = await self._policy.bindings(
-            self._store,
-            intent.channel_id,
-            principal_id=intent.recipient_principal_id,
-        )
+        if intent.human_notification_id is not None:
+            assert intent.workshop_id is not None
+            assert intent.recipient_principal_id is not None
+            bindings = await self._policy.principal_bindings(
+                self._store,
+                intent.workshop_id,
+                intent.recipient_principal_id,
+            )
+        else:
+            bindings = await self._policy.bindings(
+                self._store,
+                intent.channel_id,
+                principal_id=intent.recipient_principal_id,
+            )
         selected = tuple(
             binding
             for binding in bindings
@@ -120,6 +140,7 @@ class WorkshopDeliveryPlanner:
                         occurred_at=intent.occurred_at,
                         execution_contract=(STREAMING_FINALIZATION_CONTRACT if streaming else SEND_FRAGMENTS_CONTRACT),
                         authority_epoch_id=authority_epoch_id if streaming else None,
+                        human_notification_id=intent.human_notification_id,
                         max_attempts=intent.max_attempts,
                     )
                 )

--- a/src/kai/workshop/delivery_policy.py
+++ b/src/kai/workshop/delivery_policy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from kai.workshop.domain import ChannelBindingId, ChannelId, PrincipalId
+from kai.workshop.domain import ChannelBindingId, ChannelId, PrincipalId, WorkshopId
 from kai.workshop.store import WorkshopEventStore
 
 _TRANSPORT_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
@@ -59,6 +59,7 @@ class WorkshopDeliveryBindingPolicy:
 
     enabled_transports: frozenset[str]
     adapter_capabilities: tuple[DeliveryAdapterCapabilities, ...] = ()
+    notification_deep_link: str | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.enabled_transports, frozenset):
@@ -80,6 +81,12 @@ class WorkshopDeliveryBindingPolicy:
             raise ValueError("adapter_capabilities cannot describe a disabled transport")
         if self.enabled_transports - declared:
             raise ValueError("every enabled transport must declare adapter capabilities")
+        if self.notification_deep_link is not None and (
+            not isinstance(self.notification_deep_link, str)
+            or not self.notification_deep_link.startswith(("http://", "https://"))
+            or len(self.notification_deep_link) > 1000
+        ):
+            raise ValueError("notification_deep_link must be a bounded HTTP(S) URL when supplied")
 
     @classmethod
     def disabled(cls) -> WorkshopDeliveryBindingPolicy:
@@ -159,3 +166,51 @@ class WorkshopDeliveryBindingPolicy:
             raise ValueError("channel_id must be a ChannelId")
         bindings = await self.bindings(store, channel_id)
         return tuple(binding.binding_id for binding in bindings if transport is None or binding.transport == transport)
+
+    async def principal_bindings(
+        self,
+        store: WorkshopEventStore,
+        workshop_id: WorkshopId,
+        principal_id: PrincipalId,
+    ) -> tuple[EligibleDeliveryBinding, ...]:
+        """Resolve enabled adapter destinations from a canonical recipient.
+
+        The caller supplies no transport identity. A destination is eligible
+        only while the principal's current external identity, direct channel
+        binding, and channel membership all agree.
+        """
+        if not isinstance(workshop_id, WorkshopId):
+            raise ValueError("workshop_id must be a WorkshopId")
+        if not isinstance(principal_id, PrincipalId):
+            raise ValueError("principal_id must be a PrincipalId")
+        if not self.enabled_transports:
+            return ()
+        placeholders = ", ".join("?" for _ in self.enabled_transports)
+        async with store.connection.execute(
+            "SELECT DISTINCT cb.id, cb.transport FROM external_identities ei "
+            "JOIN channel_bindings cb ON cb.transport = ei.provider "
+            "AND cb.external_channel_id = ei.external_subject "
+            "JOIN channels c ON c.id = cb.channel_id AND c.kind = 'direct' "
+            "AND c.workshop_id = ? "
+            "JOIN channel_memberships cm ON cm.channel_id = c.id "
+            "AND cm.principal_id = ei.principal_id "
+            "JOIN workshop_memberships wm ON wm.workshop_id = c.workshop_id "
+            "AND wm.principal_id = ei.principal_id "
+            f"WHERE ei.principal_id = ? AND cb.transport IN ({placeholders}) "
+            "ORDER BY cb.transport, cb.id",
+            (workshop_id, principal_id, *sorted(self.enabled_transports)),
+        ) as cursor:
+            rows = tuple(await cursor.fetchall())
+        bindings: list[EligibleDeliveryBinding] = []
+        for row in rows:
+            transport = str(row[1])
+            capabilities = self.capabilities_for(transport)
+            assert capabilities is not None
+            bindings.append(
+                EligibleDeliveryBinding(
+                    binding_id=ChannelBindingId(str(row[0])),
+                    transport=transport,
+                    capabilities=capabilities,
+                )
+            )
+        return tuple(bindings)

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -1678,6 +1678,8 @@ def workshop_human_notification_status(db_path: Path) -> str:
                 "channels",
                 "event_log",
                 "human_notifications",
+                "human_notification_publications",
+                "delivery_outbox",
                 "messages",
                 "principals",
             }
@@ -1721,6 +1723,42 @@ def workshop_human_notification_status(db_path: Path) -> str:
                 "WHERE n.id IS NULL OR n.created_event_position != e.created_position "
                 "OR n.last_event_position != e.last_position",
             )
+            publication_totals = connection.execute(
+                "SELECT COUNT(*), "
+                "SUM(CASE WHEN policy_result = 'eligible' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN policy_result = 'suppressed_dnd' THEN 1 ELSE 0 END) "
+                "FROM human_notification_publications"
+            ).fetchone()
+            publication_gaps = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM human_notification_publications p "
+                "LEFT JOIN human_notifications n ON n.id = p.notification_id "
+                "LEFT JOIN event_log e ON e.position = p.created_event_position "
+                "WHERE n.id IS NULL OR p.workshop_id != n.workshop_id "
+                "OR p.recipient_principal_id != n.recipient_principal_id "
+                "OR p.source_message_id != n.source_message_id "
+                "OR p.source_channel_id != n.source_channel_id "
+                "OR COALESCE(p.source_thread_root_id, '') != COALESCE(n.source_thread_root_id, '') "
+                "OR p.policy_result NOT IN ('eligible', 'suppressed_dnd') "
+                "OR e.event_type != 'human_notification.created' OR e.aggregate_id != p.notification_id",
+            )
+            delivery_totals = connection.execute(
+                "SELECT COUNT(*), "
+                "SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN status = 'leased' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN status = 'retry_wait' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN status = 'succeeded' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) "
+                "FROM delivery_outbox WHERE human_notification_id IS NOT NULL"
+            ).fetchone()
+            failure_classes = tuple(
+                str(row[0])
+                for row in connection.execute(
+                    "SELECT DISTINCT last_error_code FROM delivery_outbox "
+                    "WHERE human_notification_id IS NOT NULL AND last_error_code IS NOT NULL "
+                    "ORDER BY last_error_code"
+                ).fetchall()
+            )
         finally:
             connection.close()
     except (sqlite3.Error, OSError, TypeError, ValueError) as exc:
@@ -1728,11 +1766,19 @@ def workshop_human_notification_status(db_path: Path) -> str:
     total = int(totals[0] or 0) if totals is not None else 0
     unread = int(totals[1] or 0) if totals is not None else 0
     recipients = int(totals[2] or 0) if totals is not None else 0
-    state = "active" if integrity_gaps == 0 and replay_gaps == 0 else "INCOMPLETE"
+    publications = int(publication_totals[0] or 0) if publication_totals is not None else 0
+    eligible = int(publication_totals[1] or 0) if publication_totals is not None else 0
+    suppressed = int(publication_totals[2] or 0) if publication_totals is not None else 0
+    deliveries = tuple(int(value or 0) for value in delivery_totals) if delivery_totals is not None else (0,) * 6
+    state = "active" if integrity_gaps == 0 and replay_gaps == 0 and publication_gaps == 0 else "INCOMPLETE"
     return (
         f"{prefix} {state}; notifications={total}, unread={unread}, "
         f"read={total - unread}, recipients={recipients}, integrity gaps={integrity_gaps}, "
-        f"replay gaps={replay_gaps}; authority=canonical"
+        f"replay gaps={replay_gaps}; publications={publications} "
+        f"(eligible={eligible}, DND suppressed={suppressed}, integrity gaps={publication_gaps}), "
+        f"adapter deliveries={deliveries[0]} (pending={deliveries[1]}, executing={deliveries[2]}, "
+        f"retrying={deliveries[3]}, succeeded={deliveries[4]}, failed={deliveries[5]}), "
+        f"failure classes={','.join(failure_classes) if failure_classes else 'none'}; authority=canonical"
     )
 
 

--- a/src/kai/workshop/human_notifications.py
+++ b/src/kai/workshop/human_notifications.py
@@ -7,7 +7,11 @@ import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from kai.workshop.delivery_outbox import NOTIFICATION_PURPOSE
+from kai.workshop.delivery_planning import CanonicalDeliveryIntent, WorkshopDeliveryPlanner
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     ChannelId,
     EventEnvelope,
@@ -22,6 +26,7 @@ from kai.workshop.store import AppendResult, StoredEvent, WorkshopEventStore
 
 MAX_NOTIFICATION_PAGE_SIZE = 100
 MAX_NOTIFICATION_MUTATION_BATCH = 100
+HUMAN_NOTIFICATION_DELIVERY_MODE = "human_notification"
 
 
 class WorkshopHumanNotificationError(RuntimeError):
@@ -172,9 +177,76 @@ def _decode_cursor(value: object) -> tuple[int, HumanNotificationId]:
         raise WorkshopHumanNotificationValidationError("Invalid notification cursor") from exc
 
 
+def _safe_label(value: object, *, fallback: str) -> str:
+    normalized = " ".join(str(value).split()).strip()
+    return normalized[:200] if normalized else fallback
+
+
+async def _external_delivery_policy_result(
+    store: WorkshopEventStore,
+    principal_id: PrincipalId,
+    occurred_at: datetime,
+) -> str:
+    """Apply personal DND only to adapter publication, never the inbox."""
+    async with store.connection.execute(
+        "SELECT dnd_enabled, dnd_timezone, dnd_start_minute, dnd_end_minute "
+        "FROM principal_human_notification_policies WHERE principal_id = ?",
+        (principal_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None or not bool(row[0]):
+        return "eligible"
+    try:
+        local = occurred_at.astimezone(ZoneInfo(str(row[1])))
+    except ZoneInfoNotFoundError:
+        return "suppressed_dnd"
+    minute = local.hour * 60 + local.minute
+    start = int(row[2])
+    end = int(row[3])
+    inside = start <= minute < end if start < end else minute >= start or minute < end
+    return "suppressed_dnd" if inside else "eligible"
+
+
+async def _publication_body(
+    store: WorkshopEventStore,
+    *,
+    author_principal_id: PrincipalId,
+    source_channel_id: ChannelId,
+    source_thread_root_id: MessageId | None,
+    kind: str,
+    deep_link: str | None,
+) -> str:
+    """Render bounded adapter-safe text without copying message content."""
+    async with store.connection.execute(
+        "SELECT p.display_name, c.name FROM principals p CROSS JOIN channels c WHERE p.id = ? AND c.id = ?",
+        (author_principal_id, source_channel_id),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        raise RuntimeError("Canonical human notification source context is unavailable")
+    author = _safe_label(row[0], fallback="Someone")
+    channel = _safe_label(row[1], fallback="a Workshop channel")
+    location = f"#{channel}" if row[1] is not None else channel
+    if source_thread_root_id is not None:
+        location = f"a thread in {location}"
+    verb = {
+        "mention": "mentioned you in",
+        "reply": "replied to you in",
+        "message": "posted a message in",
+    }.get(kind)
+    if verb is None:
+        raise RuntimeError("Canonical human notification kind is unsupported")
+    body = f"{author} {verb} {location}."
+    if deep_link is not None:
+        body = f"{body}\nOpen Workshop: {deep_link}"
+    return body
+
+
 async def append_human_notifications_in_transaction(
     store: WorkshopEventStore,
     message_event: StoredEvent,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy | None = None,
 ) -> tuple[AppendResult, ...]:
     """Append policy-qualified notification facts for one canonical message."""
     if not store.connection.in_transaction:
@@ -211,8 +283,8 @@ async def append_human_notifications_in_transaction(
 
     async with store.connection.execute(
         "SELECT name FROM sqlite_master WHERE type = 'table' "
-        "AND name IN ('human_notifications', 'principal_channel_notification_policies', "
-        "'principal_human_notification_policies')"
+        "AND name IN ('human_notifications', 'human_notification_publications', "
+        "'principal_channel_notification_policies', 'principal_human_notification_policies')"
     ) as cursor:
         notification_tables = {str(row[0]) for row in await cursor.fetchall()}
     if "human_notifications" not in notification_tables:
@@ -221,6 +293,7 @@ async def append_human_notifications_in_transaction(
         "principal_channel_notification_policies",
         "principal_human_notification_policies",
     } <= notification_tables
+    publication_available = "human_notification_publications" in notification_tables
 
     reply_recipient: PrincipalId | None = None
     reply_target = envelope.payload.get("reply_to_message_id") or source_thread_root
@@ -267,9 +340,28 @@ async def append_human_notifications_in_transaction(
             envelope.workshop_id,
             f"human-mention:{envelope.aggregate_id}:{recipient_id}",
         )
+        publication: dict[str, object] | None = None
+        if publication_available:
+            policy_result = await _external_delivery_policy_result(
+                store,
+                recipient_id,
+                envelope.occurred_at,
+            )
+            publication = {
+                "policy_result": policy_result,
+                "alert_body": await _publication_body(
+                    store,
+                    author_principal_id=author_principal_id,
+                    source_channel_id=source_channel_id,
+                    source_thread_root_id=source_thread_root,
+                    kind=kind,
+                    deep_link=(delivery_policy.notification_deep_link if delivery_policy is not None else None),
+                ),
+                "deep_link": delivery_policy.notification_deep_link if delivery_policy is not None else None,
+            }
         notification = EventEnvelope.create(
             event_type=WorkshopEventType.HUMAN_NOTIFICATION_CREATED,
-            event_version=2 if policy_available else 1,
+            event_version=3 if publication is not None else 2 if policy_available else 1,
             workshop_id=envelope.workshop_id,
             aggregate_type="human_notification",
             aggregate_id=notification_id,
@@ -282,19 +374,43 @@ async def append_human_notifications_in_transaction(
                 "source_channel_id": source_channel_id,
                 "source_thread_root_id": source_thread_root,
                 "kind": kind,
+                **({"publication": publication} if publication is not None else {}),
             },
             metadata={"source": "canonical_message_notification_policy"},
         )
-        results.append(await store.append_in_transaction(notification))
+        appended = await store.append_in_transaction(notification)
+        results.append(appended)
+        if appended.inserted and publication is not None:
+            await store.project_pending_in_transaction(CanonicalConversationProjection())
+            if publication["policy_result"] == "eligible":
+                effective_policy = delivery_policy or WorkshopDeliveryBindingPolicy.disabled()
+                await WorkshopDeliveryPlanner(store, effective_policy).plan_in_transaction(
+                    CanonicalDeliveryIntent(
+                        message_id=MessageId(str(envelope.aggregate_id)),
+                        channel_id=source_channel_id,
+                        mode=HUMAN_NOTIFICATION_DELIVERY_MODE,
+                        purpose=NOTIFICATION_PURPOSE,
+                        occurred_at=envelope.occurred_at,
+                        recipient_principal_id=recipient_id,
+                        human_notification_id=notification_id,
+                        workshop_id=envelope.workshop_id,
+                    )
+                )
     return tuple(results)
 
 
 async def append_human_mention_notifications_in_transaction(
     store: WorkshopEventStore,
     message_event: StoredEvent,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy | None = None,
 ) -> tuple[AppendResult, ...]:
     """Compatibility name for canonical policy-qualified notification creation."""
-    return await append_human_notifications_in_transaction(store, message_event)
+    return await append_human_notifications_in_transaction(
+        store,
+        message_event,
+        delivery_policy=delivery_policy,
+    )
 
 
 class WorkshopHumanNotificationService:

--- a/src/kai/workshop/inbound.py
+++ b/src/kai/workshop/inbound.py
@@ -7,6 +7,7 @@ import re
 from dataclasses import dataclass, replace
 from datetime import datetime
 
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import (
     ChannelId,
     EventEnvelope,
@@ -449,6 +450,8 @@ def _scheduled_inbound_envelope(
 async def record_inbound_message_in_transaction(
     store: WorkshopEventStore,
     message: InboundMessage,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy | None = None,
 ) -> AppendResult:
     """Append and project one inbound message inside a caller-owned transaction."""
     if not store.connection.in_transaction:
@@ -472,7 +475,11 @@ async def record_inbound_message_in_transaction(
         )
     )
     if result.inserted:
-        await append_human_mention_notifications_in_transaction(store, result.event)
+        await append_human_mention_notifications_in_transaction(
+            store,
+            result.event,
+            delivery_policy=delivery_policy,
+        )
     await store.project_pending_in_transaction(CanonicalConversationProjection())
     return result
 
@@ -480,6 +487,8 @@ async def record_inbound_message_in_transaction(
 async def record_client_inbound_message_in_transaction(
     store: WorkshopEventStore,
     message: ClientInboundMessage,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy | None = None,
 ) -> AppendResult:
     """Append an authenticated client message inside a caller-owned transaction."""
     if not store.connection.in_transaction:
@@ -502,7 +511,11 @@ async def record_client_inbound_message_in_transaction(
     )
     result = await store.append_in_transaction(envelope)
     if result.inserted:
-        await append_human_mention_notifications_in_transaction(store, result.event)
+        await append_human_mention_notifications_in_transaction(
+            store,
+            result.event,
+            delivery_policy=delivery_policy,
+        )
     await store.project_pending_in_transaction(CanonicalConversationProjection())
     return result
 
@@ -510,6 +523,8 @@ async def record_client_inbound_message_in_transaction(
 async def record_scheduled_inbound_message_in_transaction(
     store: WorkshopEventStore,
     message: ScheduledInboundMessage,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy | None = None,
 ) -> AppendResult:
     """Append one core-owned scheduled command inside a caller transaction."""
     if not store.connection.in_transaction:
@@ -532,12 +547,21 @@ async def record_scheduled_inbound_message_in_transaction(
     )
     result = await store.append_in_transaction(envelope)
     if result.inserted:
-        await append_human_mention_notifications_in_transaction(store, result.event)
+        await append_human_mention_notifications_in_transaction(
+            store,
+            result.event,
+            delivery_policy=delivery_policy,
+        )
     await store.project_pending_in_transaction(CanonicalConversationProjection())
     return result
 
 
-async def record_inbound_message(store: WorkshopEventStore, message: InboundMessage) -> AppendResult:
+async def record_inbound_message(
+    store: WorkshopEventStore,
+    message: InboundMessage,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy | None = None,
+) -> AppendResult:
     """Append and project one authenticated inbound transport message."""
     binding = await _resolve_binding(store, message)
     candidate = _inbound_envelope(binding, message, ())
@@ -560,7 +584,11 @@ async def record_inbound_message(store: WorkshopEventStore, message: InboundMess
             )
         )
         if result.inserted:
-            await append_human_mention_notifications_in_transaction(store, result.event)
+            await append_human_mention_notifications_in_transaction(
+                store,
+                result.event,
+                delivery_policy=delivery_policy,
+            )
         await store.project_pending_in_transaction(CanonicalConversationProjection())
         await store.connection.commit()
         return result

--- a/src/kai/workshop/outbound.py
+++ b/src/kai/workshop/outbound.py
@@ -231,7 +231,12 @@ async def _existing_outbound(
     return AppendResult(event=existing, inserted=False)
 
 
-async def record_outbound_message(store: WorkshopEventStore, message: OutboundMessage) -> AppendResult:
+async def record_outbound_message(
+    store: WorkshopEventStore,
+    message: OutboundMessage,
+    *,
+    delivery_policy: WorkshopDeliveryBindingPolicy | None = None,
+) -> AppendResult:
     """Append one canonical assistant reply to an existing inbound message."""
     try:
         await store.connection.execute("BEGIN IMMEDIATE")
@@ -242,7 +247,11 @@ async def record_outbound_message(store: WorkshopEventStore, message: OutboundMe
         projection = CanonicalConversationProjection()
         await store.project_pending_in_transaction(projection)
         if result.inserted:
-            await append_human_notifications_in_transaction(store, result.event)
+            await append_human_notifications_in_transaction(
+                store,
+                result.event,
+                delivery_policy=delivery_policy,
+            )
         await store.project_pending_in_transaction(projection)
         await store.connection.commit()
         return result
@@ -273,7 +282,11 @@ async def record_outbound_message_with_delivery(
         projection = CanonicalConversationProjection()
         await store.project_pending_in_transaction(projection)
         if message_result.inserted:
-            await append_human_notifications_in_transaction(store, message_result.event)
+            await append_human_notifications_in_transaction(
+                store,
+                message_result.event,
+                delivery_policy=delivery_policy,
+            )
         message_id = message_result.event.envelope.aggregate_id
         if not isinstance(message_id, MessageId):
             raise RuntimeError("Canonical outbound event did not identify a message")
@@ -347,7 +360,11 @@ async def record_outbound_message_with_streaming_finalization_in_transaction(
     projection = CanonicalConversationProjection()
     await store.project_pending_in_transaction(projection)
     if message_result.inserted:
-        await append_human_notifications_in_transaction(store, message_result.event)
+        await append_human_notifications_in_transaction(
+            store,
+            message_result.event,
+            delivery_policy=delivery_policy,
+        )
     message_id = message_result.event.envelope.aggregate_id
     if not isinstance(message_id, MessageId):
         raise RuntimeError("Canonical outbound event did not identify a message")

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -1119,6 +1119,7 @@ class CanonicalConversationProjection:
             "run_attempts",
             "runs",
             "message_reactions",
+            "human_notification_publications",
             "human_notifications",
             "messages",
             "principal_agent_enablements",
@@ -1991,18 +1992,18 @@ class CanonicalConversationProjection:
         elif envelope.event_type == WorkshopEventType.HUMAN_NOTIFICATION_CREATED:
             if not isinstance(envelope.aggregate_id, HumanNotificationId):
                 raise ValueError("Workshop human notification requires a typed notification aggregate")
-            if envelope.event_version not in {1, 2}:
+            if envelope.event_version not in {1, 2, 3}:
                 raise ValueError("Unsupported Workshop human notification event version")
-            _require_exact_payload(
-                payload,
-                {
-                    "recipient_principal_id",
-                    "source_message_id",
-                    "source_channel_id",
-                    "source_thread_root_id",
-                    "kind",
-                },
-            )
+            expected_payload = {
+                "recipient_principal_id",
+                "source_message_id",
+                "source_channel_id",
+                "source_thread_root_id",
+                "kind",
+            }
+            if envelope.event_version == 3:
+                expected_payload.add("publication")
+            _require_exact_payload(payload, expected_payload)
             recipient_id = PrincipalId(_required_text(payload, "recipient_principal_id"))
             source_message_id = MessageId(_required_text(payload, "source_message_id"))
             source_channel_id = ChannelId(_required_text(payload, "source_channel_id"))
@@ -2063,6 +2064,43 @@ class CanonicalConversationProjection:
                     event.position,
                 ),
             )
+            if envelope.event_version == 3:
+                publication = payload.get("publication")
+                if not isinstance(publication, dict):
+                    raise ValueError("Workshop human notification publication is malformed")
+                _require_exact_payload(publication, {"policy_result", "alert_body", "deep_link"})
+                policy_result = _required_text(publication, "policy_result")
+                if policy_result not in {"eligible", "suppressed_dnd"}:
+                    raise ValueError("Workshop human notification publication policy is invalid")
+                alert_body = _required_text(publication, "alert_body")
+                if len(alert_body) > 2000:
+                    raise ValueError("Workshop human notification publication body is too large")
+                deep_link = publication.get("deep_link")
+                if deep_link is not None and (
+                    not isinstance(deep_link, str)
+                    or not deep_link.startswith(("http://", "https://"))
+                    or len(deep_link) > 1000
+                ):
+                    raise ValueError("Workshop human notification publication link is invalid")
+                await connection.execute(
+                    "INSERT INTO human_notification_publications "
+                    "(notification_id, workshop_id, recipient_principal_id, source_message_id, "
+                    "source_channel_id, source_thread_root_id, policy_result, alert_body, deep_link, "
+                    "created_at, created_event_position) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        envelope.aggregate_id,
+                        envelope.workshop_id,
+                        recipient_id,
+                        source_message_id,
+                        source_channel_id,
+                        source_thread_root_id,
+                        policy_result,
+                        alert_body,
+                        deep_link,
+                        occurred_at,
+                        event.position,
+                    ),
+                )
         elif envelope.event_type in {
             WorkshopEventType.HUMAN_NOTIFICATION_READ,
             WorkshopEventType.HUMAN_NOTIFICATION_UNREAD,
@@ -2238,6 +2276,47 @@ class CanonicalConversationProjection:
                     binding_row = await cursor.fetchone()
                 if binding_row is None:
                     raise ValueError("Workshop delivery message and binding must belong to the same channel")
+            elif envelope.event_version == 4:
+                channel_binding_id = _required_text(payload, "channel_binding_id")
+                human_notification_id = HumanNotificationId(_required_text(payload, "human_notification_id"))
+                async with connection.execute(
+                    "SELECT 1 FROM human_notification_publications np "
+                    "JOIN messages m ON m.id = np.source_message_id "
+                    "AND m.channel_id = np.source_channel_id "
+                    "JOIN external_identities ei ON ei.principal_id = np.recipient_principal_id "
+                    "JOIN channel_bindings cb ON cb.id = ? AND cb.transport = ei.provider "
+                    "AND cb.external_channel_id = ei.external_subject "
+                    "WHERE np.notification_id = ? AND np.source_message_id = ? "
+                    "AND np.source_channel_id = ? AND cb.transport = ?",
+                    (channel_binding_id, human_notification_id, message_id, channel_id, transport),
+                ) as cursor:
+                    binding_row = await cursor.fetchone()
+                if binding_row is None:
+                    # A binding may be revoked after the publication was
+                    # durably requested. The terminal failure remains valid
+                    # when it carries the explicit sanitized revocation code.
+                    async with connection.execute(
+                        "SELECT 1 FROM human_notification_publications np "
+                        "JOIN messages m ON m.id = np.source_message_id "
+                        "AND m.channel_id = np.source_channel_id "
+                        "JOIN delivery_outbox o ON o.human_notification_id = np.notification_id "
+                        "AND o.message_id = np.source_message_id AND o.channel_id = np.source_channel_id "
+                        "AND o.channel_binding_id = ? AND o.transport = ? "
+                        "JOIN channel_bindings cb ON cb.id = o.channel_binding_id "
+                        "AND cb.transport = o.transport "
+                        "JOIN channels target ON target.id = cb.channel_id AND target.kind = 'direct' "
+                        "AND target.workshop_id = np.workshop_id "
+                        "WHERE np.notification_id = ? AND np.source_message_id = ? "
+                        "AND np.source_channel_id = ?",
+                        (channel_binding_id, transport, human_notification_id, message_id, channel_id),
+                    ) as cursor:
+                        revoked_binding_row = await cursor.fetchone()
+                    if (
+                        revoked_binding_row is None
+                        or envelope.event_type != WorkshopEventType.DELIVERY_FAILED
+                        or payload.get("error_code") != "notification_recipient_binding_revoked"
+                    ):
+                        raise ValueError("Workshop human notification delivery target is not canonical")
             else:
                 raise ValueError("Workshop delivery event version is unsupported")
             await connection.execute(

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 54
+WORKSHOP_SCHEMA_VERSION = 55
 
 
 @dataclass(frozen=True, slots=True)
@@ -2527,6 +2527,42 @@ _CHANNEL_NOTIFICATION_POLICY_SCHEMA = SchemaMigration(
     ),
 )
 
+_HUMAN_NOTIFICATION_PUBLICATION_SCHEMA = SchemaMigration(
+    version=55,
+    name="canonical_human_notification_publication",
+    statements=(
+        """
+        CREATE TABLE human_notification_publications (
+            notification_id TEXT PRIMARY KEY
+                REFERENCES human_notifications(id) ON DELETE CASCADE,
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            recipient_principal_id TEXT NOT NULL
+                REFERENCES principals(id) ON DELETE CASCADE,
+            source_message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+            source_channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            source_thread_root_id TEXT REFERENCES messages(id) ON DELETE RESTRICT,
+            policy_result TEXT NOT NULL CHECK (
+                policy_result IN ('eligible', 'suppressed_dnd')
+            ),
+            alert_body TEXT NOT NULL CHECK (length(alert_body) BETWEEN 1 AND 2000),
+            deep_link TEXT CHECK (deep_link IS NULL OR length(deep_link) BETWEEN 1 AND 1000),
+            created_at TEXT NOT NULL,
+            created_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT
+        )
+        """,
+        "CREATE INDEX human_notification_publications_recipient_idx "
+        "ON human_notification_publications (recipient_principal_id, created_event_position)",
+        "CREATE INDEX human_notification_publications_policy_idx "
+        "ON human_notification_publications (policy_result, created_event_position)",
+        # The durable outbox deliberately survives projection rebuilds, so it
+        # cannot hold a foreign key into a replayed projection table.
+        "ALTER TABLE delivery_outbox ADD COLUMN human_notification_id TEXT",
+        "CREATE INDEX delivery_outbox_human_notification_idx "
+        "ON delivery_outbox (human_notification_id, status, requested_event_position)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -2582,6 +2618,7 @@ _MIGRATIONS = (
     _MULTI_HUMAN_CHANNEL_MEMBERSHIP_SCHEMA,
     _CANONICAL_HUMAN_NOTIFICATION_SCHEMA,
     _CHANNEL_NOTIFICATION_POLICY_SCHEMA,
+    _HUMAN_NOTIFICATION_PUBLICATION_SCHEMA,
 )
 
 

--- a/src/kai/workshop/telegram_delivery.py
+++ b/src/kai/workshop/telegram_delivery.py
@@ -50,6 +50,7 @@ from kai.workshop.delivery_outbox import (
     WorkshopDeliveryOutbox,
 )
 from kai.workshop.domain import DeliveryAuthorityEpochId, DeliveryId
+from kai.workshop.human_notifications import HUMAN_NOTIFICATION_DELIVERY_MODE
 from kai.workshop.proactive_publication import PROACTIVE_ARTIFACT_MODE
 from kai.workshop.store import WorkshopEventStore
 
@@ -222,6 +223,10 @@ def _telegram_fragments(body: str) -> tuple[str, ...]:
 def _telegram_delivery_body(claim: DeliveryClaim) -> str:
     if claim.mode == "text":
         return claim.body
+    if claim.mode == HUMAN_NOTIFICATION_DELIVERY_MODE:
+        if claim.human_notification_id is None:
+            raise TelegramDeliveryContractError("telegram_notification_identity_missing")
+        return claim.body
     if claim.mode == WORKSHOP_CLIENT_TEXT_MODE:
         display_name = claim.author_display_name.strip()
         if not display_name or len(display_name) > 200:
@@ -263,8 +268,10 @@ class WorkshopTelegramDeliveryAdapter:
             raise ValueError("fragment must belong to the claimed delivery")
         if claim.transport != "telegram":
             raise TelegramDeliveryContractError("telegram_transport_mismatch")
-        if claim.mode not in {"text", WORKSHOP_CLIENT_TEXT_MODE}:
+        if claim.mode not in {"text", WORKSHOP_CLIENT_TEXT_MODE, HUMAN_NOTIFICATION_DELIVERY_MODE}:
             raise TelegramDeliveryContractError("telegram_mode_unsupported")
+        if claim.mode == HUMAN_NOTIFICATION_DELIVERY_MODE and claim.human_notification_id is None:
+            raise TelegramDeliveryContractError("telegram_notification_identity_missing")
         if fragment.operation != "send" or fragment.target_external_message_id is not None:
             raise TelegramDeliveryContractError("telegram_operation_unsupported")
         if not fragment.body or len(fragment.body) > _TELEGRAM_TEXT_LIMIT:
@@ -272,7 +279,7 @@ class WorkshopTelegramDeliveryAdapter:
 
         target = _telegram_target(claim.external_channel_id)
         try:
-            if claim.mode == WORKSHOP_CLIENT_TEXT_MODE:
+            if claim.mode in {WORKSHOP_CLIENT_TEXT_MODE, HUMAN_NOTIFICATION_DELIVERY_MODE}:
                 sent = await self._bot.send_message(chat_id=target, text=fragment.body)
             else:
                 sent = await self._bot.send_message(
@@ -638,6 +645,13 @@ class WorkshopTelegramDeliveryWorker:
     async def _run_claim(self, claim: DeliveryClaim | None) -> TelegramWorkResult:
         if claim is None:
             return TelegramWorkResult(outcome=TelegramWorkOutcome.IDLE)
+
+        if claim.human_notification_id is not None and not claim.recipient_binding_current:
+            return await self._settle_failure(
+                claim,
+                None,
+                TelegramDeliveryContractError("notification_recipient_binding_revoked"),
+            )
 
         try:
             bodies = _telegram_fragments(_telegram_delivery_body(claim))

--- a/src/kai/workshop/telegram_delivery_runtime.py
+++ b/src/kai/workshop/telegram_delivery_runtime.py
@@ -18,6 +18,7 @@ from kai.workshop.delivery_outbox import (
     WorkshopDeliveryOutbox,
 )
 from kai.workshop.domain import DeliveryAuthorityEpochId
+from kai.workshop.human_notifications import HUMAN_NOTIFICATION_DELIVERY_MODE
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.telegram_delivery import (
     WORKSHOP_CLIENT_TEXT_MODE,
@@ -364,7 +365,7 @@ class WorkshopTelegramNotificationService:
                 WorkshopTelegramDeliveryAdapter(cast(TelegramTextBot, bot)),
                 worker_id=worker_id,
                 purpose=NOTIFICATION_PURPOSE,
-                modes=("text",),
+                modes=("text", HUMAN_NOTIFICATION_DELIVERY_MODE),
             )
             runtime = WorkshopTelegramDeliveryRuntime(worker, worker)
             await runtime.start()

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -238,7 +238,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 54
+        assert await workshop_store.schema_version() == 55
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -286,7 +286,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 54
+        assert await second.schema_version() == 55
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -318,7 +318,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -346,7 +346,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -418,6 +418,7 @@ class TestWorkshopSchema:
                     52,
                     53,
                     54,
+                    55,
                 ]
         finally:
             await upgraded.close()
@@ -440,7 +441,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -481,7 +482,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -534,7 +535,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -578,7 +579,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -622,7 +623,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -666,7 +667,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -770,7 +771,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -897,7 +898,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -19,6 +19,7 @@ from kai.workshop.channel_notification_policy import (
     WorkshopChannelNotificationPolicyValidationError,
 )
 from kai.workshop.client_api import register_workshop_read_routes
+from kai.workshop.delivery_policy import DeliveryAdapterCapabilities, WorkshopDeliveryBindingPolicy
 from kai.workshop.diagnostics import (
     workshop_channel_notification_policy_status,
     workshop_human_notification_status,
@@ -26,6 +27,7 @@ from kai.workshop.diagnostics import (
 from kai.workshop.domain import AgentId, ChannelId, HumanNotificationId, MessageId, PrincipalId
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.human_notifications import (
+    HUMAN_NOTIFICATION_DELIVERY_MODE,
     HumanNotificationStateRequest,
     WorkshopHumanNotificationAccessDenied,
     WorkshopHumanNotificationConflict,
@@ -106,6 +108,7 @@ async def _record(
     *,
     occurred_at: datetime = _NOW,
     thread_root_id: MessageId | None = None,
+    delivery_policy: WorkshopDeliveryBindingPolicy | None = None,
 ) -> MessageId:
     try:
         await store.connection.execute("BEGIN IMMEDIATE")
@@ -119,6 +122,7 @@ async def _record(
                 occurred_at,
                 thread_root_id=thread_root_id,
             ),
+            delivery_policy=delivery_policy,
         )
         await store.connection.commit()
     except Exception:
@@ -165,6 +169,137 @@ async def _next_sse_event(response) -> dict[str, object]:
 
 
 class TestHumanNotificationAuthority:
+    async def test_publication_is_safe_recipient_routed_idempotent_and_replayable(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "kai.db"
+        store, daniel_id, scott_id, channel_id, _agent_id = await _notification_context(path)
+        capabilities = DeliveryAdapterCapabilities("desktop")
+        policy = WorkshopDeliveryBindingPolicy(
+            frozenset({"desktop"}),
+            (capabilities,),
+            "http://workshop.example/workshop/",
+        )
+        secret_body = "@scott private source content must not leave Workshop"
+        try:
+            message_id = await _record(
+                store,
+                daniel_id,
+                channel_id,
+                "publication-safe",
+                secret_body,
+                delivery_policy=policy,
+            )
+            await _record(
+                store,
+                daniel_id,
+                channel_id,
+                "publication-safe",
+                secret_body,
+                delivery_policy=policy,
+            )
+            async with store.connection.execute(
+                "SELECT p.notification_id, p.recipient_principal_id, p.policy_result, "
+                "p.alert_body, p.deep_link, o.mode, o.transport, o.status "
+                "FROM human_notification_publications p "
+                "JOIN delivery_outbox o ON o.human_notification_id = p.notification_id "
+                "WHERE p.source_message_id = ?",
+                (message_id,),
+            ) as cursor:
+                rows = tuple(await cursor.fetchall())
+            assert len(rows) == 1
+            row = rows[0]
+            assert str(row[1]) == scott_id
+            assert tuple(str(value) for value in row[2:]) == (
+                "eligible",
+                "Daniel mentioned you in #Human notifications.\nOpen Workshop: http://workshop.example/workshop/",
+                "http://workshop.example/workshop/",
+                HUMAN_NOTIFICATION_DELIVERY_MODE,
+                "desktop",
+                "pending",
+            )
+            assert "private source content" not in str(row[3])
+
+            await store.rebuild_projection(CanonicalConversationProjection())
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM human_notification_publications WHERE source_message_id = ?",
+                (message_id,),
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 1
+        finally:
+            await store.close()
+
+        reopened = await WorkshopEventStore.open(path)
+        try:
+            assert (await WorkshopHumanNotificationService(reopened).counts(scott_id)).total == 1
+            status = workshop_human_notification_status(path)
+            assert "publications=1 (eligible=1, DND suppressed=0, integrity gaps=0)" in status
+            assert "adapter deliveries=1 (pending=1" in status
+            assert "failure classes=none" in status
+        finally:
+            await reopened.close()
+
+    async def test_adapter_suppression_never_removes_the_canonical_inbox(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, daniel_id, scott_id, channel_id, _agent_id = await _notification_context(tmp_path / "kai.db")
+        capabilities = DeliveryAdapterCapabilities("desktop")
+        enabled = WorkshopDeliveryBindingPolicy(frozenset({"desktop"}), (capabilities,))
+        try:
+            await store.connection.execute(
+                "INSERT INTO principal_human_notification_policies "
+                "(principal_id, muted_mentions_notify, dnd_enabled, dnd_timezone, "
+                "dnd_start_minute, dnd_end_minute) VALUES (?, 1, 1, 'UTC', 660, 780)",
+                (scott_id,),
+            )
+            await store.connection.commit()
+            await _record(
+                store,
+                daniel_id,
+                channel_id,
+                "publication-dnd",
+                "@scott DND still keeps the inbox",
+                delivery_policy=enabled,
+            )
+            assert (await WorkshopHumanNotificationService(store).counts(scott_id)).total == 1
+            async with store.connection.execute("SELECT policy_result FROM human_notification_publications") as cursor:
+                assert tuple(await cursor.fetchone()) == ("suppressed_dnd",)
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM delivery_outbox WHERE human_notification_id IS NOT NULL"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+
+            await store.connection.execute(
+                "UPDATE principal_human_notification_policies SET dnd_enabled = 0 WHERE principal_id = ?",
+                (scott_id,),
+            )
+            await store.connection.execute(
+                "DELETE FROM external_identities WHERE principal_id = ? AND provider = 'desktop'",
+                (scott_id,),
+            )
+            await store.connection.commit()
+            await _record(
+                store,
+                daniel_id,
+                channel_id,
+                "publication-revoked",
+                "@scott revoked adapter still keeps the inbox",
+                delivery_policy=enabled,
+            )
+            assert (await WorkshopHumanNotificationService(store).counts(scott_id)).total == 2
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM human_notification_publications WHERE policy_result = 'eligible'"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 1
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM delivery_outbox WHERE human_notification_id IS NOT NULL"
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+        finally:
+            await store.close()
+
     async def test_version_fifty_three_notification_rows_upgrade_without_loss(
         self,
         tmp_path: Path,
@@ -183,7 +318,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 54
+            assert await upgraded.schema_version() == 55
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),

--- a/tests/test_workshop_telegram_delivery.py
+++ b/tests/test_workshop_telegram_delivery.py
@@ -14,6 +14,7 @@ from telegram.error import BadRequest, Forbidden, InvalidToken, NetworkError, Re
 
 from kai.workshop.artifacts import WorkshopArtifactService
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.channel_lifecycle import WorkshopChannelLifecycleService
 from kai.workshop.delivery_fragments import (
     DeliveryFragment,
     DeliveryFragmentOperationKind,
@@ -21,6 +22,7 @@ from kai.workshop.delivery_fragments import (
 )
 from kai.workshop.delivery_outbox import (
     CONVERSATION_REPLY_PURPOSE,
+    NOTIFICATION_PURPOSE,
     QUALIFICATION_PURPOSE,
     SEND_FRAGMENTS_CONTRACT,
     DeliveryClaim,
@@ -33,11 +35,19 @@ from kai.workshop.domain import (
     DeliveryAttemptId,
     DeliveryId,
     EventEnvelope,
+    HumanNotificationId,
     MessageId,
+    PrincipalId,
     WorkshopEventType,
     WorkshopId,
 )
-from kai.workshop.inbound import InboundMessage, record_inbound_message
+from kai.workshop.human_notifications import HUMAN_NOTIFICATION_DELIVERY_MODE
+from kai.workshop.inbound import (
+    ClientInboundMessage,
+    InboundMessage,
+    record_client_inbound_message_in_transaction,
+    record_inbound_message,
+)
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.outbound import OutboundMessage, record_outbound_message
 from kai.workshop.proactive_publication import (
@@ -69,6 +79,7 @@ def _claim(
     transport: str = "telegram",
     mode: str = "text",
     body: str = "Hello from Workshop",
+    human_notification_id: HumanNotificationId | None = None,
 ) -> DeliveryClaim:
     return DeliveryClaim(
         delivery_id=DeliveryId.new(),
@@ -87,6 +98,7 @@ def _claim(
         author_display_name="Workshop Human",
         body=body,
         lease_expires_at=_NOW + timedelta(seconds=30),
+        human_notification_id=human_notification_id,
     )
 
 
@@ -334,6 +346,30 @@ class TestWorkshopTelegramDeliveryAdapter:
             text="Workshop Human via Workshop:\nHello from the browser",
         )
 
+    async def test_human_notification_uses_safe_plain_text_adapter_contract(self):
+        bot = _successful_bot()
+        claim = _claim(
+            mode=HUMAN_NOTIFICATION_DELIVERY_MODE,
+            body="Daniel mentioned you in #General.",
+            human_notification_id=HumanNotificationId.new(),
+        )
+
+        assert await WorkshopTelegramDeliveryAdapter(bot).deliver_fragment(claim, _fragment(claim)) == 1001
+
+        bot.send_message.assert_awaited_once_with(
+            chat_id=101,
+            text="Daniel mentioned you in #General.",
+        )
+
+    async def test_human_notification_requires_canonical_notification_identity(self):
+        bot = _successful_bot()
+        claim = _claim(mode=HUMAN_NOTIFICATION_DELIVERY_MODE)
+
+        with pytest.raises(TelegramDeliveryContractError, match="telegram_notification_identity_missing"):
+            await WorkshopTelegramDeliveryAdapter(bot).deliver_fragment(claim, _fragment(claim))
+
+        bot.send_message.assert_not_awaited()
+
     async def test_thread_activity_is_flattened_as_ordered_ordinary_telegram_messages(self):
         bot = _successful_bot(1001, 1002)
         adapter = WorkshopTelegramDeliveryAdapter(bot)
@@ -565,6 +601,128 @@ class TestWorkshopTelegramDeliveryAdapterContinued:
 
 
 class TestWorkshopTelegramDeliveryWorker:
+    async def test_human_mentions_fan_out_once_and_survive_worker_restart(self, tmp_path: Path):
+        path = tmp_path / "kai.db"
+        store = await WorkshopEventStore.open(path)
+        bootstrap = await bootstrap_default_workshop(
+            store,
+            (
+                BootstrapHuman("Daniel", "admin", "telegram", "101", "101", profile_id(101)),
+                BootstrapHuman("Scott", "member", "telegram", "202", "202", profile_id(202)),
+                BootstrapHuman("Alex", "member", "telegram", "303", "303", profile_id(303)),
+            ),
+        )
+        async with store.connection.execute(
+            "SELECT ei.principal_id, cb.channel_id, ei.external_subject FROM external_identities ei "
+            "JOIN channel_bindings cb ON cb.transport = ei.provider "
+            "AND cb.external_channel_id = ei.external_subject WHERE ei.provider = 'telegram'"
+        ) as cursor:
+            identities = {
+                str(row[2]): (PrincipalId(str(row[0])), ChannelId(str(row[1]))) for row in await cursor.fetchall()
+            }
+        daniel_id, daniel_direct = identities["101"]
+        scott_id, _ = identities["202"]
+        alex_id, _ = identities["303"]
+        lifecycle = WorkshopChannelLifecycleService(store)
+        group = await lifecycle.create_group(
+            daniel_id,
+            name="Delivery qualification",
+            agent_ids=[bootstrap.agent_id],
+            origin_channel_id=daniel_direct,
+        )
+        membership = await lifecycle.human_members(daniel_id, group.channel_id)
+        added_scott = await lifecycle.add_human_member(
+            daniel_id,
+            group.channel_id,
+            scott_id,
+            expected_state_version=membership.state_version,
+            client_operation_id="delivery-add-scott",
+        )
+        await lifecycle.add_human_member(
+            daniel_id,
+            group.channel_id,
+            alex_id,
+            expected_state_version=added_scott.state_version,
+            client_operation_id="delivery-add-alex",
+        )
+        try:
+            await store.connection.execute("BEGIN IMMEDIATE")
+            await record_client_inbound_message_in_transaction(
+                store,
+                ClientInboundMessage(
+                    daniel_id,
+                    group.channel_id,
+                    "human-delivery-two-recipients",
+                    "@scott and @alex private content",
+                    _NOW,
+                ),
+                delivery_policy=TELEGRAM_DELIVERY_POLICY,
+            )
+            await store.connection.commit()
+        except Exception:
+            await store.connection.rollback()
+            await store.close()
+            raise
+
+        bot = _successful_bot(2001, 3001)
+        worker = WorkshopTelegramDeliveryWorker(
+            WorkshopDeliveryOutbox(store),
+            WorkshopDeliveryFragments(store),
+            WorkshopTelegramDeliveryAdapter(bot),
+            worker_id="human-notification-worker",
+            purpose=NOTIFICATION_PURPOSE,
+            modes=(HUMAN_NOTIFICATION_DELIVERY_MODE,),
+        )
+        try:
+            assert (await worker.run_once()).outcome == TelegramWorkOutcome.SUCCEEDED
+            assert (await worker.run_once()).outcome == TelegramWorkOutcome.SUCCEEDED
+            assert (await worker.run_once()).outcome == TelegramWorkOutcome.IDLE
+            targets = {call.kwargs["chat_id"] for call in bot.send_message.await_args_list}
+            assert targets == {202, 303}
+            assert all("private content" not in call.kwargs["text"] for call in bot.send_message.await_args_list)
+
+            await store.connection.execute("BEGIN IMMEDIATE")
+            await record_client_inbound_message_in_transaction(
+                store,
+                ClientInboundMessage(
+                    daniel_id,
+                    group.channel_id,
+                    "human-delivery-revoked-after-publication",
+                    "@alex queued before revocation",
+                    _NOW + timedelta(seconds=1),
+                ),
+                delivery_policy=TELEGRAM_DELIVERY_POLICY,
+            )
+            await store.connection.commit()
+            await store.connection.execute(
+                "DELETE FROM external_identities WHERE principal_id = ? AND provider = 'telegram'",
+                (alex_id,),
+            )
+            await store.connection.commit()
+
+            revoked = await worker.run_once()
+            assert revoked.outcome == TelegramWorkOutcome.FAILED
+            assert revoked.error_code == "notification_recipient_binding_revoked"
+            assert len(bot.send_message.await_args_list) == 2
+        finally:
+            await store.close()
+
+        reopened = await WorkshopEventStore.open(path)
+        restarted_bot = _successful_bot()
+        restarted_worker = WorkshopTelegramDeliveryWorker(
+            WorkshopDeliveryOutbox(reopened),
+            WorkshopDeliveryFragments(reopened),
+            WorkshopTelegramDeliveryAdapter(restarted_bot),
+            worker_id="human-notification-worker-restarted",
+            purpose=NOTIFICATION_PURPOSE,
+            modes=(HUMAN_NOTIFICATION_DELIVERY_MODE,),
+        )
+        try:
+            assert (await restarted_worker.run_once()).outcome == TelegramWorkOutcome.IDLE
+            restarted_bot.send_message.assert_not_awaited()
+        finally:
+            await reopened.close()
+
     async def test_client_mode_worker_delivers_attributed_human_echo(self, tmp_path: Path):
         store, _, _ = await _open_with_outbound(tmp_path / "kai.db")
         async with store.connection.execute(


### PR DESCRIPTION
Closes #1274

## Summary
- add a replayable, transport-neutral publication envelope for canonical human notifications
- resolve recipient delivery bindings server-side and preserve Workshop inbox state across DND, disabled, missing, or revoked adapters
- deliver eligible alerts through the Telegram adapter with safe context, bounded durable settlement, binding revalidation, and restart idempotency
- report publication, suppression, delivery, and sanitized failure counts in install status

## Security and authority
- publication contains canonical IDs and a bounded alert, never the source message body or a caller-supplied transport identity
- Telegram chat IDs remain in external identity/channel binding records and the adapter boundary
- revoked bindings fail before any Telegram API call
- adapter delivery cannot mutate read state or channel membership

## Verification
- `make check`
- `make typecheck`
- `make test` — 6,380 passed
- `make check-install-constraints`
- end-to-end tests cover two recipients, DND, disabled/missing binding, revocation after publication, safe alert rendering, retry settlement, restart, and duplicate suppression