### PR TITLE
Preserve unread cutover boundary on rebuild

### DIFF
--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -1376,7 +1376,7 @@ class CanonicalConversationProjection:
                         "read_through_event_position = excluded.read_through_event_position, "
                         "read_through_message_id = NULL, state_version = 0, "
                         "last_event_position = excluded.last_event_position, updated_at = excluded.updated_at",
-                        (principal_id, channel_id, baseline, baseline, event.position, occurred_at),
+                        (principal_id, channel_id, baseline, baseline, baseline, occurred_at),
                     )
             if envelope.event_version == 2:
                 await connection.execute(

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 60
+WORKSHOP_SCHEMA_VERSION = 61
 
 
 @dataclass(frozen=True, slots=True)
@@ -2737,6 +2737,17 @@ _CANONICAL_CHANNEL_READ_POSITION_SCHEMA = SchemaMigration(
     ),
 )
 
+_CANONICAL_CHANNEL_READ_POSITION_BOUNDARY_REPAIR_SCHEMA = SchemaMigration(
+    version=61,
+    name="canonical_channel_read_position_boundary_repair",
+    statements=(
+        "UPDATE channel_read_positions SET "
+        "last_event_position = membership_baseline_event_position, "
+        "updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') "
+        "WHERE last_event_position < membership_baseline_event_position",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -2798,6 +2809,7 @@ _MIGRATIONS = (
     _EXPLICIT_AGENT_CONVERSATION_SCHEMA,
     _OWNER_RUNTIME_SESSION_RECONCILIATION_SCHEMA,
     _CANONICAL_CHANNEL_READ_POSITION_SCHEMA,
+    _CANONICAL_CHANNEL_READ_POSITION_BOUNDARY_REPAIR_SCHEMA,
 )
 
 

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -418,7 +418,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 60
+        assert await upgraded.schema_version() == 61
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_channel_unread.py
+++ b/tests/test_workshop_channel_unread.py
@@ -366,6 +366,7 @@ class TestChannelUnreadAuthority:
             await store.connection.execute("DROP TABLE channel_read_positions")
             await store.connection.execute("DROP TABLE channel_unread_migration_baselines")
             await store.connection.execute("DELETE FROM workshop_schema_migrations WHERE version = 60")
+            await store.connection.execute("DELETE FROM workshop_schema_migrations WHERE version = 61")
             await store.connection.commit()
             await migrate_workshop_schema(store.connection)
             state = await WorkshopChannelUnreadService(store).channel(scott_id, channel_id)
@@ -374,6 +375,25 @@ class TestChannelUnreadAuthority:
             assert state.last_event_position == state.membership_baseline_event_position
             await store.rebuild_projection(CanonicalConversationProjection())
             assert await WorkshopChannelUnreadService(store).channel(scott_id, channel_id) == state
+        finally:
+            await store.close()
+
+    async def test_version_sixty_one_repairs_an_installed_rebuild_boundary(self, tmp_path: Path) -> None:
+        store, _daniel_id, scott_id, channel_id, _agent_id = await _context(tmp_path / "kai.db")
+        try:
+            state = await WorkshopChannelUnreadService(store).channel(scott_id, channel_id)
+            assert state.membership_baseline_event_position > 0
+            await store.connection.execute(
+                "UPDATE channel_read_positions SET last_event_position = ? WHERE principal_id = ? AND channel_id = ?",
+                (state.membership_baseline_event_position - 1, scott_id, channel_id),
+            )
+            await store.connection.execute("DELETE FROM workshop_schema_migrations WHERE version = 61")
+            await store.connection.commit()
+
+            await migrate_workshop_schema(store.connection)
+
+            repaired = await WorkshopChannelUnreadService(store).channel(scott_id, channel_id)
+            assert repaired.last_event_position == repaired.membership_baseline_event_position
         finally:
             await store.close()
 

--- a/tests/test_workshop_channel_unread.py
+++ b/tests/test_workshop_channel_unread.py
@@ -371,6 +371,9 @@ class TestChannelUnreadAuthority:
             state = await WorkshopChannelUnreadService(store).channel(scott_id, channel_id)
             assert state.unread_count == 0
             assert state.read_through_event_position == state.membership_baseline_event_position
+            assert state.last_event_position == state.membership_baseline_event_position
+            await store.rebuild_projection(CanonicalConversationProjection())
+            assert await WorkshopChannelUnreadService(store).channel(scott_id, channel_id) == state
         finally:
             await store.close()
 

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -285,7 +285,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
             after = workshop_runtime_session_status(path)
             assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
@@ -313,7 +313,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
             assert session is not None
             assert session.runtime_profile_id == _RUNTIME_PROFILE_ID

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -246,7 +246,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 60
+        assert await workshop_store.schema_version() == 61
         async with workshop_store.connection.execute("PRAGMA index_list(delivery_outbox)") as cursor:
             indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "delivery_outbox_binding_order_idx" in indexes
@@ -294,7 +294,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 60
+        assert await second.schema_version() == 61
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -326,7 +326,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -354,7 +354,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -432,6 +432,7 @@ class TestWorkshopSchema:
                     58,
                     59,
                     60,
+                    61,
                 ]
         finally:
             await upgraded.close()
@@ -454,7 +455,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -495,7 +496,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -548,7 +549,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -592,7 +593,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -636,7 +637,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -680,7 +681,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -784,7 +785,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -911,7 +912,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -319,7 +319,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 60
+            assert await upgraded.schema_version() == 61
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),


### PR DESCRIPTION
## Summary

- keep `last_event_position` at or beyond the installed unread cutover baseline during projection replay
- prove migrated state remains exactly identical after a full canonical projection rebuild
- add schema v61 to repair already-installed v60 rows immediately on upgrade

Installed qualification exposed this because Scott's correct unread count carried `last_event_position=8600` behind `membership_baseline_event_position=9302`.

Closes #1314
Parent: #1313

## Validation

- focused migration/rebuild regression test
- `make check`
- `make typecheck`
- full test suite — 6,404 passed
