### PR TITLE
Document Workshop LAN host setting

### DIFF
--- a/templates/.env
+++ b/templates/.env
@@ -115,6 +115,13 @@ CLAUDE_AUTOCOMPACT_PCT=80
 # Port for the local webhook/API server (receives GitHub events, scheduling API)
 WEBHOOK_PORT=8080
 
+# Optional private IPv4 address for direct Workshop access on a trusted LAN.
+# Requires the Workshop adapter. Only authenticated Workshop client routes are
+# exposed on this listener; webhook and internal API routes remain loopback-only.
+# Wildcard, loopback, public, multicast, and IPv6 addresses are rejected.
+# This listener uses plain HTTP, so use a TLS terminator on untrusted networks.
+#WORKSHOP_LAN_HOST=10.0.0.36
+
 # Dedicated secrets for external webhook ingress. GitHub signs request bodies
 # with GITHUB_WEBHOOK_SECRET; generic callers send GENERIC_WEBHOOK_SECRET in
 # the X-Webhook-Secret header. Leave an endpoint's value empty to disable it.


### PR DESCRIPTION
## Summary

- document `WORKSHOP_LAN_HOST` in the tracked environment template
- describe its private-IPv4 validation and Workshop-adapter requirement
- clarify route isolation and the trusted-LAN HTTP/TLS boundary

## Validation

- `make check`
- `git diff --check`

Executable code is unchanged, so pytest was not run.

Closes #1375
