### PR TITLE
Add canonical Workshop human avatar authority

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "aiosqlite>=0.19.0,<1",
     "python-dotenv>=1.0.0,<2",
     "aiohttp>=3.9.0,<4",
+    "pillow>=12.3.0,<13",
     "pyyaml>=6.0,<7",
 ]
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,6 +13,7 @@ apscheduler==3.11.2
 aiosqlite==0.22.1
 python-dotenv==1.2.2
 aiohttp==3.14.3
+pillow==12.3.0
 pyyaml==6.0.3
 
 mem0ai==2.0.0
@@ -42,5 +43,6 @@ pygments==2.20.0
 requests==2.33.0
 setuptools==83.0.0
 torch==2.13.0
-tornado==6.5.7
+tornado==6.5.8
+transformers==5.10.1
 urllib3==2.7.0

--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -41,6 +41,7 @@ from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.github_automation import WorkshopGitHubAutomationService
 from kai.workshop.github_settings import WorkshopGitHubSettingsService
 from kai.workshop.goose_model_discovery import GooseModelDiscoveryAdapter
+from kai.workshop.human_avatars import WorkshopHumanAvatarService
 from kai.workshop.integration_notifications import WorkshopIntegrationNotificationService
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.memory_queries import WorkshopMemoryQueryService
@@ -201,6 +202,7 @@ class KaiCoreServices:
     channel_notification_policy: WorkshopChannelNotificationPolicyService
     client_preferences: WorkshopClientPreferenceService
     appearance_preferences: WorkshopAppearancePreferenceService
+    human_avatars: WorkshopHumanAvatarService
     agent_enablement: WorkshopAgentEnablementService
     proactive_publication: WorkshopProactivePublicationService
     integration_notifications: WorkshopIntegrationNotificationService
@@ -394,6 +396,10 @@ class KaiApplicationHost:
                 principal_storage=self._principal_storage,
                 runtime_profiles=self._runtime_profiles,
             )
