### PR TITLE
Reconcile owner runtime sessions

### DIFF
--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -63,6 +63,22 @@ _RUNTIME_SESSION_TABLES = {
     "runs",
     "workshop_continuity_cutover",
 }
+_CURRENT_AUTHORITY_COMPLETED_LANES_SQL = (
+    "SELECT DISTINCT r.channel_id, r.agent_id FROM runs r "
+    "JOIN messages m ON m.id = r.result_message_id "
+    "JOIN channel_agents ca ON ca.channel_id = r.channel_id AND ca.agent_id = r.agent_id "
+    "JOIN channels c ON c.id = ca.channel_id "
+    "JOIN agent_definitions d ON d.agent_id = ca.agent_id "
+    "LEFT JOIN channel_agent_runtime_assignments a ON a.channel_id = ca.channel_id "
+    "AND a.agent_id = ca.agent_id "
+    "LEFT JOIN principal_agent_enablements e ON e.direct_channel_id = ca.channel_id "
+    "AND e.agent_id = ca.agent_id "
+    "WHERE r.status = 'completed' AND m.created_event_position > ? "
+    "AND ca.detached_at IS NULL AND d.lifecycle_state = 'active' "
+    "AND (c.kind != 'direct' OR e.id IS NULL OR e.lifecycle_state = 'enabled') "
+    "AND r.runtime_profile_id = COALESCE(d.owner_runtime_profile_id, "
+    "ca.sponsored_runtime_profile_id, a.runtime_profile_id)"
+)
 _EXECUTION_STATE_TABLES = {
     "channel_agent_execution_settings",
     "channel_agent_runtime_assignments",
@@ -658,17 +674,7 @@ def workshop_runtime_session_status(db_path: Path) -> str:
             cutover = int(cutover_row[0])
             successful_lanes = _scalar(
                 connection,
-                "SELECT COUNT(*) FROM (SELECT DISTINCT r.channel_id, r.agent_id FROM runs r "
-                "JOIN messages m ON m.id = r.result_message_id "
-                "WHERE r.status = 'completed' AND m.created_event_position > ? "
-                "AND EXISTS (SELECT 1 FROM channel_agents ca "
-                "JOIN channels c ON c.id = ca.channel_id "
-                "JOIN agent_definitions d ON d.agent_id = ca.agent_id "
-                "LEFT JOIN principal_agent_enablements e ON e.direct_channel_id = ca.channel_id "
-                "AND e.agent_id = ca.agent_id "
-                "WHERE ca.channel_id = r.channel_id AND ca.agent_id = r.agent_id "
-                "AND ca.detached_at IS NULL AND d.lifecycle_state = 'active' "
-                "AND (c.kind != 'direct' OR e.id IS NULL OR e.lifecycle_state = 'enabled')))",
+                f"SELECT COUNT(*) FROM ({_CURRENT_AUTHORITY_COMPLETED_LANES_SQL})",
                 (cutover,),
             )
             sessions = _scalar(connection, "SELECT COUNT(*) FROM channel_agent_runtime_sessions")
@@ -678,17 +684,7 @@ def workshop_runtime_session_status(db_path: Path) -> str:
             )
             missing = _scalar(
                 connection,
-                "SELECT COUNT(*) FROM (SELECT DISTINCT r.channel_id, r.agent_id FROM runs r "
-                "JOIN messages m ON m.id = r.result_message_id "
-                "WHERE r.status = 'completed' AND m.created_event_position > ? "
-                "AND EXISTS (SELECT 1 FROM channel_agents ca "
-                "JOIN channels c ON c.id = ca.channel_id "
-                "JOIN agent_definitions d ON d.agent_id = ca.agent_id "
-                "LEFT JOIN principal_agent_enablements e ON e.direct_channel_id = ca.channel_id "
-                "AND e.agent_id = ca.agent_id "
-                "WHERE ca.channel_id = r.channel_id AND ca.agent_id = r.agent_id "
-                "AND ca.detached_at IS NULL AND d.lifecycle_state = 'active' "
-                "AND (c.kind != 'direct' OR e.id IS NULL OR e.lifecycle_state = 'enabled'))) lanes "
+                f"SELECT COUNT(*) FROM ({_CURRENT_AUTHORITY_COMPLETED_LANES_SQL}) lanes "
                 "WHERE NOT EXISTS ("
                 "SELECT 1 FROM channel_agent_runtime_sessions s "
                 "WHERE s.channel_id = lanes.channel_id AND s.agent_id = lanes.agent_id)",

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 58
+WORKSHOP_SCHEMA_VERSION = 59
 
 
 @dataclass(frozen=True, slots=True)
@@ -2664,6 +2664,30 @@ _EXPLICIT_AGENT_CONVERSATION_SCHEMA = SchemaMigration(
     ),
 )
 
