### PR TITLE
Add attempt-scoped collaboration authority foundation

### DIFF
--- a/src/kai/workshop/agent_definitions.py
+++ b/src/kai/workshop/agent_definitions.py
@@ -20,6 +20,16 @@ AGENT_CAPABILITIES = frozenset(
         "agent_delegation",
     }
 )
+COLLABORATION_OPERATIONS = frozenset(
+    {
+        "context_read",
+        "reaction",
+        "progress_publish",
+        "thread_reply",
+        "artifact_publish",
+        "agent_delegation",
+    }
+)
 MAX_AGENT_DISPLAY_NAME = 80
 MAX_AGENT_DESCRIPTION = 1_000
 MAX_AGENT_PURPOSE = 2_000
@@ -40,6 +50,7 @@ class AgentDefinitionRevision:
     purpose: str
     instructions: str
     capabilities: tuple[str, ...]
+    collaboration_operations: tuple[str, ...]
 
 
 def normalize_agent_handle(value: object) -> str:
@@ -81,14 +92,33 @@ def validate_agent_capabilities(value: object) -> tuple[str, ...]:
     return tuple(sorted(value))
 
 
+def validate_collaboration_operations(value: object) -> tuple[str, ...]:
+    """Validate the versioned collaboration vocabulary independently of runtime capabilities."""
+    if not isinstance(value, list):
+        raise ValueError("Agent collaboration operations must be a list")
+    if any(not isinstance(item, str) or item not in COLLABORATION_OPERATIONS for item in value):
+        raise ValueError("Agent collaboration operations contain an unsupported value")
+    if len(set(value)) != len(value):
+        raise ValueError("Agent collaboration operations must be unique")
+    return tuple(sorted(value))
+
+
+def collaboration_operations_for_capabilities(capabilities: tuple[str, ...]) -> tuple[str, ...]:
+    """Preserve legacy delegation declarations without conflating both vocabularies."""
+    return ("agent_delegation",) if "agent_delegation" in capabilities else ()
+
+
 async def load_agent_definition_revision(
     store: WorkshopEventStore,
     revision_id: AgentDefinitionRevisionId,
 ) -> AgentDefinitionRevision | None:
+    async with store.connection.execute("PRAGMA table_info(agent_definition_revisions)") as cursor:
+        columns = {str(row[1]) for row in await cursor.fetchall()}
+    collaboration_column = ", r.collaboration_operations_json" if "collaboration_operations_json" in columns else ""
     async with store.connection.execute(
         "SELECT d.id, r.id, d.workshop_id, d.agent_id, d.handle, d.display_name, d.description, "
         "d.lifecycle_state, r.revision_number, r.purpose, r.instructions, "
-        "r.capabilities_json FROM agent_definition_revisions r "
+        f"r.capabilities_json{collaboration_column} FROM agent_definition_revisions r "
         "JOIN agent_definitions d ON d.id = r.agent_definition_id WHERE r.id = ?",
         (revision_id,),
     ) as cursor:
