### PR TITLE
Remove inert PR review cooldown setting

### DIFF
--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -4163,8 +4163,8 @@ async def handle_review_command(update: Update, context: ContextTypes.DEFAULT_TY
     timestamped copy is staged under the human actor's canonical file area via
     ``_save_upload()``, and the staged copy is uploaded to Telegram
     as a document attachment so phone-only use can read the full
-    review. No GitHub comment is posted; the webhook cooldown map is
-    untouched.
+    review. No GitHub comment is posted and no canonical webhook
+    automation work is created.
     """
     assert update.message is not None
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1618,9 +1618,6 @@ class Config:
     # PR review agent: per-user toggle lives in users.yaml `pr_review`
     # (or the per-chat /github reviews command). Global resource
     # controls stay on Config.
-    # Minimum seconds between reviews of the same PR. Absorbs force-push bursts
-    # so rapid pushes to an open PR don't trigger a review for each one.
-    pr_review_cooldown: int = 300
     # Subprocess timeout for a single PR review, in seconds. Sonnet with
     # extended thinking on a large diff with prior review context can take
     # a long time; the default gives thinking-heavy reviews room while
@@ -3341,12 +3338,8 @@ def load_config() -> Config:
         codex_turn_deadline_seconds = turn_deadline_seconds
 
     # PR review agent config. The global `pr_review` toggle now lives
-    # per-user in users.yaml; PR_REVIEW_COOLDOWN / PR_REVIEW_TIMEOUT_S
-    # remain as global resource controls.
-    try:
-        pr_review_cooldown = int(os.environ.get("PR_REVIEW_COOLDOWN", "300"))
-    except ValueError:
-        raise SystemExit("PR_REVIEW_COOLDOWN must be an integer") from None
+    # per-user in users.yaml; the subprocess timeout remains a global
+    # resource control.
     try:
         pr_review_timeout_s = int(os.environ.get("PR_REVIEW_TIMEOUT_S", "900"))
         if pr_review_timeout_s <= 0:
@@ -3881,7 +3874,6 @@ def load_config() -> Config:
         model_catalogue_refresh_interval_s=model_catalogue_refresh_interval_s,
         model_catalogue_refresh_timeout_s=model_catalogue_refresh_timeout_s,
         memory_projects=memory_projects,
-        pr_review_cooldown=pr_review_cooldown,
         pr_review_timeout_s=pr_review_timeout_s,
         github_repo=os.getenv("GITHUB_REPO", ""),
         spec_dir=os.getenv("SPEC_DIR", "specs"),

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -2848,24 +2848,10 @@ def _cmd_config() -> None:
     print()
 
     # -- PR review agent --
-    # PR_REVIEW_COOLDOWN and PR_REVIEW_TIMEOUT_S are global resource
-    # controls for the review subprocess: any review by any user
-    # counts against the same cooldown and the same subprocess
-    # timeout. Both fire on every wizard run. The per-user
-    # `pr_review` toggle lives in users.yaml (or /github reviews).
+    # PR_REVIEW_TIMEOUT_S is a global resource control for the review
+    # subprocess. It fires on every wizard run. The per-user `pr_review`
+    # toggle lives in users.yaml (or /github reviews).
     print("-- PR review agent --")
-
-    # Global cooldown always prompts: any opted-in user can drive
-    # reviews, so the cooldown must be configurable for any install
-    # that has any opted-in user.
-    while True:
-        pr_review_cooldown = _prompt(
-            "Review cooldown in seconds (prevents spam from rapid pushes)",
-            existing_env.get("PR_REVIEW_COOLDOWN", "300"),
-        )
-        if _validate_positive_int(pr_review_cooldown):
-            break
-        print("  Must be a positive integer.")
 
     # Timeout for the review subprocess. Always collectable: it
     # applies to any review whether or not the global env flag is set.
@@ -3281,12 +3267,6 @@ def _cmd_config() -> None:
     # emitted when set, regardless of users.yaml presence.
     if workspace_base:
         env["WORKSPACE_BASE"] = workspace_base
-
-    # PR_REVIEW_COOLDOWN is a global resource control. Always written
-    # when non-default because any user can drive reviews via users.yaml
-    # or /github reviews on|off.
-    if pr_review_cooldown != "300":
-        env["PR_REVIEW_COOLDOWN"] = pr_review_cooldown
 
     # ALLOWED_WORKSPACES is an inheritable installation default.
     if allowed_workspaces:

--- a/templates/.env
+++ b/templates/.env
@@ -121,10 +121,6 @@ WEBHOOK_PORT=8080
 GITHUB_WEBHOOK_SECRET=
 GENERIC_WEBHOOK_SECRET=
 
-# Global rate limit: minimum seconds between reviews on the same PR.
-# Machine-wide resource limit shared across all users.
-#PR_REVIEW_COOLDOWN=300
-
 # Subprocess timeout for a single PR review, in seconds. Sonnet with
 # extended thinking on a large diff and prior review context can take
 # several minutes. Raise if reviews are being killed mid-run; lower if

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,7 +53,6 @@ _CONFIG_ENV_VARS = [
     "CLAUDE_USER",
     "FILE_RETENTION_DAYS",
     "PR_REVIEW_ENABLED",
-    "PR_REVIEW_COOLDOWN",
     "PR_REVIEW_TIMEOUT_S",
     "MODEL_CATALOGUE_REFRESH_INTERVAL_S",
     "MODEL_CATALOGUE_REFRESH_TIMEOUT_S",
@@ -1040,21 +1039,14 @@ class TestPRReviewConfig:
         """PR review resource controls take dataclass defaults when env is empty."""
         _set_required(monkeypatch)
         config = load_config()
-        assert config.pr_review_cooldown == 300
         assert config.pr_review_timeout_s == 900
 
-    def test_custom_cooldown(self, monkeypatch):
-        """PR_REVIEW_COOLDOWN is picked up from env."""
+    def test_retired_cooldown_is_ignored(self, monkeypatch):
+        """A stale cooldown value cannot affect or break configuration loading."""
         _set_required(monkeypatch)
-        monkeypatch.setenv("PR_REVIEW_COOLDOWN", "60")
-        assert load_config().pr_review_cooldown == 60
-
-    def test_cooldown_invalid_raises(self, monkeypatch):
-        """Non-numeric PR_REVIEW_COOLDOWN raises SystemExit."""
-        _set_required(monkeypatch)
-        monkeypatch.setenv("PR_REVIEW_COOLDOWN", "not_a_number")
-        with pytest.raises(SystemExit, match="PR_REVIEW_COOLDOWN"):
-            load_config()
+        monkeypatch.setenv("PR_REVIEW_COOLDOWN", "not-a-number")
+        config = load_config()
+        assert not hasattr(config, "pr_review_cooldown")
 
     def test_timeout_override(self, monkeypatch):
         """PR_REVIEW_TIMEOUT_S parses to an int and reaches the Config."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1683,7 +1683,6 @@ class TestCmdConfig:
                 "0",  # periodic model-catalogue refresh disabled
                 "30",  # model-catalogue refresh timeout
                 "false",  # pr review enabled
-                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
@@ -1786,7 +1785,6 @@ class TestCmdConfig:
                 "0",  # periodic model-catalogue refresh disabled
                 "30",  # model-catalogue refresh timeout
                 "false",  # pr review enabled
-                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
@@ -1872,7 +1870,6 @@ class TestCmdConfig:
                 "0",  # periodic model-catalogue refresh disabled
                 "30",  # model-catalogue refresh timeout
                 "false",  # pr review enabled
-                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
                 "false",  # issue triage enabled
                 "",  # github notify chat id
@@ -1946,7 +1943,6 @@ class TestCmdConfig:
                 "0",  # periodic model-catalogue refresh disabled
                 "30",  # model-catalogue refresh timeout
                 "false",
-                "300",  # pr review cooldown (global resource control)
                 "900",
                 "1.0",
                 "false",
@@ -2011,7 +2007,6 @@ class TestCmdConfig:
                 "0",  # periodic model-catalogue refresh disabled
                 "30",  # model-catalogue refresh timeout
                 "false",  # pr review enabled
-                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
@@ -2149,7 +2144,6 @@ class TestCmdConfig:
                 "0",  # periodic model-catalogue refresh disabled
                 "30",  # model-catalogue refresh timeout
                 "false",  # pr review enabled
-                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout (seconds)
                 "false",  # issue triage enabled
                 "",  # github notify chat id (empty)
@@ -2386,7 +2380,6 @@ class TestCmdConfig:
             "",  # allowed workspaces
             model_catalogue_refresh_interval,
             model_catalogue_refresh_timeout,
-            "300",  # pr review cooldown (global resource control)
             "900",  # pr review timeout
             *telegram_features,
             *memory_block,
@@ -3025,7 +3018,6 @@ class TestCmdConfig:
                 "",  # allowed workspaces
                 "0",  # periodic model-catalogue refresh disabled
                 "30",  # model-catalogue refresh timeout
-                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
                 "false",  # voice
                 "false",  # tts
@@ -3371,7 +3363,6 @@ class TestCmdConfig:
                 "",  # allowed workspaces
                 "0",  # periodic model-catalogue refresh disabled
                 "30",  # model-catalogue refresh timeout
-                "300",  # pr review cooldown (global resource control)
                 "900",  # pr review timeout
                 "false",  # voice
                 "false",  # tts
@@ -3968,10 +3959,9 @@ class TestCmdConfigDefaultModelDispatch:
         """Input chain for the users_yaml_exists=True + claude path.
 
         Post-tranche-B, the global-default prompts fire unconditionally
-        even when users.yaml exists, so the chain feeds timeout,
-        workspace_base, and pr_review_cooldown
-        values that the pre-tranche-B users-yaml-exists branch had
-        skipped silently.
+        even when users.yaml exists, so the chain feeds timeout and
+        workspace_base values that the pre-tranche-B users-yaml-exists
+        branch had skipped silently.
         """
         return [
             "protected",  # deployment mode
@@ -3998,7 +3988,6 @@ class TestCmdConfigDefaultModelDispatch:
             "",  # allowed workspaces (global default, empty)
             "0",  # periodic model-catalogue refresh disabled
             "30",  # model-catalogue refresh timeout
-            "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
             "false",  # voice
             "false",  # tts
@@ -4045,7 +4034,6 @@ class TestCmdConfigDefaultModelDispatch:
             "",  # allowed workspaces (global default, empty)
             "0",  # periodic model-catalogue refresh disabled
             "30",  # model-catalogue refresh timeout
-            "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
             "false",  # voice
             "false",  # tts
@@ -4084,7 +4072,6 @@ class TestCmdConfigDefaultModelDispatch:
             "",  # allowed workspaces (global default, empty)
             "0",  # periodic model-catalogue refresh disabled
             "30",  # model-catalogue refresh timeout
-            "300",  # pr review cooldown (global resource control)
             "900",  # pr review subprocess timeout
             "false",  # voice
             "false",  # tts
@@ -11104,7 +11091,7 @@ class TestStripInstallConfKeys:
 
 class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
     """Pins the contract that installation-wide defaults (DEFAULT_MODEL,
-    DEFAULT_TIMEOUT, WORKSPACE_BASE, PR_REVIEW_COOLDOWN) prompt
+    DEFAULT_TIMEOUT, WORKSPACE_BASE) prompt
     on every wizard run and land in install.conf's env regardless of
     users.yaml presence.
 
@@ -11173,6 +11160,35 @@ class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
         assert "CLAUDE_MAX_CONTEXT_WINDOW" not in env
 
+    def test_retired_pr_review_cooldown_dropped_on_regenerate(self, tmp_path, monkeypatch):
+        """Regenerating config drops the retired review cooldown key."""
+        prior_conf = {
+            "install_dir": "/opt/kai",
+            "data_dir": "/var/lib/kai",
+            "service_user": "kai",
+            "platform": "darwin",
+            "env": {
+                "TELEGRAM_BOT_TOKEN": "fake-token",
+                "PR_REVIEW_COOLDOWN": "450",
+            },
+        }
+        (tmp_path / "install.conf").write_text(json.dumps(prior_conf))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
+        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
+        self._existing_etc_users(monkeypatch)
+
+        inputs = iter(TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
+        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
+        monkeypatch.setattr(
+            "kai.install._prompt_default_model",
+            lambda backend, prov, default: "sonnet",
+        )
+        _cmd_config()
+
+        env = json.loads((tmp_path / "install.conf").read_text())["env"]
+        assert "PR_REVIEW_COOLDOWN" not in env
+
     def test_retired_scoped_recall_keys_dropped_on_regenerate(self, tmp_path, monkeypatch):
         """A regenerate over an install.conf carrying the retired
         scoped-recall and shadow flags drops them: the runtime no
@@ -11224,33 +11240,6 @@ class TestCmdConfigGlobalDefaultsRegardlessOfUsersYaml:
 
         env = json.loads((tmp_path / "install.conf").read_text())["env"]
         assert env["WORKSPACE_BASE"] == "~/Projects"
-
-    def test_pr_review_cooldown_always_prompts(self, tmp_path, monkeypatch):
-        """PR_REVIEW_COOLDOWN is a global resource control: the prompt
-        fires whether users.yaml exists or pr_review_enabled is true,
-        and a non-default value lands in env.
-        """
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
-        monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
-        self._existing_etc_users(monkeypatch)
-
-        # Override the cooldown slot in the claude chain to a non-default
-        # value so the env-emission assertion is meaningful (the default
-        # "300" is suppressed by the delta-from-default check).
-        base = list(TestCmdConfigDefaultModelDispatch._inputs_for_claude_backend())
-        cooldown_idx = base.index("300")
-        base[cooldown_idx] = "450"
-        inputs = iter(base)
-        monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
-        monkeypatch.setattr(
-            "kai.install._prompt_default_model",
-            lambda backend, prov, default: "sonnet",
-        )
-        _cmd_config()
-
-        env = json.loads((tmp_path / "install.conf").read_text())["env"]
-        assert env["PR_REVIEW_COOLDOWN"] == "450"
 
     def test_allowed_workspaces_lands_with_users_yaml(self, tmp_path, monkeypatch):
         """ALLOWED_WORKSPACES reaches env when users.yaml is present.
@@ -11336,7 +11325,6 @@ class TestCmdConfigCanonicalUsersYaml:
             "0",  # periodic model-catalogue refresh disabled
             "30",  # model-catalogue refresh timeout
             "false",
-            "300",  # pr review cooldown (global resource control)
             "900",
             "1.0",
             "false",
@@ -11805,7 +11793,6 @@ class TestCmdConfigSingleUserMode:
             "0",  # periodic model-catalogue refresh disabled
             "30",  # model-catalogue refresh timeout
             "false",  # pr_review_enabled
-            "300",  # pr_review_cooldown
             "900",  # pr_review_timeout_s
             "false",  # issue_triage
             "",  # github_notify_chat_id
@@ -13304,7 +13291,6 @@ class TestOpenCodeConfigWizard:
             "",  # allowed workspaces
             "0",  # periodic model-catalogue refresh disabled
             "30",  # model-catalogue refresh timeout
-            "300",  # pr review cooldown (global resource control)
             "900",  # pr review timeout
             "false",  # voice
             "false",  # tts

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -265,12 +265,6 @@ class TestFmtPullRequestReview:
         assert _fmt_pull_request_review(_review_payload("edited", "approved")) is None
 
 
-# ── _should_skip_review / _record_review ────────────────────────────
-
-
-# ── _prune_expired / cooldown dict cleanup ───────────────────────────
-
-
 # ── PR review routing (integration tests) ──────────────────────────
 
 
@@ -308,7 +302,6 @@ def _default_github_token_lookup():
 
 
 def _build_test_app(
-    cooldown: int = 300,
     config: object | None = None,
 ) -> web.Application:
     """Build a minimal aiohttp app with _handle_github wired up.
@@ -651,7 +644,6 @@ class TestNotificationChatIdMutations:
         config.telegram_webhook_secret = None
         config.github_webhook_secret = None
         config.generic_webhook_secret = None
-        config.pr_review_cooldown = 0
         config.pr_review_timeout_s = 0
         config.webhook_port = 0
         config.workshop_lan_host = ""
@@ -720,7 +712,6 @@ class TestNotificationChatIdMutations:
         config.telegram_webhook_secret = None
         config.github_webhook_secret = "configured-but-telegram-owned"
         config.generic_webhook_secret = "configured-but-telegram-owned"
-        config.pr_review_cooldown = 0
         config.pr_review_timeout_s = 0
         config.webhook_port = 8080
         config.workshop_lan_host = ""
@@ -788,7 +779,6 @@ class TestNotificationChatIdMutations:
         config.telegram_webhook_secret = None
         config.github_webhook_secret = None
         config.generic_webhook_secret = None
-        config.pr_review_cooldown = 0
         config.pr_review_timeout_s = 0
         config.webhook_port = 8080
         config.workshop_lan_host = "10.0.0.36"


### PR DESCRIPTION
## Summary

- remove the inert `PR_REVIEW_COOLDOWN` field and environment parsing
- remove the `make config` prompt, installer emission, and env-template entry
- remove stale fixtures and prompt inputs while preserving `PR_REVIEW_TIMEOUT_S`
- ignore legacy cooldown values and drop them when `install.conf` is regenerated
- clarify that manual `/review` does not create canonical webhook automation work

The canonical GitHub automation queue continues to deduplicate repeated delivery identities. Distinct deliveries remain distinct work; no cooldown or silent event suppression is introduced.

## Verification

- `.venv/bin/python -m pytest tests/test_config.py tests/test_install.py tests/test_webhook.py` — 1,062 passed
- `make test` — 6,437 passed
- focused retirement regressions — 8 passed
- `make check`
- `make typecheck`
- `git diff --check`

Closes #1398

