### PR TITLE
Clarify GitHub notification bootstrap setting

### DIFF
--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -1635,9 +1635,10 @@ class Config:
     # Issue triage agent: per-user toggle lives in users.yaml
     # `issue_triage` (or the per-chat /github triage command).
 
-    # GitHub notification routing is per-user: `github_notify_chat_id`
-    # in users.yaml, with /github notify as the per-chat override. When
-    # neither is set the runtime falls back to the user's own chat_id.
+    # A negative per-user `github_notify_chat_id` in users.yaml bootstraps a
+    # canonical Workshop notification channel as operator policy. Live GitHub
+    # delivery and `/github notify` use canonical per-principal notification
+    # preferences, with the principal's direct channel as the final fallback.
 
     # File retention: delete uploaded files older than this many days.
     # 0 = no cleanup (default). Cleanup runs once every 24 hours.

--- a/templates/users.yaml
+++ b/templates/users.yaml
@@ -63,8 +63,11 @@ users:
     # initial notification list. Omission grants no review/triage authority,
     # even to admins. `/github add` can add notification subscriptions but
     # never expands this operations allowlist. pr_review and issue_triage
-    # toggle automated processing. github_notify_chat_id sends notifications
-    # to a separate chat (e.g., a Telegram group) instead of the DM.
+    # toggle automated processing. At startup, a negative
+    # github_notify_chat_id seeds a canonical Workshop notification channel
+    # for that Telegram group. The seeded channel becomes the operator-policy
+    # default; live delivery uses the principal's canonical notification
+    # preference, which may select another authorized destination.
     # github_repos:
     #   - alice/my-project
     #   - alice/other-repo


### PR DESCRIPTION
## Summary

- explain that a negative `github_notify_chat_id` bootstraps a canonical Workshop notification channel
- distinguish the seeded operator-policy default from live canonical per-principal routing
- retain the supported setting and its direct-channel fallback without changing behavior

## Validation

- `make check`
- `git diff --check`

Executable code is unchanged, so pytest was not run.

Closes #1399