@@ -96,6 +126,11 @@ async def load_agent_definition_revision(
     if row is None:
         return None
     capabilities = validate_agent_capabilities(json.loads(str(row[11])))
+    collaboration_operations = (
+        validate_collaboration_operations(json.loads(str(row[12])))
+        if len(row) > 12
+        else collaboration_operations_for_capabilities(capabilities)
+    )
     return AgentDefinitionRevision(
         definition_id=AgentDefinitionId(str(row[0])),
         revision_id=AgentDefinitionRevisionId(str(row[1])),
@@ -109,6 +144,7 @@ async def load_agent_definition_revision(
         purpose=str(row[9]),
         instructions=str(row[10]),
         capabilities=capabilities,
+        collaboration_operations=collaboration_operations,
     )
 
 
@@ -129,6 +165,7 @@ async def active_agent_definition_revision(
 def render_agent_definition_context(revision: AgentDefinitionRevision) -> str:
     """Render behavior metadata; this block conveys no additional authority."""
     capabilities = ", ".join(revision.capabilities)
+    collaboration_operations = ", ".join(revision.collaboration_operations) or "none"
     return (
         "<kai_agent_definition>\n"
         f"Handle: @{revision.handle}\n"
@@ -136,6 +173,7 @@ def render_agent_definition_context(revision: AgentDefinitionRevision) -> str:
         f"Definition revision: {revision.revision_number} ({revision.revision_id})\n"
         f"Purpose: {revision.purpose}\n"
         f"Declared capabilities: {capabilities}\n"
+        f"Requested collaboration operations: {collaboration_operations}\n"
         "Instructions:\n"
         f"{revision.instructions}\n"
         "This versioned agent definition describes behavior only. It does not grant "

--- a/src/kai/workshop/collaboration_authority.py
+++ b/src/kai/workshop/collaboration_authority.py
@@ -1,0 +1,575 @@
+"""Attempt-scoped authority for structured Workshop agent collaboration."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+import secrets
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from kai.workshop.agent_definitions import (
+    COLLABORATION_OPERATIONS,
+    AgentDefinitionRevision,
+    load_agent_definition_revision,
+    validate_collaboration_operations,
+)
+from kai.workshop.domain import (
+    AgentDefinitionRevisionId,
+    AgentId,
+    ChannelId,
+    CollaborationGrantId,
+    EventEnvelope,
+    EventId,
+    MessageId,
+    PrincipalId,
+    RunAttemptId,
+    RunExecutionOwnerId,
+    RunId,
+    RuntimeProfileId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_execution_authority import RunExecutionClaim
+from kai.workshop.store import WorkshopEventStore
+
+_REVOCATION_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_PROOF_REDACTION = "[redacted collaboration proof]"
+
+
+class CollaborationOperation(StrEnum):
+    """Versioned operation groups kept separate from runtime capabilities."""
+
+    CONTEXT_READ = "context_read"
+    REACTION = "reaction"
+    PROGRESS_PUBLISH = "progress_publish"
+    THREAD_REPLY = "thread_reply"
+    ARTIFACT_PUBLISH = "artifact_publish"
+    AGENT_DELEGATION = "agent_delegation"
+
+
+if {item.value for item in CollaborationOperation} != COLLABORATION_OPERATIONS:
+    raise RuntimeError("Collaboration operation vocabulary drifted from agent-definition validation")
+
+
+class CollaborationAuthorityError(RuntimeError):
+    """Base error for collaboration-grant operations."""
+
+
+class CollaborationProofError(CollaborationAuthorityError):
+    """A transient invocation proof is absent, unknown, or no longer usable."""
+
+
+class CollaborationDenied(CollaborationAuthorityError):
+    """A known invocation does not have the requested effective authority."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class CollaborationGrantConflict(CollaborationAuthorityError):
+    """Durable state conflicts with the proposed attempt grant."""
+
+
+@dataclass(frozen=True, slots=True)
+class CollaborationOwnerPolicy:
+    """Owner-controlled allowance captured immutably at attempt acceptance."""
+
+    version: int
+    allowed_operations: frozenset[CollaborationOperation]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.version, int) or isinstance(self.version, bool) or self.version < 0:
+            raise ValueError("owner policy version must be a non-negative integer")
+        _validate_operation_set(self.allowed_operations, field_name="owner allowed_operations")
+
+
+@dataclass(frozen=True, slots=True)
+class CollaborationHostPolicy:
+    """Server-owned maxima that no agent revision or owner can exceed."""
+
+    version: int = 1
+    allowed_operations: frozenset[CollaborationOperation] = frozenset(CollaborationOperation)
+    quotas: Mapping[CollaborationOperation, int] = field(
+        default_factory=lambda: {
+            CollaborationOperation.CONTEXT_READ: 200,
+            CollaborationOperation.REACTION: 64,
+            CollaborationOperation.PROGRESS_PUBLISH: 32,
+            CollaborationOperation.THREAD_REPLY: 32,
+            CollaborationOperation.ARTIFACT_PUBLISH: 16,
+            CollaborationOperation.AGENT_DELEGATION: 12,
+        }
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.version, int) or isinstance(self.version, bool) or self.version < 1:
+            raise ValueError("host policy version must be a positive integer")
+        _validate_operation_set(self.allowed_operations, field_name="host allowed_operations")
+        if set(self.quotas) != set(self.allowed_operations):
+            raise ValueError("host quotas must cover exactly the host-allowed operations")
+        if any(not isinstance(limit, int) or isinstance(limit, bool) or limit < 1 for limit in self.quotas.values()):
+            raise ValueError("host quotas must be positive integers")
+
+
+@dataclass(frozen=True, slots=True)
+class CollaborationGrantSnapshot:
+    grant_id: CollaborationGrantId
+    attempt_id: RunAttemptId
+    run_id: RunId
+    execution_owner_id: RunExecutionOwnerId
+    fence_token: int
+    workshop_id: WorkshopId
+    requested_by_principal_id: PrincipalId
+    agent_principal_id: PrincipalId
+    agent_id: AgentId
+    agent_definition_revision_id: AgentDefinitionRevisionId
+    sponsor_principal_id: PrincipalId
+    runtime_profile_id: RuntimeProfileId
+    channel_id: ChannelId
+    thread_root_id: MessageId | None
+    requested_operations: frozenset[CollaborationOperation]
+    owner_allowed_operations: frozenset[CollaborationOperation]
+    host_allowed_operations: frozenset[CollaborationOperation]
+    effective_operations: frozenset[CollaborationOperation]
+    owner_policy_version: int
+    host_policy_version: int
+    quotas: Mapping[CollaborationOperation, int]
+    proof_fingerprint: str
+    issued_at: datetime
+    initial_lease_expires_at: datetime
+    revoked_at: datetime | None
+    revocation_code: str | None
+    state_version: int
+
+
+@dataclass(frozen=True, slots=True)
+class CollaborationInvocation:
+    """Transient proof held only for one live attempt and never persisted."""
+
+    grant_id: CollaborationGrantId
+    attempt_id: RunAttemptId
+    token: str = field(repr=False)
+
+    def redact(self, text: str) -> str:
+        return text.replace(self.token, _PROOF_REDACTION)
+
+
+@dataclass(frozen=True, slots=True)
+class CollaborationAuthorization:
+    """Server-derived context returned after a proof and live-state check."""
+
+    grant: CollaborationGrantSnapshot
+    operation: CollaborationOperation
+
+
+type OwnerPolicyResolver = Callable[[AgentDefinitionRevision], CollaborationOwnerPolicy]
+
+
+def _default_owner_policy(revision: AgentDefinitionRevision) -> CollaborationOwnerPolicy:
+    """Preserve existing delegation only; every new operation starts denied."""
+    allowed = (
+        frozenset({CollaborationOperation.AGENT_DELEGATION})
+        if CollaborationOperation.AGENT_DELEGATION.value in revision.collaboration_operations
+        else frozenset()
+    )
+    return CollaborationOwnerPolicy(version=0, allowed_operations=allowed)
+
+
+def _validate_operation_set(value: object, *, field_name: str) -> None:
+    if not isinstance(value, frozenset) or any(not isinstance(item, CollaborationOperation) for item in value):
+        raise TypeError(f"{field_name} must be a frozenset of CollaborationOperation values")
+
+
+def _timestamp(value: datetime, *, field_name: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    return value.astimezone(UTC)
+
+
+def _parse_timestamp(value: object) -> datetime:
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _operations_json(operations: frozenset[CollaborationOperation]) -> list[str]:
+    return sorted(item.value for item in operations)
+
+
+def _decode_operations(value: object) -> frozenset[CollaborationOperation]:
+    normalized = validate_collaboration_operations(json.loads(str(value)))
+    return frozenset(CollaborationOperation(item) for item in normalized)
+
+
+class WorkshopCollaborationAuthority:
+    """Issue durable grants and authenticate transient exact-attempt proofs."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        *,
+        host_policy: CollaborationHostPolicy | None = None,
+        owner_policy_resolver: OwnerPolicyResolver | None = None,
+        token_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self._store = store
+        self._host_policy = host_policy or CollaborationHostPolicy()
+        self._owner_policy_resolver = owner_policy_resolver or _default_owner_policy
+        self._token_factory = token_factory or (lambda: secrets.token_urlsafe(32))
+        self._invocations_by_token: dict[str, CollaborationInvocation] = {}
+        self._invocations_by_attempt: dict[RunAttemptId, CollaborationInvocation] = {}
+
+    async def available(self) -> bool:
+        """Return whether the current database has crossed the authority schema boundary."""
+        async with self._store.connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'collaboration_grants'"
+        ) as cursor:
+            return await cursor.fetchone() is not None
+
+    async def issue(
+        self,
+        claim: RunExecutionClaim,
+        *,
+        occurred_at: datetime,
+    ) -> tuple[CollaborationGrantSnapshot, CollaborationInvocation]:
+        """Snapshot effective policy for one exact started attempt and mint its proof."""
+        if not isinstance(claim, RunExecutionClaim):
+            raise ValueError("claim must be a RunExecutionClaim")
+        now = _timestamp(occurred_at, field_name="occurred_at")
+        existing_invocation = self._invocations_by_attempt.get(claim.attempt_id)
+        if existing_invocation is not None:
+            return await self.snapshot(existing_invocation.grant_id), existing_invocation
+
+        connection = self._store.connection
+        token = self._new_token()
+        fingerprint = hashlib.sha256(token.encode()).hexdigest()
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            async with connection.execute(
+                "SELECT ra.run_id, ra.owner_id, ra.fence_token, ra.status, ra.lease_expires_at, "
+                "r.workshop_id, r.requested_by_principal_id, r.agent_id, "
+                "r.agent_definition_revision_id, r.sponsor_principal_id, r.runtime_profile_id, "
+                "r.channel_id, r.status, r.cancellation_requested_at, m.thread_root_id, a.principal_id "
+                "FROM run_attempts ra JOIN runs r ON r.id = ra.run_id "
+                "JOIN messages m ON m.id = r.inbound_message_id "
+                "JOIN agents a ON a.id = r.agent_id WHERE ra.id = ?",
+                (claim.attempt_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if (
+                row is None
+                or RunId(str(row[0])) != claim.run_id
+                or RunExecutionOwnerId(str(row[1])) != claim.owner_id
+                or int(row[2]) != claim.fence_token
+                or str(row[3]) != "started"
+                or str(row[12]) != "started"
+                or row[13] is not None
+                or now >= _parse_timestamp(row[4])
+            ):
+                raise CollaborationGrantConflict("Collaboration requires the exact active started attempt")
+            revision_id = AgentDefinitionRevisionId(str(row[8]))
+            revision = await load_agent_definition_revision(self._store, revision_id)
+            if revision is None or revision.agent_id != AgentId(str(row[7])):
+                raise CollaborationGrantConflict("Collaboration revision is unavailable")
+            requested = frozenset(CollaborationOperation(item) for item in revision.collaboration_operations)
+            owner_policy = self._owner_policy_resolver(revision)
+            if not isinstance(owner_policy, CollaborationOwnerPolicy):
+                raise TypeError("owner_policy_resolver must return CollaborationOwnerPolicy")
+            host_allowed = self._host_policy.allowed_operations
+            effective = requested & owner_policy.allowed_operations & host_allowed
+            grant_id = CollaborationGrantId.derived(claim.attempt_id, "collaboration-grant")
+            key = f"workshop-collaboration-grant:v1:{grant_id}:issued"
+            prior = await self._store.event_by_idempotency_key(key)
+            if prior is not None:
+                await connection.rollback()
+                raise CollaborationGrantConflict("Durable collaboration grant exists without a live invocation proof")
+            workshop_id = WorkshopId(str(row[5]))
+            requested_by = PrincipalId(str(row[6]))
+            agent_id = AgentId(str(row[7]))
+            sponsor = PrincipalId(str(row[9]))
+            runtime_profile = RuntimeProfileId(str(row[10]))
+            channel_id = ChannelId(str(row[11]))
+            thread_root = MessageId(str(row[14])) if row[14] is not None else None
+            agent_principal = PrincipalId(str(row[15]))
+            expiry = _parse_timestamp(row[4])
+            event = EventEnvelope.create(
+                event_id=EventId.derived(grant_id, "issued"),
+                event_type=WorkshopEventType.COLLABORATION_GRANT_ISSUED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="collaboration_grant",
+                aggregate_id=grant_id,
+                actor_principal_id=agent_principal,
+                occurred_at=now,
+                idempotency_key=key,
+                payload={
+                    "attempt_id": claim.attempt_id,
+                    "run_id": claim.run_id,
+                    "execution_owner_id": claim.owner_id,
+                    "fence_token": claim.fence_token,
+                    "requested_by_principal_id": requested_by,
+                    "agent_principal_id": agent_principal,
+                    "agent_id": agent_id,
+                    "agent_definition_revision_id": revision_id,
+                    "sponsor_principal_id": sponsor,
+                    "runtime_profile_id": runtime_profile,
+                    "channel_id": channel_id,
+                    "thread_root_id": thread_root,
+                    "requested_operations": _operations_json(requested),
+                    "owner_allowed_operations": _operations_json(owner_policy.allowed_operations),
+                    "host_allowed_operations": _operations_json(host_allowed),
+                    "effective_operations": _operations_json(effective),
+                    "owner_policy_version": owner_policy.version,
+                    "host_policy_version": self._host_policy.version,
+                    "quotas": {
+                        operation.value: self._host_policy.quotas[operation]
+                        for operation in sorted(effective, key=lambda item: item.value)
+                    },
+                    "proof_fingerprint": fingerprint,
+                    "initial_lease_expires_at": expiry.isoformat(),
+                },
+                metadata={"source": "workshop_collaboration_authority"},
+            )
+            await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(projection)
+            snapshot = await self._snapshot(grant_id)
+            await connection.commit()
+        except Exception:
+            await connection.rollback()
+            raise
+        invocation = CollaborationInvocation(grant_id, claim.attempt_id, token)
+        self._invocations_by_token[token] = invocation
+        self._invocations_by_attempt[claim.attempt_id] = invocation
+        return snapshot, invocation
+
+    async def authenticate(
+        self,
+        token: str,
+        operation: CollaborationOperation,
+        *,
+        occurred_at: datetime,
+    ) -> CollaborationAuthorization:
+        """Resolve an untrusted token through the exact live grant and attempt."""
+        if not isinstance(operation, CollaborationOperation):
+            raise ValueError("operation must be a CollaborationOperation")
+        invocation = self._match_token(token)
+        if invocation is None:
+            raise CollaborationProofError("Invalid collaboration proof")
+        now = _timestamp(occurred_at, field_name="occurred_at")
+        grant = await self._live_grant(invocation.grant_id, occurred_at=now)
+        fingerprint = hashlib.sha256(token.encode()).hexdigest()
+        if not hmac.compare_digest(fingerprint, grant.proof_fingerprint):
+            raise CollaborationProofError("Invalid collaboration proof")
+        if operation not in grant.effective_operations:
+            raise CollaborationDenied(
+                "operation_not_granted",
+                f"The active attempt is not authorized for {operation.value}",
+            )
+        return CollaborationAuthorization(grant, operation)
+
+    async def revoke(
+        self,
+        invocation: CollaborationInvocation,
+        *,
+        revocation_code: str,
+        occurred_at: datetime,
+    ) -> tuple[CollaborationGrantSnapshot, bool]:
+        """Fence one live proof first, then record durable revocation."""
+        if not isinstance(invocation, CollaborationInvocation):
+            raise ValueError("invocation must be a CollaborationInvocation")
+        if not _REVOCATION_CODE_PATTERN.fullmatch(revocation_code):
+            raise ValueError("revocation_code must be a lowercase bounded identifier")
+        now = _timestamp(occurred_at, field_name="occurred_at")
+        self._drop_invocation(invocation)
+        return await self._revoke_grant(
+            invocation.grant_id,
+            revocation_code=revocation_code,
+            occurred_at=now,
+        )
+
+    async def reconcile_unbound(self, *, occurred_at: datetime) -> int:
+        """Durably revoke grants whose transient proof did not survive this host."""
+        now = _timestamp(occurred_at, field_name="occurred_at")
+        async with self._store.connection.execute(
+            "SELECT id FROM collaboration_grants WHERE revoked_at IS NULL ORDER BY issued_event_position"
+        ) as cursor:
+            grant_ids = [CollaborationGrantId(str(row[0])) for row in await cursor.fetchall()]
+        live_grants = {invocation.grant_id for invocation in self._invocations_by_attempt.values()}
+        reconciled = 0
+        for grant_id in grant_ids:
+            if grant_id in live_grants:
+                continue
+            _snapshot, changed = await self._revoke_grant(
+                grant_id,
+                revocation_code="host_restart",
+                occurred_at=now,
+            )
+            reconciled += int(changed)
+        return reconciled
+
+    async def _revoke_grant(
+        self,
+        grant_id: CollaborationGrantId,
+        *,
+        revocation_code: str,
+        occurred_at: datetime,
+    ) -> tuple[CollaborationGrantSnapshot, bool]:
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            current = await self._snapshot(grant_id)
+            if current.revoked_at is not None:
+                await connection.commit()
+                return current, False
+            key = f"workshop-collaboration-grant:v1:{grant_id}:revoked"
+            event = EventEnvelope.create(
+                event_id=EventId.derived(grant_id, "revoked"),
+                event_type=WorkshopEventType.COLLABORATION_GRANT_REVOKED,
+                event_version=1,
+                workshop_id=current.workshop_id,
+                aggregate_type="collaboration_grant",
+                aggregate_id=grant_id,
+                actor_principal_id=current.agent_principal_id,
+                occurred_at=occurred_at,
+                idempotency_key=key,
+                payload={
+                    "revocation_code": revocation_code,
+                    "expected_state_version": current.state_version,
+                },
+                metadata={"source": "workshop_collaboration_authority"},
+            )
+            await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(projection)
+            updated = await self._snapshot(grant_id)
+            await connection.commit()
+            return updated, True
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def snapshot(self, grant_id: CollaborationGrantId) -> CollaborationGrantSnapshot:
+        if not isinstance(grant_id, CollaborationGrantId):
+            raise ValueError("grant_id must be a CollaborationGrantId")
+        snapshot = await self._snapshot(grant_id)
+        return snapshot
+
+    def _new_token(self) -> str:
+        for _ in range(100):
+            token = self._token_factory()
+            if not isinstance(token, str) or len(token) < 32:
+                raise ValueError("collaboration token factory must return at least 32 characters")
+            if token not in self._invocations_by_token:
+                return token
+        raise RuntimeError("Could not allocate a unique collaboration proof")
+
+    def _match_token(self, token: str) -> CollaborationInvocation | None:
+        if not isinstance(token, str) or not token:
+            return None
+        matched = None
+        for expected, invocation in self._invocations_by_token.items():
+            if hmac.compare_digest(token, expected):
+                matched = invocation
+        return matched
+
+    def _drop_invocation(self, invocation: CollaborationInvocation) -> None:
+        current = self._invocations_by_attempt.get(invocation.attempt_id)
+        if current == invocation:
+            self._invocations_by_attempt.pop(invocation.attempt_id, None)
+        stored = self._invocations_by_token.get(invocation.token)
+        if stored == invocation:
+            self._invocations_by_token.pop(invocation.token, None)
+
+    async def _live_grant(
+        self,
+        grant_id: CollaborationGrantId,
+        *,
+        occurred_at: datetime,
+    ) -> CollaborationGrantSnapshot:
+        snapshot = await self._snapshot(grant_id)
+        async with self._store.connection.execute(
+            "SELECT ra.status, ra.lease_expires_at, r.status, r.cancellation_requested_at, "
+            "d.lifecycle_state, c.archived_at, "
+            "EXISTS(SELECT 1 FROM channel_agents ca WHERE ca.channel_id = g.channel_id "
+            "AND ca.agent_id = g.agent_id AND ca.sponsor_principal_id = g.sponsor_principal_id "
+            "AND ca.sponsored_runtime_profile_id = g.runtime_profile_id AND ca.detached_at IS NULL), "
+            "EXISTS(SELECT 1 FROM principal_agent_enablements pae "
+            "WHERE pae.principal_id = g.sponsor_principal_id AND pae.agent_id = g.agent_id "
+            "AND pae.runtime_profile_id = g.runtime_profile_id AND pae.lifecycle_state = 'enabled') "
+            "FROM collaboration_grants g JOIN run_attempts ra ON ra.id = g.attempt_id "
+            "JOIN runs r ON r.id = g.run_id JOIN agent_definition_revisions revision "
+            "ON revision.id = g.agent_definition_revision_id JOIN agent_definitions d "
+            "ON d.id = revision.agent_definition_id JOIN channels c ON c.id = g.channel_id "
+            "WHERE g.id = ?",
+            (grant_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if snapshot.revoked_at is not None:
+            raise CollaborationDenied("grant_revoked", "The collaboration grant was revoked")
+        if row is None:
+            raise CollaborationProofError("Collaboration grant is unavailable")
+        if str(row[0]) != "started" or str(row[2]) != "started" or row[3] is not None:
+            raise CollaborationDenied("attempt_not_active", "The collaboration attempt is no longer active")
+        if occurred_at >= _parse_timestamp(row[1]):
+            raise CollaborationDenied("grant_expired", "The collaboration grant has expired")
+        if str(row[4]) != "active" or row[5] is not None:
+            raise CollaborationDenied("agent_unavailable", "The collaboration agent or channel is unavailable")
+        if not bool(row[6]) or not bool(row[7]):
+            raise CollaborationDenied("authority_detached", "The collaboration runtime authority is detached")
+        return snapshot
+
+    async def _snapshot(self, grant_id: CollaborationGrantId) -> CollaborationGrantSnapshot:
+        async with self._store.connection.execute(
+            "SELECT id, attempt_id, run_id, execution_owner_id, fence_token, workshop_id, "
+            "requested_by_principal_id, agent_principal_id, agent_id, "
+            "agent_definition_revision_id, sponsor_principal_id, runtime_profile_id, "
+            "channel_id, thread_root_id, requested_operations_json, "
+            "owner_allowed_operations_json, host_allowed_operations_json, "
+            "effective_operations_json, owner_policy_version, host_policy_version, quotas_json, "
+            "proof_fingerprint, issued_at, initial_lease_expires_at, revoked_at, "
+            "revocation_code, state_version FROM collaboration_grants WHERE id = ?",
+            (grant_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise CollaborationGrantConflict("Collaboration grant was not found")
+        quotas_payload = json.loads(str(row[20]))
+        if not isinstance(quotas_payload, dict):
+            raise CollaborationGrantConflict("Stored collaboration quotas are invalid")
+        quotas = {CollaborationOperation(str(key)): int(value) for key, value in quotas_payload.items()}
+        return CollaborationGrantSnapshot(
+            grant_id=CollaborationGrantId(str(row[0])),
+            attempt_id=RunAttemptId(str(row[1])),
+            run_id=RunId(str(row[2])),
+            execution_owner_id=RunExecutionOwnerId(str(row[3])),
+            fence_token=int(row[4]),
+            workshop_id=WorkshopId(str(row[5])),
+            requested_by_principal_id=PrincipalId(str(row[6])),
+            agent_principal_id=PrincipalId(str(row[7])),
+            agent_id=AgentId(str(row[8])),
+            agent_definition_revision_id=AgentDefinitionRevisionId(str(row[9])),
+            sponsor_principal_id=PrincipalId(str(row[10])),
+            runtime_profile_id=RuntimeProfileId(str(row[11])),
+            channel_id=ChannelId(str(row[12])),
+            thread_root_id=MessageId(str(row[13])) if row[13] is not None else None,
+            requested_operations=_decode_operations(row[14]),
+            owner_allowed_operations=_decode_operations(row[15]),
+            host_allowed_operations=_decode_operations(row[16]),
+            effective_operations=_decode_operations(row[17]),
+            owner_policy_version=int(row[18]),
+            host_policy_version=int(row[19]),
+            quotas=quotas,
+            proof_fingerprint=str(row[21]),
+            issued_at=_parse_timestamp(row[22]),
+            initial_lease_expires_at=_parse_timestamp(row[23]),
+            revoked_at=_parse_timestamp(row[24]) if row[24] is not None else None,
+            revocation_code=str(row[25]) if row[25] is not None else None,
+            state_version=int(row[26]),
+        )

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -79,6 +79,8 @@ class WorkshopEventType(StrEnum):
     RUN_ATTEMPT_COMPLETED = "run_attempt.completed"
     RUN_ATTEMPT_FAILED = "run_attempt.failed"
     RUN_ATTEMPT_CANCELLED = "run_attempt.cancelled"
+    COLLABORATION_GRANT_ISSUED = "collaboration_grant.issued"
+    COLLABORATION_GRANT_REVOKED = "collaboration_grant.revoked"
     AGENT_DELEGATION_REQUESTED = "agent_delegation.requested"
     AGENT_DELEGATION_STARTED = "agent_delegation.started"
     AGENT_DELEGATION_COMPLETED = "agent_delegation.completed"
@@ -262,6 +264,10 @@ class RunExecutionOwnerId(OpaqueId):
     prefix = "reo"
 
 
+class CollaborationGrantId(OpaqueId):
+    prefix = "cgr"
+
+
 class AgentDelegationId(OpaqueId):
     prefix = "dlg"
 
@@ -299,6 +305,7 @@ _ID_TYPES: dict[str, type[OpaqueId]] = {
         DeliveryAuthorityEpochId,
         RunId,
         RunAttemptId,
+        CollaborationGrantId,
         AgentDelegationId,
         RunExecutionOwnerId,
         EventId,

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -18,6 +18,10 @@ from kai.workshop.agent_definitions import (
     render_agent_definition_context,
 )
 from kai.workshop.artifacts import ArtifactMessageNotFoundError, build_agent_prompt_for_message
+from kai.workshop.collaboration_authority import (
+    CollaborationInvocation,
+    WorkshopCollaborationAuthority,
+)
 from kai.workshop.conversation_context import assemble_canonical_conversation_context
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 from kai.workshop.domain import AgentId, ChannelId, RunExecutionOwnerId, RunId
@@ -117,6 +121,7 @@ class _ActiveExecution:
     prepared: PreparedWorkshopExecution | None = None
     authority: WorkshopRunExecutionAuthority | None = None
     claim: RunExecutionClaim | None = None
+    collaboration_invocation: CollaborationInvocation | None = None
     started: bool = False
     settling: bool = False
 
@@ -171,6 +176,12 @@ class WorkshopCanonicalExecutionCoordinator:
         self._artifact_storage_root = artifact_storage_root
         self._trace_store = WorkshopRunTraceStore(store)
         self._delivery_policy = delivery_policy
+        self._collaboration_authority = WorkshopCollaborationAuthority(store)
+
+    @property
+    def collaboration_authority(self) -> WorkshopCollaborationAuthority:
+        """Return the host-owned authority used by future backend tool bridges."""
+        return self._collaboration_authority
 
     async def execute(
         self,
@@ -290,6 +301,10 @@ class WorkshopCanonicalExecutionCoordinator:
                         occurred_at=now,
                     )
                     interrupted += 1
+            if await self._collaboration_authority.available():
+                await self._collaboration_authority.reconcile_unbound(
+                    occurred_at=now,
+                )
         return CanonicalRecoveryResult(expired, interrupted)
 
     async def _execute_owned(
@@ -325,6 +340,12 @@ class WorkshopCanonicalExecutionCoordinator:
                 started = await authority.start(granted.claim, occurred_at=self._now())
             active.claim = started.claim
             active.started = True
+            async with self._database_lock:
+                if await self._collaboration_authority.available():
+                    _grant, active.collaboration_invocation = await self._collaboration_authority.issue(
+                        started.claim,
+                        occurred_at=self._now(),
+                    )
 
             response = await self._consume_with_renewal(active, prepared, stream_observer=stream_observer)
             if active.cancellation_requested:
@@ -446,6 +467,20 @@ class WorkshopCanonicalExecutionCoordinator:
             return CanonicalExecutionResult(
                 CanonicalExecutionDisposition.PREPARATION_DEFERRED, await self._run(run.run_id)
             )
+        finally:
+            if active.collaboration_invocation is not None:
+                try:
+                    async with self._database_lock:
+                        await self._collaboration_authority.revoke(
+                            active.collaboration_invocation,
+                            revocation_code="attempt_terminal",
+                            occurred_at=self._now(),
+                        )
+                except Exception:
+                    # The transient proof is dropped before the durable event is
+                    # attempted, so failure remains fail-closed. Recovery and
+                    # diagnostics can reconcile the immutable grant later.
+                    log.exception("Workshop collaboration-grant revocation could not be recorded")
 
     async def _settle_requested_cancellation(self, active: _ActiveExecution) -> CanonicalExecutionResult:
         await active.cancellation_done.wait()

--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from kai.workshop.artifacts import StagedArtifact
+from kai.workshop.collaboration_authority import WorkshopCollaborationAuthority
 from kai.workshop.conversation_commands import (
     ClientConversationCommandAcceptance,
     ConversationCommandAcceptance,
@@ -123,6 +124,11 @@ class WorkshopPrivateTextExecutionService:
     @property
     def ready(self) -> bool:
         return not self._closed and self._task is not None and not self._task.done()
+
+    @property
+    def collaboration_authority(self) -> WorkshopCollaborationAuthority:
+        """Expose the coordinator-owned authority to trusted host adapters only."""
+        return self._coordinator.collaboration_authority
 
     async def accept(
         self,

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -17,10 +17,12 @@ from kai.workshop.agent_definitions import (
     MAX_AGENT_DISPLAY_NAME,
     MAX_AGENT_INSTRUCTIONS,
     MAX_AGENT_PURPOSE,
+    collaboration_operations_for_capabilities,
     normalize_agent_handle,
     validate_agent_capabilities,
     validate_agent_presentation,
     validate_agent_text,
+    validate_collaboration_operations,
 )
 from kai.workshop.domain import (
     AgentDefinitionId,
@@ -30,6 +32,7 @@ from kai.workshop.domain import (
     AgentId,
     ChannelId,
     ChannelReadPositionId,
+    CollaborationGrantId,
     HumanNotificationId,
     MessageId,
     PrincipalId,
@@ -804,6 +807,206 @@ async def _apply_run_attempt_event(connection: aiosqlite.Connection, event: Stor
     )
 
 
+async def _apply_collaboration_grant_event(
+    connection: aiosqlite.Connection,
+    event: StoredEvent,
+) -> None:
+    envelope = event.envelope
+    if (
+        not isinstance(envelope.aggregate_id, CollaborationGrantId)
+        or envelope.aggregate_type != "collaboration_grant"
+        or envelope.event_version != 1
+    ):
+        raise ValueError("Workshop collaboration-grant events require a typed v1 grant aggregate")
+    payload = envelope.payload
+    occurred_at = envelope.occurred_at
+
+    if envelope.event_type == WorkshopEventType.COLLABORATION_GRANT_ISSUED:
+        _require_exact_payload(
+            payload,
+            {
+                "attempt_id",
+                "run_id",
+                "execution_owner_id",
+                "fence_token",
+                "requested_by_principal_id",
+                "agent_principal_id",
+                "agent_id",
+                "agent_definition_revision_id",
+                "sponsor_principal_id",
+                "runtime_profile_id",
+                "channel_id",
+                "thread_root_id",
+                "requested_operations",
+                "owner_allowed_operations",
+                "host_allowed_operations",
+                "effective_operations",
+                "owner_policy_version",
+                "host_policy_version",
+                "quotas",
+                "proof_fingerprint",
+                "initial_lease_expires_at",
+            },
+        )
+        attempt_id = RunAttemptId(_required_text(payload, "attempt_id"))
+        run_id = RunId(_required_text(payload, "run_id"))
+        execution_owner_id = RunExecutionOwnerId(_required_text(payload, "execution_owner_id"))
+        requested_by = PrincipalId(_required_text(payload, "requested_by_principal_id"))
+        agent_principal = PrincipalId(_required_text(payload, "agent_principal_id"))
+        agent_id = AgentId(_required_text(payload, "agent_id"))
+        revision_id = AgentDefinitionRevisionId(_required_text(payload, "agent_definition_revision_id"))
+        sponsor = PrincipalId(_required_text(payload, "sponsor_principal_id"))
+        runtime_profile_id = _required_text(payload, "runtime_profile_id")
+        channel_id = ChannelId(_required_text(payload, "channel_id"))
+        thread_value = payload.get("thread_root_id")
+        thread_root_id = MessageId(str(thread_value)) if thread_value is not None else None
+        fence_token = payload.get("fence_token")
+        owner_policy_version = payload.get("owner_policy_version")
+        host_policy_version = payload.get("host_policy_version")
+        if (
+            isinstance(fence_token, bool)
+            or not isinstance(fence_token, int)
+            or fence_token < 1
+            or isinstance(owner_policy_version, bool)
+            or not isinstance(owner_policy_version, int)
+            or owner_policy_version < 0
+            or isinstance(host_policy_version, bool)
+            or not isinstance(host_policy_version, int)
+            or host_policy_version < 1
+        ):
+            raise ValueError("Workshop collaboration policy and fence versions are invalid")
+        requested = validate_collaboration_operations(payload.get("requested_operations"))
+        owner_allowed = validate_collaboration_operations(payload.get("owner_allowed_operations"))
+        host_allowed = validate_collaboration_operations(payload.get("host_allowed_operations"))
+        effective = validate_collaboration_operations(payload.get("effective_operations"))
+        if set(effective) != set(requested).intersection(owner_allowed, host_allowed):
+            raise ValueError("Workshop collaboration effective operations do not match the policy intersection")
+        quotas = payload.get("quotas")
+        if (
+            not isinstance(quotas, dict)
+            or set(quotas) != set(effective)
+            or any(
+                operation not in effective or isinstance(limit, bool) or not isinstance(limit, int) or limit < 1
+                for operation, limit in quotas.items()
+            )
+        ):
+            raise ValueError("Workshop collaboration quotas are invalid")
+        proof_fingerprint = _required_text(payload, "proof_fingerprint")
+        if not _SHA256_PATTERN.fullmatch(proof_fingerprint):
+            raise ValueError("Workshop collaboration proof fingerprint must be SHA-256")
+        initial_expiry = _parse_projection_timestamp(payload.get("initial_lease_expires_at"))
+        async with connection.execute(
+            "SELECT ra.run_id, ra.owner_id, ra.fence_token, ra.status, ra.lease_expires_at, "
+            "r.workshop_id, r.requested_by_principal_id, r.agent_id, "
+            "r.agent_definition_revision_id, r.sponsor_principal_id, r.runtime_profile_id, "
+            "r.channel_id, m.thread_root_id, a.principal_id "
+            "FROM run_attempts ra JOIN runs r ON r.id = ra.run_id "
+            "JOIN messages m ON m.id = r.inbound_message_id "
+            "JOIN agents a ON a.id = r.agent_id WHERE ra.id = ?",
+            (attempt_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if (
+            row is None
+            or RunId(str(row[0])) != run_id
+            or RunExecutionOwnerId(str(row[1])) != execution_owner_id
+            or int(row[2]) != fence_token
+            or str(row[3]) != "started"
+            or _parse_projection_timestamp(row[4]) != initial_expiry
+            or WorkshopId(str(row[5])) != envelope.workshop_id
+            or requested_by != PrincipalId(str(row[6]))
+            or agent_id != AgentId(str(row[7]))
+            or revision_id != AgentDefinitionRevisionId(str(row[8]))
+            or sponsor != PrincipalId(str(row[9]))
+            or runtime_profile_id != str(row[10])
+            or channel_id != ChannelId(str(row[11]))
+            or thread_root_id != (MessageId(str(row[12])) if row[12] is not None else None)
+            or agent_principal != PrincipalId(str(row[13]))
+            or envelope.actor_principal_id != agent_principal
+            or envelope.aggregate_id != CollaborationGrantId.derived(attempt_id, "collaboration-grant")
+            or occurred_at >= initial_expiry
+        ):
+            raise ValueError("Workshop collaboration grant does not match its active attempt")
+        async with connection.execute(
+            "SELECT collaboration_operations_json FROM agent_definition_revisions WHERE id = ?",
+            (revision_id,),
+        ) as cursor:
+            revision_row = await cursor.fetchone()
+        if revision_row is None or requested != validate_collaboration_operations(json.loads(str(revision_row[0]))):
+            raise ValueError("Workshop collaboration request does not match the immutable revision")
+        await connection.execute(
+            "INSERT INTO collaboration_grants "
+            "(id, attempt_id, run_id, execution_owner_id, fence_token, workshop_id, "
+            "requested_by_principal_id, agent_principal_id, agent_id, "
+            "agent_definition_revision_id, sponsor_principal_id, runtime_profile_id, "
+            "channel_id, thread_root_id, requested_operations_json, "
+            "owner_allowed_operations_json, host_allowed_operations_json, "
+            "effective_operations_json, owner_policy_version, host_policy_version, "
+            "quotas_json, proof_fingerprint, issued_at, initial_lease_expires_at, "
+            "issued_event_position) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                envelope.aggregate_id,
+                attempt_id,
+                run_id,
+                execution_owner_id,
+                fence_token,
+                envelope.workshop_id,
+                requested_by,
+                agent_principal,
+                agent_id,
+                revision_id,
+                sponsor,
+                runtime_profile_id,
+                channel_id,
+                thread_root_id,
+                json.dumps(requested, separators=(",", ":")),
+                json.dumps(owner_allowed, separators=(",", ":")),
+                json.dumps(host_allowed, separators=(",", ":")),
+                json.dumps(effective, separators=(",", ":")),
+                owner_policy_version,
+                host_policy_version,
+                json.dumps(quotas, separators=(",", ":"), sort_keys=True),
+                proof_fingerprint,
+                occurred_at.isoformat(),
+                initial_expiry.isoformat(),
+                event.position,
+            ),
+        )
+        return
+
+    if envelope.event_type == WorkshopEventType.COLLABORATION_GRANT_REVOKED:
+        _require_exact_payload(payload, {"revocation_code", "expected_state_version"})
+        revocation_code = _required_text(payload, "revocation_code")
+        expected_state_version = payload.get("expected_state_version")
+        if (
+            not _RUN_TERMINAL_CODE_PATTERN.fullmatch(revocation_code)
+            or isinstance(expected_state_version, bool)
+            or not isinstance(expected_state_version, int)
+            or expected_state_version < 0
+        ):
+            raise ValueError("Workshop collaboration revocation state is invalid")
+        async with connection.execute(
+            "SELECT agent_principal_id, state_version, revoked_at FROM collaboration_grants WHERE id = ?",
+            (envelope.aggregate_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if (
+            row is None
+            or envelope.actor_principal_id != PrincipalId(str(row[0]))
+            or int(row[1]) != expected_state_version
+            or row[2] is not None
+        ):
+            raise ValueError("Workshop collaboration grant revocation is stale")
+        await connection.execute(
+            "UPDATE collaboration_grants SET revoked_at = ?, revocation_code = ?, "
+            "revoked_event_position = ?, state_version = state_version + 1 WHERE id = ?",
+            (occurred_at.isoformat(), revocation_code, event.position, envelope.aggregate_id),
+        )
+        return
+
+    raise ValueError(f"Unsupported Workshop collaboration-grant event: {envelope.event_type}")
+
+
 async def _apply_agent_delegation_event(
     connection: aiosqlite.Connection,
     event: StoredEvent,
@@ -1107,7 +1310,7 @@ class CanonicalConversationProjection:
 
     name = "canonical_conversations"
     # Agent ownership and runtime sponsorship project from explicit authority events.
-    version = 26
+    version = 27
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -1126,6 +1329,7 @@ class CanonicalConversationProjection:
             "deliveries",
             "artifacts",
             "agent_delegations",
+            "collaboration_grants",
             "run_attempts",
             "runs",
             "message_reactions",
@@ -1160,6 +1364,13 @@ class CanonicalConversationProjection:
         envelope = event.envelope
         payload = envelope.payload
         occurred_at = envelope.occurred_at.isoformat()
+
+        if envelope.event_type in {
+            WorkshopEventType.COLLABORATION_GRANT_ISSUED,
+            WorkshopEventType.COLLABORATION_GRANT_REVOKED,
+        }:
+            await _apply_collaboration_grant_event(connection, event)
+            return
 
         if envelope.event_type in {
             WorkshopEventType.RUN_ACCEPTED,
@@ -1750,6 +1961,7 @@ class CanonicalConversationProjection:
                 payload.get("instructions"), field="instructions", maximum=MAX_AGENT_INSTRUCTIONS
             )
             capabilities = validate_agent_capabilities(payload.get("capabilities"))
+            collaboration_operations = collaboration_operations_for_capabilities(capabilities)
             async with connection.execute(
                 "SELECT workshop_id FROM agent_definitions WHERE id = ?", (definition_id,)
             ) as cursor:
@@ -1766,22 +1978,45 @@ class CanonicalConversationProjection:
             expected_number = int(revision_count_row[0]) + 1
             if revision_number != expected_number:
                 raise ValueError("Workshop agent revisions must be sequential")
-            await connection.execute(
-                "INSERT INTO agent_definition_revisions "
-                "(id, agent_definition_id, revision_number, purpose, instructions, "
-                "capabilities_json, created_at, created_event_position) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    envelope.aggregate_id,
-                    definition_id,
-                    revision_number,
-                    purpose,
-                    instructions,
-                    json.dumps(capabilities, separators=(",", ":")),
-                    occurred_at,
-                    event.position,
-                ),
-            )
+            if await _table_has_column(
+                connection,
+                "agent_definition_revisions",
+                "collaboration_operations_json",
+            ):
+                await connection.execute(
+                    "INSERT INTO agent_definition_revisions "
+                    "(id, agent_definition_id, revision_number, purpose, instructions, "
+                    "capabilities_json, collaboration_operations_json, created_at, created_event_position) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        envelope.aggregate_id,
+                        definition_id,
+                        revision_number,
+                        purpose,
+                        instructions,
+                        json.dumps(capabilities, separators=(",", ":")),
+                        json.dumps(collaboration_operations, separators=(",", ":")),
+                        occurred_at,
+                        event.position,
+                    ),
+                )
+            else:
+                await connection.execute(
+                    "INSERT INTO agent_definition_revisions "
+                    "(id, agent_definition_id, revision_number, purpose, instructions, "
+                    "capabilities_json, created_at, created_event_position) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        envelope.aggregate_id,
+                        definition_id,
+                        revision_number,
+                        purpose,
+                        instructions,
+                        json.dumps(capabilities, separators=(",", ":")),
+                        occurred_at,
+                        event.position,
+                    ),
+                )
         elif envelope.event_type == WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED:
             if (
                 not isinstance(envelope.aggregate_id, AgentDefinitionId)

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 66
+WORKSHOP_SCHEMA_VERSION = 67
 
 
 @dataclass(frozen=True, slots=True)
@@ -2876,6 +2876,80 @@ _EXPANDED_MESSAGE_REACTIONS_SCHEMA = SchemaMigration(
     ),
 )
 
+_ATTEMPT_SCOPED_COLLABORATION_AUTHORITY_SCHEMA = SchemaMigration(
+    version=67,
+    name="attempt_scoped_collaboration_authority",
+    statements=(
+        "ALTER TABLE agent_definition_revisions ADD COLUMN collaboration_operations_json "
+        "TEXT NOT NULL DEFAULT '[]' CHECK ("
+        "json_valid(collaboration_operations_json) "
+        "AND json_type(collaboration_operations_json) = 'array')",
+        "UPDATE agent_definition_revisions SET collaboration_operations_json = "
+        "'[\"agent_delegation\"]' WHERE EXISTS (SELECT 1 FROM json_each(capabilities_json) "
+        "WHERE value = 'agent_delegation')",
+        """
+        CREATE TABLE collaboration_grants (
+            id TEXT PRIMARY KEY,
+            attempt_id TEXT NOT NULL UNIQUE REFERENCES run_attempts(id) ON DELETE CASCADE,
+            run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+            execution_owner_id TEXT NOT NULL,
+            fence_token INTEGER NOT NULL CHECK (fence_token > 0),
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            requested_by_principal_id TEXT NOT NULL
+                REFERENCES principals(id) ON DELETE RESTRICT,
+            agent_principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
+            agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE RESTRICT,
+            agent_definition_revision_id TEXT NOT NULL
+                REFERENCES agent_definition_revisions(id) ON DELETE RESTRICT,
+            sponsor_principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
+            runtime_profile_id TEXT NOT NULL,
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE RESTRICT,
+            thread_root_id TEXT REFERENCES messages(id) ON DELETE RESTRICT,
+            requested_operations_json TEXT NOT NULL CHECK (
+                json_valid(requested_operations_json)
+                AND json_type(requested_operations_json) = 'array'
+            ),
+            owner_allowed_operations_json TEXT NOT NULL CHECK (
+                json_valid(owner_allowed_operations_json)
+                AND json_type(owner_allowed_operations_json) = 'array'
+            ),
+            host_allowed_operations_json TEXT NOT NULL CHECK (
+                json_valid(host_allowed_operations_json)
+                AND json_type(host_allowed_operations_json) = 'array'
+            ),
+            effective_operations_json TEXT NOT NULL CHECK (
+                json_valid(effective_operations_json)
+                AND json_type(effective_operations_json) = 'array'
+            ),
+            owner_policy_version INTEGER NOT NULL CHECK (owner_policy_version >= 0),
+            host_policy_version INTEGER NOT NULL CHECK (host_policy_version > 0),
+            quotas_json TEXT NOT NULL CHECK (
+                json_valid(quotas_json) AND json_type(quotas_json) = 'object'
+            ),
+            proof_fingerprint TEXT NOT NULL UNIQUE CHECK (length(proof_fingerprint) = 64),
+            issued_at TEXT NOT NULL,
+            initial_lease_expires_at TEXT NOT NULL,
+            issued_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            revoked_at TEXT,
+            revocation_code TEXT,
+            revoked_event_position INTEGER UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            state_version INTEGER NOT NULL DEFAULT 0 CHECK (state_version >= 0),
+            CHECK (
+                (revoked_at IS NULL AND revocation_code IS NULL AND revoked_event_position IS NULL)
+                OR
+                (revoked_at IS NOT NULL AND revocation_code IS NOT NULL
+                    AND revoked_event_position IS NOT NULL)
+            )
+        )
+        """,
+        "CREATE INDEX collaboration_grants_run_idx ON collaboration_grants (run_id, issued_event_position)",
+        "CREATE INDEX collaboration_grants_active_idx ON collaboration_grants "
+        "(attempt_id, revoked_at) WHERE revoked_at IS NULL",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -2943,6 +3017,7 @@ _MIGRATIONS = (
     _CANONICAL_HUMAN_PROFILE_SCHEMA,
     _CANONICAL_HUMAN_AVATAR_SCHEMA,
     _EXPANDED_MESSAGE_REACTIONS_SCHEMA,
+    _ATTEMPT_SCOPED_COLLABORATION_AUTHORITY_SCHEMA,
 )
 
 

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -418,7 +418,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 66
+        assert await upgraded.schema_version() == 67
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -529,7 +529,7 @@ class TestArtifactShadowRecordingAfterRestart:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 26
+            assert checkpoint.version == 27
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -1,0 +1,416 @@
+"""Contracts for exact-attempt Workshop collaboration authority."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from kai.internal_api_auth import InternalAPIAuth
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.collaboration_authority import (
+    CollaborationDenied,
+    CollaborationHostPolicy,
+    CollaborationOperation,
+    CollaborationOwnerPolicy,
+    CollaborationProofError,
+    WorkshopCollaborationAuthority,
+)
+from kai.workshop.conversation_commands import WorkshopConversationCommandService
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.domain import RunExecutionOwnerId, RuntimeProfileId
+from kai.workshop.inbound import InboundMessage
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_execution_authority import (
+    RunExecutionSelection,
+    WorkshopRunExecutionAuthority,
+)
+from kai.workshop.store import WorkshopEventStore
+
+_NOW = datetime(2026, 9, 5, 12, 0, tzinfo=UTC)
+_RUNTIME_PROFILE_ID = RuntimeProfileId.new()
+
+
+async def _running_attempt(path: Path, *, suffix: str = "1"):
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                display_name="Workshop Human",
+                role="admin",
+                transport="telegram",
+                external_subject="101",
+                external_channel_id="101",
+                runtime_profile_id=_RUNTIME_PROFILE_ID,
+            ),
+        ),
+    )
+    accepted = await WorkshopConversationCommandService(store).accept(
+        InboundMessage(
+            transport="telegram",
+            update_id=f"collaboration-command-{suffix}",
+            message_id=f"collaboration-message-{suffix}",
+            sender_subject="101",
+            channel_subject="101",
+            body=f"Perform collaboration qualification {suffix}",
+            occurred_at=_NOW,
+        )
+    )
+    await WorkshopConversationDeliveryAuthority(store).activate()
+    execution = WorkshopRunExecutionAuthority(
+        store,
+        selection_resolver=lambda _run: RunExecutionSelection("codex", "gpt-5.6-sol"),
+        registered_backend_ids=frozenset({"codex"}),
+    )
+    granted = await execution.grant(
+        accepted.run.run_id,
+        owner_id=RunExecutionOwnerId.new(),
+        occurred_at=_NOW + timedelta(seconds=1),
+        lease_expires_at=_NOW + timedelta(minutes=1),
+    )
+    started = await execution.start(granted.claim, occurred_at=_NOW + timedelta(seconds=2))
+    return store, execution, started
+
+
+async def test_grant_snapshots_revision_owner_host_context_and_limits(tmp_path: Path) -> None:
+    store, _execution, started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        authority = WorkshopCollaborationAuthority(
+            store,
+            owner_policy_resolver=lambda _revision: CollaborationOwnerPolicy(
+                version=7,
+                allowed_operations=frozenset(
+                    {
+                        CollaborationOperation.AGENT_DELEGATION,
+                        CollaborationOperation.CONTEXT_READ,
+                    }
+                ),
+            ),
+            token_factory=lambda: "attempt-proof-000000000000000000000000000001",
+        )
+
+        grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+
+        assert grant.attempt_id == started.claim.attempt_id
+        assert grant.run_id == started.run.run_id
+        assert grant.fence_token == started.claim.fence_token
+        assert grant.agent_definition_revision_id == started.run.agent_definition_revision_id
+        assert grant.requested_operations == frozenset({CollaborationOperation.AGENT_DELEGATION})
+        assert grant.owner_allowed_operations == frozenset(
+            {
+                CollaborationOperation.AGENT_DELEGATION,
+                CollaborationOperation.CONTEXT_READ,
+            }
+        )
+        assert grant.effective_operations == frozenset({CollaborationOperation.AGENT_DELEGATION})
+        assert grant.owner_policy_version == 7
+        assert grant.host_policy_version == 1
+        assert grant.quotas[CollaborationOperation.AGENT_DELEGATION] == 12
+        assert grant.proof_fingerprint != invocation.token
+        assert invocation.token not in repr(invocation)
+        async with store.connection.execute(
+            "SELECT payload_json, metadata_json FROM event_log WHERE aggregate_id = ? ORDER BY position",
+            (grant.grant_id,),
+        ) as cursor:
+            serialized_events = "".join(str(value) for row in await cursor.fetchall() for value in row)
+        assert invocation.token not in serialized_events
+    finally:
+        await store.close()
+
+
+async def test_persistent_internal_credential_cannot_authenticate_collaboration(tmp_path: Path) -> None:
+    store, _execution, started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        authority = WorkshopCollaborationAuthority(store)
+        await authority.issue(started.claim, occurred_at=_NOW + timedelta(seconds=3))
+        runtime_profile_id = started.run.runtime_profile_id
+        assert runtime_profile_id is not None
+        context = WorkshopInternalAPIExecutionContext(
+            principal_id=started.run.requested_by_principal_id,
+            channel_id=started.run.channel_id,
+            agent_id=started.run.agent_id,
+            runtime_profile_id=runtime_profile_id,
+        )
+        persistent_token = InternalAPIAuth.for_execution_contexts((context,)).agent_credential_for(context)
+
+        with pytest.raises(CollaborationProofError, match="Invalid collaboration proof"):
+            await authority.authenticate(
+                persistent_token,
+                CollaborationOperation.AGENT_DELEGATION,
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+    finally:
+        await store.close()
+
+
+async def test_exact_attempt_proof_fails_after_terminal_state_and_revocation(tmp_path: Path) -> None:
+    store, execution, started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        authority = WorkshopCollaborationAuthority(
+            store,
+            token_factory=lambda: "attempt-proof-000000000000000000000000000002",
+        )
+        grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+        authorized = await authority.authenticate(
+            invocation.token,
+            CollaborationOperation.AGENT_DELEGATION,
+            occurred_at=_NOW + timedelta(seconds=4),
+        )
+        assert authorized.grant.grant_id == grant.grant_id
+
+        await execution.fail(
+            started.claim,
+            failure_code="qualification_complete",
+            occurred_at=_NOW + timedelta(seconds=5),
+        )
+        with pytest.raises(CollaborationDenied, match="no longer active"):
+            await authority.authenticate(
+                invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                occurred_at=_NOW + timedelta(seconds=6),
+            )
+
+        revoked, changed = await authority.revoke(
+            invocation,
+            revocation_code="attempt_terminal",
+            occurred_at=_NOW + timedelta(seconds=6),
+        )
+        assert changed is True
+        assert revoked.revocation_code == "attempt_terminal"
+        with pytest.raises(CollaborationProofError, match="Invalid collaboration proof"):
+            await authority.authenticate(
+                invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                occurred_at=_NOW + timedelta(seconds=7),
+            )
+    finally:
+        await store.close()
+
+
+async def test_host_policy_can_deny_requested_operation_without_changing_revision(tmp_path: Path) -> None:
+    store, _execution, started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        authority = WorkshopCollaborationAuthority(
+            store,
+            host_policy=CollaborationHostPolicy(
+                version=4,
+                allowed_operations=frozenset(),
+                quotas={},
+            ),
+            token_factory=lambda: "attempt-proof-000000000000000000000000000003",
+        )
+        grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+
+        assert grant.requested_operations == frozenset({CollaborationOperation.AGENT_DELEGATION})
+        assert grant.effective_operations == frozenset()
+        assert grant.quotas == {}
+        with pytest.raises(CollaborationDenied) as denied:
+            await authority.authenticate(
+                invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+        assert denied.value.code == "operation_not_granted"
+    finally:
+        await store.close()
+
+
+async def test_restart_does_not_recover_transient_proof_but_projection_recovers_snapshot(tmp_path: Path) -> None:
+    store, _execution, started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        first = WorkshopCollaborationAuthority(
+            store,
+            token_factory=lambda: "attempt-proof-000000000000000000000000000004",
+        )
+        grant, invocation = await first.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+
+        restarted = WorkshopCollaborationAuthority(store)
+        with pytest.raises(CollaborationProofError, match="Invalid collaboration proof"):
+            await restarted.authenticate(
+                invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+
+        assert await restarted.reconcile_unbound(occurred_at=_NOW + timedelta(seconds=5)) == 1
+        assert await restarted.reconcile_unbound(occurred_at=_NOW + timedelta(seconds=6)) == 0
+        reconciled = await restarted.snapshot(grant.grant_id)
+        assert reconciled.revocation_code == "host_restart"
+        await store.rebuild_projection(CanonicalConversationProjection())
+        replayed = await restarted.snapshot(grant.grant_id)
+        assert replayed == reconciled
+    finally:
+        await store.close()
+
+
+async def test_old_attempt_proof_cannot_act_during_later_attempt_on_same_runtime(
+    tmp_path: Path,
+) -> None:
+    store, execution, first_started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        tokens = iter(
+            (
+                "attempt-proof-000000000000000000000000000006",
+                "attempt-proof-000000000000000000000000000007",
+            )
+        )
+        authority = WorkshopCollaborationAuthority(store, token_factory=lambda: next(tokens))
+        _first_grant, first_invocation = await authority.issue(
+            first_started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+        await execution.fail(
+            first_started.claim,
+            failure_code="qualification_complete",
+            occurred_at=_NOW + timedelta(seconds=4),
+        )
+        await authority.revoke(
+            first_invocation,
+            revocation_code="attempt_terminal",
+            occurred_at=_NOW + timedelta(seconds=5),
+        )
+
+        accepted = await WorkshopConversationCommandService(store).accept(
+            InboundMessage(
+                transport="telegram",
+                update_id="collaboration-command-later",
+                message_id="collaboration-message-later",
+                sender_subject="101",
+                channel_subject="101",
+                body="Perform later collaboration qualification",
+                occurred_at=_NOW + timedelta(seconds=6),
+            )
+        )
+        granted = await execution.grant(
+            accepted.run.run_id,
+            owner_id=RunExecutionOwnerId.new(),
+            occurred_at=_NOW + timedelta(seconds=7),
+            lease_expires_at=_NOW + timedelta(minutes=2),
+        )
+        second_started = await execution.start(
+            granted.claim,
+            occurred_at=_NOW + timedelta(seconds=8),
+        )
+        _second_grant, second_invocation = await authority.issue(
+            second_started.claim,
+            occurred_at=_NOW + timedelta(seconds=9),
+        )
+
+        with pytest.raises(CollaborationProofError, match="Invalid collaboration proof"):
+            await authority.authenticate(
+                first_invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                occurred_at=_NOW + timedelta(seconds=10),
+            )
+        authorized = await authority.authenticate(
+            second_invocation.token,
+            CollaborationOperation.AGENT_DELEGATION,
+            occurred_at=_NOW + timedelta(seconds=10),
+        )
+        assert authorized.grant.attempt_id == second_started.claim.attempt_id
+    finally:
+        await store.close()
+
+
+async def test_archive_and_detach_immediately_fence_live_grant(tmp_path: Path) -> None:
+    store, _execution, started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        authority = WorkshopCollaborationAuthority(
+            store,
+            token_factory=lambda: "attempt-proof-000000000000000000000000000005",
+        )
+        _grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+        await store.connection.execute(
+            "UPDATE agent_definitions SET lifecycle_state = 'archived' WHERE agent_id = ?",
+            (started.run.agent_id,),
+        )
+        await store.connection.commit()
+
+        with pytest.raises(CollaborationDenied) as denied:
+            await authority.authenticate(
+                invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+        assert denied.value.code == "agent_unavailable"
+    finally:
+        await store.close()
+
+
+async def test_version_sixty_seven_migrates_only_legacy_delegation_requests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kai.workshop import schema
+
+    path = tmp_path / "kai.db"
+    with monkeypatch.context() as migration_context:
+        migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 66)
+        migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:66])
+        legacy = await WorkshopEventStore.open(path)
+        try:
+            await bootstrap_default_workshop(
+                legacy,
+                (
+                    BootstrapHuman(
+                        display_name="Workshop Human",
+                        role="admin",
+                        transport="telegram",
+                        external_subject="101",
+                        external_channel_id="101",
+                        runtime_profile_id=_RUNTIME_PROFILE_ID,
+                    ),
+                ),
+            )
+            async with legacy.connection.execute(
+                "SELECT id FROM agent_definition_revisions ORDER BY revision_number LIMIT 1"
+            ) as cursor:
+                row = await cursor.fetchone()
+            assert row is not None
+            no_delegation_revision_id = str(row[0])
+            await legacy.connection.execute(
+                "UPDATE agent_definition_revisions SET capabilities_json = '[]' WHERE id = ?",
+                (no_delegation_revision_id,),
+            )
+            await legacy.connection.commit()
+        finally:
+            await legacy.close()
+
+    upgraded = await WorkshopEventStore.open(path)
+    try:
+        assert await upgraded.schema_version() == 67
+        async with upgraded.connection.execute(
+            "SELECT id, capabilities_json, collaboration_operations_json "
+            "FROM agent_definition_revisions ORDER BY revision_number"
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        assert rows
+        for revision_id, capabilities_json, operations_json in rows:
+            capabilities = json.loads(str(capabilities_json))
+            operations = json.loads(str(operations_json))
+            if str(revision_id) == no_delegation_revision_id:
+                assert capabilities == []
+                assert operations == []
+            else:
+                assert operations == (["agent_delegation"] if "agent_delegation" in capabilities else [])
+    finally:
+        await upgraded.close()

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -389,7 +389,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 26
+            assert checkpoint.version == 27
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -210,6 +210,18 @@ class TestCanonicalExecutionCoordinator:
             assert prepared.validated is True
             assert prepared.prompts == ["Canonical prompt 1"]
             assert await _terminal_bodies(store) == ["Canonical prompt 1", "Canonical answer"]
+            async with store.connection.execute(
+                "SELECT requested_operations_json, effective_operations_json, "
+                "revocation_code, length(proof_fingerprint) "
+                "FROM collaboration_grants WHERE run_id = ?",
+                (run.run_id,),
+            ) as cursor:
+                assert tuple(await cursor.fetchone()) == (
+                    '["agent_delegation"]',
+                    '["agent_delegation"]',
+                    "attempt_terminal",
+                    64,
+                )
             session = await load_runtime_session(store, run.channel_id, run.agent_id)
             assert session is not None
             assert session.last_run_id == run.run_id
@@ -285,7 +297,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
             after = workshop_runtime_session_status(path)
             assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
@@ -313,7 +325,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
             assert session is not None
             assert session.runtime_profile_id == _RUNTIME_PROFILE_ID

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -149,6 +149,8 @@ class TestEventEnvelope:
             "run_attempt.completed",
             "run_attempt.failed",
             "run_attempt.cancelled",
+            "collaboration_grant.issued",
+            "collaboration_grant.revoked",
         }
 
     def test_create_builds_a_versioned_transport_independent_envelope(self):
@@ -242,6 +244,7 @@ class TestWorkshopSchema:
             "runs",
             "run_attempts",
             "agent_delegations",
+            "collaboration_grants",
             "principal_human_notification_policies",
             "principal_human_notification_adapter_preferences",
             "principal_channel_notification_policies",
@@ -257,7 +260,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 66
+        assert await workshop_store.schema_version() == 67
         async with workshop_store.connection.execute("PRAGMA table_info(principals)") as cursor:
             principal_columns = {str(row[1]) for row in await cursor.fetchall()}
         assert {"display_name_state_version", "display_name_event_position"} <= principal_columns
@@ -308,7 +311,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 66
+        assert await second.schema_version() == 67
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -392,7 +395,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             async with upgraded.connection.execute(
                 "SELECT reaction, created_event_position FROM message_reactions "
                 "WHERE message_id = ? AND principal_id = ?",
@@ -433,7 +436,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -461,7 +464,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -545,6 +548,7 @@ class TestWorkshopSchema:
                     64,
                     65,
                     66,
+                    67,
                 ]
         finally:
             await upgraded.close()
@@ -567,7 +571,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -608,7 +612,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -661,7 +665,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -705,7 +709,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -749,7 +753,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -793,7 +797,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -897,7 +901,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -1024,7 +1028,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -319,7 +319,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 66
+            assert await upgraded.schema_version() == 67
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -391,7 +391,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 26
+            assert checkpoint.version == 27
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -166,7 +166,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 26
+            assert checkpoint.version == 27
             assert after == before
         finally:
             await store.close()

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -178,7 +178,7 @@ class TestRuntimeAssignmentPolicy:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 26
+            assert checkpoint.version == 27
             assert await resolve_channel_runtime_profile(store, human.channel_id) == (
                 assigned.agent_id,
                 profile_id(202),


### PR DESCRIPTION
Refs #1377

## Summary

- separate collaboration-operation requests from runtime capability declarations while safely migrating existing delegation intent
- persist exact-attempt grant snapshots bounded by immutable agent revision, owner policy, host policy, canonical context, quotas, and lease expiry
- keep invocation proofs process-local and persist only SHA-256 fingerprints
- fence proofs on terminal settlement, restart, cancellation state, expiry, supersession, archive, detach, and disable conditions
- establish a coordinator-owned authority seam for later operation adapters

## Staging boundary

This is the first stage of #1377. It establishes the grant/proof authority and execution lifecycle, but intentionally does not yet expose collaboration mutation endpoints or migrate the existing delegation endpoint away from the persistent internal credential. The issue remains open for that cutover, common denial/idempotency/quota enforcement, and the remaining operation adapters.

## Validation

- `make check`
- `make typecheck`
- focused Workshop authority/coordinator/schema tests: 88 passed
- broader run lifecycle/runtime/artifact tests: 72 passed
- `make test`: 6,459 passed