### PR TITLE
Add canonical private human DM authority

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -10240,18 +10240,37 @@ def _channel_lifecycle_status(db_path: Path) -> str:
                     "AND e.event_type IN ('channel.member_added', 'channel.member_removed'))))"
                 ).fetchone()[0]
             )
+            human_dm_counts = connection.execute(
+                "SELECT COUNT(*), SUM(CASE WHEN "
+                "(SELECT COUNT(*) FROM channel_memberships cm WHERE cm.channel_id = c.id) = 2 "
+                "AND (SELECT COUNT(*) FROM channel_memberships cm JOIN principals p "
+                "ON p.id = cm.principal_id AND p.kind = 'human' WHERE cm.channel_id = c.id) = 2 "
+                "AND (SELECT COUNT(*) FROM channel_memberships cm JOIN workshop_memberships wm "
+                "ON wm.principal_id = cm.principal_id AND wm.workshop_id = c.workshop_id "
+                "WHERE cm.channel_id = c.id) = 2 "
+                "AND (SELECT COUNT(*) FROM channel_memberships cm "
+                "WHERE cm.channel_id = c.id AND cm.role = 'owner') = 2 "
+                "AND c.archived_at IS NULL "
+                "AND NOT EXISTS (SELECT 1 FROM channel_agent_runtime_assignments cara "
+                "WHERE cara.channel_id = c.id) THEN 1 ELSE 0 END) "
+                "FROM channels c WHERE c.kind = 'direct' "
+                "AND NOT EXISTS (SELECT 1 FROM channel_agents ca WHERE ca.channel_id = c.id) "
+                "AND NOT EXISTS (SELECT 1 FROM channel_bindings cb WHERE cb.channel_id = c.id)"
+            ).fetchone()
         finally:
             connection.close()
     except sqlite3.Error as exc:
         return f"{prefix} NOT VERIFIED ({exc})"
     total, active, archived = tuple(int(value or 0) for value in (totals or (0, 0, 0)))
     humans, owners, participants = tuple(int(value or 0) for value in (human_counts or (0, 0, 0)))
-    gaps = invalid + membership_invalid
+    human_dms, valid_human_dms = tuple(int(value or 0) for value in (human_dm_counts or (0, 0)))
+    human_dm_gaps = human_dms - valid_human_dms
+    gaps = invalid + membership_invalid + human_dm_gaps
     status = "active" if gaps == 0 else "INCOMPLETE"
     return (
         f"{prefix} {status}; group channels={total}, active={active}, "
         f"archived={archived}, human members={humans} (owners={owners}, participants={participants}), "
-        f"integrity gaps={gaps}; authority=canonical"
+        f"human DMs={human_dms} (invalid={human_dm_gaps}), integrity gaps={gaps}; authority=canonical"
     )
 
 

--- a/src/kai/workshop/authorization.py
+++ b/src/kai/workshop/authorization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from kai.workshop.domain import ChannelId, PrincipalId
+from kai.workshop.human_direct_messages import is_canonical_human_direct_channel
 from kai.workshop.store import WorkshopEventStore
 
 
@@ -30,6 +31,8 @@ class CanonicalChannelAuthorizer:
         """Authorize a human in one executable conversational channel."""
         if not isinstance(principal_id, PrincipalId) or not isinstance(channel_id, ChannelId):
             return False