+            human_avatars = WorkshopHumanAvatarService(
+                client_store,
+                data_dir=Path(self._config.session_db_path).parent,
+            )
             settings_workspaces = WorkshopSettingsWorkspaceService(
                 self._config,
                 runtime_pool,
@@ -484,6 +490,7 @@ class KaiApplicationHost:
                 run_previews=run_previews,
                 scheduler=scheduler,
                 artifacts=artifacts,
+                human_avatars=human_avatars,
                 settings_workspaces=settings_workspaces,
                 memory_queries=memory_queries,
                 preference_documents=preference_documents,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -86,6 +86,7 @@ from kai.workshop.diagnostics import (
     workshop_client_preference_status,
     workshop_delivery_authority_status,
     workshop_execution_state_status,
+    workshop_human_avatar_status,
     workshop_human_handle_status,
     workshop_human_notification_status,
     workshop_legacy_jsonl_archive_status,
@@ -9539,6 +9540,7 @@ def _cmd_status() -> None:
     )
     print(workshop_agent_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_human_handle_status(Path(data_dir) / "kai.db"))
+    print(workshop_human_avatar_status(Path(data_dir) / "kai.db", Path(data_dir) / "files" / "avatars"))
     print(workshop_human_notification_status(Path(data_dir) / "kai.db"))
     print(workshop_channel_notification_policy_status(Path(data_dir) / "kai.db"))
     print(workshop_unread_authority_status(Path(data_dir) / "kai.db"))

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -92,6 +92,7 @@ from kai.workshop.github_automation import (
     WorkshopGitHubAutomationService,
 )
 from kai.workshop.github_settings import WorkshopGitHubSettingsService
+from kai.workshop.human_avatars import WorkshopHumanAvatarService
 from kai.workshop.integration_notifications import (
     DEFAULT_INTEGRATION_ROUTE,
     IntegrationNotification,
@@ -1899,6 +1900,7 @@ async def _register_workshop_client_api(
     client_preferences: WorkshopClientPreferenceService | None = None,
     appearance_preferences: WorkshopAppearancePreferenceService | None = None,
     agent_enablement: WorkshopAgentEnablementService | None = None,
+    human_avatars: WorkshopHumanAvatarService | None = None,
 ) -> Callable[[web.Application], None]:
     """Register the client API against the core-owned canonical store.
 
@@ -1942,6 +1944,7 @@ async def _register_workshop_client_api(
             client_preferences=client_preferences,
             appearance_preferences=appearance_preferences,
             agent_enablement=agent_enablement,
+            human_avatars=human_avatars,
         )
         if command_submitter is not None:
             register_workshop_command_routes(
@@ -2029,6 +2032,7 @@ async def start(
             client_preferences=getattr(core_services, "client_preferences", None),
             appearance_preferences=getattr(core_services, "appearance_preferences", None),
             agent_enablement=getattr(core_services, "agent_enablement", None),
+            human_avatars=getattr(core_services, "human_avatars", None),
         )
 
     _runner = web.AppRunner(

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -146,6 +146,18 @@ from kai.workshop.github_settings import (
     WorkshopGitHubSettingsStorageError,
     WorkshopGitHubSettingsValidationError,
 )
+from kai.workshop.human_avatars import (
+    MAX_AVATAR_UPLOAD_BYTES,
+    HumanAvatarSnapshot,
+    WorkshopHumanAvatarAccessDenied,
+    WorkshopHumanAvatarConflict,
+    WorkshopHumanAvatarError,
+    WorkshopHumanAvatarService,
+    WorkshopHumanAvatarStorageError,
+    WorkshopHumanAvatarTooLarge,
+    WorkshopHumanAvatarUnsupportedType,
+    WorkshopHumanAvatarValidationError,
+)
 from kai.workshop.human_direct_messages import (
     WorkshopHumanDirectConversation,
     WorkshopHumanDirectMessageAccessDenied,
@@ -340,6 +352,8 @@ _CHANNEL_NOTIFICATION_POLICY_PATH = "/v1/settings/channel-notifications"
 _CLIENT_PREFERENCES_PATH = "/v1/settings/clients"
 _APPEARANCE_PREFERENCES_PATH = "/v1/settings/appearance"
 _HUMAN_PROFILE_PATH = "/v1/settings/profile"
+_HUMAN_AVATAR_PATH = "/v1/settings/profile/avatar"
+_PRINCIPAL_AVATAR_PATH = "/v1/principals/{principal_id}/avatar/{state_version}"
 _HUMAN_NOTIFICATIONS_PATH = "/v1/client/notifications"
 _HUMAN_NOTIFICATION_COUNTS_PATH = "/v1/client/notifications/counts"
 _HUMAN_NOTIFICATION_EVENTS_PATH = "/v1/client/notifications/events"
@@ -401,6 +415,9 @@ _APPEARANCE_PREFERENCE_REQUEST_FIELDS = frozenset({"revision", "theme_id"})
 _MAX_APPEARANCE_PREFERENCE_BODY_BYTES = 1_024
 _HUMAN_PROFILE_REQUEST_FIELDS = frozenset({"display_name", "expected_state_version", "client_operation_id"})
 _MAX_HUMAN_PROFILE_BODY_BYTES = 2_048
+_HUMAN_AVATAR_CLEAR_FIELDS = frozenset({"expected_state_version", "client_operation_id"})
+_HUMAN_AVATAR_MULTIPART_FIELDS = frozenset({"file", "expected_state_version", "client_operation_id"})
+_MAX_HUMAN_AVATAR_REQUEST_BYTES = MAX_AVATAR_UPLOAD_BYTES + 64 * 1024
 _MAX_HUMAN_NOTIFICATION_BODY_BYTES = 32_768
 _HUMAN_NOTIFICATION_STATE_FIELDS = frozenset({"expected_state_version", "client_operation_id"})
 _HUMAN_NOTIFICATION_BULK_FIELDS = frozenset({"notifications", "client_operation_id"})
@@ -801,6 +818,26 @@ def _serialize_human_profile(snapshot: HumanProfileSnapshot) -> dict[str, object
                 "changed": snapshot.mutation_changed,
                 "replayed": snapshot.replayed,
             }
+            if snapshot.mutation_changed is not None
+            else None
+        ),
+    }
+
+
+def _serialize_human_avatar(snapshot: HumanAvatarSnapshot) -> dict[str, object]:
+    return {
+        "version": 1,
+        "principal_id": str(snapshot.principal_id),
+        "state_version": snapshot.state_version,
+        "active": snapshot.active,
+        "media_type": snapshot.media_type,
+        "byte_size": snapshot.byte_size,
+        "width": snapshot.width,
+        "height": snapshot.height,
+        "sha256": snapshot.sha256,
+        "url": (f"/v1/principals/{snapshot.principal_id}/avatar/{snapshot.state_version}" if snapshot.active else None),
+        "mutation": (
+            {"changed": snapshot.mutation_changed, "replayed": snapshot.replayed}
             if snapshot.mutation_changed is not None
             else None
         ),
@@ -2652,6 +2689,191 @@ async def _handle_human_profile_update(
     except WorkshopHumanProfileError as exc:
         return _human_profile_error_response(exc)
     return _json_response(_serialize_human_profile(snapshot), status=200)
+
+
+def _human_avatar_error_response(exc: WorkshopHumanAvatarError) -> web.Response:
+    if isinstance(exc, WorkshopHumanAvatarConflict):
+        return _error_response(status=409, code="avatar_conflict", message=str(exc))
+    if isinstance(exc, WorkshopHumanAvatarTooLarge):
+        return _error_response(status=413, code="avatar_too_large", message=str(exc))
+    if isinstance(exc, WorkshopHumanAvatarUnsupportedType):
+        return _error_response(status=415, code="unsupported_avatar_type", message=str(exc))
+    if isinstance(exc, WorkshopHumanAvatarValidationError):
+        return _error_response(status=400, code="invalid_avatar", message=str(exc))
+    if isinstance(exc, WorkshopHumanAvatarAccessDenied):
+        return _error_response(status=404, code="avatar_not_found", message="Avatar not found")
+    if isinstance(exc, WorkshopHumanAvatarStorageError):
+        return _error_response(status=503, code="avatar_unavailable", message="Avatar is temporarily unavailable")
+    return _error_response(status=503, code="avatar_unavailable", message="Avatar is temporarily unavailable")
+
+
+async def _authenticate_human_avatar_request(
+    request: web.Request,
+    authenticator: WorkshopClientAuthenticator,
+) -> tuple[PrincipalId | None, web.Response | None]:
+    principal_id = await authenticator.authenticate(request)
+    if isinstance(principal_id, PrincipalId):
+        return principal_id, None
+    response = _error_response(status=401, code="authentication_required", message="Authentication required")
+    response.headers["WWW-Authenticate"] = "Bearer"
+    return None, response
+
+
+async def _handle_human_avatar(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopHumanAvatarService,
+) -> web.Response:
+    principal_id, error = await _authenticate_human_avatar_request(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid avatar request")
+    try:
+        snapshot = await service.inspect(principal_id)
+    except WorkshopHumanAvatarError as exc:
+        return _human_avatar_error_response(exc)
+    return _json_response(_serialize_human_avatar(snapshot), status=200)
+
+
+async def _read_bounded_multipart_part(part: BodyPartReader, limit: int) -> bytes:
+    content = bytearray()
+    while True:
+        chunk = await part.read_chunk(size=64 * 1024)
+        if not chunk:
+            return bytes(content)
+        content.extend(chunk)
+        if len(content) > limit:
+            raise WorkshopHumanAvatarTooLarge("Avatar multipart field is too large")
+
+
+async def _handle_human_avatar_upload(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopHumanAvatarService,
+) -> web.Response:
+    principal_id, error = await _authenticate_human_avatar_request(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    if request.query:
+        return _error_response(status=400, code="invalid_request", message="Invalid avatar request")
+    try:
+        if request.content_type != "multipart/form-data":
+            raise WorkshopHumanAvatarValidationError("Content-Type must be multipart/form-data")
+        if request.content_length is not None and request.content_length > _MAX_HUMAN_AVATAR_REQUEST_BYTES:
+            raise WorkshopHumanAvatarTooLarge("Avatar request is too large")
+        reader = await request.multipart()
+        fields: dict[str, object] = {}
+        while (part := await reader.next()) is not None:
+            if not isinstance(part, BodyPartReader) or part.name not in _HUMAN_AVATAR_MULTIPART_FIELDS:
+                raise WorkshopHumanAvatarValidationError("Avatar multipart fields are invalid")
+            if part.name in fields:
+                raise WorkshopHumanAvatarValidationError("Avatar multipart fields must not be repeated")
+            if part.name == "file":
+                content = await _read_bounded_multipart_part(part, MAX_AVATAR_UPLOAD_BYTES)
+                media_type = part.headers.get("Content-Type", "").partition(";")[0].strip().lower()
+                fields[part.name] = (content, media_type)
+            else:
+                raw_value = await _read_bounded_multipart_part(part, 512)
+                try:
+                    fields[part.name] = raw_value.decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise WorkshopHumanAvatarValidationError("Avatar metadata must be UTF-8") from exc
+        if set(fields) != _HUMAN_AVATAR_MULTIPART_FIELDS:
+            raise WorkshopHumanAvatarValidationError("Avatar multipart fields are incomplete")
+        expected_text = fields["expected_state_version"]
+        operation_id = fields["client_operation_id"]
+        file_value = fields["file"]
+        if not isinstance(expected_text, str) or re.fullmatch(r"[0-9]{1,20}", expected_text) is None:
+            raise WorkshopHumanAvatarValidationError("expected_state_version must be a non-negative integer")
+        if not isinstance(operation_id, str) or not isinstance(file_value, tuple):
+            raise WorkshopHumanAvatarValidationError("Avatar multipart fields are invalid")
+        file_content, media_type = file_value
+        if not isinstance(file_content, bytes) or not isinstance(media_type, str):
+            raise WorkshopHumanAvatarValidationError("Avatar file field is invalid")
+        snapshot = await service.upload(
+            principal_id,
+            file_content,
+            media_type,
+            expected_state_version=int(expected_text),
+            client_operation_id=operation_id,
+        )
+    except WorkshopHumanAvatarError as exc:
+        return _human_avatar_error_response(exc)
+    except (ValueError, OSError):
+        return _human_avatar_error_response(WorkshopHumanAvatarValidationError("Invalid avatar request"))
+    return _json_response(_serialize_human_avatar(snapshot), status=200)
+
+
+async def _handle_human_avatar_clear(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopHumanAvatarService,
+) -> web.Response:
+    principal_id, error = await _authenticate_human_avatar_request(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    if request.query:
+        return _error_response(status=400, code="invalid_request", message="Invalid avatar request")
+    try:
+        if request.content_type != "application/json":
+            raise WorkshopHumanAvatarValidationError("Content-Type must be application/json")
+        if request.content_length is not None and request.content_length > _MAX_HUMAN_PROFILE_BODY_BYTES:
+            raise WorkshopHumanAvatarValidationError("Avatar request is too large")
+        raw = await request.content.read(_MAX_HUMAN_PROFILE_BODY_BYTES + 1)
+        if len(raw) > _MAX_HUMAN_PROFILE_BODY_BYTES:
+            raise WorkshopHumanAvatarValidationError("Avatar request is too large")
+        payload = json.loads(raw)
+        if not isinstance(payload, dict) or set(payload) != _HUMAN_AVATAR_CLEAR_FIELDS:
+            raise WorkshopHumanAvatarValidationError("Invalid avatar request")
+        snapshot = await service.clear(
+            principal_id,
+            expected_state_version=payload.get("expected_state_version"),
+            client_operation_id=payload.get("client_operation_id"),
+        )
+    except (UnicodeDecodeError, ValueError):
+        return _human_avatar_error_response(WorkshopHumanAvatarValidationError("Invalid avatar request"))
+    except WorkshopHumanAvatarError as exc:
+        return _human_avatar_error_response(exc)
+    return _json_response(_serialize_human_avatar(snapshot), status=200)
+
+
+async def _handle_principal_avatar(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopHumanAvatarService,
+) -> web.StreamResponse:
+    requester, error = await _authenticate_human_avatar_request(request, authenticator)
+    if error is not None:
+        return error
+    assert requester is not None
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid avatar request")
+    try:
+        target = PrincipalId(request.match_info["principal_id"])
+        state_version = int(request.match_info["state_version"])
+        content = await service.retrieve(requester, target, state_version)
+    except (TypeError, ValueError):
+        return _error_response(status=404, code="avatar_not_found", message="Avatar not found")
+    except WorkshopHumanAvatarError as exc:
+        return _human_avatar_error_response(exc)
+    assert content.snapshot.sha256 is not None
+    return web.FileResponse(
+        content.path,
+        headers={
+            "Cache-Control": "private, max-age=31536000, immutable",
+            "Content-Type": "image/png",
+            "ETag": f'"{content.snapshot.sha256}"',
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
 
 
 async def _handle_runtime_settings(
@@ -6995,6 +7217,7 @@ def register_workshop_read_routes(
     client_preferences: WorkshopClientPreferenceService | None = None,
     appearance_preferences: WorkshopAppearancePreferenceService | None = None,
     agent_enablement: WorkshopAgentEnablementService | None = None,
+    human_avatars: WorkshopHumanAvatarService | None = None,
 ) -> None:
     """Register authenticated Workshop client routes on an application."""
     if event_poll_interval <= 0 or event_heartbeat_interval <= 0 or event_authentication_recheck_interval <= 0:
@@ -7487,6 +7710,43 @@ def register_workshop_read_routes(
 
     app.router.add_get(_HUMAN_PROFILE_PATH, handle_human_profile)
     app.router.add_patch(_HUMAN_PROFILE_PATH, handle_human_profile_update)
+    if human_avatars is not None:
+
+        async def handle_human_avatar(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_human_avatar(
+                    request,
+                    authenticator=authenticator,
+                    service=human_avatars,
+                )
+
+        async def handle_human_avatar_upload(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_human_avatar_upload(
+                    request,
+                    authenticator=authenticator,
+                    service=human_avatars,
+                )
+
+        async def handle_human_avatar_clear(request: web.Request) -> web.Response:
+            async with request_lock:
+                return await _handle_human_avatar_clear(
+                    request,
+                    authenticator=authenticator,
+                    service=human_avatars,
+                )
+
+        async def handle_principal_avatar(request: web.Request) -> web.StreamResponse:
+            return await _handle_principal_avatar(
+                request,
+                authenticator=authenticator,
+                service=human_avatars,
+            )
+
+        app.router.add_get(_HUMAN_AVATAR_PATH, handle_human_avatar)
+        app.router.add_post(_HUMAN_AVATAR_PATH, handle_human_avatar_upload)
+        app.router.add_delete(_HUMAN_AVATAR_PATH, handle_human_avatar_clear)
+        app.router.add_get(_PRINCIPAL_AVATAR_PATH, handle_principal_avatar)
     if preference_documents is not None:
 
         async def handle_preference_document(request: web.Request) -> web.Response:

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -1985,6 +1985,86 @@ def workshop_human_handle_status(db_path: Path) -> str:
     )
 
 
+def workshop_human_avatar_status(db_path: Path, avatar_root: Path) -> str:
+    """Report canonical avatar projection and normalized-file integrity."""
+    prefix = "Workshop human avatars:"
+    if not db_path.is_file():
+        return f"{prefix} pending; canonical human-avatar schema unavailable"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            connection.execute("PRAGMA query_only=ON")
+            connection.execute("BEGIN")
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            if "principal_avatars" not in tables:
+                return f"{prefix} pending; canonical human-avatar schema unavailable"
+            rows = connection.execute(
+                "SELECT principal_id, state_version, active, media_type, byte_size, width, height, sha256 "
+                "FROM principal_avatars"
+            ).fetchall()
+        finally:
+            connection.close()
+        expected: dict[Path, tuple[int, str]] = {}
+        active = cleared = malformed = 0
+        resolved_root = avatar_root.resolve()
+        for row in rows:
+            principal_id = str(row[0])
+            version = int(row[1])
+            is_active = int(row[2]) == 1
+            metadata = row[3:]
+            if version <= 0:
+                malformed += 1
+            if is_active:
+                active += 1
+                media_type, byte_size, width, height, digest = metadata
+                if (
+                    media_type != "image/png"
+                    or not isinstance(byte_size, int)
+                    or byte_size <= 0
+                    or not isinstance(width, int)
+                    or width <= 0
+                    or not isinstance(height, int)
+                    or height <= 0
+                    or not isinstance(digest, str)
+                    or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+                ):
+                    malformed += 1
+                    continue
+                expected[resolved_root / principal_id / f"{version}.png"] = (byte_size, digest)
+            else:
+                cleared += 1
+                if any(value is not None for value in metadata):
+                    malformed += 1
+        missing = corrupt = 0
+        for path, (byte_size, digest) in expected.items():
+            try:
+                if not path.exists():
+                    missing += 1
+                    continue
+                if path.is_symlink() or not path.is_file() or path.stat().st_size != byte_size:
+                    corrupt += 1
+                    continue
+                if hashlib.sha256(path.read_bytes()).hexdigest() != digest:
+                    corrupt += 1
+            except OSError:
+                corrupt += 1
+        files: set[Path] = set()
+        if resolved_root.is_dir() and not resolved_root.is_symlink():
+            files = set(resolved_root.glob("*/*"))
+        orphaned = len(files - set(expected))
+    except (sqlite3.Error, OSError, TypeError, ValueError) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+    state = "active" if missing == 0 and corrupt == 0 and orphaned == 0 and malformed == 0 else "INCOMPLETE"
+    return (
+        f"{prefix} {state}; states={len(rows)}, active={active}, cleared={cleared}, "
+        f"missing files={missing}, orphaned files={orphaned}, corrupt files={corrupt}, "
+        f"malformed={malformed}; authority=canonical"
+    )
+
+
 def workshop_human_notification_status(db_path: Path) -> str:
     """Report canonical human-notification projection and replay integrity."""
     prefix = "Workshop human notifications:"

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -26,6 +26,7 @@ class WorkshopEventType(StrEnum):
     PRINCIPAL_CREATED = "principal.created"
     PRINCIPAL_HANDLE_ASSIGNED = "principal.handle_assigned"
     PRINCIPAL_DISPLAY_NAME_CHANGED = "principal.display_name_changed"
+    PRINCIPAL_AVATAR_CHANGED = "principal.avatar_changed"
     EXTERNAL_IDENTITY_BOUND = "external_identity.bound"
     CHANNEL_CREATED = "channel.created"
     CHANNEL_ARCHIVED = "channel.archived"

--- a/src/kai/workshop/human_avatars.py
+++ b/src/kai/workshop/human_avatars.py
@@ -1,0 +1,483 @@
+"""Canonical, self-owned human avatars for Kai Workshop."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import os
+import tempfile
+import warnings
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+from kai.workshop.domain import EventEnvelope, PrincipalId, WorkshopEventType, WorkshopId
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import StoredEvent, WorkshopEventStore
+
+MAX_AVATAR_UPLOAD_BYTES = 256 * 1024
+MAX_AVATAR_OUTPUT_BYTES = 512 * 1024
+MAX_AVATAR_SOURCE_DIMENSION = 4096
+MAX_AVATAR_SOURCE_PIXELS = 16_000_000
+MAX_AVATAR_DIMENSION = 256
+_ACCEPTED_FORMATS = {
+    "image/png": "PNG",
+    "image/jpeg": "JPEG",
+    "image/gif": "GIF",
+    "image/webp": "WEBP",
+}
+
+
+class WorkshopHumanAvatarError(RuntimeError):
+    """A canonical human-avatar operation failed."""
+
+
+class WorkshopHumanAvatarAccessDenied(WorkshopHumanAvatarError):
+    """The principal cannot access the requested avatar."""
+
+
+class WorkshopHumanAvatarValidationError(WorkshopHumanAvatarError):
+    """The supplied avatar request is invalid."""
+
+
+class WorkshopHumanAvatarUnsupportedType(WorkshopHumanAvatarValidationError):
+    """The supplied file is not an accepted image type."""
+
+
+class WorkshopHumanAvatarTooLarge(WorkshopHumanAvatarValidationError):
+    """The supplied image exceeds an avatar safety limit."""
+
+
+class WorkshopHumanAvatarConflict(WorkshopHumanAvatarError):
+    """The avatar state changed after the caller loaded it."""
+
+
+class WorkshopHumanAvatarStorageError(WorkshopHumanAvatarError):
+    """Canonical avatar state or bytes are unavailable."""
+
+
+@dataclass(frozen=True, slots=True)
+class HumanAvatarSnapshot:
+    principal_id: PrincipalId
+    state_version: int
+    active: bool
+    media_type: str | None = None
+    byte_size: int | None = None
+    width: int | None = None
+    height: int | None = None
+    sha256: str | None = None
+    mutation_changed: bool | None = None
+    replayed: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class HumanAvatarBytes:
+    snapshot: HumanAvatarSnapshot
+    path: Path
+
+
+@dataclass(frozen=True, slots=True)
+class _NormalizedAvatar:
+    content: bytes
+    width: int
+    height: int
+    sha256: str
+
+
+def _validate_operation(expected_state_version: object, client_operation_id: object) -> tuple[int, str]:
+    if (
+        not isinstance(expected_state_version, int)
+        or isinstance(expected_state_version, bool)
+        or expected_state_version < 0
+    ):
+        raise WorkshopHumanAvatarValidationError("expected_state_version must be a non-negative integer")
+    if not isinstance(client_operation_id, str) or not client_operation_id.strip() or len(client_operation_id) > 200:
+        raise WorkshopHumanAvatarValidationError("client_operation_id must be a non-empty string")
+    return expected_state_version, client_operation_id.strip()
+
+
+def _normalize_avatar(raw: bytes, claimed_media_type: str) -> _NormalizedAvatar:
+    if claimed_media_type not in _ACCEPTED_FORMATS:
+        raise WorkshopHumanAvatarUnsupportedType("Avatar must be a PNG, JPEG, GIF, or WebP image")
+    if not raw:
+        raise WorkshopHumanAvatarValidationError("Avatar image is empty")
+    if len(raw) > MAX_AVATAR_UPLOAD_BYTES:
+        raise WorkshopHumanAvatarTooLarge("Avatar upload exceeds 256 KiB")
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(io.BytesIO(raw)) as source:
+                if source.format != _ACCEPTED_FORMATS[claimed_media_type]:
+                    raise WorkshopHumanAvatarUnsupportedType(
+                        "Avatar Content-Type does not match the decoded image format"
+                    )
+                width, height = source.size
+                if (
+                    width <= 0
+                    or height <= 0
+                    or width > MAX_AVATAR_SOURCE_DIMENSION
+                    or height > MAX_AVATAR_SOURCE_DIMENSION
+                    or width * height > MAX_AVATAR_SOURCE_PIXELS
+                ):
+                    raise WorkshopHumanAvatarTooLarge("Avatar image dimensions are too large")
+                source.seek(0)
+                source.load()
+                normalized = ImageOps.exif_transpose(source).convert("RGBA")
+                normalized.thumbnail(
+                    (MAX_AVATAR_DIMENSION, MAX_AVATAR_DIMENSION),
+                    Image.Resampling.LANCZOS,
+                )
+                output = io.BytesIO()
+                normalized.save(output, format="PNG", optimize=True)
+    except WorkshopHumanAvatarError:
+        raise
+    except (Image.DecompressionBombError, Image.DecompressionBombWarning):
+        raise WorkshopHumanAvatarTooLarge("Avatar image dimensions are too large") from None
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise WorkshopHumanAvatarValidationError("Avatar image could not be decoded") from exc
+    content = output.getvalue()
+    if len(content) > MAX_AVATAR_OUTPUT_BYTES:
+        raise WorkshopHumanAvatarTooLarge("Normalized avatar is too large")
+    return _NormalizedAvatar(
+        content=content,
+        width=normalized.width,
+        height=normalized.height,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+class WorkshopHumanAvatarService:
+    """Own canonical avatar state and normalized image storage."""
+
+    def __init__(self, store: WorkshopEventStore, *, data_dir: Path) -> None:
+        self._store = store
+        self._root = data_dir.resolve() / "files" / "avatars"
+
+    @property
+    def storage_root(self) -> Path:
+        return self._root
+
+    async def inspect(self, principal_id: PrincipalId) -> HumanAvatarSnapshot:
+        await self._require_human(principal_id)
+        return await self._snapshot(principal_id)
+
+    async def upload(
+        self,
+        principal_id: PrincipalId,
+        raw: bytes,
+        claimed_media_type: str,
+        *,
+        expected_state_version: object,
+        client_operation_id: object,
+    ) -> HumanAvatarSnapshot:
+        expected, operation_id = _validate_operation(expected_state_version, client_operation_id)
+        normalized = await asyncio.to_thread(_normalize_avatar, raw, claimed_media_type)
+        await self._require_human(principal_id)
+        payload: dict[str, object] = {
+            "expected_state_version": expected,
+            "media_type": "image/png",
+            "byte_size": len(normalized.content),
+            "width": normalized.width,
+            "height": normalized.height,
+            "sha256": normalized.sha256,
+        }
+        return await self._change(
+            principal_id,
+            payload=payload,
+            expected_state_version=expected,
+            operation_id=operation_id,
+            normalized=normalized,
+        )
+
+    async def clear(
+        self,
+        principal_id: PrincipalId,
+        *,
+        expected_state_version: object,
+        client_operation_id: object,
+    ) -> HumanAvatarSnapshot:
+        expected, operation_id = _validate_operation(expected_state_version, client_operation_id)
+        await self._require_human(principal_id)
+        payload: dict[str, object] = {"expected_state_version": expected, "cleared": True}
+        existing = await self._store.event_by_idempotency_key(
+            f"workshop-client:human-avatar:{principal_id}:{operation_id}"
+        )
+        if existing is not None:
+            return await self._change(
+                principal_id,
+                payload=payload,
+                expected_state_version=expected,
+                operation_id=operation_id,
+                normalized=None,
+            )
+        before = await self._snapshot(principal_id)
+        if before.state_version != expected:
+            raise WorkshopHumanAvatarConflict("Human avatar changed since it was loaded")
+        if not before.active:
+            return HumanAvatarSnapshot(
+                before.principal_id,
+                before.state_version,
+                False,
+                mutation_changed=False,
+            )
+        return await self._change(
+            principal_id,
+            payload=payload,
+            expected_state_version=expected,
+            operation_id=operation_id,
+            normalized=None,
+        )
+
+    async def retrieve(
+        self,
+        requester_principal_id: PrincipalId,
+        target_principal_id: PrincipalId,
+        state_version: int,
+    ) -> HumanAvatarBytes:
+        if state_version <= 0:
+            raise WorkshopHumanAvatarAccessDenied("Avatar access denied")
+        await self._require_shared_workshop(requester_principal_id, target_principal_id)
+        snapshot = await self._snapshot(target_principal_id)
+        if not snapshot.active or snapshot.state_version != state_version:
+            raise WorkshopHumanAvatarAccessDenied("Avatar access denied")
+        path = self._avatar_path(target_principal_id, state_version)
+        try:
+            if path.parent.is_symlink():
+                raise WorkshopHumanAvatarStorageError("Avatar bytes are unavailable")
+            stat = path.lstat()
+            if not path.is_file() or path.is_symlink() or stat.st_size != snapshot.byte_size:
+                raise WorkshopHumanAvatarStorageError("Avatar bytes are unavailable")
+            digest = await asyncio.to_thread(_sha256_file, path)
+        except FileNotFoundError as exc:
+            raise WorkshopHumanAvatarStorageError("Avatar bytes are unavailable") from exc
+        if digest != snapshot.sha256:
+            raise WorkshopHumanAvatarStorageError("Avatar bytes failed integrity validation")
+        return HumanAvatarBytes(snapshot=snapshot, path=path)
+
+    async def _change(
+        self,
+        principal_id: PrincipalId,
+        *,
+        payload: dict[str, object],
+        expected_state_version: int,
+        operation_id: str,
+        normalized: _NormalizedAvatar | None,
+    ) -> HumanAvatarSnapshot:
+        connection = self._store.connection
+        created_path: Path | None = None
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            idempotency_key = f"workshop-client:human-avatar:{principal_id}:{operation_id}"
+            existing = await self._store.event_by_idempotency_key(idempotency_key)
+            if existing is not None:
+                self._validate_replay(existing, principal_id, payload)
+                current = await self._snapshot(principal_id)
+                if (
+                    normalized is not None
+                    and current.active
+                    and current.state_version == expected_state_version + 1
+                    and current.sha256 == normalized.sha256
+                ):
+                    replay_path = self._avatar_path(principal_id, current.state_version)
+                    if not replay_path.exists():
+                        await asyncio.to_thread(self._write_version_file, replay_path, normalized.content)
+                await connection.rollback()
+                return _with_mutation(current, changed=True, replayed=True)
+            before = await self._snapshot(principal_id)
+            if before.state_version != expected_state_version:
+                raise WorkshopHumanAvatarConflict("Human avatar changed since it was loaded")
+            if normalized is not None:
+                created_path = self._avatar_path(principal_id, expected_state_version + 1)
+                await asyncio.to_thread(self._write_version_file, created_path, normalized.content)
+            workshop_id = await self._workshop_id(principal_id)
+            event = EventEnvelope.create(
+                event_type=WorkshopEventType.PRINCIPAL_AVATAR_CHANGED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="principal_profile",
+                aggregate_id=principal_id,
+                actor_principal_id=principal_id,
+                occurred_at=datetime.now(UTC),
+                idempotency_key=idempotency_key,
+                payload=payload,
+                metadata={"source": "workshop_client"},
+            )
+            result = await self._store.append_in_transaction(event)
+            if not result.inserted:
+                raise WorkshopHumanAvatarConflict("New human-avatar event already exists")
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            after = await self._snapshot(principal_id)
+            await connection.commit()
+        except WorkshopHumanAvatarError:
+            await connection.rollback()
+            if created_path is not None:
+                await asyncio.to_thread(_unlink_if_exists, created_path)
+            raise
+        except Exception as exc:
+            await connection.rollback()
+            if created_path is not None:
+                await asyncio.to_thread(_unlink_if_exists, created_path)
+            raise WorkshopHumanAvatarStorageError("Human avatar could not be saved") from exc
+        try:
+            await asyncio.to_thread(
+                self._remove_other_versions,
+                principal_id,
+                after.state_version if after.active else None,
+            )
+        except OSError:
+            # The canonical mutation succeeded. Retained obsolete bytes are
+            # non-authoritative and surfaced by install diagnostics.
+            pass
+        return _with_mutation(after, changed=True)
+
+    async def _snapshot(self, principal_id: PrincipalId) -> HumanAvatarSnapshot:
+        async with self._store.connection.execute(
+            "SELECT state_version, active, media_type, byte_size, width, height, sha256 "
+            "FROM principal_avatars WHERE principal_id = ?",
+            (principal_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            return HumanAvatarSnapshot(principal_id, 0, False)
+        return HumanAvatarSnapshot(
+            principal_id,
+            int(row[0]),
+            bool(row[1]),
+            str(row[2]) if row[2] is not None else None,
+            int(row[3]) if row[3] is not None else None,
+            int(row[4]) if row[4] is not None else None,
+            int(row[5]) if row[5] is not None else None,
+            str(row[6]) if row[6] is not None else None,
+        )
+
+    async def _require_human(self, principal_id: PrincipalId) -> None:
+        if not isinstance(principal_id, PrincipalId):
+            raise WorkshopHumanAvatarAccessDenied("Avatar access denied")
+        async with self._store.connection.execute(
+            "SELECT 1 FROM principals p JOIN workshop_memberships wm ON wm.principal_id = p.id "
+            "WHERE p.id = ? AND p.kind = 'human' LIMIT 1",
+            (principal_id,),
+        ) as cursor:
+            if await cursor.fetchone() is None:
+                raise WorkshopHumanAvatarAccessDenied("Avatar access denied")
+
+    async def _require_shared_workshop(self, requester: PrincipalId, target: PrincipalId) -> None:
+        if not isinstance(requester, PrincipalId) or not isinstance(target, PrincipalId):
+            raise WorkshopHumanAvatarAccessDenied("Avatar access denied")
+        async with self._store.connection.execute(
+            "SELECT 1 FROM workshop_memberships requester "
+            "JOIN workshop_memberships target ON target.workshop_id = requester.workshop_id "
+            "JOIN principals requester_principal "
+            "ON requester_principal.id = requester.principal_id AND requester_principal.kind = 'human' "
+            "JOIN principals target_principal "
+            "ON target_principal.id = target.principal_id AND target_principal.kind = 'human' "
+            "WHERE requester.principal_id = ? AND target.principal_id = ? LIMIT 1",
+            (requester, target),
+        ) as cursor:
+            if await cursor.fetchone() is None:
+                raise WorkshopHumanAvatarAccessDenied("Avatar access denied")
+
+    async def _workshop_id(self, principal_id: PrincipalId) -> WorkshopId:
+        async with self._store.connection.execute(
+            "SELECT workshop_id FROM workshop_memberships WHERE principal_id = ? ORDER BY created_at LIMIT 1",
+            (principal_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise WorkshopHumanAvatarAccessDenied("Avatar access denied")
+        return WorkshopId(str(row[0]))
+
+    def _avatar_path(self, principal_id: PrincipalId, state_version: int) -> Path:
+        path = self._root / str(principal_id) / f"{state_version}.png"
+        if not path.resolve().is_relative_to(self._root):
+            raise WorkshopHumanAvatarStorageError("Avatar storage boundary rejected the path")
+        return path
+
+    def _write_version_file(self, path: Path, content: bytes) -> None:
+        self._root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if self._root.is_symlink() or not self._root.is_dir():
+            raise WorkshopHumanAvatarStorageError("Avatar storage root is invalid")
+        os.chmod(self._root, 0o700)
+        path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if path.parent.is_symlink() or not path.parent.is_dir() or path.parent.resolve().parent != self._root:
+            raise WorkshopHumanAvatarStorageError("Avatar storage boundary rejected the path")
+        os.chmod(path.parent, 0o700)
+        if path.exists():
+            if path.is_symlink() or not path.is_file() or _sha256_file(path) != hashlib.sha256(content).hexdigest():
+                raise WorkshopHumanAvatarStorageError("Avatar version path already contains different bytes")
+            return
+        descriptor, temporary_name = tempfile.mkstemp(prefix=".avatar-", dir=path.parent)
+        temporary_path = Path(temporary_name)
+        try:
+            with os.fdopen(descriptor, "wb") as output:
+                output.write(content)
+                output.flush()
+                os.fsync(output.fileno())
+            os.chmod(temporary_path, 0o600)
+            os.link(temporary_path, path)
+            os.chmod(path, 0o600)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+    def _remove_other_versions(self, principal_id: PrincipalId, keep_version: int | None) -> None:
+        directory = self._root / str(principal_id)
+        if directory.is_symlink():
+            raise OSError("Avatar principal storage directory is a symlink")
+        try:
+            entries = tuple(directory.iterdir())
+        except FileNotFoundError:
+            return
+        keep_name = f"{keep_version}.png" if keep_version is not None else None
+        for path in entries:
+            if path.name != keep_name and path.is_file() and not path.is_symlink():
+                path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _validate_replay(stored: StoredEvent, principal_id: PrincipalId, payload: dict[str, object]) -> None:
+        envelope = stored.envelope
+        if (
+            envelope.event_type != WorkshopEventType.PRINCIPAL_AVATAR_CHANGED
+            or envelope.event_version != 1
+            or envelope.aggregate_type != "principal_profile"
+            or envelope.aggregate_id != principal_id
+            or envelope.actor_principal_id != principal_id
+            or envelope.payload != payload
+        ):
+            raise WorkshopHumanAvatarConflict(
+                "client_operation_id is already bound to a different human-avatar operation"
+            )
+
+
+def _with_mutation(
+    snapshot: HumanAvatarSnapshot,
+    *,
+    changed: bool,
+    replayed: bool = False,
+) -> HumanAvatarSnapshot:
+    return HumanAvatarSnapshot(
+        snapshot.principal_id,
+        snapshot.state_version,
+        snapshot.active,
+        snapshot.media_type,
+        snapshot.byte_size,
+        snapshot.width,
+        snapshot.height,
+        snapshot.sha256,
+        mutation_changed=changed,
+        replayed=replayed,
+    )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _unlink_if_exists(path: Path) -> None:
+    path.unlink(missing_ok=True)

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -1107,7 +1107,7 @@ class CanonicalConversationProjection:
 
     name = "canonical_conversations"
     # Agent ownership and runtime sponsorship project from explicit authority events.
-    version = 25
+    version = 26
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -1132,6 +1132,7 @@ class CanonicalConversationProjection:
             "human_notification_adapter_delivery_decisions",
             "human_notification_publications",
             "human_notifications",
+            "principal_avatars",
             "principal_direct_message_archives",
             "thread_read_positions",
             "channel_read_positions",
@@ -1264,6 +1265,102 @@ class CanonicalConversationProjection:
             )
             if cursor.rowcount != 1:
                 raise ValueError("Workshop display-name change is stale or unauthorized")
+        elif envelope.event_type == WorkshopEventType.PRINCIPAL_AVATAR_CHANGED:
+            if envelope.event_version != 1:
+                raise ValueError("Unsupported Workshop avatar event version")
+            if (
+                not isinstance(envelope.aggregate_id, PrincipalId)
+                or envelope.aggregate_type != "principal_profile"
+                or envelope.actor_principal_id != envelope.aggregate_id
+            ):
+                raise ValueError("Workshop avatar changes require a self-owned principal profile")
+            expected_state_version = payload.get("expected_state_version")
+            if (
+                not isinstance(expected_state_version, int)
+                or isinstance(expected_state_version, bool)
+                or expected_state_version < 0
+            ):
+                raise ValueError("Workshop avatar expected version is invalid")
+            active = not payload.get("cleared", False)
+            if active:
+                _require_exact_payload(
+                    payload,
+                    {
+                        "expected_state_version",
+                        "media_type",
+                        "byte_size",
+                        "width",
+                        "height",
+                        "sha256",
+                    },
+                )
+                media_type = _required_text(payload, "media_type")
+                byte_size = payload.get("byte_size")
+                width = payload.get("width")
+                height = payload.get("height")
+                sha256 = _required_text(payload, "sha256")
+                if (
+                    media_type != "image/png"
+                    or not isinstance(byte_size, int)
+                    or isinstance(byte_size, bool)
+                    or byte_size <= 0
+                    or byte_size > 512 * 1024
+                    or not isinstance(width, int)
+                    or isinstance(width, bool)
+                    or width <= 0
+                    or width > 256
+                    or not isinstance(height, int)
+                    or isinstance(height, bool)
+                    or height <= 0
+                    or height > 256
+                    or not re.fullmatch(r"[0-9a-f]{64}", sha256)
+                ):
+                    raise ValueError("Workshop avatar metadata is invalid")
+            else:
+                _require_exact_payload(payload, {"expected_state_version", "cleared"})
+                if payload.get("cleared") is not True:
+                    raise ValueError("Workshop avatar clear payload is invalid")
+                media_type = None
+                byte_size = None
+                width = None
+                height = None
+                sha256 = None
+            async with connection.execute(
+                "SELECT state_version FROM principal_avatars WHERE principal_id = ?",
+                (envelope.aggregate_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            current_version = int(row[0]) if row is not None else 0
+            if current_version != expected_state_version:
+                raise ValueError("Workshop avatar change is stale")
+            async with connection.execute(
+                "SELECT 1 FROM principals p JOIN workshop_memberships wm ON wm.principal_id = p.id "
+                "WHERE p.id = ? AND p.kind = 'human' AND wm.workshop_id = ?",
+                (envelope.aggregate_id, envelope.workshop_id),
+            ) as cursor:
+                if await cursor.fetchone() is None:
+                    raise ValueError("Workshop avatar change is unauthorized")
+            next_version = expected_state_version + 1
+            await connection.execute(
+                "INSERT INTO principal_avatars "
+                "(principal_id, state_version, active, media_type, byte_size, width, height, sha256, event_position) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(principal_id) DO UPDATE SET state_version = excluded.state_version, "
+                "active = excluded.active, media_type = excluded.media_type, byte_size = excluded.byte_size, "
+                "width = excluded.width, height = excluded.height, sha256 = excluded.sha256, "
+                "event_position = excluded.event_position",
+                (
+                    envelope.aggregate_id,
+                    next_version,
+                    int(active),
+                    media_type,
+                    byte_size,
+                    width,
+                    height,
+                    sha256,
+                    event.position,
+                ),
+            )
         elif envelope.event_type == WorkshopEventType.EXTERNAL_IDENTITY_BOUND:
             await connection.execute(
                 "INSERT INTO external_identities "

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 64
+WORKSHOP_SCHEMA_VERSION = 65
 
 
 @dataclass(frozen=True, slots=True)
@@ -2818,6 +2818,33 @@ _CANONICAL_HUMAN_PROFILE_SCHEMA = SchemaMigration(
     ),
 )
 
+_CANONICAL_HUMAN_AVATAR_SCHEMA = SchemaMigration(
+    version=65,
+    name="canonical_human_profile_avatars",
+    statements=(
+        """
+        CREATE TABLE principal_avatars (
+            principal_id TEXT PRIMARY KEY REFERENCES principals(id) ON DELETE CASCADE,
+            state_version INTEGER NOT NULL CHECK (state_version > 0),
+            active INTEGER NOT NULL CHECK (active IN (0, 1)),
+            media_type TEXT,
+            byte_size INTEGER CHECK (byte_size IS NULL OR byte_size > 0),
+            width INTEGER CHECK (width IS NULL OR width > 0),
+            height INTEGER CHECK (height IS NULL OR height > 0),
+            sha256 TEXT,
+            event_position INTEGER NOT NULL UNIQUE REFERENCES event_log(position) ON DELETE RESTRICT,
+            CHECK (
+                (active = 1 AND media_type = 'image/png' AND byte_size IS NOT NULL
+                    AND width IS NOT NULL AND height IS NOT NULL AND length(sha256) = 64)
+                OR
+                (active = 0 AND media_type IS NULL AND byte_size IS NULL
+                    AND width IS NULL AND height IS NULL AND sha256 IS NULL)
+            )
+        )
+        """,
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -2883,6 +2910,7 @@ _MIGRATIONS = (
     _CANONICAL_FOLLOWED_THREAD_UNREAD_SCHEMA,
     _PRINCIPAL_DIRECT_MESSAGE_ARCHIVE_SCHEMA,
     _CANONICAL_HUMAN_PROFILE_SCHEMA,
+    _CANONICAL_HUMAN_AVATAR_SCHEMA,
 )
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8919,7 +8919,8 @@ class TestReviewedDependencyConstraints:
             "requests==2.33.0",
             "setuptools==83.0.0",
             "torch==2.13.0",
-            "tornado==6.5.7",
+            "tornado==6.5.8",
+            "transformers==5.10.1",
             "urllib3==2.7.0",
         } <= constraints
 

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -418,7 +418,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 64
+        assert await upgraded.schema_version() == 65
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -529,7 +529,7 @@ class TestArtifactShadowRecordingAfterRestart:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 25
+            assert checkpoint.version == 26
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import json
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
@@ -12,6 +13,7 @@ from types import SimpleNamespace
 import pytest
 from aiohttp import FormData, web
 from aiohttp.test_utils import TestClient, TestServer
+from PIL import Image
 
 from kai.workshop.agent_enablement import EligibleAgentRuntime, PrincipalAgentEnablement
 from kai.workshop.appearance_preferences import (
@@ -49,6 +51,7 @@ from kai.workshop.client_sessions import (
     WorkshopClientSessionManager,
 )
 from kai.workshop.conversation_commands import ConversationCommandDisposition
+from kai.workshop.diagnostics import workshop_human_avatar_status
 from kai.workshop.domain import (
     AgentDefinitionId,
     AgentId,
@@ -74,6 +77,7 @@ from kai.workshop.github_settings import (
     WorkshopGitHubSettingsAccessDenied,
     WorkshopGitHubSettingsConflict,
 )
+from kai.workshop.human_avatars import WorkshopHumanAvatarService
 from kai.workshop.inbound import (
     ClientInboundMessage,
     InboundBindingNotFoundError,
@@ -866,6 +870,7 @@ async def _open_client(
     client_preferences=None,
     appearance_preferences=None,
     agent_enablement=None,
+    human_avatars=None,
 ) -> TestClient:
     app = web.Application()
     register_workshop_read_routes(
@@ -888,6 +893,7 @@ async def _open_client(
         client_preferences=client_preferences,
         appearance_preferences=appearance_preferences,
         agent_enablement=agent_enablement,
+        human_avatars=human_avatars,
     )
     client = TestClient(TestServer(app))
     await client.start_server()
@@ -1030,6 +1036,429 @@ async def test_memory_api_uses_bearer_principal_and_stable_read_schema(
         )
         assert foreign.status == 404
         assert await foreign.json() == {"error": {"code": "memory_not_found", "message": "Memory not found"}}
+    finally:
+        await client.close()
+        await store.close()
+
+
+def _avatar_form(content: bytes, *, media_type: str, expected_version: int, operation_id: str) -> FormData:
+    form = FormData()
+    form.add_field("client_operation_id", operation_id)
+    form.add_field("file", content, filename="avatar", content_type=media_type)
+    form.add_field("expected_state_version", str(expected_version))
+    return form
+
+
+def _jpeg_avatar_bytes(color: tuple[int, int, int] = (32, 96, 160)) -> bytes:
+    output = io.BytesIO()
+    Image.new("RGB", (640, 320), color).save(
+        output,
+        format="JPEG",
+        exif=b"Exif\x00\x00private metadata",
+    )
+    return output.getvalue()
+
+
+def _avatar_bytes(image_format: str, *, size: tuple[int, int] = (96, 48)) -> bytes:
+    output = io.BytesIO()
+    mode = "RGB" if image_format == "JPEG" else "RGBA"
+    color = (220, 40, 60) if mode == "RGB" else (220, 40, 60, 255)
+    Image.new(mode, size, color).save(output, format=image_format)
+    return output.getvalue()
+
+
+def _animated_gif_avatar_bytes() -> bytes:
+    output = io.BytesIO()
+    first = Image.new("RGB", (32, 32), (255, 0, 0))
+    second = Image.new("RGB", (32, 32), (0, 0, 255))
+    first.save(output, format="GIF", save_all=True, append_images=[second], duration=100, loop=0)
+    return output.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_human_avatar_api_normalizes_versions_authorizes_and_clears(
+    tmp_path: Path,
+) -> None:
+    store, alice_id, _, bob_id, _ = await _open_store(tmp_path / "kai.db")
+    async with store.connection.execute("SELECT id FROM principals WHERE kind = 'agent' ORDER BY id LIMIT 1") as cursor:
+        agent_row = await cursor.fetchone()
+    assert agent_row is not None
+    agent_principal_id = PrincipalId(str(agent_row[0]))
+    service = WorkshopHumanAvatarService(store, data_dir=tmp_path)
+    client = await _open_client(
+        store,
+        _Authenticator(
+            {
+                "alice-token": alice_id,
+                "bob-token": bob_id,
+                "agent-token": agent_principal_id,
+            }
+        ),
+        human_avatars=service,
+    )
+    alice_headers = {"Authorization": "Bearer alice-token"}
+    bob_headers = {"Authorization": "Bearer bob-token"}
+    source = _jpeg_avatar_bytes()
+    try:
+        initial = await client.get("/v1/settings/profile/avatar", headers=alice_headers)
+        assert initial.status == 200
+        assert await initial.json() == {
+            "version": 1,
+            "principal_id": str(alice_id),
+            "state_version": 0,
+            "active": False,
+            "media_type": None,
+            "byte_size": None,
+            "width": None,
+            "height": None,
+            "sha256": None,
+            "url": None,
+            "mutation": None,
+        }
+
+        uploaded = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=alice_headers,
+            data=_avatar_form(source, media_type="image/jpeg", expected_version=0, operation_id="avatar-1"),
+        )
+        payload = await uploaded.json()
+        assert uploaded.status == 200
+        assert payload["state_version"] == 1
+        assert payload["active"] is True
+        assert payload["media_type"] == "image/png"
+        assert payload["width"] == 256
+        assert payload["height"] == 128
+        assert payload["mutation"] == {"changed": True, "replayed": False}
+        assert payload["url"] == f"/v1/principals/{alice_id}/avatar/1"
+
+        content = await client.get(payload["url"], headers=bob_headers)
+        normalized = await content.read()
+        assert content.status == 200
+        assert content.headers["Content-Type"].startswith("image/png")
+        assert content.headers["Cache-Control"] == "private, max-age=31536000, immutable"
+        assert content.headers["X-Content-Type-Options"] == "nosniff"
+        assert len(normalized) == payload["byte_size"]
+        with Image.open(io.BytesIO(normalized)) as decoded:
+            assert decoded.format == "PNG"
+            assert decoded.size == (256, 128)
+            assert decoded.info == {}
+        nonhuman = await client.get(
+            payload["url"],
+            headers={"Authorization": "Bearer agent-token"},
+        )
+        assert nonhuman.status == 404
+
+        conflicting_replay = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=alice_headers,
+            data=_avatar_form(
+                _jpeg_avatar_bytes((160, 96, 32)),
+                media_type="image/jpeg",
+                expected_version=0,
+                operation_id="avatar-1",
+            ),
+        )
+        assert conflicting_replay.status == 409
+
+        replay = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=alice_headers,
+            data=_avatar_form(source, media_type="image/jpeg", expected_version=0, operation_id="avatar-1"),
+        )
+        assert replay.status == 200
+        assert (await replay.json())["mutation"] == {"changed": True, "replayed": True}
+        stale = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=alice_headers,
+            data=_avatar_form(source, media_type="image/jpeg", expected_version=0, operation_id="avatar-2"),
+        )
+        assert stale.status == 409
+
+        cleared = await client.delete(
+            "/v1/settings/profile/avatar",
+            headers=alice_headers,
+            json={"expected_state_version": 1, "client_operation_id": "avatar-clear-1"},
+        )
+        cleared_payload = await cleared.json()
+        assert cleared.status == 200
+        assert cleared_payload["state_version"] == 2
+        assert cleared_payload["active"] is False
+        assert cleared_payload["url"] is None
+        assert (await client.get(payload["url"], headers=bob_headers)).status == 404
+
+        replay_clear = await client.delete(
+            "/v1/settings/profile/avatar",
+            headers=alice_headers,
+            json={"expected_state_version": 1, "client_operation_id": "avatar-clear-1"},
+        )
+        assert replay_clear.status == 200
+        assert (await replay_clear.json())["mutation"] == {"changed": True, "replayed": True}
+
+        await store.rebuild_projection(CanonicalConversationProjection())
+        rebuilt = await client.get("/v1/settings/profile/avatar", headers=alice_headers)
+        rebuilt_payload = await rebuilt.json()
+        assert rebuilt_payload["state_version"] == 2
+        assert rebuilt_payload["active"] is False
+
+        reuploaded = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=alice_headers,
+            data=_avatar_form(source, media_type="image/jpeg", expected_version=2, operation_id="avatar-2"),
+        )
+        reuploaded_payload = await reuploaded.json()
+        assert reuploaded.status == 200
+        assert reuploaded_payload["state_version"] == 3
+        assert (await client.get(reuploaded_payload["url"], headers=bob_headers)).status == 200
+        assert (await client.get("/v1/settings/profile/avatar")).status == 401
+        status = workshop_human_avatar_status(tmp_path / "kai.db", service.storage_root)
+        assert "active; states=1, active=1, cleared=0" in status
+        assert "missing files=0, orphaned files=0, corrupt files=0, malformed=0" in status
+    finally:
+        await client.close()
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_human_avatar_api_rejects_mismatched_and_oversized_uploads(
+    tmp_path: Path,
+) -> None:
+    store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+    client = await _open_client(
+        store,
+        _Authenticator({"alice-token": alice_id}),
+        human_avatars=WorkshopHumanAvatarService(store, data_dir=tmp_path),
+    )
+    headers = {"Authorization": "Bearer alice-token"}
+    try:
+        mismatch = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=headers,
+            data=_avatar_form(
+                _jpeg_avatar_bytes(),
+                media_type="image/png",
+                expected_version=0,
+                operation_id="mismatch",
+            ),
+        )
+        oversized = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=headers,
+            data=_avatar_form(
+                b"x" * (256 * 1024 + 1),
+                media_type="image/png",
+                expected_version=0,
+                operation_id="oversized",
+            ),
+        )
+        malformed = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=headers,
+            data=_avatar_form(
+                b"not an image",
+                media_type="image/png",
+                expected_version=0,
+                operation_id="malformed",
+            ),
+        )
+        svg = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=headers,
+            data=_avatar_form(
+                b'<svg xmlns="http://www.w3.org/2000/svg"/>',
+                media_type="image/svg+xml",
+                expected_version=0,
+                operation_id="svg",
+            ),
+        )
+        dangerous_dimensions = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=headers,
+            data=_avatar_form(
+                _avatar_bytes("PNG", size=(4097, 1)),
+                media_type="image/png",
+                expected_version=0,
+                operation_id="dimensions",
+            ),
+        )
+        assert mismatch.status == 415
+        assert oversized.status == 413
+        assert malformed.status == 400
+        assert svg.status == 415
+        assert dangerous_dimensions.status == 413
+        async with store.connection.execute("SELECT COUNT(*) FROM principal_avatars") as cursor:
+            assert int((await cursor.fetchone())[0]) == 0
+    finally:
+        await client.close()
+        await store.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("image_format", "media_type"),
+    (("PNG", "image/png"), ("JPEG", "image/jpeg"), ("GIF", "image/gif"), ("WEBP", "image/webp")),
+)
+async def test_human_avatar_api_accepts_every_bounded_raster_format(
+    tmp_path: Path,
+    image_format: str,
+    media_type: str,
+) -> None:
+    store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+    service = WorkshopHumanAvatarService(store, data_dir=tmp_path)
+    client = await _open_client(
+        store,
+        _Authenticator({"alice-token": alice_id}),
+        human_avatars=service,
+    )
+    try:
+        uploaded = await client.post(
+            "/v1/settings/profile/avatar",
+            headers={"Authorization": "Bearer alice-token"},
+            data=_avatar_form(
+                _avatar_bytes(image_format),
+                media_type=media_type,
+                expected_version=0,
+                operation_id=f"format-{image_format.lower()}",
+            ),
+        )
+        payload = await uploaded.json()
+        assert uploaded.status == 200
+        assert payload["media_type"] == "image/png"
+        normalized = await client.get(
+            payload["url"],
+            headers={"Authorization": "Bearer alice-token"},
+        )
+        with Image.open(io.BytesIO(await normalized.read())) as decoded:
+            assert decoded.format == "PNG"
+            assert decoded.size == (96, 48)
+            assert decoded.info == {}
+    finally:
+        await client.close()
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_human_avatar_api_flattens_animation_to_the_first_frame(tmp_path: Path) -> None:
+    store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+    service = WorkshopHumanAvatarService(store, data_dir=tmp_path)
+    client = await _open_client(
+        store,
+        _Authenticator({"alice-token": alice_id}),
+        human_avatars=service,
+    )
+    headers = {"Authorization": "Bearer alice-token"}
+    try:
+        uploaded = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=headers,
+            data=_avatar_form(
+                _animated_gif_avatar_bytes(),
+                media_type="image/gif",
+                expected_version=0,
+                operation_id="animated-gif",
+            ),
+        )
+        payload = await uploaded.json()
+        normalized = await client.get(payload["url"], headers=headers)
+        with Image.open(io.BytesIO(await normalized.read())) as decoded:
+            assert getattr(decoded, "n_frames", 1) == 1
+            assert decoded.convert("RGB").getpixel((0, 0)) == (255, 0, 0)
+    finally:
+        await client.close()
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_human_avatar_api_isolates_workshops_and_reports_storage_damage(
+    tmp_path: Path,
+) -> None:
+    store, alice_id, _, bob_id, _ = await _open_store(tmp_path / "kai.db")
+    foreign_workshop_id = WorkshopId.new()
+    foreign_principal_id = PrincipalId.new()
+    await store.connection.execute(
+        "INSERT INTO workshops (id, name, created_at) VALUES (?, ?, ?)",
+        (foreign_workshop_id, "Foreign", _NOW.isoformat()),
+    )
+    await store.connection.execute(
+        "INSERT INTO principals (id, kind, display_name, created_at) VALUES (?, 'human', ?, ?)",
+        (foreign_principal_id, "Foreign human", _NOW.isoformat()),
+    )
+    await store.connection.execute(
+        "INSERT INTO workshop_memberships (id, workshop_id, principal_id, role, created_at) "
+        "VALUES (?, ?, ?, 'member', ?)",
+        (WorkshopMembershipId.new(), foreign_workshop_id, foreign_principal_id, _NOW.isoformat()),
+    )
+    await store.connection.commit()
+    service = WorkshopHumanAvatarService(store, data_dir=tmp_path)
+    client = await _open_client(
+        store,
+        _Authenticator(
+            {
+                "alice-token": alice_id,
+                "bob-token": bob_id,
+                "foreign-token": foreign_principal_id,
+            }
+        ),
+        human_avatars=service,
+    )
+    alice_headers = {"Authorization": "Bearer alice-token"}
+    try:
+        uploaded = await client.post(
+            "/v1/settings/profile/avatar",
+            headers=alice_headers,
+            data=_avatar_form(
+                _avatar_bytes("PNG"),
+                media_type="image/png",
+                expected_version=0,
+                operation_id="storage-check",
+            ),
+        )
+        payload = await uploaded.json()
+        assert uploaded.status == 200
+        assert (
+            await client.get(
+                payload["url"],
+                headers={"Authorization": "Bearer foreign-token"},
+            )
+        ).status == 404
+        cross_principal_mutation = await client.delete(
+            "/v1/settings/profile/avatar",
+            headers=alice_headers,
+            json={
+                "expected_state_version": 1,
+                "client_operation_id": "foreign-clear",
+                "principal_id": str(bob_id),
+            },
+        )
+        assert cross_principal_mutation.status == 400
+
+        path = service.storage_root / str(alice_id) / "1.png"
+        original = path.read_bytes()
+        assert path.stat().st_mode & 0o777 == 0o600
+        assert path.parent.stat().st_mode & 0o777 == 0o700
+        path.unlink()
+        assert (await client.get(payload["url"], headers=alice_headers)).status == 503
+        assert "missing files=1" in workshop_human_avatar_status(tmp_path / "kai.db", service.storage_root)
+
+        path.write_bytes(original)
+        path.chmod(0o600)
+        path.write_bytes(bytes((original[0] ^ 0xFF,)) + original[1:])
+        assert (await client.get(payload["url"], headers=alice_headers)).status == 503
+        assert "corrupt files=1" in workshop_human_avatar_status(tmp_path / "kai.db", service.storage_root)
+
+        path.write_bytes(original)
+        orphan = path.parent / "999.png"
+        orphan.write_bytes(b"orphan")
+        assert "orphaned files=1" in workshop_human_avatar_status(tmp_path / "kai.db", service.storage_root)
+        orphan.unlink()
+
+        await store.connection.execute(
+            "UPDATE principal_avatars SET sha256 = ? WHERE principal_id = ?",
+            ("z" * 64, alice_id),
+        )
+        await store.connection.commit()
+        malformed_status = workshop_human_avatar_status(tmp_path / "kai.db", service.storage_root)
+        assert "INCOMPLETE" in malformed_status
+        assert "malformed=1" in malformed_status
     finally:
         await client.close()
         await store.close()

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -389,7 +389,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 25
+            assert checkpoint.version == 26
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -285,7 +285,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
             after = workshop_runtime_session_status(path)
             assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
@@ -313,7 +313,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
             assert session is not None
             assert session.runtime_profile_id == _RUNTIME_PROFILE_ID

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -91,6 +91,7 @@ class TestEventEnvelope:
             "principal.created",
             "principal.handle_assigned",
             "principal.display_name_changed",
+            "principal.avatar_changed",
             "external_identity.bound",
             "channel.created",
             "channel.archived",
@@ -248,6 +249,7 @@ class TestWorkshopSchema:
             "channel_unread_migration_baselines",
             "channel_read_positions",
             "principal_direct_message_archives",
+            "principal_avatars",
             "thread_unread_authority_cutover",
             "thread_read_positions",
             "event_log",
@@ -255,7 +257,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 64
+        assert await workshop_store.schema_version() == 65
         async with workshop_store.connection.execute("PRAGMA table_info(principals)") as cursor:
             principal_columns = {str(row[1]) for row in await cursor.fetchall()}
         assert {"display_name_state_version", "display_name_event_position"} <= principal_columns
@@ -306,7 +308,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 64
+        assert await second.schema_version() == 65
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -338,7 +340,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -366,7 +368,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -448,6 +450,7 @@ class TestWorkshopSchema:
                     62,
                     63,
                     64,
+                    65,
                 ]
         finally:
             await upgraded.close()