+_OWNER_RUNTIME_SESSION_RECONCILIATION_SCHEMA = SchemaMigration(
+    version=59,
+    name="owner_runtime_session_reconciliation",
+    statements=(
+        # Provider sessions are resumable only under the runtime authority that
+        # created them.  The single-owner cutover changed that authority for
+        # non-owner direct lanes, so retire any historical session that no
+        # longer matches the effective owner/sponsored/assignment profile.
+        "DELETE FROM channel_agent_runtime_sessions AS s WHERE NOT EXISTS ("
+        "SELECT 1 FROM channel_agents ca "
+        "JOIN channels c ON c.id = ca.channel_id "
+        "JOIN agent_definitions d ON d.agent_id = ca.agent_id "
+        "LEFT JOIN channel_agent_runtime_assignments a ON a.channel_id = ca.channel_id "
+        "AND a.agent_id = ca.agent_id "
+        "LEFT JOIN principal_agent_enablements e ON e.direct_channel_id = ca.channel_id "
+        "AND e.agent_id = ca.agent_id "
+        "WHERE ca.channel_id = s.channel_id AND ca.agent_id = s.agent_id "
+        "AND ca.detached_at IS NULL AND d.lifecycle_state = 'active' "
+        "AND (c.kind != 'direct' OR e.id IS NULL OR e.lifecycle_state = 'enabled') "
+        "AND COALESCE(d.owner_runtime_profile_id, ca.sponsored_runtime_profile_id, "
+        "a.runtime_profile_id) = s.runtime_profile_id)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -2723,6 +2747,7 @@ _MIGRATIONS = (
     _HUMAN_NOTIFICATION_ADAPTER_PREFERENCE_SCHEMA,
     _SINGLE_OWNER_AGENT_AUTHORITY_SCHEMA,
     _EXPLICIT_AGENT_CONVERSATION_SCHEMA,
+    _OWNER_RUNTIME_SESSION_RECONCILIATION_SCHEMA,
 )
 
 

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -418,7 +418,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 58
+        assert await upgraded.schema_version() == 59
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -7,6 +7,8 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
 from kai.agent_failure import AgentFailureKind
 from kai.backend import AgentResponse, StreamEvent, TraceEntry
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
@@ -250,6 +252,76 @@ class TestCanonicalExecutionCoordinator:
             )
         finally:
             await store.close()
+
+    async def test_version_fifty_nine_retires_a_pre_owner_runtime_session(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kai.workshop import schema
+
+        path = tmp_path / "kai.db"
+        replacement_profile = RuntimeProfileId.new()
+        with monkeypatch.context() as migration_context:
+            migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 58)
+            migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:58])
+            legacy, run = await _accepted(path)
+            try:
+                result = await _coordinator(legacy, _Preparation(_Prepared(run))).execute(run.run_id)
+                assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+                assert await load_runtime_session(legacy, run.channel_id, run.agent_id) is not None
+
+                await legacy.connection.execute(
+                    "UPDATE agent_definitions SET owner_runtime_profile_id = ? WHERE agent_id = ?",
+                    (replacement_profile, run.agent_id),
+                )
+                await legacy.connection.commit()
+            finally:
+                await legacy.close()
+
+        before = workshop_runtime_session_status(path)
+        assert before.startswith("Workshop conversation continuity: INCOMPLETE; successful lanes=0, sessions=1")
+        assert "missing=0, stale=1" in before
+
+        upgraded = await WorkshopEventStore.open(path)
+        try:
+            assert await upgraded.schema_version() == 59
+            assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
+            after = workshop_runtime_session_status(path)
+            assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
+            assert "missing=0, stale=0" in after
+        finally:
+            await upgraded.close()
+
+    async def test_version_fifty_nine_retains_a_current_owner_runtime_session(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kai.workshop import schema
+
+        path = tmp_path / "kai.db"
+        with monkeypatch.context() as migration_context:
+            migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 58)
+            migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:58])
+            legacy, run = await _accepted(path)
+            try:
+                result = await _coordinator(legacy, _Preparation(_Prepared(run))).execute(run.run_id)
+                assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+            finally:
+                await legacy.close()
+
+        upgraded = await WorkshopEventStore.open(path)
+        try:
+            assert await upgraded.schema_version() == 59
+            session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
+            assert session is not None
+            assert session.runtime_profile_id == _RUNTIME_PROFILE_ID
+            status = workshop_runtime_session_status(path)
+            assert status.startswith("Workshop conversation continuity: active; successful lanes=1, sessions=1")
+            assert "missing=0, stale=0" in status
+        finally:
+            await upgraded.close()
 
     async def test_retired_successful_lane_does_not_require_a_live_provider_session(
         self,

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -243,7 +243,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 58
+        assert await workshop_store.schema_version() == 59
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -291,7 +291,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 58
+        assert await second.schema_version() == 59
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -323,7 +323,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -351,7 +351,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -427,6 +427,7 @@ class TestWorkshopSchema:
                     56,
                     57,
                     58,
+                    59,
                 ]
         finally:
             await upgraded.close()
@@ -449,7 +450,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -490,7 +491,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -543,7 +544,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -587,7 +588,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -631,7 +632,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -675,7 +676,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -779,7 +780,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -906,7 +907,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -319,7 +319,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 58
+            assert await upgraded.schema_version() == 59
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),


### PR DESCRIPTION
## Summary
- add schema migration 59 to retire provider sessions whose stored runtime profile no longer matches effective owner authority
- scope successful continuity lanes to completed runs under that same current authority
- keep diagnostics and migration on one owner/sponsored/assignment resolution rule

## Installed-state proof
A consistent SQLite online backup of the deployed schema-58 database was upgraded locally:
- before: missing=0, stale=1, sessions=9
- after: missing=0, stale=0, sessions=8
- exactly the obsolete pre-owner session was removed; no new message was required

## Validation
- make check
- make typecheck
- make client-check (152 tests)
- make check-install-constraints
- make test (6,395 passed)
- targeted schema/continuity suite (90 passed)

Closes #1308