+        if await is_canonical_human_direct_channel(self._store, channel_id):
+            return await self.can_read_channel(principal_id, channel_id)
         async with self._store.connection.execute(
             "SELECT 1 FROM channel_memberships cm "
             "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -125,6 +125,7 @@ from kai.workshop.domain import (
     RunId,
     RuntimeProfileId,
     WorkshopEventType,
+    WorkshopId,
 )
 from kai.workshop.execution_coordinator import CanonicalCancellationDisposition
 from kai.workshop.github_settings import (
@@ -136,6 +137,15 @@ from kai.workshop.github_settings import (
     WorkshopGitHubSettingsService,
     WorkshopGitHubSettingsStorageError,
     WorkshopGitHubSettingsValidationError,
+)
+from kai.workshop.human_direct_messages import (
+    WorkshopHumanDirectConversation,
+    WorkshopHumanDirectMessageAccessDenied,
+    WorkshopHumanDirectMessageConflict,
+    WorkshopHumanDirectMessageService,
+    WorkshopHumanDirectMessageStorageError,
+    WorkshopHumanPeerSnapshot,
+    is_canonical_human_direct_channel,
 )
 from kai.workshop.human_notifications import (
     HumanNotification,
@@ -273,6 +283,8 @@ _CHANNEL_RESTORATION_PATH = "/v1/channels/{channel_id}/restore"
 _CHANNEL_MEMBERS_PATH = "/v1/channels/{channel_id}/members"
 _CHANNEL_MEMBER_ADDITION_PATH = "/v1/channels/{channel_id}/members/{principal_id}/add"
 _CHANNEL_MEMBER_REMOVAL_PATH = "/v1/channels/{channel_id}/members/{principal_id}/remove"
+_WORKSHOP_HUMANS_PATH = "/v1/workshops/{workshop_id}/humans"
+_HUMAN_CONVERSATION_PATH = "/v1/workshops/{workshop_id}/humans/{principal_id}/conversation"
 _AGENT_DEFINITIONS_PATH = "/v1/client/agents"
 _AGENT_EVENTS_PATH = "/v1/client/agents/events"
 _AGENT_DEFINITION_PATH = "/v1/client/agents/{definition_id}"
@@ -841,6 +853,39 @@ def _serialize_human_membership_mutation(
             "display_name": mutation.member.display_name,
             "handle": mutation.member.handle,
             "role": mutation.member.role,
+        },
+    }
+
+
+def _serialize_human_peers(snapshot: WorkshopHumanPeerSnapshot) -> dict[str, object]:
+    return {
+        "version": 1,
+        "workshop_id": str(snapshot.workshop_id),
+        "humans": [
+            {
+                "principal_id": str(peer.principal_id),
+                "display_name": peer.display_name,
+                "handle": peer.handle,
+                "conversation_channel_id": str(peer.channel_id) if peer.channel_id is not None else None,
+            }
+            for peer in snapshot.peers
+        ],
+    }
+
+
+def _serialize_human_conversation(conversation: WorkshopHumanDirectConversation) -> dict[str, object]:
+    return {
+        "version": 1,
+        "created": conversation.created,
+        "conversation": {
+            "workshop_id": str(conversation.workshop_id),
+            "channel_id": str(conversation.channel_id),
+            "kind": "direct",
+            "peer": {
+                "principal_id": str(conversation.peer.principal_id),
+                "display_name": conversation.peer.display_name,
+                "handle": conversation.peer.handle,
+            },
         },
     }
 
@@ -3665,7 +3710,15 @@ async def _handle_client_navigation(
                 raise RuntimeError("Workshop navigation capability assembly failed")
             if channel["kind"] == "direct" and enablement is not None and not conversation_started:
                 continue
-            channel["can_submit_commands"] = (
+            human_direct = (
+                channel["kind"] == "direct"
+                and not agents
+                and await is_canonical_human_direct_channel(
+                    store,
+                    ChannelId(str(channel["channel_id"])),
+                )
+            )
+            channel["can_submit_commands"] = human_direct or (
                 channel["archived_at"] is None
                 and channel["kind"] in {"direct", "group"}
                 and len(agents) >= 1
@@ -3794,6 +3847,77 @@ async def _handle_channel_creation(
             message="Channel creation conflicted with current state",
         )
     return _json_response(_serialize_created_channel(created), status=201)
+
+
+async def _handle_workshop_humans(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopHumanDirectMessageService,
+) -> web.Response:
+    """List only the authenticated human's same-Workshop peers."""
+    principal_id = await authenticator.authenticate(request)
+    if not isinstance(principal_id, PrincipalId):
+        response = _error_response(status=401, code="authentication_required", message="Authentication required")
+        response.headers["WWW-Authenticate"] = "Bearer"
+        return response
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid Workshop humans request")
+    try:
+        snapshot = await service.list_peers(principal_id, WorkshopId(request.match_info["workshop_id"]))
+    except (TypeError, ValueError):
+        return _error_response(status=400, code="invalid_request", message="Invalid Workshop humans request")
+    except WorkshopHumanDirectMessageAccessDenied:
+        return _error_response(status=403, code="access_denied", message="Access denied")
+    except WorkshopHumanDirectMessageConflict:
+        return _error_response(
+            status=409,
+            code="human_conversation_conflict",
+            message="Human conversation state is inconsistent",
+        )
+    return _json_response(_serialize_human_peers(snapshot), status=200)
+
+
+async def _handle_human_conversation_start(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopHumanDirectMessageService,
+) -> web.Response:
+    """Start or reuse one private same-Workshop human conversation."""
+    principal_id = await authenticator.authenticate(request)
+    if not isinstance(principal_id, PrincipalId):
+        response = _error_response(status=401, code="authentication_required", message="Authentication required")
+        response.headers["WWW-Authenticate"] = "Bearer"
+        return response
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid human conversation request")
+    try:
+        conversation = await service.start(
+            principal_id,
+            WorkshopId(request.match_info["workshop_id"]),
+            PrincipalId(request.match_info["principal_id"]),
+        )
+    except (TypeError, ValueError):
+        return _error_response(status=400, code="invalid_request", message="Invalid human conversation request")
+    except WorkshopHumanDirectMessageAccessDenied:
+        return _error_response(status=403, code="access_denied", message="Access denied")
+    except WorkshopHumanDirectMessageConflict:
+        return _error_response(
+            status=409,
+            code="human_conversation_conflict",
+            message="Human conversation state is inconsistent",
+        )
+    except WorkshopHumanDirectMessageStorageError:
+        return _error_response(
+            status=503,
+            code="human_conversation_unavailable",
+            message="Human conversation creation is temporarily unavailable",
+        )
+    return _json_response(
+        _serialize_human_conversation(conversation),
+        status=201 if conversation.created else 200,
+    )
 
 
 async def _handle_channel_lifecycle_operation(
@@ -6650,6 +6774,7 @@ def register_workshop_read_routes(
         raise ValueError("Event-stream intervals must be positive")
     stream_limiter = event_stream_limiter or WorkshopEventStreamLimiter()
     channel_lifecycle = WorkshopChannelLifecycleService(store)
+    human_direct_messages = WorkshopHumanDirectMessageService(store)
     agent_lifecycle = WorkshopAgentLifecycleService(store)
     human_notifications = WorkshopHumanNotificationService(store)
     channel_unread = WorkshopChannelUnreadService(store)
@@ -6692,6 +6817,22 @@ def register_workshop_read_routes(
                 request,
                 authenticator=authenticator,
                 service=channel_lifecycle,
+            )
+
+    async def handle_workshop_humans(request: web.Request) -> web.Response:
+        async with request_lock:
+            return await _handle_workshop_humans(
+                request,
+                authenticator=authenticator,
+                service=human_direct_messages,
+            )
+
+    async def handle_human_conversation_start(request: web.Request) -> web.Response:
+        async with request_lock:
+            return await _handle_human_conversation_start(
+                request,
+                authenticator=authenticator,
+                service=human_direct_messages,
             )
 
     async def handle_channel_archival(request: web.Request) -> web.Response:
@@ -7019,6 +7160,8 @@ def register_workshop_read_routes(
     app.router.add_post(_HUMAN_NOTIFICATION_READ_PATH, handle_human_notification_read)
     app.router.add_post(_HUMAN_NOTIFICATION_UNREAD_PATH, handle_human_notification_unread)
     app.router.add_post(_CHANNEL_CREATION_PATH, handle_channel_creation)
+    app.router.add_get(_WORKSHOP_HUMANS_PATH, handle_workshop_humans)
+    app.router.add_post(_HUMAN_CONVERSATION_PATH, handle_human_conversation_start)
     app.router.add_post(_CHANNEL_ARCHIVAL_PATH, handle_channel_archival)
     app.router.add_post(_CHANNEL_RESTORATION_PATH, handle_channel_restoration)
     app.router.add_get(_CHANNEL_MEMBERS_PATH, handle_channel_members)

--- a/src/kai/workshop/human_direct_messages.py
+++ b/src/kai/workshop/human_direct_messages.py
@@ -1,0 +1,271 @@
+"""Canonical private direct conversations between two Workshop humans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from kai.workshop.domain import (
+    ChannelId,
+    ChannelMembershipId,
+    EventEnvelope,
+    PrincipalId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import WorkshopEventStore
+
+
+class WorkshopHumanDirectMessageError(RuntimeError):
+    """A canonical human direct-message operation could not be completed."""
+
+
+class WorkshopHumanDirectMessageAccessDenied(WorkshopHumanDirectMessageError):
+    """The actor cannot discover or contact the requested Workshop human."""
+
+
+class WorkshopHumanDirectMessageConflict(WorkshopHumanDirectMessageError):
+    """Existing canonical state does not identify one safe human conversation."""
+
+
+class WorkshopHumanDirectMessageStorageError(WorkshopHumanDirectMessageError):
+    """A human direct-message mutation could not be persisted atomically."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopHumanPeer:
+    """One same-Workshop human the authenticated principal may contact."""
+
+    principal_id: PrincipalId
+    display_name: str
+    handle: str
+    channel_id: ChannelId | None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopHumanPeerSnapshot:
+    """Principal-bounded human discovery within one Workshop."""
+
+    workshop_id: WorkshopId
+    peers: tuple[WorkshopHumanPeer, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopHumanDirectConversation:
+    """One canonical unordered human pair and its private channel."""
+
+    workshop_id: WorkshopId
+    channel_id: ChannelId
+    peer: WorkshopHumanPeer
+    created: bool
+
+
+async def is_canonical_human_direct_channel(
+    store: WorkshopEventStore,
+    channel_id: ChannelId,
+) -> bool:
+    """Return whether a channel has the exact non-executable human-DM shape."""
+    if not isinstance(channel_id, ChannelId):
+        return False
+    async with store.connection.execute(
+        "SELECT c.kind, c.archived_at, "
+        "(SELECT COUNT(*) FROM channel_memberships cm WHERE cm.channel_id = c.id), "
+        "(SELECT COUNT(*) FROM channel_memberships cm JOIN principals p "
+        "ON p.id = cm.principal_id AND p.kind = 'human' WHERE cm.channel_id = c.id), "
+        "(SELECT COUNT(*) FROM channel_memberships cm JOIN workshop_memberships wm "
+        "ON wm.principal_id = cm.principal_id AND wm.workshop_id = c.workshop_id "
+        "WHERE cm.channel_id = c.id), "
+        "(SELECT COUNT(*) FROM channel_memberships cm WHERE cm.channel_id = c.id AND cm.role = 'owner'), "
+        "(SELECT COUNT(*) FROM channel_agents ca WHERE ca.channel_id = c.id), "
+        "(SELECT COUNT(*) FROM channel_agent_runtime_assignments cara WHERE cara.channel_id = c.id), "
+        "(SELECT COUNT(*) FROM channel_bindings cb WHERE cb.channel_id = c.id) "
+        "FROM channels c WHERE c.id = ?",
+        (channel_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    return bool(
+        row is not None
+        and str(row[0]) == "direct"
+        and row[1] is None
+        and int(row[2]) == 2
+        and int(row[3]) == 2
+        and int(row[4]) == 2
+        and int(row[5]) == 2
+        and int(row[6]) == 0
+        and int(row[7]) == 0
+        and int(row[8]) == 0
+    )
+
+
+class WorkshopHumanDirectMessageService:
+    """Discover peers and idempotently create one channel per human pair."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def list_peers(
+        self,
+        principal_id: PrincipalId,
+        workshop_id: WorkshopId,
+    ) -> WorkshopHumanPeerSnapshot:
+        await self._require_workshop_human(principal_id, workshop_id)
+        async with self._store.connection.execute(
+            "SELECT p.id, p.display_name, hh.handle FROM workshop_memberships wm "
+            "JOIN principals p ON p.id = wm.principal_id AND p.kind = 'human' "
+            "JOIN human_handles hh ON hh.workshop_id = wm.workshop_id AND hh.principal_id = p.id "
+            "WHERE wm.workshop_id = ? AND wm.principal_id != ? "
+            "ORDER BY lower(p.display_name), p.id",
+            (workshop_id, principal_id),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        peers: list[WorkshopHumanPeer] = []
+        for row in rows:
+            peer_id = PrincipalId(str(row[0]))
+            channels = await self._matching_channels(workshop_id, principal_id, peer_id)
+            if len(channels) > 1:
+                raise WorkshopHumanDirectMessageConflict(
+                    "Multiple canonical direct conversations exist for this human pair"
+                )
+            peers.append(
+                WorkshopHumanPeer(
+                    peer_id,
+                    str(row[1]),
+                    str(row[2]),
+                    channels[0] if channels else None,
+                )
+            )
+        return WorkshopHumanPeerSnapshot(workshop_id, tuple(peers))
+
+    async def start(
+        self,
+        principal_id: PrincipalId,
+        workshop_id: WorkshopId,
+        peer_principal_id: PrincipalId,
+    ) -> WorkshopHumanDirectConversation:
+        """Create or return the sole canonical conversation for an unordered pair."""
+        if principal_id == peer_principal_id:
+            raise WorkshopHumanDirectMessageAccessDenied("A human cannot start a direct conversation with themself")
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            await self._require_workshop_human(principal_id, workshop_id)
+            peer = await self._require_workshop_human(peer_principal_id, workshop_id)
+            channels = await self._matching_channels(workshop_id, principal_id, peer_principal_id)
+            if len(channels) > 1:
+                raise WorkshopHumanDirectMessageConflict(
+                    "Multiple canonical direct conversations exist for this human pair"
+                )
+            if channels:
+                await connection.rollback()
+                return WorkshopHumanDirectConversation(
+                    workshop_id,
+                    channels[0],
+                    WorkshopHumanPeer(peer_principal_id, peer[0], peer[1], channels[0]),
+                    False,
+                )
+
+            low, high = sorted((str(principal_id), str(peer_principal_id)))
+            channel_id = ChannelId.derived(workshop_id, f"human-direct:{low}:{high}")
+            async with connection.execute("SELECT 1 FROM channels WHERE id = ?", (channel_id,)) as cursor:
+                if await cursor.fetchone() is not None:
+                    raise WorkshopHumanDirectMessageConflict(
+                        "The deterministic human conversation identity is already occupied"
+                    )
+            now = datetime.now(UTC)
+            events = (
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.CHANNEL_CREATED,
+                    event_version=1,
+                    workshop_id=workshop_id,
+                    aggregate_type="channel",
+                    aggregate_id=channel_id,
+                    actor_principal_id=principal_id,
+                    occurred_at=now,
+                    idempotency_key=f"workshop:human-direct:{low}:{high}:channel",
+                    payload={"kind": "direct", "name": "Direct"},
+                    metadata={"source": "workshop_client", "conversation_kind": "human_direct"},
+                ),
+                *(
+                    EventEnvelope.create(
+                        event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                        event_version=1,
+                        workshop_id=workshop_id,
+                        aggregate_type="channel_membership",
+                        aggregate_id=ChannelMembershipId.derived(channel_id, f"principal:{member_id}"),
+                        actor_principal_id=principal_id,
+                        occurred_at=now,
+                        idempotency_key=f"workshop:human-direct:{low}:{high}:member:{member_id}",
+                        payload={
+                            "channel_id": channel_id,
+                            "principal_id": member_id,
+                            "role": "owner",
+                        },
+                        metadata={"source": "workshop_client", "conversation_kind": "human_direct"},
+                    )
+                    for member_id in (PrincipalId(low), PrincipalId(high))
+                ),
+            )
+            for event in events:
+                appended = await self._store.append_in_transaction(event)
+                if not appended.inserted:
+                    raise WorkshopHumanDirectMessageConflict(
+                        "Human conversation creation conflicted with existing canonical events"
+                    )
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            if not await is_canonical_human_direct_channel(self._store, channel_id):
+                raise WorkshopHumanDirectMessageConflict("Created human conversation failed canonical validation")
+            await connection.commit()
+            return WorkshopHumanDirectConversation(
+                workshop_id,
+                channel_id,
+                WorkshopHumanPeer(peer_principal_id, peer[0], peer[1], channel_id),
+                True,
+            )
+        except WorkshopHumanDirectMessageError:
+            await connection.rollback()
+            raise
+        except Exception as exc:
+            await connection.rollback()
+            raise WorkshopHumanDirectMessageStorageError("Human direct conversation could not be persisted") from exc
+
+    async def _require_workshop_human(
+        self,
+        principal_id: PrincipalId,
+        workshop_id: WorkshopId,
+    ) -> tuple[str, str]:
+        if not isinstance(principal_id, PrincipalId) or not isinstance(workshop_id, WorkshopId):
+            raise WorkshopHumanDirectMessageAccessDenied("Canonical Workshop human identity is required")
+        async with self._store.connection.execute(
+            "SELECT p.display_name, hh.handle FROM workshop_memberships wm "
+            "JOIN principals p ON p.id = wm.principal_id AND p.kind = 'human' "
+            "JOIN human_handles hh ON hh.workshop_id = wm.workshop_id AND hh.principal_id = p.id "
+            "WHERE wm.workshop_id = ? AND wm.principal_id = ?",
+            (workshop_id, principal_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise WorkshopHumanDirectMessageAccessDenied("Human is unavailable in this Workshop")
+        return str(row[0]), str(row[1])
+
+    async def _matching_channels(
+        self,
+        workshop_id: WorkshopId,
+        first: PrincipalId,
+        second: PrincipalId,
+    ) -> tuple[ChannelId, ...]:
+        async with self._store.connection.execute(
+            "SELECT c.id FROM channels c WHERE c.workshop_id = ? AND c.kind = 'direct' "
+            "AND c.archived_at IS NULL "
+            "AND (SELECT COUNT(*) FROM channel_memberships cm WHERE cm.channel_id = c.id) = 2 "
+            "AND EXISTS (SELECT 1 FROM channel_memberships cm WHERE cm.channel_id = c.id "
+            "AND cm.principal_id = ? AND cm.role = 'owner') "
+            "AND EXISTS (SELECT 1 FROM channel_memberships cm WHERE cm.channel_id = c.id "
+            "AND cm.principal_id = ? AND cm.role = 'owner') "
+            "AND NOT EXISTS (SELECT 1 FROM channel_agents ca WHERE ca.channel_id = c.id) "
+            "AND NOT EXISTS (SELECT 1 FROM channel_agent_runtime_assignments cara WHERE cara.channel_id = c.id) "
+            "AND NOT EXISTS (SELECT 1 FROM channel_bindings cb WHERE cb.channel_id = c.id) "
+            "ORDER BY c.id",
+            (workshop_id, first, second),
+        ) as cursor:
+            return tuple(ChannelId(str(row[0])) for row in await cursor.fetchall())

--- a/src/kai/workshop/wake_policy.py
+++ b/src/kai/workshop/wake_policy.py
@@ -16,6 +16,7 @@ from kai.workshop.domain import (
     WorkshopEventType,
     WorkshopId,
 )
+from kai.workshop.human_direct_messages import is_canonical_human_direct_channel
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.store import AppendResult, WorkshopEventStore
 
@@ -234,6 +235,8 @@ async def resolve_message_wake_targets(
     ) as cursor:
         attached = [(AgentId(str(item[0])), PrincipalId(str(item[1]))) for item in await cursor.fetchall()]
     if kind == "direct":
+        if not attached and await is_canonical_human_direct_channel(store, channel_id):
+            return WakeDecision(())
         if len(attached) != 1:
             raise WakePolicyError("Inbound message must resolve to one human channel member and one attached agent")
         return WakeDecision((attached[0][0],))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5367,6 +5367,9 @@ class TestCmdStatus:
             "CREATE TABLE channel_memberships (channel_id TEXT, principal_id TEXT, role TEXT);"
             "CREATE TABLE workshop_memberships (workshop_id TEXT, principal_id TEXT);"
             "CREATE TABLE human_handles (workshop_id TEXT, principal_id TEXT);"
+            "CREATE TABLE channel_agents (channel_id TEXT);"
+            "CREATE TABLE channel_agent_runtime_assignments (channel_id TEXT);"
+            "CREATE TABLE channel_bindings (channel_id TEXT);"
             "CREATE TABLE event_log (position INTEGER PRIMARY KEY, aggregate_id TEXT, "
             "aggregate_type TEXT, event_type TEXT);"
             "INSERT INTO channels VALUES "
@@ -5386,7 +5389,7 @@ class TestCmdStatus:
         assert _channel_lifecycle_status(db_path) == (
             "Workshop channel lifecycle: active; group channels=2, active=1, "
             "archived=1, human members=2 (owners=2, participants=0), "
-            "integrity gaps=0; authority=canonical"
+            "human DMs=0 (invalid=0), integrity gaps=0; authority=canonical"
         )
 
     def test_status_reports_canonical_internal_api_context_coverage(self, tmp_path):

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -875,6 +875,8 @@ class TestNotificationChatIdMutations:
                 "/v1/client/notifications/read",
                 "/v1/client/notifications/{notification_id}/read",
                 "/v1/client/notifications/{notification_id}/unread",
+                "/v1/workshops/{workshop_id}/humans",
+                "/v1/workshops/{workshop_id}/humans/{principal_id}/conversation",
                 "/v1/channels",
                 "/v1/channels/{channel_id}/archive",
                 "/v1/channels/{channel_id}/restore",

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -1382,7 +1382,74 @@ class TestWorkshopNavigationHTTPContract:
                 }
             ]
             assert direct["agents"] == []
-            assert direct["can_submit_commands"] is False
+            assert direct["can_submit_commands"] is True
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_human_peer_discovery_and_conversation_start_are_principal_bound(self, tmp_path: Path):
+        store, alice_id, _, bob_id, _ = await _open_store(tmp_path / "kai.db")
+        async with store.connection.execute("SELECT id FROM workshops LIMIT 1") as cursor:
+            workshop_id = WorkshopId(str((await cursor.fetchone())[0]))
+        client = await _open_client(store, _Authenticator({"alice": alice_id, "bob": bob_id}))
+        try:
+            peers = await client.get(
+                f"/v1/workshops/{workshop_id}/humans",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert peers.status == 200
+            assert (await peers.json())["humans"] == [
+                {
+                    "principal_id": bob_id,
+                    "display_name": "Bob",
+                    "handle": "bob",
+                    "conversation_channel_id": None,
+                }
+            ]
+
+            created = await client.post(
+                f"/v1/workshops/{workshop_id}/humans/{bob_id}/conversation",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert created.status == 201
+            created_payload = await created.json()
+            channel_id = created_payload["conversation"]["channel_id"]
+            assert created_payload["created"] is True
+            assert created_payload["conversation"]["peer"]["principal_id"] == bob_id
+
+            reused = await client.post(
+                f"/v1/workshops/{workshop_id}/humans/{alice_id}/conversation",
+                headers={"Authorization": "Bearer bob"},
+            )
+            assert reused.status == 200
+            assert (await reused.json())["conversation"]["channel_id"] == channel_id
+
+            bob_navigation = await client.get(
+                "/v1/client/navigation",
+                headers={"Authorization": "Bearer bob"},
+            )
+            assert bob_navigation.status == 200
+            human_direct = next(
+                channel
+                for channel in (await bob_navigation.json())["workshops"][0]["channels"]
+                if channel["channel_id"] == channel_id
+            )
+            assert human_direct["agents"] == []
+            assert human_direct["participants"] == [
+                {
+                    "principal_id": alice_id,
+                    "kind": "human",
+                    "display_name": "Alice",
+                    "handle": "alice",
+                }
+            ]
+            assert human_direct["can_submit_commands"] is True
+
+            rejected = await client.post(
+                f"/v1/workshops/{workshop_id}/humans/{bob_id}/conversation?principal_id={alice_id}",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert rejected.status == 400
         finally:
             await client.close()
             await store.close()

--- a/tests/test_workshop_human_direct_messages.py
+++ b/tests/test_workshop_human_direct_messages.py
@@ -1,0 +1,167 @@
+"""Contracts for canonical private conversations between Workshop humans."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.authorization import CanonicalChannelAuthorizer
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.conversation_commands import (
+    ConversationCommandDisposition,
+    WorkshopConversationCommandService,
+)
+from kai.workshop.domain import ChannelId, PrincipalId, WorkshopId
+from kai.workshop.human_direct_messages import (
+    WorkshopHumanDirectMessageAccessDenied,
+    WorkshopHumanDirectMessageService,
+    is_canonical_human_direct_channel,
+)
+from kai.workshop.inbound import ClientInboundMessage
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 9, 3, 12, 0, tzinfo=UTC)
+
+
+async def _open_store(
+    path: Path,
+) -> tuple[WorkshopEventStore, WorkshopId, PrincipalId, PrincipalId]:
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman("Alice", "admin", "telegram", "101", "101"),
+            BootstrapHuman("Bob", "member", "telegram", "202", "202"),
+        ),
+    )
+    async with store.connection.execute("SELECT id FROM workshops") as cursor:
+        workshop_id = WorkshopId(str((await cursor.fetchone())[0]))
+    async with store.connection.execute(
+        "SELECT display_name, id FROM principals WHERE kind = 'human' ORDER BY display_name"
+    ) as cursor:
+        rows = list(await cursor.fetchall())
+    return store, workshop_id, PrincipalId(str(rows[0][1])), PrincipalId(str(rows[1][1]))
+
+
+class TestWorkshopHumanDirectMessageAuthority:
+    async def test_discovers_same_workshop_peers_and_creates_one_unordered_pair(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, workshop_id, alice_id, bob_id = await _open_store(tmp_path / "kai.db")
+        service = WorkshopHumanDirectMessageService(store)
+        try:
+            initial = await service.list_peers(alice_id, workshop_id)
+            assert [(peer.principal_id, peer.display_name, peer.handle, peer.channel_id) for peer in initial.peers] == [
+                (bob_id, "Bob", "bob", None)
+            ]
+
+            created = await service.start(alice_id, workshop_id, bob_id)
+            reverse = await service.start(bob_id, workshop_id, alice_id)
+
+            assert created.created is True
+            assert reverse.created is False
+            assert reverse.channel_id == created.channel_id
+            assert await is_canonical_human_direct_channel(store, created.channel_id)
+            assert (await service.list_peers(alice_id, workshop_id)).peers[0].channel_id == created.channel_id
+            async with store.connection.execute(
+                "SELECT cm.principal_id, cm.role FROM channel_memberships cm "
+                "WHERE cm.channel_id = ? ORDER BY cm.principal_id",
+                (created.channel_id,),
+            ) as cursor:
+                assert [(str(row[0]), str(row[1])) for row in await cursor.fetchall()] == sorted(
+                    [(str(alice_id), "owner"), (str(bob_id), "owner")]
+                )
+            async with store.connection.execute(
+                "SELECT (SELECT COUNT(*) FROM channel_agents WHERE channel_id = ?), "
+                "(SELECT COUNT(*) FROM channel_agent_runtime_assignments WHERE channel_id = ?), "
+                "(SELECT COUNT(*) FROM channel_bindings WHERE channel_id = ?)",
+                (created.channel_id, created.channel_id, created.channel_id),
+            ) as cursor:
+                assert tuple(await cursor.fetchone()) == (0, 0, 0)
+        finally:
+            await store.close()
+
+    async def test_pair_is_private_message_only_and_survives_projection_rebuild(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, workshop_id, alice_id, bob_id = await _open_store(tmp_path / "kai.db")
+        try:
+            conversation = await WorkshopHumanDirectMessageService(store).start(alice_id, workshop_id, bob_id)
+            outsider = PrincipalId.new()
+            await store.connection.execute(
+                "INSERT INTO principals (id, kind, display_name, created_at) VALUES (?, 'human', 'Outsider', ?)",
+                (outsider, _NOW.isoformat()),
+            )
+            await store.connection.execute(
+                "INSERT INTO workshop_memberships (id, workshop_id, principal_id, role, created_at) "
+                "VALUES (?, ?, ?, 'admin', ?)",
+                (f"wmb_{'1' * 32}", workshop_id, outsider, _NOW.isoformat()),
+            )
+            await store.connection.commit()
+
+            authorizer = CanonicalChannelAuthorizer(store)
+            assert await authorizer.can_submit_command(alice_id, conversation.channel_id)
+            assert await authorizer.can_submit_command(bob_id, conversation.channel_id)
+            assert not await authorizer.can_read_channel(outsider, conversation.channel_id)
+            assert not await authorizer.can_submit_command(outsider, conversation.channel_id)
+
+            accepted = await WorkshopConversationCommandService(store).accept_client(
+                ClientInboundMessage(
+                    principal_id=alice_id,
+                    channel_id=conversation.channel_id,
+                    client_message_id="alice-to-bob-1",
+                    body="Private hello",
+                    occurred_at=_NOW,
+                )
+            )
+            assert accepted.command.disposition == ConversationCommandDisposition.MESSAGE_ONLY
+            assert accepted.command.runs == ()
+            assert accepted.runtime_profile_ids == ()
+            assert accepted.deliveries == ()
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM runs WHERE channel_id = ?", (conversation.channel_id,)
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+
+            await store.rebuild_projection(CanonicalConversationProjection())
+            assert await is_canonical_human_direct_channel(store, conversation.channel_id)
+            assert await CanonicalChannelAuthorizer(store).can_read_channel(bob_id, conversation.channel_id)
+        finally:
+            await store.close()
+
+    async def test_rejects_self_agent_unknown_and_cross_workshop_targets(self, tmp_path: Path) -> None:
+        store, workshop_id, alice_id, _ = await _open_store(tmp_path / "kai.db")
+        service = WorkshopHumanDirectMessageService(store)
+        async with store.connection.execute("SELECT principal_id FROM agents LIMIT 1") as cursor:
+            agent_id = PrincipalId(str((await cursor.fetchone())[0]))
+        try:
+            for target in (alice_id, agent_id, PrincipalId.new()):
+                with pytest.raises(WorkshopHumanDirectMessageAccessDenied):
+                    await service.start(alice_id, workshop_id, target)
+            with pytest.raises(WorkshopHumanDirectMessageAccessDenied):
+                await service.list_peers(alice_id, WorkshopId.new())
+        finally:
+            await store.close()
+
+    async def test_malformed_direct_channel_never_becomes_a_submit_lane(self, tmp_path: Path) -> None:
+        store, _, alice_id, _ = await _open_store(tmp_path / "kai.db")
+        try:
+            channel_id = ChannelId.new()
+            async with store.connection.execute(
+                "SELECT workshop_id FROM workshop_memberships WHERE principal_id = ?", (alice_id,)
+            ) as cursor:
+                workshop_id = WorkshopId(str((await cursor.fetchone())[0]))
+            await store.connection.execute(
+                "INSERT INTO channels (id, workshop_id, kind, name, created_at) VALUES (?, ?, 'direct', 'Direct', ?)",
+                (channel_id, workshop_id, _NOW.isoformat()),
+            )
+            await store.connection.commit()
+            assert not await is_canonical_human_direct_channel(store, channel_id)
+            assert not await CanonicalChannelAuthorizer(store).can_submit_command(alice_id, channel_id)
+        finally:
+            await store.close()


### PR DESCRIPTION
Closes #1357

## Summary
- add principal-bound same-Workshop human discovery and one idempotent direct channel per unordered human pair
- authorize human DMs as message-only channels with no agent wake, runtime assignment, or adapter delivery
- expose authenticated list/start contracts, navigation capability, and installed integrity diagnostics
- fail closed for self, agent, unknown, cross-Workshop, duplicate, and malformed channel state

## Validation
- `make check`
- `make test` (6,425 passed)
- focused human-DM, authorization, wake-policy, HTTP, projection-rebuild, and diagnostics tests