@@ -470,7 +473,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -511,7 +514,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -564,7 +567,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -608,7 +611,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -652,7 +655,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -696,7 +699,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -800,7 +803,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -927,7 +930,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -319,7 +319,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 64
+            assert await upgraded.schema_version() == 65
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -391,7 +391,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 25
+            assert checkpoint.version == 26
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -166,7 +166,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 25
+            assert checkpoint.version == 26
             assert after == before
         finally:
             await store.close()

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -178,7 +178,7 @@ class TestRuntimeAssignmentPolicy:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 25
+            assert checkpoint.version == 26
             assert await resolve_channel_runtime_profile(store, human.channel_id) == (
                 assigned.agent_id,
                 profile_id(202),


### PR DESCRIPTION
## Summary

- add canonical, versioned, self-owned human-avatar state and deterministic projection replay
- normalize bounded PNG, JPEG, GIF, and WebP uploads into metadata-free static PNGs in a dedicated private storage namespace
- add authenticated inspect/upload/clear and shared-Workshop retrieval routes with optimistic concurrency and idempotency
- add install diagnostics for missing, corrupt, orphaned, and malformed avatar state
- add Pillow as a direct dependency and advance newly vulnerable Tornado/Transformers constraints to fixed releases

The Workshop rendering and profile-editing UI remains isolated in follow-up #1413.

## Validation

- `make test` — 6,449 passed
- `make check`
- `make typecheck`
- `make audit-deps` — no known vulnerabilities
- all supported install dependency combinations resolve under `requirements/constraints.txt`

Closes #1412
