### PR TITLE
Enforce attempt-scoped collaboration invocation proofs

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -955,12 +955,16 @@ class AcpBackend(AgentBackend):
                 return TraceEntry(
                     kind="tool_result",
                     tool_use_id=tool_call_id,
-                    summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                    summary=scrub_trace_text(
+                        summary, self.active_trace_secrets(self._trace_secrets), TRACE_SUMMARY_MAX_CHARS
+                    ),
                     # A recognized result with no content blocks keeps an
                     # empty detail, matching the codex emitter's no-output
                     # results; the raw-payload fallback is for shapes that
                     # would otherwise lose information.
-                    detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                    detail=scrub_trace_text(
+                        detail, self.active_trace_secrets(self._trace_secrets), TRACE_DETAIL_MAX_CHARS
+                    ),
                     is_error=status == "failed",
                 )
             if update_type == "tool_call":
@@ -975,10 +979,12 @@ class AcpBackend(AgentBackend):
                 return TraceEntry(
                     kind="tool_call",
                     tool_use_id=tool_call_id,
-                    summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                    summary=scrub_trace_text(
+                        summary, self.active_trace_secrets(self._trace_secrets), TRACE_SUMMARY_MAX_CHARS
+                    ),
                     detail=scrub_trace_text(
                         detail or json.dumps(update, ensure_ascii=False),
-                        self._trace_secrets,
+                        self.active_trace_secrets(self._trace_secrets),
                         TRACE_DETAIL_MAX_CHARS,
                     ),
                     tool_name=tool_name,
@@ -989,10 +995,10 @@ class AcpBackend(AgentBackend):
             return TraceEntry(
                 kind="tool_call",
                 tool_use_id=tool_call_id if isinstance(tool_call_id, str) else "",
-                summary=scrub_trace_text(name, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
+                summary=scrub_trace_text(name, self.active_trace_secrets(self._trace_secrets), TRACE_SUMMARY_MAX_CHARS),
                 detail=scrub_trace_text(
                     json.dumps(update, ensure_ascii=False),
-                    self._trace_secrets,
+                    self.active_trace_secrets(self._trace_secrets),
                     TRACE_DETAIL_MAX_CHARS,
                 ),
                 tool_name=name,
@@ -1475,6 +1481,7 @@ class AcpBackend(AgentBackend):
             runtime_identity=runtime_identity if had_user_text else None,
             session_context=session_ctx,
             agent_definition_context=self.consume_canonical_agent_context(),
+            collaboration_context=self.consume_collaboration_context(),
             workspace_reminder=reminder,
             workspace=self.workspace,
             backend_name=self.backend_name,

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -14,6 +14,7 @@ process management; the context functions here handle the Kai-specific
 prompt assembly that is identical across all backends.
 """
 
+import hmac
 import logging
 import os
 import shutil
@@ -556,6 +557,39 @@ class AgentBackend(ABC):
         if hasattr(self, "_canonical_agent_context"):
             del self._canonical_agent_context
 
+    def stage_collaboration_invocation(self, context: str, proof: str) -> None:
+        """Stage exact-attempt collaboration authority for one protected turn.
+
+        The proof is deliberately separate from the persistent subprocess
+        environment.  It is injected only into the turn that owns it and is
+        retained solely as a trace-redaction value until dispatch finishes.
+        """
+        if not isinstance(context, str) or not context:
+            raise ValueError("collaboration context must be non-empty text")
+        if not isinstance(proof, str) or len(proof) < 32:
+            raise ValueError("collaboration proof must contain at least 32 characters")
+        self._canonical_collaboration_context = context
+        self._collaboration_trace_secret = proof
+
+    def consume_collaboration_context(self) -> str:
+        """Consume the staged authority instructions without dropping redaction."""
+        context = getattr(self, "_canonical_collaboration_context", "")
+        if hasattr(self, "_canonical_collaboration_context"):
+            del self._canonical_collaboration_context
+        return context
+
+    def discard_collaboration_invocation(self, proof: str) -> None:
+        """Clear one turn's unconsumed context and transient redaction value."""
+        if hasattr(self, "_canonical_collaboration_context"):
+            del self._canonical_collaboration_context
+        if hmac.compare_digest(getattr(self, "_collaboration_trace_secret", ""), proof):
+            del self._collaboration_trace_secret
+
+    def active_trace_secrets(self, secrets: tuple[str, ...]) -> tuple[str, ...]:
+        """Include the current attempt proof in backend trace scrubbing."""
+        proof = getattr(self, "_collaboration_trace_secret", "")
+        return secrets + ((proof,) if proof else ())
+
     @abstractmethod
     async def send(
         self,
@@ -985,20 +1019,25 @@ def build_session_context(
         )
         parts.append("\n".join(svc_lines))
 
-    # Internal API authority is carried only by the short-lived credential.
-    # Explicit identity selectors are rejected at the HTTP boundary.
+    # The persistent credential establishes only the backend's server-owned
+    # base identity. Explicit identity selectors are rejected at the HTTP
+    # boundary, and collaboration additionally requires a proof injected into
+    # the exact active turn.
     if api.webhook_secret:
         parts.append(
-            "[Internal API identity: $KAI_WEBHOOK_SECRET already binds your "
+            "[Internal API identity: $KAI_WEBHOOK_SECRET binds your persistent "
             "canonical human, channel, agent, and runtime context. Never include "
-            "chat_id or another identity selector in an internal API request.]"
+            "chat_id or another identity selector in an internal API request. "
+            "This credential alone never authorizes collaboration.]"
         )
         parts.append(
             "[Agent delegation API: In a shared channel, you may explicitly request "
             "work from another attached agent only when your immutable definition "
             "declares the agent_delegation capability. POST JSON to "
-            f"http://localhost:{api.webhook_port}/api/agent-delegations with header "
-            "'X-Webhook-Secret: $KAI_WEBHOOK_SECRET'. Required fields are "
+            f"http://localhost:{api.webhook_port}/api/agent-delegations with headers "
+            "'X-Webhook-Secret: $KAI_WEBHOOK_SECRET' and the exact-attempt "
+            "'X-Kai-Collaboration-Proof' injected separately for the current turn. "
+            "If no proof is present, delegation is unavailable. Required fields are "
             "target_handle, task, and idempotency_key. Optional context accepts only "
             "summary and canonical same-channel message_ids. The request waits for a "
             "bounded terminal response. Never include credentials, secrets, private "
@@ -1603,6 +1642,7 @@ async def assemble_turn_context(
     runtime_identity: AgentRuntimeIdentity | None = None,
     session_context: str = "",
     agent_definition_context: str = "",
+    collaboration_context: str = "",
     workspace_reminder: str = "",
     workspace: Path | None = None,
     backend_name: str | None = None,
@@ -1622,6 +1662,7 @@ async def assemble_turn_context(
         workspace_reminder    (topmost)
         semantic memory block
         session_context
+        collaboration_context
         agent_definition_context
         USER_MESSAGE_MARKER
         user prompt           (bottom; the real message)
@@ -1679,6 +1720,12 @@ async def assemble_turn_context(
     # context and never carries authority of its own.
     if agent_definition_context:
         prompt = prepend_to_prompt(prompt, agent_definition_context)
+
+    # Exact-attempt collaboration authority is refreshed on every turn, even
+    # when the provider subprocess/session remains live.  It sits above the
+    # immutable definition and below general session context.
+    if collaboration_context:
+        prompt = prepend_to_prompt(prompt, collaboration_context)
 
     # First-session context (AGENTS.md + PREFERENCES.md + recent
     # history + API context) is built by the caller because the

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -860,6 +860,7 @@ class ClaudeCodeBackend(AgentBackend):
             runtime_identity=runtime_identity,
             session_context=session_ctx,
             agent_definition_context=self.consume_canonical_agent_context(),
+            collaboration_context=self.consume_collaboration_context(),
             workspace_reminder=reminder,
             workspace=self.workspace,
             backend_name=self.backend_name,
@@ -1180,8 +1181,10 @@ class ClaudeCodeBackend(AgentBackend):
             return TraceEntry(
                 kind="tool_call",
                 tool_use_id=tool_use_id,
-                summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
-                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                summary=scrub_trace_text(
+                    summary, self.active_trace_secrets(self._trace_secrets), TRACE_SUMMARY_MAX_CHARS
+                ),
+                detail=scrub_trace_text(detail, self.active_trace_secrets(self._trace_secrets), TRACE_DETAIL_MAX_CHARS),
                 tool_name=tool_name,
                 is_diff=is_diff,
             )
@@ -1216,8 +1219,10 @@ class ClaudeCodeBackend(AgentBackend):
             return TraceEntry(
                 kind="tool_result",
                 tool_use_id=tool_use_id,
-                summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
-                detail=scrub_trace_text(text, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                summary=scrub_trace_text(
+                    summary, self.active_trace_secrets(self._trace_secrets), TRACE_SUMMARY_MAX_CHARS
+                ),
+                detail=scrub_trace_text(text, self.active_trace_secrets(self._trace_secrets), TRACE_DETAIL_MAX_CHARS),
                 is_error=bool(block.get("is_error", False)),
             )
         except Exception:

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -967,6 +967,7 @@ class CodexBackend(AgentBackend):
             runtime_identity=runtime_identity if had_user_text else None,
             session_context=session_ctx,
             agent_definition_context=self.consume_canonical_agent_context(),
+            collaboration_context=self.consume_collaboration_context(),
             workspace_reminder=reminder,
             workspace=self.workspace,
             backend_name=self.backend_name,
@@ -1432,8 +1433,10 @@ class CodexBackend(AgentBackend):
             return TraceEntry(
                 kind="tool_call",
                 tool_use_id=item_id,
-                summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
-                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                summary=scrub_trace_text(
+                    summary, self.active_trace_secrets(self._trace_secrets), TRACE_SUMMARY_MAX_CHARS
+                ),
+                detail=scrub_trace_text(detail, self.active_trace_secrets(self._trace_secrets), TRACE_DETAIL_MAX_CHARS),
                 tool_name=item_type,
                 is_diff=is_diff,
             )
@@ -1471,8 +1474,10 @@ class CodexBackend(AgentBackend):
             return TraceEntry(
                 kind="tool_result",
                 tool_use_id=item_id,
-                summary=scrub_trace_text(summary, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
-                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                summary=scrub_trace_text(
+                    summary, self.active_trace_secrets(self._trace_secrets), TRACE_SUMMARY_MAX_CHARS
+                ),
+                detail=scrub_trace_text(detail, self.active_trace_secrets(self._trace_secrets), TRACE_DETAIL_MAX_CHARS),
                 # The item's terminal status enum is the protocol's own
                 # failure signal. exitCode deliberately does not feed
                 # is_error: a command that ran to completion with a

--- a/src/kai/internal_api_auth.py
+++ b/src/kai/internal_api_auth.py
@@ -29,7 +29,7 @@ class InternalAPIScope(StrEnum):
     MEMORY_READ = "memory:read"
     MEMORY_ADD = "memory:add"
     MEMORY_DELETE_ALL = "memory:delete-all"
-    AGENTS_DELEGATE = "agents:delegate"
+    COLLABORATION_INVOKE = "collaboration:invoke"
 
 
 # Keep the persistent-agent base profile explicit. Constructing it from the
@@ -44,7 +44,7 @@ _PERSISTENT_AGENT_BASE_SCOPES = frozenset(
         InternalAPIScope.FILES_SEND,
         InternalAPIScope.MEMORY_READ,
         InternalAPIScope.MEMORY_ADD,
-        InternalAPIScope.AGENTS_DELEGATE,
+        InternalAPIScope.COLLABORATION_INVOKE,
     }
 )
 _NOTIFICATION_SCOPES = frozenset({InternalAPIScope.MESSAGES_SEND})

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -451,6 +451,7 @@ class PiBackend(AgentBackend):
             runtime_identity=runtime_identity if had_user_text else None,
             session_context=session_context,
             agent_definition_context=self.consume_canonical_agent_context(),
+            collaboration_context=self.consume_collaboration_context(),
             workspace_reminder=reminder,
             workspace=self.workspace,
             backend_name=self.backend_name,
@@ -612,8 +613,10 @@ class PiBackend(AgentBackend):
             return TraceEntry(
                 kind="tool_call",
                 tool_use_id=tool_call_id,
-                summary=scrub_trace_text(tool_name, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
-                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                summary=scrub_trace_text(
+                    tool_name, self.active_trace_secrets(self._trace_secrets), TRACE_SUMMARY_MAX_CHARS
+                ),
+                detail=scrub_trace_text(detail, self.active_trace_secrets(self._trace_secrets), TRACE_DETAIL_MAX_CHARS),
                 tool_name=tool_name,
             )
         except Exception:
@@ -642,8 +645,10 @@ class PiBackend(AgentBackend):
             return TraceEntry(
                 kind="tool_result",
                 tool_use_id=tool_call_id,
-                summary=scrub_trace_text(tool_name, self._trace_secrets, TRACE_SUMMARY_MAX_CHARS),
-                detail=scrub_trace_text(detail, self._trace_secrets, TRACE_DETAIL_MAX_CHARS),
+                summary=scrub_trace_text(
+                    tool_name, self.active_trace_secrets(self._trace_secrets), TRACE_SUMMARY_MAX_CHARS
+                ),
+                detail=scrub_trace_text(detail, self.active_trace_secrets(self._trace_secrets), TRACE_DETAIL_MAX_CHARS),
                 is_error=bool(message.get("isError", False)),
             )
         except Exception:

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -142,6 +142,15 @@ class PreparedBackendExecution:
         self._pool._validate_prepared(self)
         self._instance.stage_canonical_agent_context(context)
 
+    def stage_collaboration_invocation(self, context: str, proof: str) -> None:
+        """Stage exact-attempt collaboration authority on this runtime."""
+        self._pool._validate_prepared(self)
+        self._instance.stage_collaboration_invocation(context, proof)
+
+    def discard_collaboration_invocation(self, proof: str) -> None:
+        """Drop exact-attempt context and proof redaction after dispatch."""
+        self._instance.discard_collaboration_invocation(proof)
+
     def validate_current(self) -> None:
         """Fail before dispatch if the protected runtime selection drifted."""
         self._pool._validate_prepared(self)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -64,7 +64,6 @@ from kai.config import (
 from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, InternalAPIScope
 from kai.job_types import CANONICAL_JOB_TYPES, normalize_job_type
 from kai.workshop.agent_delegation import (
-    AgentDelegationAuthority,
     AgentDelegationConflict,
     AgentDelegationDenied,
 )
@@ -87,6 +86,7 @@ from kai.workshop.client_sessions import (
     WorkshopClientSessionManager,
 )
 from kai.workshop.client_shell import register_workshop_shell_routes
+from kai.workshop.collaboration_authority import CollaborationBaseIdentity
 from kai.workshop.github_automation import (
     GitHubSubscriptionRoute,
     WorkshopGitHubAutomationService,
@@ -1201,7 +1201,7 @@ async def _handle_send_message(request: web.Request, principal: InternalAPIPrinc
     return _proactive_response(result)
 
 
-@_require_internal_api(InternalAPIScope.AGENTS_DELEGATE)
+@_require_internal_api(InternalAPIScope.COLLABORATION_INVOKE)
 async def _handle_agent_delegation(
     request: web.Request,
     principal: InternalAPIPrincipal,
@@ -1232,20 +1232,39 @@ async def _handle_agent_delegation(
     if missing:
         return web.json_response({"error": f"Missing required field: {missing[0]}"}, status=400)
     try:
+        proof = request.headers.get("X-Kai-Collaboration-Proof", "")
         result = await request.app[CORE_HOST_KEY].services.agent_delegation.delegate(
-            AgentDelegationAuthority(
-                sponsor_principal_id=principal.principal_id,
+            CollaborationBaseIdentity(
+                principal_id=principal.principal_id,
                 channel_id=principal.channel_id,
-                caller_agent_id=principal.agent_id,
+                agent_id=principal.agent_id,
                 runtime_profile_id=principal.runtime_profile_id,
             ),
+            proof=proof,
             target_handle=payload["target_handle"],
             task=payload["task"],
             context=payload.get("context"),
             idempotency_key=payload["idempotency_key"],
         )
     except AgentDelegationDenied as exc:
-        status = 400 if exc.code.startswith("invalid_") or exc.code.endswith("_too_large") else 409
+        status = (
+            403
+            if exc.code
+            in {
+                "invalid_proof",
+                "base_identity_mismatch",
+                "operation_not_granted",
+                "grant_revoked",
+                "grant_expired",
+                "attempt_not_active",
+                "agent_unavailable",
+                "authority_detached",
+                "quota_exhausted",
+            }
+            else 400
+            if exc.code.startswith("invalid_") or exc.code.endswith("_too_large")
+            else 409
+        )
         return web.json_response(
             {"error": str(exc), "code": exc.code},
             status=status,

--- a/src/kai/workshop/agent_delegation.py
+++ b/src/kai/workshop/agent_delegation.py
@@ -13,6 +13,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 from kai.workshop.agent_definitions import normalize_agent_handle
+from kai.workshop.collaboration_authority import (
+    CollaborationAuthorization,
+    CollaborationBaseIdentity,
+    CollaborationDenied,
+    CollaborationOperation,
+    CollaborationProofError,
+)
 from kai.workshop.domain import (
     AgentDefinitionRevisionId,
     AgentDelegationId,
@@ -33,7 +40,7 @@ from kai.workshop.execution_coordinator import (
     CanonicalExecutionResult,
 )
 from kai.workshop.projection import CanonicalConversationProjection
-from kai.workshop.run_lifecycle import DurableRun, RunStatus
+from kai.workshop.run_lifecycle import DurableRun, RunStatus, WorkshopRunLifecycle
 from kai.workshop.store import WorkshopEventStore
 
 if TYPE_CHECKING:
@@ -82,16 +89,6 @@ class AgentDelegationPolicy:
                 raise ValueError(f"{name} must be a positive integer")
         if self.max_elapsed <= timedelta(0):
             raise ValueError("max_elapsed must be positive")
-
-
-@dataclass(frozen=True, slots=True)
-class AgentDelegationAuthority:
-    """Exact canonical runtime lane bound to the internal API credential."""
-
-    sponsor_principal_id: PrincipalId
-    channel_id: ChannelId
-    caller_agent_id: AgentId
-    runtime_profile_id: RuntimeProfileId
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,6 +161,17 @@ class _TargetAuthority:
 
 
 class _ExecutionService(Protocol):
+    async def authorize_collaboration(
+        self,
+        proof: str,
+        operation: CollaborationOperation,
+        *,
+        base_identity: CollaborationBaseIdentity,
+        idempotency_key: str,
+        request_hash: str,
+        occurred_at: datetime,
+    ) -> CollaborationAuthorization: ...
+
     async def execute(self, run_id: RunId) -> CanonicalExecutionResult: ...
 
     async def run_state(self, run_id: RunId) -> DurableRun: ...
@@ -308,8 +316,9 @@ class WorkshopAgentDelegationService:
 
     async def delegate(
         self,
-        authority: AgentDelegationAuthority,
+        base_identity: CollaborationBaseIdentity,
         *,
+        proof: str,
         target_handle: object,
         task: object,
         context: object = None,
@@ -324,9 +333,23 @@ class WorkshopAgentDelegationService:
         normalized_task = _normalize_task(task)
         normalized_context = _normalize_context(context)
         key = _normalize_idempotency_key(idempotency_key)
+        fingerprint = _request_hash(handle, normalized_task, normalized_context)
+        try:
+            authorization = await self._execution.authorize_collaboration(
+                proof,
+                CollaborationOperation.AGENT_DELEGATION,
+                base_identity=base_identity,
+                idempotency_key=key,
+                request_hash=fingerprint,
+                occurred_at=datetime.now(UTC),
+            )
+        except CollaborationProofError as exc:
+            raise AgentDelegationDenied("invalid_proof", str(exc)) from exc
+        except CollaborationDenied as exc:
+            raise AgentDelegationDenied(exc.code, str(exc)) from exc
         async with self._lock:
             delegation = await self._accept(
-                authority,
+                authorization,
                 target_handle=handle,
                 task=normalized_task,
                 context=normalized_context,
@@ -416,14 +439,14 @@ class WorkshopAgentDelegationService:
 
     async def _accept(
         self,
-        authority: AgentDelegationAuthority,
+        authorization: CollaborationAuthorization,
         *,
         target_handle: str,
         task: str,
         context: AgentDelegationContext,
         idempotency_key: str,
     ) -> AgentDelegationSnapshot:
-        if not isinstance(authority, AgentDelegationAuthority):
+        if not isinstance(authorization, CollaborationAuthorization):
             raise AgentDelegationDenied("invalid_authority", "Delegation authority is unavailable")
         now = datetime.now(UTC)
         connection = self._store.connection
@@ -431,7 +454,7 @@ class WorkshopAgentDelegationService:
             await connection.execute("BEGIN IMMEDIATE")
             projection = CanonicalConversationProjection()
             await self._store.project_pending_in_transaction(projection)
-            parent = await self._active_parent(authority)
+            parent = await self._active_parent(authorization)
             delegation_id = AgentDelegationId.derived(
                 parent.workshop_id,
                 f"agent-delegation:{parent.run.run_id}:{idempotency_key}",
@@ -527,8 +550,8 @@ class WorkshopAgentDelegationService:
                     "requesting_principal_id": parent.run.requested_by_principal_id,
                     "caller_agent_id": parent.run.agent_id,
                     "target_agent_id": target.agent_id,
-                    "caller_sponsor_principal_id": authority.sponsor_principal_id,
-                    "caller_runtime_profile_id": authority.runtime_profile_id,
+                    "caller_sponsor_principal_id": authorization.grant.sponsor_principal_id,
+                    "caller_runtime_profile_id": authorization.grant.runtime_profile_id,
                     "target_sponsor_principal_id": target.sponsor_principal_id,
                     "target_runtime_profile_id": target.runtime_profile_id,
                     "caller_definition_revision_id": parent.caller_revision_id,
@@ -552,10 +575,11 @@ class WorkshopAgentDelegationService:
             await connection.rollback()
             raise
 
-    async def _active_parent(self, authority: AgentDelegationAuthority) -> _ParentAuthority:
+    async def _active_parent(self, authorization: CollaborationAuthorization) -> _ParentAuthority:
+        grant = authorization.grant
         async with self._store.connection.execute(
             "SELECT kind FROM channels WHERE id = ? AND archived_at IS NULL",
-            (authority.channel_id,),
+            (grant.channel_id,),
         ) as cursor:
             channel_row = await cursor.fetchone()
         if channel_row is None or str(channel_row[0]) != "group":
@@ -563,68 +587,21 @@ class WorkshopAgentDelegationService:
                 "shared_channel_required",
                 "Agent delegation is available only in a shared group channel",
             )
-        async with self._store.connection.execute(
-            "SELECT r.id, r.workshop_id, r.channel_id, r.requested_by_principal_id, "
-            "r.agent_id, r.inbound_message_id, r.status, r.accepted_at, r.started_at, "
-            "r.terminal_at, r.terminal_code, r.cancellation_requested_at, r.cancellation_code, "
-            "r.result_message_id, r.last_event_position, r.agent_definition_revision_id, "
-            "r.runtime_profile_id, r.sponsor_principal_id, r.parent_run_id, r.delegation_id, "
-            "a.principal_id, m.thread_root_id "
-            "FROM runs r JOIN run_attempts attempt ON attempt.run_id = r.id "
-            "AND attempt.status = 'started' "
-            "JOIN agents a ON a.id = r.agent_id "
-            "JOIN messages m ON m.id = r.inbound_message_id "
-            "WHERE r.channel_id = ? AND r.agent_id = ? AND r.runtime_profile_id = ? "
-            "AND r.sponsor_principal_id = ? AND r.status = 'started' "
-            "AND r.cancellation_requested_at IS NULL ORDER BY r.started_at DESC",
-            (
-                authority.channel_id,
-                authority.caller_agent_id,
-                authority.runtime_profile_id,
-                authority.sponsor_principal_id,
-            ),
-        ) as cursor:
-            rows = list(await cursor.fetchall())
-        if len(rows) != 1:
+        run = await WorkshopRunLifecycle(self._store).state(grant.run_id)
+        if (
+            run.status != RunStatus.STARTED
+            or run.cancellation_requested_at is not None
+            or run.channel_id != grant.channel_id
+            or run.agent_id != grant.agent_id
+            or run.runtime_profile_id != grant.runtime_profile_id
+            or run.sponsor_principal_id != grant.sponsor_principal_id
+            or run.agent_definition_revision_id != grant.agent_definition_revision_id
+        ):
             raise AgentDelegationDenied(
                 "no_active_attempt",
-                "Delegation requires exactly one active caller attempt in this canonical lane",
+                "Delegation requires its exact active caller attempt",
             )
-        row = rows[0]
-        run = DurableRun(
-            run_id=RunId(str(row[0])),
-            workshop_id=WorkshopId(str(row[1])),
-            channel_id=ChannelId(str(row[2])),
-            requested_by_principal_id=PrincipalId(str(row[3])),
-            agent_id=AgentId(str(row[4])),
-            inbound_message_id=MessageId(str(row[5])),
-            status=RunStatus(str(row[6])),
-            accepted_at=_timestamp(row[7]),
-            started_at=_optional_timestamp(row[8]),
-            terminal_at=_optional_timestamp(row[9]),
-            terminal_code=str(row[10]) if row[10] is not None else None,
-            cancellation_requested_at=_optional_timestamp(row[11]),
-            cancellation_code=str(row[12]) if row[12] is not None else None,
-            result_message_id=MessageId(str(row[13])) if row[13] is not None else None,
-            last_event_position=int(row[14]),
-            agent_definition_revision_id=AgentDefinitionRevisionId(str(row[15])),
-            runtime_profile_id=RuntimeProfileId(str(row[16])),
-            sponsor_principal_id=PrincipalId(str(row[17])),
-            parent_run_id=RunId(str(row[18])) if row[18] is not None else None,
-            delegation_id=AgentDelegationId(str(row[19])) if row[19] is not None else None,
-        )
         assert run.agent_definition_revision_id is not None
-        async with self._store.connection.execute(
-            "SELECT capabilities_json FROM agent_definition_revisions WHERE id = ?",
-            (run.agent_definition_revision_id,),
-        ) as cursor:
-            capability_row = await cursor.fetchone()
-        capabilities = () if capability_row is None else tuple(json.loads(str(capability_row[0])))
-        if "agent_delegation" not in capabilities:
-            raise AgentDelegationDenied(
-                "delegation_not_granted",
-                "The caller's immutable agent revision does not grant delegation",
-            )
         root_run_id = run.run_id
         parent_delegation_id = run.delegation_id
         depth = 1
@@ -644,9 +621,9 @@ class WorkshopAgentDelegationService:
         return _ParentAuthority(
             run=run,
             workshop_id=run.workshop_id,
-            caller_principal_id=PrincipalId(str(row[20])),
+            caller_principal_id=grant.agent_principal_id,
             caller_revision_id=run.agent_definition_revision_id,
-            thread_root_id=MessageId(str(row[21])) if row[21] is not None else None,
+            thread_root_id=grant.thread_root_id,
             root_run_id=root_run_id,
             parent_delegation_id=parent_delegation_id,
             depth=depth,

--- a/src/kai/workshop/collaboration_authority.py
+++ b/src/kai/workshop/collaboration_authority.py
@@ -39,6 +39,8 @@ from kai.workshop.run_execution_authority import RunExecutionClaim
 from kai.workshop.store import WorkshopEventStore
 
 _REVOCATION_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_IDEMPOTENCY_KEY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 _PROOF_REDACTION = "[redacted collaboration proof]"
 
 
@@ -75,6 +77,16 @@ class CollaborationDenied(CollaborationAuthorityError):
 
 class CollaborationGrantConflict(CollaborationAuthorityError):
     """Durable state conflicts with the proposed attempt grant."""
+
+
+@dataclass(frozen=True, slots=True)
+class CollaborationBaseIdentity:
+    """Stable process identity that must agree with a transient proof."""
+
+    principal_id: PrincipalId
+    channel_id: ChannelId
+    agent_id: AgentId
+    runtime_profile_id: RuntimeProfileId
 
 
 @dataclass(frozen=True, slots=True)
@@ -158,6 +170,18 @@ class CollaborationInvocation:
 
     def redact(self, text: str) -> str:
         return text.replace(self.token, _PROOF_REDACTION)
+
+    def render_context(self) -> str:
+        """Render the proof only into its exact turn, never durable context."""
+        return (
+            "[Attempt-scoped collaboration authority: This turn alone may use "
+            "the collaboration operations granted by your immutable agent revision. "
+            "Every collaboration request must include header "
+            f"'X-Kai-Collaboration-Proof: {self.token}'. "
+            "The persistent $KAI_WEBHOOK_SECRET identifies your backend process but "
+            "does not authorize collaboration. Never print, quote, persist, or pass "
+            "this proof to another agent. It expires when this exact attempt ends.]"
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -353,6 +377,7 @@ class WorkshopCollaborationAuthority:
         token: str,
         operation: CollaborationOperation,
         *,
+        base_identity: CollaborationBaseIdentity | None = None,
         occurred_at: datetime,
     ) -> CollaborationAuthorization:
         """Resolve an untrusted token through the exact live grant and attempt."""
@@ -366,11 +391,146 @@ class WorkshopCollaborationAuthority:
         fingerprint = hashlib.sha256(token.encode()).hexdigest()
         if not hmac.compare_digest(fingerprint, grant.proof_fingerprint):
             raise CollaborationProofError("Invalid collaboration proof")
+        if base_identity is not None and (
+            base_identity.principal_id != grant.requested_by_principal_id
+            or base_identity.channel_id != grant.channel_id
+            or base_identity.agent_id != grant.agent_id
+            or base_identity.runtime_profile_id != grant.runtime_profile_id
+        ):
+            raise CollaborationDenied(
+                "base_identity_mismatch",
+                "The persistent backend identity does not match this collaboration attempt",
+            )
         if operation not in grant.effective_operations:
             raise CollaborationDenied(
                 "operation_not_granted",
                 f"The active attempt is not authorized for {operation.value}",
             )
+        return CollaborationAuthorization(grant, operation)
+
+    async def authorize(
+        self,
+        token: str,
+        operation: CollaborationOperation,
+        *,
+        base_identity: CollaborationBaseIdentity,
+        idempotency_key: str,
+        request_hash: str,
+        occurred_at: datetime,
+    ) -> CollaborationAuthorization:
+        """Authorize and durably audit one idempotent operation invocation."""
+        if not isinstance(operation, CollaborationOperation):
+            raise ValueError("operation must be a CollaborationOperation")
+        if not isinstance(base_identity, CollaborationBaseIdentity):
+            raise ValueError("base_identity must be a CollaborationBaseIdentity")
+        if not _IDEMPOTENCY_KEY_PATTERN.fullmatch(idempotency_key):
+            raise ValueError("idempotency_key must be a bounded identifier")
+        if not _SHA256_PATTERN.fullmatch(request_hash):
+            raise ValueError("request_hash must be a SHA-256 fingerprint")
+        invocation = self._match_token(token)
+        if invocation is None:
+            raise CollaborationProofError("Invalid collaboration proof")
+        now = _timestamp(occurred_at, field_name="occurred_at")
+        grant = await self._snapshot(invocation.grant_id)
+        fingerprint = hashlib.sha256(token.encode()).hexdigest()
+        if not hmac.compare_digest(fingerprint, grant.proof_fingerprint):
+            raise CollaborationProofError("Invalid collaboration proof")
+
+        denial: CollaborationDenied | None = None
+        try:
+            grant = await self._live_grant(invocation.grant_id, occurred_at=now)
+        except CollaborationDenied as exc:
+            denial = exc
+        if denial is None and (
+            base_identity.principal_id != grant.requested_by_principal_id
+            or base_identity.channel_id != grant.channel_id
+            or base_identity.agent_id != grant.agent_id
+            or base_identity.runtime_profile_id != grant.runtime_profile_id
+        ):
+            denial = CollaborationDenied(
+                "base_identity_mismatch",
+                "The persistent backend identity does not match this collaboration attempt",
+            )
+        if denial is None and operation not in grant.effective_operations:
+            denial = CollaborationDenied(
+                "operation_not_granted",
+                f"The active attempt is not authorized for {operation.value}",
+            )
+
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            async with connection.execute(
+                "SELECT request_hash, decision, denial_code FROM collaboration_operation_decisions "
+                "WHERE grant_id = ? AND operation = ? AND idempotency_key = ?",
+                (grant.grant_id, operation.value, idempotency_key),
+            ) as cursor:
+                existing = await cursor.fetchone()
+            if existing is not None:
+                if not hmac.compare_digest(str(existing[0]), request_hash):
+                    raise CollaborationDenied(
+                        "idempotency_conflict",
+                        "Collaboration idempotency key was reused with different content",
+                    )
+                await connection.commit()
+                if str(existing[1]) == "denied":
+                    code = str(existing[2])
+                    raise CollaborationDenied(code, f"Collaboration invocation was denied: {code}")
+                return CollaborationAuthorization(grant, operation)
+
+            quota_ordinal: int | None = None
+            if denial is None:
+                async with connection.execute(
+                    "SELECT COUNT(*) FROM collaboration_operation_decisions "
+                    "WHERE grant_id = ? AND operation = ? AND decision = 'authorized'",
+                    (grant.grant_id, operation.value),
+                ) as cursor:
+                    count_row = await cursor.fetchone()
+                assert count_row is not None
+                quota_ordinal = int(count_row[0]) + 1
+                if quota_ordinal > grant.quotas[operation]:
+                    quota_ordinal = None
+                    denial = CollaborationDenied(
+                        "quota_exhausted",
+                        f"The active attempt exhausted its {operation.value} quota",
+                    )
+
+            decision = "denied" if denial is not None else "authorized"
+            event = EventEnvelope.create(
+                event_id=EventId.derived(
+                    grant.grant_id,
+                    f"operation:{operation.value}:{idempotency_key}",
+                ),
+                event_type=WorkshopEventType.COLLABORATION_OPERATION_DECIDED,
+                event_version=1,
+                workshop_id=grant.workshop_id,
+                aggregate_type="collaboration_grant",
+                aggregate_id=grant.grant_id,
+                actor_principal_id=grant.agent_principal_id,
+                occurred_at=now,
+                idempotency_key=(
+                    f"workshop-collaboration-operation:v1:{grant.grant_id}:{operation.value}:{idempotency_key}"
+                ),
+                payload={
+                    "operation": operation.value,
+                    "idempotency_key": idempotency_key,
+                    "request_hash": request_hash,
+                    "decision": decision,
+                    "denial_code": denial.code if denial is not None else None,
+                    "quota_ordinal": quota_ordinal,
+                },
+                metadata={"source": "workshop_collaboration_authority"},
+            )
+            await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(projection)
+            await connection.commit()
+        except Exception:
+            await connection.rollback()
+            raise
+        if denial is not None:
+            raise denial
         return CollaborationAuthorization(grant, operation)
 
     async def revoke(

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -81,6 +81,7 @@ class WorkshopEventType(StrEnum):
     RUN_ATTEMPT_CANCELLED = "run_attempt.cancelled"
     COLLABORATION_GRANT_ISSUED = "collaboration_grant.issued"
     COLLABORATION_GRANT_REVOKED = "collaboration_grant.revoked"
+    COLLABORATION_OPERATION_DECIDED = "collaboration_operation.decided"
     AGENT_DELEGATION_REQUESTED = "agent_delegation.requested"
     AGENT_DELEGATION_STARTED = "agent_delegation.started"
     AGENT_DELEGATION_COMPLETED = "agent_delegation.completed"

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -19,7 +19,10 @@ from kai.workshop.agent_definitions import (
 )
 from kai.workshop.artifacts import ArtifactMessageNotFoundError, build_agent_prompt_for_message
 from kai.workshop.collaboration_authority import (
+    CollaborationAuthorization,
+    CollaborationBaseIdentity,
     CollaborationInvocation,
+    CollaborationOperation,
     WorkshopCollaborationAuthority,
 )
 from kai.workshop.conversation_context import assemble_canonical_conversation_context
@@ -182,6 +185,27 @@ class WorkshopCanonicalExecutionCoordinator:
     def collaboration_authority(self) -> WorkshopCollaborationAuthority:
         """Return the host-owned authority used by future backend tool bridges."""
         return self._collaboration_authority
+
+    async def authorize_collaboration(
+        self,
+        proof: str,
+        operation: CollaborationOperation,
+        *,
+        base_identity: CollaborationBaseIdentity,
+        idempotency_key: str,
+        request_hash: str,
+        occurred_at: datetime,
+    ) -> CollaborationAuthorization:
+        """Serialize collaboration authorization with run-state transactions."""
+        async with self._database_lock:
+            return await self._collaboration_authority.authorize(
+                proof,
+                operation,
+                base_identity=base_identity,
+                idempotency_key=idempotency_key,
+                request_hash=request_hash,
+                occurred_at=occurred_at,
+            )
 
     async def execute(
         self,
@@ -347,6 +371,9 @@ class WorkshopCanonicalExecutionCoordinator:
                         occurred_at=self._now(),
                     )
 
+            if active.collaboration_invocation is not None:
+                prepared.stage_collaboration_invocation(active.collaboration_invocation)
+
             response = await self._consume_with_renewal(active, prepared, stream_observer=stream_observer)
             if active.cancellation_requested:
                 return await self._settle_requested_cancellation(active)
@@ -469,6 +496,8 @@ class WorkshopCanonicalExecutionCoordinator:
             )
         finally:
             if active.collaboration_invocation is not None:
+                if active.prepared is not None:
+                    active.prepared.discard_collaboration_invocation(active.collaboration_invocation)
                 try:
                     async with self._database_lock:
                         await self._collaboration_authority.revoke(
@@ -561,6 +590,8 @@ class WorkshopCanonicalExecutionCoordinator:
         response: AgentResponse | None = None
         traces_truncated = False
         async for event in prepared.stream(prompt):
+            if active.collaboration_invocation is not None:
+                event = _redact_collaboration_event(event, active.collaboration_invocation)
             if event.done:
                 response = event.response
                 break
@@ -684,3 +715,37 @@ def _history_with_transcript_pointer(history: str, transcript_path: object) -> s
         "Search it with grep or jq only when older context is needed."
     )
     return f"{history}\n\n{note}" if history else note
+
+
+def _redact_collaboration_event(
+    event: StreamEvent,
+    invocation: CollaborationInvocation,
+) -> StreamEvent:
+    """Fail closed if a backend echoes its short-lived proof."""
+    response = event.response
+    if response is not None:
+        response = AgentResponse(
+            success=response.success,
+            text=invocation.redact(response.text),
+            session_id=response.session_id,
+            duration_ms=response.duration_ms,
+            error=invocation.redact(response.error) if response.error is not None else None,
+            failure_kind=response.failure_kind,
+        )
+    trace = event.trace
+    if trace is not None:
+        trace = type(trace)(
+            kind=trace.kind,
+            tool_use_id=trace.tool_use_id,
+            summary=invocation.redact(trace.summary),
+            detail=invocation.redact(trace.detail),
+            tool_name=trace.tool_name,
+            is_diff=trace.is_diff,
+            is_error=trace.is_error,
+        )
+    return StreamEvent(
+        text_so_far=invocation.redact(event.text_so_far),
+        done=event.done,
+        response=response,
+        trace=trace,
+    )

--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 from kai.workshop.artifacts import StagedArtifact
-from kai.workshop.collaboration_authority import WorkshopCollaborationAuthority
+from kai.workshop.collaboration_authority import (
+    CollaborationAuthorization,
+    CollaborationBaseIdentity,
+    CollaborationOperation,
+    WorkshopCollaborationAuthority,
+)
 from kai.workshop.conversation_commands import (
     ClientConversationCommandAcceptance,
     ConversationCommandAcceptance,
@@ -129,6 +135,28 @@ class WorkshopPrivateTextExecutionService:
     def collaboration_authority(self) -> WorkshopCollaborationAuthority:
         """Expose the coordinator-owned authority to trusted host adapters only."""
         return self._coordinator.collaboration_authority
+
+    async def authorize_collaboration(
+        self,
+        proof: str,
+        operation: CollaborationOperation,
+        *,
+        base_identity: CollaborationBaseIdentity,
+        idempotency_key: str,
+        request_hash: str,
+        occurred_at: datetime,
+    ) -> CollaborationAuthorization:
+        """Authorize one operation through the coordinator's transaction lock."""
+        if self._closed:
+            raise RuntimeError("Workshop private-text execution service is closed")
+        return await self._coordinator.authorize_collaboration(
+            proof,
+            operation,
+            base_identity=base_identity,
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+            occurred_at=occurred_at,
+        )
 
     async def accept(
         self,

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -52,6 +52,7 @@ _MEDIA_TYPE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9!#$&^_.+-]*/[a-z0-9][a-z0-9!#
 _RUN_TERMINAL_CODE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 _EXECUTION_IDENTIFIER_PATTERN = re.compile(r"^[a-z][a-z0-9_.-]{0,63}$")
 _MODEL_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_COLLABORATION_IDEMPOTENCY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 
 
 def _required_text(payload: dict[str, Any], key: str) -> str:
@@ -1004,6 +1005,95 @@ async def _apply_collaboration_grant_event(
         )
         return
 
+    if envelope.event_type == WorkshopEventType.COLLABORATION_OPERATION_DECIDED:
+        _require_exact_payload(
+            payload,
+            {
+                "operation",
+                "idempotency_key",
+                "request_hash",
+                "decision",
+                "denial_code",
+                "quota_ordinal",
+            },
+        )
+        operation = _required_text(payload, "operation")
+        validate_collaboration_operations([operation])
+        idempotency_key = _required_text(payload, "idempotency_key")
+        request_hash = _required_text(payload, "request_hash")
+        decision = _required_text(payload, "decision")
+        denial_value = payload.get("denial_code")
+        denial_code = str(denial_value) if denial_value is not None else None
+        quota_ordinal = payload.get("quota_ordinal")
+        if (
+            not _COLLABORATION_IDEMPOTENCY_PATTERN.fullmatch(idempotency_key)
+            or not _SHA256_PATTERN.fullmatch(request_hash)
+            or decision not in {"authorized", "denied"}
+            or (denial_code is not None and not _RUN_TERMINAL_CODE_PATTERN.fullmatch(denial_code))
+        ):
+            raise ValueError("Workshop collaboration operation decision is malformed")
+        async with connection.execute(
+            "SELECT agent_principal_id, effective_operations_json, quotas_json, revoked_at, attempt_id "
+            "FROM collaboration_grants WHERE id = ?",
+            (envelope.aggregate_id,),
+        ) as cursor:
+            grant_row = await cursor.fetchone()
+        if grant_row is None or envelope.actor_principal_id != PrincipalId(str(grant_row[0])):
+            raise ValueError("Workshop collaboration operation decision has no matching grant")
+        effective = validate_collaboration_operations(json.loads(str(grant_row[1])))
+        quotas = json.loads(str(grant_row[2]))
+        async with connection.execute(
+            "SELECT COUNT(*) FROM collaboration_operation_decisions "
+            "WHERE grant_id = ? AND operation = ? AND decision = 'authorized'",
+            (envelope.aggregate_id, operation),
+        ) as cursor:
+            count_row = await cursor.fetchone()
+        assert count_row is not None
+        prior_authorized = int(count_row[0])
+        if decision == "authorized":
+            async with connection.execute(
+                "SELECT ra.status, r.status, r.cancellation_requested_at, ra.lease_expires_at "
+                "FROM run_attempts ra JOIN runs r ON r.id = ra.run_id WHERE ra.id = ?",
+                (str(grant_row[4]),),
+            ) as cursor:
+                attempt_row = await cursor.fetchone()
+            limit = quotas.get(operation) if isinstance(quotas, dict) else None
+            if (
+                denial_code is not None
+                or isinstance(quota_ordinal, bool)
+                or not isinstance(quota_ordinal, int)
+                or quota_ordinal != prior_authorized + 1
+                or operation not in effective
+                or not isinstance(limit, int)
+                or quota_ordinal > limit
+                or grant_row[3] is not None
+                or attempt_row is None
+                or str(attempt_row[0]) != "started"
+                or str(attempt_row[1]) != "started"
+                or attempt_row[2] is not None
+                or occurred_at >= _parse_projection_timestamp(attempt_row[3])
+            ):
+                raise ValueError("Workshop collaboration authorization decision is invalid")
+        elif denial_code is None or quota_ordinal is not None:
+            raise ValueError("Workshop collaboration denial decision is invalid")
+        await connection.execute(
+            "INSERT INTO collaboration_operation_decisions "
+            "(grant_id, operation, idempotency_key, request_hash, decision, denial_code, "
+            "quota_ordinal, decided_at, decided_event_position) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                envelope.aggregate_id,
+                operation,
+                idempotency_key,
+                request_hash,
+                decision,
+                denial_code,
+                quota_ordinal,
+                occurred_at.isoformat(),
+                event.position,
+            ),
+        )
+        return
+
     raise ValueError(f"Unsupported Workshop collaboration-grant event: {envelope.event_type}")
 
 
@@ -1310,7 +1400,7 @@ class CanonicalConversationProjection:
 
     name = "canonical_conversations"
     # Agent ownership and runtime sponsorship project from explicit authority events.
-    version = 27
+    version = 28
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -1329,6 +1419,7 @@ class CanonicalConversationProjection:
             "deliveries",
             "artifacts",
             "agent_delegations",
+            "collaboration_operation_decisions",
             "collaboration_grants",
             "run_attempts",
             "runs",
@@ -1368,6 +1459,7 @@ class CanonicalConversationProjection:
         if envelope.event_type in {
             WorkshopEventType.COLLABORATION_GRANT_ISSUED,
             WorkshopEventType.COLLABORATION_GRANT_REVOKED,
+            WorkshopEventType.COLLABORATION_OPERATION_DECIDED,
         }:
             await _apply_collaboration_grant_event(connection, event)
             return

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from kai.backend import StreamEvent
 from kai.config import VALID_BACKENDS, validate_model_for_backend
+from kai.workshop.collaboration_authority import CollaborationInvocation
 from kai.workshop.domain import ChannelId, RunId, RuntimeProfileId
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.routing_policy import RunRoutingDecision, WorkshopRoutingPolicyService
@@ -59,6 +60,12 @@ class PreparedWorkshopExecution:
 
     def stage_agent_definition_context(self, context: str) -> None:
         self._runtime.stage_canonical_agent_context(context)
+
+    def stage_collaboration_invocation(self, invocation: CollaborationInvocation) -> None:
+        self._runtime.stage_collaboration_invocation(invocation.render_context(), invocation.token)
+
+    def discard_collaboration_invocation(self, invocation: CollaborationInvocation) -> None:
+        self._runtime.discard_collaboration_invocation(invocation.token)
 
     def validate_current(self) -> None:
         """Verify the exact runtime immediately before the started boundary."""

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 67
+WORKSHOP_SCHEMA_VERSION = 68
 
 
 @dataclass(frozen=True, slots=True)
@@ -2950,6 +2950,40 @@ _ATTEMPT_SCOPED_COLLABORATION_AUTHORITY_SCHEMA = SchemaMigration(
     ),
 )
 
+_COLLABORATION_OPERATION_DECISION_SCHEMA = SchemaMigration(
+    version=68,
+    name="collaboration_operation_decisions",
+    statements=(
+        """
+        CREATE TABLE collaboration_operation_decisions (
+            grant_id TEXT NOT NULL REFERENCES collaboration_grants(id) ON DELETE CASCADE,
+            operation TEXT NOT NULL CHECK (
+                operation IN (
+                    'context_read', 'reaction', 'progress_publish',
+                    'thread_reply', 'artifact_publish', 'agent_delegation'
+                )
+            ),
+            idempotency_key TEXT NOT NULL,
+            request_hash TEXT NOT NULL CHECK (length(request_hash) = 64),
+            decision TEXT NOT NULL CHECK (decision IN ('authorized', 'denied')),
+            denial_code TEXT,
+            quota_ordinal INTEGER,
+            decided_at TEXT NOT NULL,
+            decided_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            PRIMARY KEY (grant_id, operation, idempotency_key),
+            CHECK (
+                (decision = 'authorized' AND denial_code IS NULL AND quota_ordinal > 0)
+                OR
+                (decision = 'denied' AND denial_code IS NOT NULL AND quota_ordinal IS NULL)
+            )
+        )
+        """,
+        "CREATE INDEX collaboration_operation_decisions_quota_idx ON "
+        "collaboration_operation_decisions (grant_id, operation, decision, quota_ordinal)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -3018,6 +3052,7 @@ _MIGRATIONS = (
     _CANONICAL_HUMAN_AVATAR_SCHEMA,
     _EXPANDED_MESSAGE_REACTIONS_SCHEMA,
     _ATTEMPT_SCOPED_COLLABORATION_AUTHORITY_SCHEMA,
+    _COLLABORATION_OPERATION_DECISION_SCHEMA,
 )
 
 

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -56,7 +56,7 @@ def test_persistent_agent_profile_is_explicit_and_excludes_delete_all() -> None:
             InternalAPIScope.FILES_SEND,
             InternalAPIScope.MEMORY_READ,
             InternalAPIScope.MEMORY_ADD,
-            InternalAPIScope.AGENTS_DELEGATE,
+            InternalAPIScope.COLLABORATION_INVOKE,
         }
     )
     assert principal.allowed_services == frozenset()

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -263,7 +263,10 @@ class TestAgentDelegation:
             ),
             response="Bounded result.",
         )
-        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        mock_request.headers = {
+            "X-Webhook-Secret": "test-secret",
+            "X-Kai-Collaboration-Proof": "attempt-proof-000000000000000000000000000001",
+        }
         mock_request.json = AsyncMock(
             return_value={
                 "target_handle": "nova",
@@ -280,10 +283,11 @@ class TestAgentDelegation:
         assert body["status"] == "completed"
         assert body["response"] == "Bounded result."
         authority = service.delegate.await_args.args[0]
-        assert authority.sponsor_principal_id == _internal_api_context(123).principal_id
+        assert authority.principal_id == _internal_api_context(123).principal_id
         assert authority.channel_id == _internal_api_context(123).channel_id
-        assert authority.caller_agent_id == _internal_api_context(123).agent_id
+        assert authority.agent_id == _internal_api_context(123).agent_id
         assert authority.runtime_profile_id == _internal_api_context(123).runtime_profile_id
+        assert service.delegate.await_args.kwargs["proof"] == mock_request.headers["X-Kai-Collaboration-Proof"]
 
     async def test_rejects_caller_selected_run_identity_before_delegating(self, mock_request):
         service = mock_request.app[CORE_HOST_KEY].services.agent_delegation

--- a/tests/test_workshop_agent_delegation.py
+++ b/tests/test_workshop_agent_delegation.py
@@ -10,16 +10,19 @@ from pathlib import Path
 import pytest
 
 from kai.workshop.agent_delegation import (
-    AgentDelegationAuthority,
     AgentDelegationContext,
     AgentDelegationDenied,
     WorkshopAgentDelegationService,
+)
+from kai.workshop.collaboration_authority import (
+    CollaborationBaseIdentity,
+    CollaborationOperation,
+    WorkshopCollaborationAuthority,
 )
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.diagnostics import workshop_agent_authority_status
 from kai.workshop.domain import (
     MessageId,
-    PrincipalId,
     RunExecutionOwnerId,
     RunId,
     RuntimeProfileId,
@@ -40,10 +43,18 @@ from tests.test_workshop_wake_policy import _message, _open_group_store
 
 
 class _CompletingExecution:
-    def __init__(self, authority: WorkshopRunExecutionAuthority) -> None:
+    def __init__(
+        self,
+        authority: WorkshopRunExecutionAuthority,
+        collaboration_authority: WorkshopCollaborationAuthority,
+    ) -> None:
         self._authority = authority
+        self.collaboration_authority = collaboration_authority
         self._store = authority.event_store
         self.executed: list[RunId] = []
+
+    async def authorize_collaboration(self, proof, operation, **kwargs):
+        return await self.collaboration_authority.authorize(proof, operation, **kwargs)
 
     async def execute(self, run_id: RunId) -> CanonicalExecutionResult:
         self.executed.append(run_id)
@@ -90,11 +101,19 @@ class _CompletingExecution:
 
 
 class _CancellableExecution:
-    def __init__(self, authority: WorkshopRunExecutionAuthority) -> None:
+    def __init__(
+        self,
+        authority: WorkshopRunExecutionAuthority,
+        collaboration_authority: WorkshopCollaborationAuthority,
+    ) -> None:
         self._authority = authority
+        self.collaboration_authority = collaboration_authority
         self._store = authority.event_store
         self.started = asyncio.Event()
         self.cancelled = asyncio.Event()
+
+    async def authorize_collaboration(self, proof, operation, **kwargs):
+        return await self.collaboration_authority.authorize(proof, operation, **kwargs)
 
     async def execute(self, run_id: RunId) -> CanonicalExecutionResult:
         self.started.set()
@@ -150,7 +169,12 @@ async def _running_parent(path: Path):
         occurred_at=now,
         lease_expires_at=now + timedelta(minutes=1),
     )
-    await authority.start(granted.claim, occurred_at=now + timedelta(milliseconds=1))
+    started = await authority.start(granted.claim, occurred_at=now + timedelta(milliseconds=1))
+    collaboration_authority = WorkshopCollaborationAuthority(store)
+    _grant, invocation = await collaboration_authority.issue(
+        started.claim,
+        occurred_at=now + timedelta(milliseconds=2),
+    )
     async with store.connection.execute(
         "SELECT sponsor_principal_id, runtime_profile_id FROM runs WHERE id = ?",
         (parent.run_id,),
@@ -160,12 +184,14 @@ async def _running_parent(path: Path):
     return (
         store,
         authority,
-        AgentDelegationAuthority(
-            sponsor_principal_id=PrincipalId(str(row[0])),
+        CollaborationBaseIdentity(
+            principal_id=parent.requested_by_principal_id,
             channel_id=channel_id,
-            caller_agent_id=caller_agent_id,
+            agent_id=caller_agent_id,
             runtime_profile_id=RuntimeProfileId(str(row[1])),
         ),
+        invocation.token,
+        collaboration_authority,
         parent,
         target_agent_id,
     )
@@ -174,8 +200,10 @@ async def _running_parent(path: Path):
 async def test_explicit_delegation_is_visible_durable_bounded_and_idempotent(
     tmp_path: Path,
 ) -> None:
-    store, authority, caller, parent, target_agent_id = await _running_parent(tmp_path / "kai.db")
-    execution = _CompletingExecution(authority)
+    store, authority, caller, proof, collaboration_authority, parent, target_agent_id = await _running_parent(
+        tmp_path / "kai.db"
+    )
+    execution = _CompletingExecution(authority, collaboration_authority)
     service = WorkshopAgentDelegationService(store, execution)  # type: ignore[arg-type]
     await service.start()
     try:
@@ -185,6 +213,7 @@ async def test_explicit_delegation_is_visible_durable_bounded_and_idempotent(
         before_position = int(before_row[0])
         result = await service.delegate(
             caller,
+            proof=proof,
             target_handle="nova",
             task="Return a bounded qualification result.",
             context={"summary": "Only shared channel context."},
@@ -192,6 +221,7 @@ async def test_explicit_delegation_is_visible_durable_bounded_and_idempotent(
         )
         replay = await service.delegate(
             caller,
+            proof=proof,
             target_handle="NOVA",
             task="Return a bounded qualification result.",
             context={"summary": "Only shared channel context."},
@@ -222,6 +252,11 @@ async def test_explicit_delegation_is_visible_durable_bounded_and_idempotent(
         assert messages[1] == ("agent", "Delegated result from Nova.")
 
         replay_events = await store.read_events(after_position=before_position)
+        await store.connection.execute(
+            "DELETE FROM collaboration_operation_decisions WHERE grant_id = "
+            "(SELECT id FROM collaboration_grants WHERE run_id = ?)",
+            (parent.run_id,),
+        )
         await store.connection.execute(
             "DELETE FROM agent_delegations WHERE id = ?",
             (result.delegation.delegation_id,),
@@ -269,16 +304,19 @@ async def test_explicit_delegation_is_visible_durable_bounded_and_idempotent(
 async def test_delegation_rejects_cycles_before_creating_any_child_state(
     tmp_path: Path,
 ) -> None:
-    store, authority, caller, _parent, _target_agent_id = await _running_parent(tmp_path / "kai.db")
+    store, authority, caller, proof, collaboration_authority, _parent, _target_agent_id = await _running_parent(
+        tmp_path / "kai.db"
+    )
     service = WorkshopAgentDelegationService(
         store,
-        _CompletingExecution(authority),  # type: ignore[arg-type]
+        _CompletingExecution(authority, collaboration_authority),  # type: ignore[arg-type]
     )
     await service.start()
     try:
         with pytest.raises(AgentDelegationDenied) as denied:
             await service.delegate(
                 caller,
+                proof=proof,
                 target_handle="kai",
                 task="Delegate back to the caller.",
                 idempotency_key="cycle",
@@ -291,13 +329,48 @@ async def test_delegation_rejects_cycles_before_creating_any_child_state(
         await store.close()
 
 
+async def test_delegation_rejects_base_identity_without_exact_attempt_proof(tmp_path: Path) -> None:
+    store, authority, caller, _proof, collaboration_authority, _parent, _target_agent_id = await _running_parent(
+        tmp_path / "kai.db"
+    )
+    service = WorkshopAgentDelegationService(
+        store,
+        _CompletingExecution(authority, collaboration_authority),  # type: ignore[arg-type]
+    )
+    await service.start()
+    try:
+        with pytest.raises(AgentDelegationDenied) as denied:
+            await service.delegate(
+                caller,
+                proof="",
+                target_handle="nova",
+                task="This must not run.",
+                idempotency_key="missing-proof",
+            )
+        assert denied.value.code == "invalid_proof"
+        async with store.connection.execute("SELECT COUNT(*) FROM agent_delegations") as cursor:
+            assert int((await cursor.fetchone())[0]) == 0
+        async with store.connection.execute("SELECT COUNT(*) FROM collaboration_operation_decisions") as cursor:
+            assert int((await cursor.fetchone())[0]) == 0
+    finally:
+        await service.stop()
+        await store.close()
+
+
 async def test_requested_delegation_resumes_after_service_restart(tmp_path: Path) -> None:
-    store, authority, caller, _parent, _target_agent_id = await _running_parent(tmp_path / "kai.db")
-    execution = _CompletingExecution(authority)
+    store, authority, caller, proof, collaboration_authority, _parent, _target_agent_id = await _running_parent(
+        tmp_path / "kai.db"
+    )
+    execution = _CompletingExecution(authority, collaboration_authority)
     seed = WorkshopAgentDelegationService(store, execution)  # type: ignore[arg-type]
     # Call the acceptance seam directly to simulate a crash after its durable commit.
     delegation = await seed._accept(
-        caller,
+        await collaboration_authority.authenticate(
+            proof,
+            CollaborationOperation.AGENT_DELEGATION,
+            base_identity=caller,
+            occurred_at=datetime.now(UTC),
+        ),
         target_handle="nova",
         task="Complete after restart.",
         context=AgentDelegationContext(),
@@ -321,12 +394,19 @@ async def test_requested_delegation_resumes_after_service_restart(tmp_path: Path
 
 
 async def test_service_shutdown_cancels_the_delegated_child_tree(tmp_path: Path) -> None:
-    store, authority, caller, _parent, _target_agent_id = await _running_parent(tmp_path / "kai.db")
-    execution = _CancellableExecution(authority)
+    store, authority, caller, proof, collaboration_authority, _parent, _target_agent_id = await _running_parent(
+        tmp_path / "kai.db"
+    )
+    execution = _CancellableExecution(authority, collaboration_authority)
     service = WorkshopAgentDelegationService(store, execution)  # type: ignore[arg-type]
     # Seed the durable pre-dispatch boundary before the worker starts.
     delegation = await service._accept(
-        caller,
+        await collaboration_authority.authenticate(
+            proof,
+            CollaborationOperation.AGENT_DELEGATION,
+            base_identity=caller,
+            occurred_at=datetime.now(UTC),
+        ),
         target_handle="nova",
         task="Remain active until shutdown.",
         context=AgentDelegationContext(),

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -418,7 +418,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 67
+        assert await upgraded.schema_version() == 68
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -529,7 +529,7 @@ class TestArtifactShadowRecordingAfterRestart:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 27
+            assert checkpoint.version == 28
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -11,6 +11,7 @@ import pytest
 from kai.internal_api_auth import InternalAPIAuth
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.collaboration_authority import (
+    CollaborationBaseIdentity,
     CollaborationDenied,
     CollaborationHostPolicy,
     CollaborationOperation,
@@ -32,6 +33,16 @@ from kai.workshop.store import WorkshopEventStore
 
 _NOW = datetime(2026, 9, 5, 12, 0, tzinfo=UTC)
 _RUNTIME_PROFILE_ID = RuntimeProfileId.new()
+
+
+def _base_identity(started) -> CollaborationBaseIdentity:
+    assert started.run.runtime_profile_id is not None
+    return CollaborationBaseIdentity(
+        principal_id=started.run.requested_by_principal_id,
+        channel_id=started.run.channel_id,
+        agent_id=started.run.agent_id,
+        runtime_profile_id=started.run.runtime_profile_id,
+    )
 
 
 async def _running_attempt(path: Path, *, suffix: str = "1"):
@@ -397,7 +408,7 @@ async def test_version_sixty_seven_migrates_only_legacy_delegation_requests(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 67
+        assert await upgraded.schema_version() == 68
         async with upgraded.connection.execute(
             "SELECT id, capabilities_json, collaboration_operations_json "
             "FROM agent_definition_revisions ORDER BY revision_number"
@@ -414,3 +425,99 @@ async def test_version_sixty_seven_migrates_only_legacy_delegation_requests(
                 assert operations == (["agent_delegation"] if "agent_delegation" in capabilities else [])
     finally:
         await upgraded.close()
+
+
+async def test_operation_authorization_is_durable_idempotent_and_quota_bounded(tmp_path: Path) -> None:
+    store, _execution, started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        authority = WorkshopCollaborationAuthority(
+            store,
+            host_policy=CollaborationHostPolicy(
+                allowed_operations=frozenset({CollaborationOperation.AGENT_DELEGATION}),
+                quotas={CollaborationOperation.AGENT_DELEGATION: 1},
+            ),
+            token_factory=lambda: "attempt-proof-000000000000000000000000000008",
+        )
+        _grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+        request_hash = "a" * 64
+        first = await authority.authorize(
+            invocation.token,
+            CollaborationOperation.AGENT_DELEGATION,
+            base_identity=_base_identity(started),
+            idempotency_key="operation-one",
+            request_hash=request_hash,
+            occurred_at=_NOW + timedelta(seconds=4),
+        )
+        replay = await authority.authorize(
+            invocation.token,
+            CollaborationOperation.AGENT_DELEGATION,
+            base_identity=_base_identity(started),
+            idempotency_key="operation-one",
+            request_hash=request_hash,
+            occurred_at=_NOW + timedelta(seconds=5),
+        )
+        assert replay == first
+
+        with pytest.raises(CollaborationDenied) as denied:
+            await authority.authorize(
+                invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                base_identity=_base_identity(started),
+                idempotency_key="operation-two",
+                request_hash="b" * 64,
+                occurred_at=_NOW + timedelta(seconds=6),
+            )
+        assert denied.value.code == "quota_exhausted"
+        async with store.connection.execute(
+            "SELECT idempotency_key, decision, denial_code, quota_ordinal "
+            "FROM collaboration_operation_decisions ORDER BY decided_event_position"
+        ) as cursor:
+            assert [tuple(row) for row in await cursor.fetchall()] == [
+                ("operation-one", "authorized", None, 1),
+                ("operation-two", "denied", "quota_exhausted", None),
+            ]
+
+        await store.rebuild_projection(CanonicalConversationProjection())
+        async with store.connection.execute("SELECT COUNT(*) FROM collaboration_operation_decisions") as cursor:
+            assert int((await cursor.fetchone())[0]) == 2
+    finally:
+        await store.close()
+
+
+async def test_mismatched_base_identity_is_denied_and_audited(tmp_path: Path) -> None:
+    store, _execution, started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        authority = WorkshopCollaborationAuthority(
+            store,
+            token_factory=lambda: "attempt-proof-000000000000000000000000000009",
+        )
+        _grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+        correct = _base_identity(started)
+        mismatched = CollaborationBaseIdentity(
+            principal_id=correct.principal_id,
+            channel_id=correct.channel_id,
+            agent_id=correct.agent_id,
+            runtime_profile_id=RuntimeProfileId.new(),
+        )
+        with pytest.raises(CollaborationDenied) as denied:
+            await authority.authorize(
+                invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                base_identity=mismatched,
+                idempotency_key="wrong-runtime",
+                request_hash="c" * 64,
+                occurred_at=_NOW + timedelta(seconds=4),
+            )
+        assert denied.value.code == "base_identity_mismatch"
+        async with store.connection.execute(
+            "SELECT decision, denial_code FROM collaboration_operation_decisions"
+        ) as cursor:
+            assert tuple(await cursor.fetchone()) == ("denied", "base_identity_mismatch")
+    finally:
+        await store.close()

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -389,7 +389,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 27
+            assert checkpoint.version == 28
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -65,12 +65,21 @@ class _Prepared:
         self.reject_validation = False
         self.canonical_histories: list[str] = []
         self.agent_definition_contexts: list[str] = []
+        self.collaboration_invocations = []
+        self.discarded_collaboration_invocations = []
 
     def stage_canonical_history(self, history: str) -> None:
         self.canonical_histories.append(history)
 
     def stage_agent_definition_context(self, context: str) -> None:
         self.agent_definition_contexts.append(context)
+
+    def stage_collaboration_invocation(self, invocation) -> None:
+        self.collaboration_invocations.append(invocation)
+
+    def discard_collaboration_invocation(self, invocation) -> None:
+        assert self.collaboration_invocations[-1] == invocation
+        self.discarded_collaboration_invocations.append(invocation)
 
     def validate_current(self) -> None:
         self.validated = True
@@ -209,6 +218,8 @@ class TestCanonicalExecutionCoordinator:
             assert result.run.status == RunStatus.COMPLETED
             assert prepared.validated is True
             assert prepared.prompts == ["Canonical prompt 1"]
+            assert len(prepared.collaboration_invocations) == 1
+            assert prepared.discarded_collaboration_invocations == prepared.collaboration_invocations
             assert await _terminal_bodies(store) == ["Canonical prompt 1", "Canonical answer"]
             async with store.connection.execute(
                 "SELECT requested_operations_json, effective_operations_json, "
@@ -297,7 +308,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
             after = workshop_runtime_session_status(path)
             assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
@@ -325,7 +336,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
             assert session is not None
             assert session.runtime_profile_id == _RUNTIME_PROFILE_ID
@@ -487,6 +498,56 @@ class TestCanonicalExecutionCoordinator:
             ) as cursor:
                 rows = list(await cursor.fetchall())
             assert [tuple(row) for row in rows] == [(1, "tool_call", "Bash: ls")]
+        finally:
+            await store.close()
+
+    async def test_attempt_proof_is_redacted_from_preview_trace_and_terminal_message(self, tmp_path: Path):
+        store, run = await _accepted(tmp_path / "kai.db")
+        prepared = _Prepared(run)
+        observed: list[StreamEvent] = []
+
+        async def stream_with_proof(prompt: str) -> AsyncIterator[StreamEvent]:
+            proof = prepared.collaboration_invocations[-1].token
+            yield StreamEvent(text_so_far=f"preview {proof}")
+            yield StreamEvent(
+                text_so_far="",
+                trace=TraceEntry(
+                    kind="tool_call",
+                    tool_use_id="proof-tool",
+                    summary=f"curl {proof}",
+                    detail=f"header={proof}",
+                    tool_name="curl",
+                ),
+            )
+            yield StreamEvent(
+                text_so_far=f"answer {proof}",
+                done=True,
+                response=AgentResponse(success=True, text=f"answer {proof}"),
+            )
+
+        async def observe(event: StreamEvent) -> None:
+            observed.append(event)
+
+        prepared.stream = stream_with_proof  # type: ignore[method-assign]
+        try:
+            result = await _coordinator(store, _Preparation(prepared)).execute(
+                run.run_id,
+                stream_observer=observe,
+            )
+            proof = prepared.collaboration_invocations[-1].token
+            assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+            assert proof not in "".join(event.text_so_far for event in observed)
+            async with store.connection.execute(
+                "SELECT summary, detail FROM run_traces WHERE run_id = ?",
+                (run.run_id,),
+            ) as cursor:
+                trace_row = tuple(await cursor.fetchone())
+            assert proof not in "".join(trace_row)
+            assert trace_row == (
+                "curl [redacted collaboration proof]",
+                "header=[redacted collaboration proof]",
+            )
+            assert (await _terminal_bodies(store))[-1] == "answer [redacted collaboration proof]"
         finally:
             await store.close()
 

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -151,6 +151,7 @@ class TestEventEnvelope:
             "run_attempt.cancelled",
             "collaboration_grant.issued",
             "collaboration_grant.revoked",
+            "collaboration_operation.decided",
         }
 
     def test_create_builds_a_versioned_transport_independent_envelope(self):
@@ -245,6 +246,7 @@ class TestWorkshopSchema:
             "run_attempts",
             "agent_delegations",
             "collaboration_grants",
+            "collaboration_operation_decisions",
             "principal_human_notification_policies",
             "principal_human_notification_adapter_preferences",
             "principal_channel_notification_policies",
@@ -260,7 +262,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 67
+        assert await workshop_store.schema_version() == 68
         async with workshop_store.connection.execute("PRAGMA table_info(principals)") as cursor:
             principal_columns = {str(row[1]) for row in await cursor.fetchall()}
         assert {"display_name_state_version", "display_name_event_position"} <= principal_columns
@@ -311,7 +313,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 67
+        assert await second.schema_version() == 68
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -395,7 +397,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             async with upgraded.connection.execute(
                 "SELECT reaction, created_event_position FROM message_reactions "
                 "WHERE message_id = ? AND principal_id = ?",
@@ -436,7 +438,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -464,7 +466,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -549,6 +551,7 @@ class TestWorkshopSchema:
                     65,
                     66,
                     67,
+                    68,
                 ]
         finally:
             await upgraded.close()
@@ -571,7 +574,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -612,7 +615,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -665,7 +668,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -709,7 +712,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -753,7 +756,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -797,7 +800,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -901,7 +904,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -1028,7 +1031,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -319,7 +319,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 67
+            assert await upgraded.schema_version() == 68
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -51,12 +51,20 @@ class _Runtime:
         self.cancelled = False
         self.canonical_histories: list[str] = []
         self.agent_definition_contexts: list[str] = []
+        self.collaboration_proof: str | None = None
 
     def stage_canonical_history(self, history: str) -> None:
         self.canonical_histories.append(history)
 
     def stage_canonical_agent_context(self, context: str) -> None:
         self.agent_definition_contexts.append(context)
+
+    def stage_collaboration_invocation(self, _context: str, proof: str) -> None:
+        self.collaboration_proof = proof
+
+    def discard_collaboration_invocation(self, proof: str) -> None:
+        assert proof == self.collaboration_proof
+        self.collaboration_proof = None
 
     def validate_current(self) -> None:
         self.validated = True

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -391,7 +391,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 27
+            assert checkpoint.version == 28
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -166,7 +166,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 27
+            assert checkpoint.version == 28
             assert after == before
         finally:
             await store.close()

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -178,7 +178,7 @@ class TestRuntimeAssignmentPolicy:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 27
+            assert checkpoint.version == 28
             assert await resolve_channel_runtime_profile(store, human.channel_id) == (
                 assigned.agent_id,
                 profile_id(202),

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -111,12 +111,20 @@ class _CanonicalRuntime:
             model="gpt-5.6-sol",
         )
         self.workspace = workspace
+        self.collaboration_proof: str | None = None
 
     def stage_canonical_history(self, _history: str) -> None:
         pass
 
     def stage_canonical_agent_context(self, _context: str) -> None:
         pass
+
+    def stage_collaboration_invocation(self, _context: str, proof: str) -> None:
+        self.collaboration_proof = proof
+
+    def discard_collaboration_invocation(self, proof: str) -> None:
+        assert proof == self.collaboration_proof
+        self.collaboration_proof = None
 
     def validate_current(self) -> None:
         pass


### PR DESCRIPTION
## Summary
- inject a transient collaboration proof into only the exact protected backend turn while retaining persistent credentials as identity-only
- authorize delegation through the common collaboration authority with canonical base-identity matching, live-attempt fencing, quotas, and durable idempotent allow/deny decisions
- redact proofs from streaming previews, traces, terminal responses, and persistent backend state across Claude, Codex, ACP/OpenCode, and Pi
- serialize authorization with run lease and terminal-state transactions, and migrate existing delegation safely onto the common operation vocabulary

## Validation
- full suite: 6,463 passed
- post-adjustment focused backend/API tests: 396 passed
- Workshop client: 187 passed; generated bundle verified
- Ruff format/lint: passed
- Pyright strict: passed
- diff/security audit: passed; only proof fingerprints enter durable events

Closes #1377