### PR TITLE
Clarify principal-owned agent lifecycle

### DIFF
--- a/src/kai/workshop/agent_lifecycle.py
+++ b/src/kai/workshop/agent_lifecycle.py
@@ -1,4 +1,4 @@
-"""Admin-authorized lifecycle operations for Workshop agent definitions."""
+"""Principal-owned lifecycle operations for canonical Workshop agent definitions."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- describe Workshop agent lifecycle operations as principal-owned rather than administrator-authorized
- preserve the intentional member-wide agent creation policy established by #1302 and #1303
- leave all runtime authorization behavior unchanged

## Validation

- `make check`
- `git diff --check`

Executable code is unchanged, so pytest was not run.

Closes #1383
