### PR TITLE
Parallelize complete CI test suite

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,0 +1,35 @@
+# Continuous integration validation
+
+Kai's pull-request validation preserves the complete pytest suite while running its slowest domains concurrently.
+
+## Change scopes
+
+`scripts/ci_change_scope.py` selects validation conservatively:
+
+- documentation-only changes use the no-runtime fast path;
+- Workshop client or generated-asset-only changes run the Workshop client checks;
+- every other change runs client checks, Python quality checks, and every pytest shard;
+- pushes to `main` force every validation lane, providing a complete post-merge backstop;
+- dependency inputs additionally run the independent dependency audit.
+
+Unknown or empty change input fails closed to complete validation.
+
+## Complete pytest gate
+
+`scripts/ci_test_shard.py` assigns every `tests/test_*.py` module to exactly one stable shard:
+
+- `core`: general application, adapter, configuration, installation, and integration tests;
+- `memory`: `test_memory*` and `test_eval_*` modules;
+- `workshop`: `test_workshop_*` modules.
+
+The shards run concurrently with fail-fast disabled, so failures remain independently visible. Unit coverage proves that their sets are exhaustive and disjoint. The required `check` job succeeds only after the quality job and every selected shard succeed.
+
+The separate `core-workshop` job remains intentional: it installs Kai without Telegram and proves the transport-independent architecture in that distinct dependency environment.
+
+Run a shard locally with:
+
+```bash
+python scripts/ci_test_shard.py core
+python scripts/ci_test_shard.py memory
+python scripts/ci_test_shard.py workshop
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             python3 scripts/ci_change_scope.py --force-full
           fi
 
-  check:
+  quality:
     needs: changes
     runs-on: ubuntu-latest
     steps:
@@ -81,13 +81,61 @@ jobs:
         if: needs.changes.outputs.full == 'true'
         run: make BIN= typecheck
 
-      - name: Run tests
-        if: needs.changes.outputs.full == 'true'
-        run: make BIN= test
-
       - name: Confirm documentation-only fast path
         if: needs.changes.outputs.client != 'true' && needs.changes.outputs.full != 'true'
         run: echo "No runtime validation is required for documentation-only changes."
+
+  tests:
+    name: tests / ${{ matrix.shard }}
+    needs: changes
+    if: needs.changes.outputs.full == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [core, memory, workshop]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade \
+            --constraint requirements/constraints.txt pip setuptools
+          python -m pip install --upgrade \
+            --constraint requirements/constraints.txt -e '.[dev,telegram,totp]'
+
+      - name: Run ${{ matrix.shard }} tests
+        run: python scripts/ci_test_shard.py "${{ matrix.shard }}"
+
+  check:
+    needs: [changes, quality, tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every selected validation lane
+        env:
+          CHANGE_RESULT: ${{ needs.changes.result }}
+          FULL_SCOPE: ${{ needs.changes.outputs.full }}
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          TEST_RESULT: ${{ needs.tests.result }}
+        run: |
+          if [[ "$CHANGE_RESULT" != "success" || "$QUALITY_RESULT" != "success" ]]; then
+            echo "Change classification or quality validation failed."
+            exit 1
+          fi
+          if [[ "$FULL_SCOPE" == "true" && "$TEST_RESULT" != "success" ]]; then
+            echo "At least one complete-suite test shard failed."
+            exit 1
+          fi
+          if [[ "$FULL_SCOPE" != "true" && "$TEST_RESULT" != "skipped" ]]; then
+            echo "Unexpected test-shard result for the selected fast path."
+            exit 1
+          fi
 
   core-workshop:
     needs: changes

--- a/scripts/ci_change_scope.py
+++ b/scripts/ci_change_scope.py
@@ -12,6 +12,7 @@ from pathlib import PurePosixPath
 _CLIENT_PREFIXES = ("workshop-client/", "src/kai/workshop/static/")
 _DOCUMENTATION_PREFIXES = ("docs/", "home/docs/", ".github/ISSUE_TEMPLATE/")
 _DOCUMENTATION_FILES = {
+    ".github/CI.md",
     "AGENTS.md",
     "CHANGELOG.md",
     "CONTRIBUTING.md",

--- a/scripts/ci_test_shard.py
+++ b/scripts/ci_test_shard.py
@@ -1,0 +1,59 @@
+"""Select and run one exhaustive, deterministic Kai pytest shard."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+CI_TEST_SHARDS = ("core", "memory", "workshop")
+_REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+
+
+def classify_test_file(path: Path) -> str:
+    """Assign one test module to exactly one stable CI shard."""
+    name = path.name
+    if name.startswith("test_workshop_"):
+        return "workshop"
+    if name.startswith(("test_memory", "test_eval_")):
+        return "memory"
+    return "core"
+
+
+def discover_test_files(repository_root: Path = _REPOSITORY_ROOT) -> tuple[Path, ...]:
+    """Return every pytest module in deterministic repository-relative order."""
+    tests_root = repository_root / "tests"
+    return tuple(
+        sorted(
+            (path.relative_to(repository_root) for path in tests_root.rglob("test_*.py")),
+            key=lambda path: path.as_posix(),
+        )
+    )
+
+
+def select_test_files(shard: str, repository_root: Path = _REPOSITORY_ROOT) -> tuple[Path, ...]:
+    """Return the complete non-overlapping module set for one known shard."""
+    if shard not in CI_TEST_SHARDS:
+        raise ValueError(f"Unknown CI test shard: {shard}")
+    return tuple(path for path in discover_test_files(repository_root) if classify_test_file(path) == shard)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("shard", choices=CI_TEST_SHARDS)
+    parser.add_argument("--list", action="store_true", help="List selected modules without running pytest")
+    args = parser.parse_args(argv)
+    selected = select_test_files(args.shard)
+    if not selected:
+        parser.error(f"CI test shard {args.shard!r} selected no test modules")
+    if args.list:
+        for path in selected:
+            print(path.as_posix())
+        return 0
+
+    import pytest
+
+    return int(pytest.main(["-v", *(path.as_posix() for path in selected)]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_change_scope.py
+++ b/tests/test_ci_change_scope.py
@@ -13,11 +13,9 @@ def test_client_sources_and_generated_assets_use_only_client_lane() -> None:
 
 
 def test_documentation_only_change_needs_no_runtime_lane() -> None:
-    assert classify_paths(["README.md", "docs/design.md", "home/docs/specs/workshop.md"]) == ChangeScope(
-        client=False,
-        full=False,
-        dependency=False,
-    )
+    assert classify_paths(
+        ["README.md", "docs/design.md", "home/docs/specs/workshop.md", ".github/CI.md"]
+    ) == ChangeScope(client=False, full=False, dependency=False)
 
 
 def test_unknown_and_mixed_paths_fail_closed_to_complete_validation() -> None:

--- a/tests/test_ci_test_shard.py
+++ b/tests/test_ci_test_shard.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.ci_test_shard import (
+    CI_TEST_SHARDS,
+    classify_test_file,
+    discover_test_files,
+    select_test_files,
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("test_bot.py", "core"),
+        ("test_memory.py", "memory"),
+        ("test_memory_extraction.py", "memory"),
+        ("test_eval_behavioral.py", "memory"),
+        ("test_workshop_foundation.py", "workshop"),
+    ],
+)
+def test_test_module_classification_is_stable(name: str, expected: str) -> None:
+    assert classify_test_file(Path("tests") / name) == expected
+
+
+def test_shards_are_disjoint_and_cover_every_test_module() -> None:
+    discovered = set(discover_test_files())
+    selected = {shard: set(select_test_files(shard)) for shard in CI_TEST_SHARDS}
+
+    assert discovered
+    assert set().union(*selected.values()) == discovered
+    for shard in CI_TEST_SHARDS:
+        other_files = set().union(*(files for other, files in selected.items() if other != shard))
+        assert selected[shard].isdisjoint(other_files)
+
+
+def test_unknown_shard_fails_closed() -> None:
+    with pytest.raises(ValueError, match="Unknown CI test shard"):
+        select_test_files("unknown")


### PR DESCRIPTION
## Summary

- split the complete pytest corpus into deterministic core, memory/evaluation, and Workshop matrix shards
- retain the existing required `check` name as an aggregate gate over quality checks and every selected shard
- prove shard coverage is exhaustive and disjoint
- document runtime, client-only, documentation, main-branch, dependency-audit, and Telegram-free validation lanes

## Why

The latest pre-change CI measurement on PR #1365 was 5m49s. Its monolithic pytest step consumed 4m19s, while setup plus client, constraint, lint, and type checks consumed 1m28s. The three shards preserve every test but run the dominant work concurrently.

## Validation

- `14 passed` — change-scope and shard-selection contracts
- `make check`
- `make typecheck`
- YAML syntax load
- shard inventory: 62 core modules, 20 memory/evaluation modules, 81 Workshop modules; exhaustive and non-overlapping
- the complete 6,431-test product suite passed immediately before this CI-only change

Closes #1333
