### PR TITLE
Add attempt-scoped agent publications

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -32,6 +32,7 @@ from kai.workshop.client_preferences import (
 )
 from kai.workshop.codex_model_discovery import CodexModelDiscoveryAdapter
 from kai.workshop.collaboration_context import WorkshopCollaborationContextService
+from kai.workshop.collaboration_publications import WorkshopCollaborationPublicationService
 from kai.workshop.collaboration_reactions import WorkshopCollaborationReactionService
 from kai.workshop.conversation_runs import WorkshopConversationRunService
 from kai.workshop.delivery_authority import (
@@ -213,6 +214,7 @@ class KaiCoreServices:
     agent_delegation: WorkshopAgentDelegationService
     collaboration_context: WorkshopCollaborationContextService
     collaboration_reactions: WorkshopCollaborationReactionService
+    collaboration_publications: WorkshopCollaborationPublicationService
     delivery_policy: WorkshopDeliveryBindingPolicy
 
 
@@ -397,16 +399,23 @@ class KaiApplicationHost:
                 client_store,
                 private_execution,
             )
-            scheduler = await WorkshopCanonicalScheduler.open_and_start(
-                Path(self._config.session_db_path),
-                private_execution,
-                delivery_policy,
-            )
             artifacts = WorkshopArtifactService(
                 client_store,
                 data_dir=Path(self._config.session_db_path).parent,
                 principal_storage=self._principal_storage,
                 runtime_profiles=self._runtime_profiles,
+            )
+            collaboration_publications = WorkshopCollaborationPublicationService(
+                client_store,
+                private_execution,
+                artifacts,
+                data_dir=Path(self._config.session_db_path).parent,
+                delivery_policy=delivery_policy,
+            )
+            scheduler = await WorkshopCanonicalScheduler.open_and_start(
+                Path(self._config.session_db_path),
+                private_execution,
+                delivery_policy,
             )
             human_avatars = WorkshopHumanAvatarService(
                 client_store,
@@ -519,6 +528,7 @@ class KaiApplicationHost:
                 agent_delegation=agent_delegation,
                 collaboration_context=collaboration_context,
                 collaboration_reactions=collaboration_reactions,
+                collaboration_publications=collaboration_publications,
                 delivery_policy=delivery_policy,
             )
             self._state = KaiApplicationState.READY

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -1066,6 +1066,20 @@ def build_session_context(
             "Never send a channel, thread, run, agent, principal, or other identity selector. "
             "A reaction is participation metadata only: it never wakes or delegates to an agent.]"
         )
+        parts.append(
+            "[Workshop collaboration publication APIs: When your immutable definition and owner "
+            "policy grant progress_publish or thread_reply for this exact attempt, POST JSON to "
+            f"http://localhost:{api.webhook_port}/api/collaboration/messages with headers "
+            "'X-Webhook-Secret: $KAI_WEBHOOK_SECRET' and the separately injected "
+            "'X-Kai-Collaboration-Proof'. Required fields: kind ('progress' or 'thread_reply'), "
+            "body, and idempotency_key. When artifact_publish is granted, POST JSON to "
+            f"http://localhost:{api.webhook_port}/api/collaboration/artifacts with those headers "
+            "and required fields path, caption, and idempotency_key. The server derives the exact "
+            "channel or thread; never send destination, channel, thread, run, agent, principal, "
+            "or runtime selectors. These publications supplement progress but never replace your "
+            "ordinary terminal response. Agent mentions in them never wake another agent; use "
+            "explicit delegation for agent work.]"
+        )
 
     # No trailing \n\n here - prepend_to_prompt() adds the separator
     # between the context block and the user's message.

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -22,6 +22,8 @@ Routes are organized into these groups:
     - /api/agent-delegations - Run one bounded agent-to-agent delegation
     - /api/collaboration/context - Read exact-attempt bounded conversation context
     - /api/collaboration/reactions - Add or remove an exact-attempt reaction
+    - /api/collaboration/messages - Publish exact-attempt progress or a thread reply
+    - /api/collaboration/artifacts - Publish an exact-attempt artifact
     - /api/memory/add       - Store a structured memory (POST)
     - /api/memory/search    - Search memories by query (POST)
     - /api/memory/stats     - Memory statistics for a user (GET)
@@ -95,6 +97,10 @@ from kai.workshop.collaboration_authority import (
 )
 from kai.workshop.collaboration_context import (
     CollaborationContextValidationError,
+)
+from kai.workshop.collaboration_publications import (
+    CollaborationPublicationDenied,
+    CollaborationPublicationValidationError,
 )
 from kai.workshop.collaboration_reactions import (
     CollaborationReactionDenied,
@@ -1418,6 +1424,136 @@ async def _handle_collaboration_reaction(
     )
 
 
+def _collaboration_base_identity(principal: InternalAPIPrincipal) -> CollaborationBaseIdentity:
+    return CollaborationBaseIdentity(
+        principal_id=principal.principal_id,
+        channel_id=principal.channel_id,
+        agent_id=principal.agent_id,
+        runtime_profile_id=principal.runtime_profile_id,
+    )
+
+
+def _collaboration_publication_error(exc: Exception) -> web.Response:
+    if isinstance(exc, CollaborationProofError):
+        return web.json_response({"error": str(exc), "code": "invalid_proof"}, status=403)
+    if isinstance(exc, (CollaborationDenied, CollaborationPublicationDenied)):
+        return web.json_response({"error": str(exc), "code": exc.code}, status=403)
+    if isinstance(exc, CollaborationPublicationValidationError):
+        return web.json_response({"error": str(exc), "code": "invalid_request"}, status=400)
+    if isinstance(exc, TimeoutError):
+        return web.json_response(
+            {"error": "Collaboration publication timed out", "code": "publication_timeout"},
+            status=504,
+        )
+    raise exc
+
+
+@_require_internal_api(InternalAPIScope.COLLABORATION_INVOKE)
+async def _handle_collaboration_message(
+    request: web.Request,
+    principal: InternalAPIPrincipal,
+) -> web.Response:
+    """Publish one proof-bound progress update or current-thread reply."""
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+    required = {"kind", "body", "idempotency_key"}
+    if not isinstance(payload, dict) or set(payload) != required:
+        return web.json_response({"error": "Invalid collaboration message request"}, status=400)
+    try:
+        result = await request.app[CORE_HOST_KEY].services.collaboration_publications.publish_message(
+            _collaboration_base_identity(principal),
+            proof=request.headers.get("X-Kai-Collaboration-Proof", ""),
+            kind=payload["kind"],
+            body=payload["body"],
+            idempotency_key=payload["idempotency_key"],
+        )
+    except (
+        CollaborationProofError,
+        CollaborationDenied,
+        CollaborationPublicationDenied,
+        CollaborationPublicationValidationError,
+        TimeoutError,
+    ) as exc:
+        return _collaboration_publication_error(exc)
+    except Exception:
+        log.exception("Canonical collaboration message publication failed")
+        return web.json_response({"error": "Collaboration publication failed"}, status=500)
+    return web.json_response(
+        {
+            "version": 1,
+            "message_id": str(result.message_id),
+            "event_position": result.event_position,
+            "replayed": result.replayed,
+        }
+    )
+
+
+@_require_internal_api(InternalAPIScope.COLLABORATION_INVOKE)
+async def _handle_collaboration_artifact(
+    request: web.Request,
+    principal: InternalAPIPrincipal,
+) -> web.Response:
+    """Publish one proof-bound file into the exact current context."""
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+    if not isinstance(payload, dict) or set(payload) != {"path", "caption", "idempotency_key"}:
+        return web.json_response({"error": "Invalid collaboration artifact request"}, status=400)
+    raw_path = payload.get("path")
+    if not isinstance(raw_path, str):
+        return web.json_response({"error": "path must be a string"}, status=400)
+    path = Path(raw_path).resolve()
+    core_host = request.app.get(CORE_HOST_KEY)
+    storage_registry = request.app.get(WORKSHOP_PRINCIPAL_STORAGE_KEY)
+    if core_host is None or storage_registry is None:
+        return web.json_response({"error": "Publication storage unavailable"}, status=403)
+    try:
+        workspace = Path(
+            str(await core_host.services.runtime_pool.get_effective_workspace(_internal_execution_context(principal)))
+        ).resolve()
+        namespace = storage_registry.for_runtime_profile(principal.runtime_profile_id)
+    except Exception:
+        return web.json_response({"error": "Publication storage unavailable"}, status=403)
+    if namespace.principal_id != principal.principal_id:
+        return web.json_response({"error": "Publication storage unavailable"}, status=403)
+    allowed_roots = (workspace, namespace.files_directory(DATA_DIR).resolve())
+    if not any(path.is_relative_to(root) for root in allowed_roots):
+        return web.json_response({"error": "Path outside allowed directories"}, status=403)
+    if not path.is_file():
+        return web.json_response({"error": f"File not found: {raw_path}"}, status=404)
+    try:
+        result = await core_host.services.collaboration_publications.publish_artifact(
+            _collaboration_base_identity(principal),
+            proof=request.headers.get("X-Kai-Collaboration-Proof", ""),
+            path=path,
+            caption=payload["caption"],
+            idempotency_key=payload["idempotency_key"],
+        )
+    except (
+        CollaborationProofError,
+        CollaborationDenied,
+        CollaborationPublicationDenied,
+        CollaborationPublicationValidationError,
+        TimeoutError,
+    ) as exc:
+        return _collaboration_publication_error(exc)
+    except Exception:
+        log.exception("Canonical collaboration artifact publication failed")
+        return web.json_response({"error": "Collaboration artifact publication failed"}, status=500)
+    return web.json_response(
+        {
+            "version": 1,
+            "message_id": str(result.message_id),
+            "artifact_id": str(result.artifact_id),
+            "event_position": result.event_position,
+            "replayed": result.replayed,
+        }
+    )
+
+
 # ── File exchange ────────────────────────────────────────────────────
 
 
@@ -2028,6 +2164,8 @@ def _register_routes(
     app.router.add_post("/api/agent-delegations", _handle_agent_delegation)
     app.router.add_post("/api/collaboration/context", _handle_collaboration_context)
     app.router.add_post("/api/collaboration/reactions", _handle_collaboration_reaction)
+    app.router.add_post("/api/collaboration/messages", _handle_collaboration_message)
+    app.router.add_post("/api/collaboration/artifacts", _handle_collaboration_artifact)
 
 
 async def _register_workshop_client_api(

--- a/src/kai/workshop/artifacts.py
+++ b/src/kai/workshop/artifacts.py
@@ -17,12 +17,16 @@ from datetime import datetime
 from pathlib import Path
 
 from kai.workshop.domain import (
+    AgentDefinitionRevisionId,
     ArtifactId,
     ChannelId,
+    CollaborationGrantId,
     EventEnvelope,
     EventId,
     MessageId,
     PrincipalId,
+    RunAttemptId,
+    RunId,
     RuntimeProfileId,
     WorkshopEventType,
     WorkshopId,
@@ -226,6 +230,14 @@ class InboundArtifact:
                 raise ValueError("original_filename must be a bounded basename or None")
         if self.occurred_at.tzinfo is None or self.occurred_at.utcoffset() is None:
             raise ValueError("occurred_at must be timezone-aware")
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactCollaborationAttribution:
+    grant_id: CollaborationGrantId
+    agent_definition_revision_id: AgentDefinitionRevisionId
+    run_id: RunId
+    run_attempt_id: RunAttemptId
 
 
 @dataclass(frozen=True, slots=True)
@@ -463,6 +475,7 @@ async def record_published_artifact_in_transaction(
     artifact: InboundArtifact,
     *,
     storage_root: Path,
+    collaboration: ArtifactCollaborationAttribution | None = None,
 ) -> AppendResult:
     """Append agent-authored artifact metadata inside a publication transaction."""
     return await _record_artifact_in_transaction(
@@ -470,8 +483,9 @@ async def record_published_artifact_in_transaction(
         artifact,
         storage_root=storage_root,
         author_kind="agent",
-        event_version=2,
-        metadata_source="internal_api",
+        event_version=3 if collaboration is not None else 2,
+        metadata_source=("workshop_collaboration_publication" if collaboration is not None else "internal_api"),
+        collaboration=collaboration,
     )
 
 
@@ -483,6 +497,7 @@ async def _record_artifact_in_transaction(
     author_kind: str,
     event_version: int,
     metadata_source: str,
+    collaboration: ArtifactCollaborationAttribution | None = None,
 ) -> AppendResult:
     if not store.connection.in_transaction:
         raise RuntimeError("artifact recording requires an active transaction")
@@ -521,6 +536,16 @@ async def _record_artifact_in_transaction(
                 "storage_path": storage_path,
                 "source_transport": artifact.source_transport,
                 "source_unique_id": artifact.source_unique_id,
+                **(
+                    {
+                        "collaboration_grant_id": collaboration.grant_id,
+                        "agent_definition_revision_id": collaboration.agent_definition_revision_id,
+                        "run_id": collaboration.run_id,
+                        "run_attempt_id": collaboration.run_attempt_id,
+                    }
+                    if collaboration is not None
+                    else {}
+                ),
             },
             metadata={"source": metadata_source},
         )

--- a/src/kai/workshop/collaboration_publications.py
+++ b/src/kai/workshop/collaboration_publications.py
@@ -1,0 +1,576 @@
+"""Attempt-scoped, canonical agent-authored Workshop publications."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from kai.backend import TraceEntry
+from kai.workshop.artifacts import (
+    MAX_ARTIFACT_BYTES,
+    ArtifactCollaborationAttribution,
+    StagedArtifact,
+    WorkshopArtifactService,
+    record_published_artifact_in_transaction,
+)
+from kai.workshop.collaboration_authority import (
+    CollaborationAuthorization,
+    CollaborationBaseIdentity,
+    CollaborationOperation,
+)
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
+from kai.workshop.domain import (
+    ArtifactId,
+    EventEnvelope,
+    EventId,
+    MessageId,
+    MessageMention,
+    WorkshopEventType,
+)
+from kai.workshop.human_notifications import append_human_notifications_in_transaction
+from kai.workshop.inbound import resolve_message_mentions
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_execution_authority import RunExecutionClaim, StaleRunExecutionAuthorityError
+from kai.workshop.run_traces import WorkshopRunTraceStore
+from kai.workshop.store import WorkshopEventStore
+
+_IDEMPOTENCY_KEY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_MAX_BODY_LENGTH = 10_000
+_MAX_CAPTION_LENGTH = 2_000
+_MUTATION_TIMEOUT_SECONDS = 5.0
+
+
+class CollaborationPublicationError(RuntimeError):
+    """An attempt-scoped publication could not be completed."""
+
+
+class CollaborationPublicationValidationError(CollaborationPublicationError):
+    """The publication request is malformed."""
+
+
+class CollaborationPublicationDenied(CollaborationPublicationError):
+    """The exact attempt can no longer publish to its granted context."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class CollaborationPublicationResult:
+    message_id: MessageId
+    artifact_id: ArtifactId | None
+    event_position: int
+    replayed: bool
+
+
+class _ExecutionService(Protocol):
+    async def authorize_collaboration(
+        self,
+        proof: str,
+        operation: CollaborationOperation,
+        *,
+        base_identity: CollaborationBaseIdentity,
+        idempotency_key: str,
+        request_hash: str,
+        occurred_at: datetime,
+    ) -> CollaborationAuthorization: ...
+
+
+def _normalize_text(value: object, *, field: str, limit: int) -> str:
+    if not isinstance(value, str):
+        raise CollaborationPublicationValidationError(f"{field} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise CollaborationPublicationValidationError(f"{field} must not be empty")
+    if len(normalized) > limit:
+        raise CollaborationPublicationValidationError(f"{field} must be at most {limit} characters")
+    return normalized
+
+
+def _normalize_key(value: object) -> str:
+    if not isinstance(value, str) or not _IDEMPOTENCY_KEY_PATTERN.fullmatch(value):
+        raise CollaborationPublicationValidationError("idempotency_key must be a bounded opaque identifier")
+    return value
+
+
+def _hash(payload: dict[str, object]) -> str:
+    return hashlib.sha256(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()).hexdigest()
+
+
+def _timestamp(value: object) -> datetime:
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise CollaborationPublicationError("Stored collaboration lease is invalid")
+    return parsed.astimezone(UTC)
+
+
+def _mention_payload(mentions: tuple[MessageMention, ...]) -> list[dict[str, object]]:
+    return [
+        {
+            "principal_id": mention.principal_id,
+            "kind": mention.kind,
+            "start": mention.start,
+            "length": mention.length,
+        }
+        for mention in mentions
+    ]
+
+
+class WorkshopCollaborationPublicationService:
+    """Publish bounded progress, thread replies, and artifacts from one exact attempt."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        execution: _ExecutionService,
+        artifacts: WorkshopArtifactService,
+        *,
+        data_dir: Path,
+        delivery_policy: WorkshopDeliveryBindingPolicy,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._store = store
+        self._execution = execution
+        self._artifacts = artifacts
+        self._artifact_storage_root = data_dir.resolve() / "files"
+        self._delivery_policy = delivery_policy
+        self._traces = WorkshopRunTraceStore(store)
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    async def publish_message(
+        self,
+        base_identity: CollaborationBaseIdentity,
+        *,
+        proof: str,
+        kind: object,
+        body: object,
+        idempotency_key: object,
+    ) -> CollaborationPublicationResult:
+        if kind == "progress":
+            operation = CollaborationOperation.PROGRESS_PUBLISH
+        elif kind == "thread_reply":
+            operation = CollaborationOperation.THREAD_REPLY
+        else:
+            raise CollaborationPublicationValidationError("kind must be progress or thread_reply")
+        text = _normalize_text(body, field="body", limit=_MAX_BODY_LENGTH)
+        key = _normalize_key(idempotency_key)
+        request_hash = _hash({"body": text, "kind": str(kind)})
+        now = self._clock()
+        async with asyncio.timeout(_MUTATION_TIMEOUT_SECONDS):
+            authorization = await self._execution.authorize_collaboration(
+                proof,
+                operation,
+                base_identity=base_identity,
+                idempotency_key=key,
+                request_hash=request_hash,
+                occurred_at=now,
+            )
+            return await self._record(
+                authorization,
+                body=text,
+                idempotency_key=key,
+                request_hash=request_hash,
+                occurred_at=now,
+                staged=None,
+            )
+
+    async def publish_artifact(
+        self,
+        base_identity: CollaborationBaseIdentity,
+        *,
+        proof: str,
+        path: Path,
+        caption: object,
+        idempotency_key: object,
+    ) -> CollaborationPublicationResult:
+        if not isinstance(path, Path) or not path.is_absolute() or not path.is_file():
+            raise CollaborationPublicationValidationError("path must identify an existing absolute file")
+        normalized_caption = ""
+        if caption is not None and caption != "":
+            normalized_caption = _normalize_text(caption, field="caption", limit=_MAX_CAPTION_LENGTH)
+        key = _normalize_key(idempotency_key)
+        byte_size, digest = self._file_identity(path)
+        request_hash = _hash(
+            {
+                "byte_size": byte_size,
+                "caption": normalized_caption,
+                "content_sha256": digest,
+                "filename": path.name,
+            }
+        )
+        now = self._clock()
+        async with asyncio.timeout(_MUTATION_TIMEOUT_SECONDS):
+            authorization = await self._execution.authorize_collaboration(
+                proof,
+                CollaborationOperation.ARTIFACT_PUBLISH,
+                base_identity=base_identity,
+                idempotency_key=key,
+                request_hash=request_hash,
+                occurred_at=now,
+            )
+            staged = await self._stage(authorization, path, key, now)
+            try:
+                return await self._record(
+                    authorization,
+                    body=normalized_caption or f"File: {path.name}",
+                    idempotency_key=key,
+                    request_hash=request_hash,
+                    occurred_at=now,
+                    staged=staged,
+                )
+            except Exception:
+                staged.discard()
+                raise
+
+    @staticmethod
+    def _file_identity(path: Path) -> tuple[int, str]:
+        digest = hashlib.sha256()
+        size = 0
+        try:
+            with path.open("rb") as source:
+                while chunk := source.read(1024 * 1024):
+                    size += len(chunk)
+                    if size > MAX_ARTIFACT_BYTES:
+                        raise CollaborationPublicationValidationError(
+                            f"artifact must be at most {MAX_ARTIFACT_BYTES} bytes"
+                        )
+                    digest.update(chunk)
+        except OSError as exc:
+            raise CollaborationPublicationValidationError("artifact content is unavailable") from exc
+        if size == 0:
+            raise CollaborationPublicationValidationError("artifact content must not be empty")
+        return size, digest.hexdigest()
+
+    async def _stage(
+        self,
+        authorization: CollaborationAuthorization,
+        path: Path,
+        key: str,
+        occurred_at: datetime,
+    ) -> StagedArtifact:
+        async def chunks() -> AsyncIterator[bytes]:
+            with path.open("rb") as source:
+                while chunk := source.read(1024 * 1024):
+                    yield chunk
+
+        grant = authorization.grant
+        return await self._artifacts.stage_upload(
+            principal_id=grant.sponsor_principal_id,
+            runtime_profile_id=grant.runtime_profile_id,
+            filename=path.name,
+            claimed_media_type=None,
+            chunks=chunks(),
+            source_transport="workshop_collaboration",
+            source_unique_id=f"{grant.grant_id}:{key}",
+            occurred_at=occurred_at,
+            original_filename=path.name,
+        )
+
+    async def _record(
+        self,
+        authorization: CollaborationAuthorization,
+        *,
+        body: str,
+        idempotency_key: str,
+        request_hash: str,
+        occurred_at: datetime,
+        staged: StagedArtifact | None,
+    ) -> CollaborationPublicationResult:
+        grant = authorization.grant
+        operation = authorization.operation
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            replay = await self._receipt(grant.grant_id, operation, idempotency_key)
+            if replay is not None:
+                if str(replay[0]) != request_hash:
+                    raise CollaborationPublicationDenied(
+                        "idempotency_conflict",
+                        "Collaboration publication idempotency key was reused with different content",
+                    )
+                if staged is not None:
+                    staged.discard()
+                await connection.commit()
+                if str(replay[1]) == "denied":
+                    raise CollaborationPublicationDenied(
+                        str(replay[2]),
+                        f"Collaboration publication was denied: {replay[2]}",
+                    )
+                return CollaborationPublicationResult(
+                    MessageId(str(replay[3])),
+                    ArtifactId(str(replay[4])) if replay[4] is not None else None,
+                    int(str(replay[5])),
+                    True,
+                )
+            try:
+                lease_version = await self._require_active(authorization, occurred_at)
+            except CollaborationPublicationDenied as exc:
+                await self._append_receipt(
+                    authorization,
+                    idempotency_key=idempotency_key,
+                    request_hash=request_hash,
+                    outcome="denied",
+                    denial_code=exc.code,
+                    message_id=None,
+                    artifact_id=None,
+                    occurred_at=occurred_at,
+                )
+                await self._store.project_pending_in_transaction(projection)
+                await connection.commit()
+                raise
+            message_id = MessageId.derived(
+                grant.grant_id,
+                f"publication:{operation.value}:{idempotency_key}",
+            )
+            thread_root = grant.thread_root_id
+            mentions = await resolve_message_mentions(self._store, grant.channel_id, body)
+            event = EventEnvelope.create(
+                event_id=EventId.derived(message_id, "created"),
+                event_type=WorkshopEventType.MESSAGE_CREATED,
+                event_version=3,
+                workshop_id=grant.workshop_id,
+                aggregate_type="message",
+                aggregate_id=message_id,
+                actor_principal_id=grant.agent_principal_id,
+                occurred_at=occurred_at,
+                idempotency_key=(
+                    f"workshop-collaboration-publication:v1:{grant.grant_id}:"
+                    f"{operation.value}:{idempotency_key}:message"
+                ),
+                payload={
+                    "channel_id": grant.channel_id,
+                    "author_principal_id": grant.agent_principal_id,
+                    "body": body,
+                    "mentions": _mention_payload(mentions),
+                    "reply_to_message_id": thread_root,
+                    "thread_root_id": thread_root,
+                    "collaboration_operation": operation.value,
+                    "collaboration_grant_id": grant.grant_id,
+                    "agent_definition_revision_id": grant.agent_definition_revision_id,
+                    "run_id": grant.run_id,
+                    "run_attempt_id": grant.attempt_id,
+                },
+                metadata={"source": "workshop_collaboration_publication"},
+            )
+            inserted = await self._store.append_in_transaction(event)
+            if not inserted.inserted:
+                raise CollaborationPublicationError("Publication message unexpectedly already exists")
+            await append_human_notifications_in_transaction(
+                self._store,
+                inserted.event,
+                delivery_policy=self._delivery_policy,
+            )
+            await self._store.project_pending_in_transaction(projection)
+            artifact_id: ArtifactId | None = None
+            if staged is not None:
+                artifact = await record_published_artifact_in_transaction(
+                    self._store,
+                    staged.for_message(message_id),
+                    storage_root=self._artifact_storage_root,
+                    collaboration=ArtifactCollaborationAttribution(
+                        grant.grant_id,
+                        grant.agent_definition_revision_id,
+                        grant.run_id,
+                        grant.attempt_id,
+                    ),
+                )
+                if not artifact.inserted:
+                    raise CollaborationPublicationError("Publication artifact unexpectedly already exists")
+                artifact_id = ArtifactId(str(artifact.event.envelope.aggregate_id))
+            await self._append_receipt(
+                authorization,
+                idempotency_key=idempotency_key,
+                request_hash=request_hash,
+                outcome="succeeded",
+                denial_code=None,
+                message_id=message_id,
+                artifact_id=artifact_id,
+                occurred_at=occurred_at,
+            )
+            await self._store.project_pending_in_transaction(projection)
+            await self._append_trace(
+                authorization,
+                idempotency_key=idempotency_key,
+                message_id=message_id,
+                artifact_id=artifact_id,
+                lease_version=lease_version,
+                occurred_at=occurred_at,
+            )
+            await connection.commit()
+            return CollaborationPublicationResult(message_id, artifact_id, inserted.event.position, False)
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def _receipt(
+        self,
+        grant_id: object,
+        operation: CollaborationOperation,
+        key: str,
+    ) -> tuple[object, ...] | None:
+        async with self._store.connection.execute(
+            "SELECT receipt.request_hash, receipt.outcome, receipt.denial_code, "
+            "receipt.message_id, receipt.artifact_id, message.created_event_position "
+            "FROM collaboration_publication_receipts receipt "
+            "LEFT JOIN messages message ON message.id = receipt.message_id "
+            "WHERE grant_id = ? AND operation = ? AND idempotency_key = ?",
+            (grant_id, operation.value, key),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return tuple(row) if row is not None else None
+
+    async def _require_active(
+        self,
+        authorization: CollaborationAuthorization,
+        now: datetime,
+    ) -> int:
+        grant = authorization.grant
+        async with self._store.connection.execute(
+            "SELECT ra.lease_version, ra.status, ra.lease_expires_at, r.status, "
+            "r.cancellation_requested_at, d.lifecycle_state, d.active_revision_id, c.archived_at, "
+            "g.revoked_at, g.thread_root_id, c.kind, "
+            "EXISTS(SELECT 1 FROM channel_agents ca WHERE ca.channel_id = g.channel_id "
+            "AND ca.agent_id = g.agent_id AND ca.sponsor_principal_id = g.sponsor_principal_id "
+            "AND ca.sponsored_runtime_profile_id = g.runtime_profile_id AND ca.detached_at IS NULL), "
+            "EXISTS(SELECT 1 FROM principal_agent_enablements pae "
+            "WHERE pae.principal_id = g.sponsor_principal_id AND pae.agent_id = g.agent_id "
+            "AND pae.runtime_profile_id = g.runtime_profile_id AND pae.lifecycle_state = 'enabled') "
+            "FROM collaboration_grants g JOIN run_attempts ra ON ra.id = g.attempt_id "
+            "JOIN runs r ON r.id = g.run_id JOIN agent_definition_revisions revision "
+            "ON revision.id = g.agent_definition_revision_id JOIN agent_definitions d "
+            "ON d.id = revision.agent_definition_id JOIN channels c ON c.id = g.channel_id "
+            "WHERE g.id = ? AND g.attempt_id = ? AND g.run_id = ? "
+            "AND g.agent_principal_id = ? AND g.agent_definition_revision_id = ?",
+            (
+                grant.grant_id,
+                grant.attempt_id,
+                grant.run_id,
+                grant.agent_principal_id,
+                grant.agent_definition_revision_id,
+            ),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise CollaborationPublicationDenied("authority_unavailable", "Publication authority is unavailable")
+        if (
+            str(row[1]) != "started"
+            or str(row[3]) != "started"
+            or row[4] is not None
+            or now >= _timestamp(row[2])
+            or str(row[5]) != "active"
+            or str(row[6]) != str(grant.agent_definition_revision_id)
+            or row[7] is not None
+            or row[8] is not None
+            or not bool(row[11])
+            or not bool(row[12])
+        ):
+            raise CollaborationPublicationDenied("attempt_not_active", "The collaboration attempt is no longer active")
+        thread_root = str(row[9]) if row[9] is not None else None
+        if authorization.operation == CollaborationOperation.PROGRESS_PUBLISH and thread_root is not None:
+            raise CollaborationPublicationDenied("invalid_context", "Progress publication requires a top-level context")
+        if authorization.operation == CollaborationOperation.THREAD_REPLY and (
+            thread_root is None or str(row[10]) != "group"
+        ):
+            raise CollaborationPublicationDenied("invalid_context", "Thread reply requires the granted group thread")
+        return int(row[0])
+
+    async def _append_receipt(
+        self,
+        authorization: CollaborationAuthorization,
+        *,
+        idempotency_key: str,
+        request_hash: str,
+        outcome: str,
+        denial_code: str | None,
+        message_id: MessageId | None,
+        artifact_id: ArtifactId | None,
+        occurred_at: datetime,
+    ) -> None:
+        grant = authorization.grant
+        event = EventEnvelope.create(
+            event_id=EventId.derived(
+                grant.grant_id,
+                f"publication:{authorization.operation.value}:{idempotency_key}:recorded",
+            ),
+            event_type=WorkshopEventType.COLLABORATION_PUBLICATION_RECORDED,
+            event_version=1,
+            workshop_id=grant.workshop_id,
+            aggregate_type="collaboration_grant",
+            aggregate_id=grant.grant_id,
+            actor_principal_id=grant.agent_principal_id,
+            occurred_at=occurred_at,
+            idempotency_key=(
+                f"workshop-collaboration-publication:v1:{grant.grant_id}:"
+                f"{authorization.operation.value}:{idempotency_key}:recorded"
+            ),
+            payload={
+                "operation": authorization.operation.value,
+                "idempotency_key": idempotency_key,
+                "request_hash": request_hash,
+                "outcome": outcome,
+                "denial_code": denial_code,
+                "message_id": message_id,
+                "artifact_id": artifact_id,
+            },
+            metadata={"source": "workshop_collaboration_publication"},
+        )
+        result = await self._store.append_in_transaction(event)
+        if not result.inserted:
+            raise CollaborationPublicationError("Publication receipt unexpectedly already exists")
+
+    async def _append_trace(
+        self,
+        authorization: CollaborationAuthorization,
+        *,
+        idempotency_key: str,
+        message_id: MessageId,
+        artifact_id: ArtifactId | None,
+        lease_version: int,
+        occurred_at: datetime,
+    ) -> None:
+        grant = authorization.grant
+        detail = json.dumps(
+            {
+                "artifact_id": str(artifact_id) if artifact_id is not None else None,
+                "channel_id": str(grant.channel_id),
+                "grant_id": str(grant.grant_id),
+                "message_id": str(message_id),
+                "operation": authorization.operation.value,
+                "thread_root_id": str(grant.thread_root_id) if grant.thread_root_id is not None else None,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        try:
+            await self._traces.append_in_transaction(
+                RunExecutionClaim(
+                    grant.attempt_id,
+                    grant.run_id,
+                    grant.execution_owner_id,
+                    grant.fence_token,
+                    lease_version,
+                ),
+                TraceEntry(
+                    kind="tool_result",
+                    tool_use_id=f"publication:{idempotency_key}",
+                    summary=f"Published {authorization.operation.value.replace('_', ' ')}",
+                    detail=detail,
+                    is_error=False,
+                ),
+                occurred_at=occurred_at,
+            )
+        except StaleRunExecutionAuthorityError as exc:
+            raise CollaborationPublicationDenied(
+                "attempt_not_active",
+                "The collaboration attempt ended before publication was committed",
+            ) from exc

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -1080,7 +1080,7 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
                 _required_payload_text(payload, "kind"),
             )
             continue
-        if envelope.event_type == WorkshopEventType.MESSAGE_CREATED and envelope.event_version not in {1, 2}:
+        if envelope.event_type == WorkshopEventType.MESSAGE_CREATED and envelope.event_version not in {1, 2, 3}:
             raise ValueError("Workshop event replay encountered an unsupported message version")
         if envelope.event_type == WorkshopEventType.CHANNEL_CREATED:
             _insert_replayed_fact(

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -83,6 +83,7 @@ class WorkshopEventType(StrEnum):
     COLLABORATION_GRANT_REVOKED = "collaboration_grant.revoked"
     COLLABORATION_OPERATION_DECIDED = "collaboration_operation.decided"
     COLLABORATION_REACTION_RECORDED = "collaboration_reaction.recorded"
+    COLLABORATION_PUBLICATION_RECORDED = "collaboration_publication.recorded"
     AGENT_DELEGATION_REQUESTED = "agent_delegation.requested"
     AGENT_DELEGATION_STARTED = "agent_delegation.started"
     AGENT_DELEGATION_COMPLETED = "agent_delegation.completed"

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -30,6 +30,7 @@ from kai.workshop.domain import (
     AgentDelegationId,
     AgentEnablementId,
     AgentId,
+    ArtifactId,
     ChannelId,
     ChannelReadPositionId,
     CollaborationGrantId,
@@ -1226,6 +1227,119 @@ async def _apply_collaboration_grant_event(
         )
         return
 
+    if envelope.event_type == WorkshopEventType.COLLABORATION_PUBLICATION_RECORDED:
+        _require_exact_payload(
+            payload,
+            {
+                "operation",
+                "idempotency_key",
+                "request_hash",
+                "outcome",
+                "denial_code",
+                "message_id",
+                "artifact_id",
+            },
+        )
+        operation = _required_text(payload, "operation")
+        idempotency_key = _required_text(payload, "idempotency_key")
+        request_hash = _required_text(payload, "request_hash")
+        outcome = _required_text(payload, "outcome")
+        denial_value = payload.get("denial_code")
+        denial_code = str(denial_value) if denial_value is not None else None
+        message_value = payload.get("message_id")
+        artifact_value = payload.get("artifact_id")
+        message_id = MessageId(str(message_value)) if message_value is not None else None
+        artifact_id = ArtifactId(str(artifact_value)) if artifact_value is not None else None
+        if (
+            operation not in {"progress_publish", "thread_reply", "artifact_publish"}
+            or not _COLLABORATION_IDEMPOTENCY_PATTERN.fullmatch(idempotency_key)
+            or not _SHA256_PATTERN.fullmatch(request_hash)
+            or outcome not in {"succeeded", "denied"}
+            or (denial_code is not None and not _RUN_TERMINAL_CODE_PATTERN.fullmatch(denial_code))
+            or (
+                outcome == "succeeded"
+                and (
+                    denial_code is not None
+                    or message_id is None
+                    or (operation == "artifact_publish") != (artifact_id is not None)
+                )
+            )
+            or (outcome == "denied" and (denial_code is None or message_id is not None or artifact_id is not None))
+        ):
+            raise ValueError("Workshop collaboration publication receipt is malformed")
+        async with connection.execute(
+            "SELECT agent_principal_id, agent_definition_revision_id, run_id, attempt_id "
+            "FROM collaboration_grants WHERE id = ?",
+            (envelope.aggregate_id,),
+        ) as cursor:
+            grant_row = await cursor.fetchone()
+        if grant_row is None or envelope.actor_principal_id != PrincipalId(str(grant_row[0])):
+            raise ValueError("Workshop collaboration publication receipt has no matching grant")
+        async with connection.execute(
+            "SELECT decision FROM collaboration_operation_decisions WHERE grant_id = ? "
+            "AND operation = ? AND idempotency_key = ? AND request_hash = ?",
+            (envelope.aggregate_id, operation, idempotency_key, request_hash),
+        ) as cursor:
+            decision_row = await cursor.fetchone()
+        if decision_row is None or str(decision_row[0]) != "authorized":
+            raise ValueError("Workshop collaboration publication receipt was not authorized")
+        if outcome == "succeeded":
+            async with connection.execute(
+                "SELECT author_principal_id, agent_definition_revision_id, run_id, "
+                "run_attempt_id, collaboration_grant_id, collaboration_operation "
+                "FROM messages WHERE id = ?",
+                (message_id,),
+            ) as cursor:
+                message_row = await cursor.fetchone()
+            if message_row is None or tuple(str(value) for value in message_row) != (
+                str(grant_row[0]),
+                str(grant_row[1]),
+                str(grant_row[2]),
+                str(grant_row[3]),
+                str(envelope.aggregate_id),
+                operation,
+            ):
+                raise ValueError("Workshop collaboration publication message attribution is invalid")
+            if artifact_id is not None:
+                async with connection.execute(
+                    "SELECT message_id, agent_definition_revision_id, run_id, run_attempt_id, "
+                    "collaboration_grant_id FROM artifacts WHERE id = ?",
+                    (artifact_id,),
+                ) as cursor:
+                    artifact_row = await cursor.fetchone()
+                if artifact_row is None or tuple(str(value) for value in artifact_row) != (
+                    str(message_id),
+                    str(grant_row[1]),
+                    str(grant_row[2]),
+                    str(grant_row[3]),
+                    str(envelope.aggregate_id),
+                ):
+                    raise ValueError("Workshop collaboration publication artifact attribution is invalid")
+        await connection.execute(
+            "INSERT INTO collaboration_publication_receipts "
+            "(grant_id, operation, idempotency_key, request_hash, outcome, denial_code, "
+            "message_id, artifact_id, agent_principal_id, agent_definition_revision_id, "
+            "run_id, run_attempt_id, recorded_at, recorded_event_position) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                envelope.aggregate_id,
+                operation,
+                idempotency_key,
+                request_hash,
+                outcome,
+                denial_code,
+                message_id,
+                artifact_id,
+                grant_row[0],
+                grant_row[1],
+                grant_row[2],
+                grant_row[3],
+                occurred_at.isoformat(),
+                event.position,
+            ),
+        )
+        return
+
     raise ValueError(f"Unsupported Workshop collaboration-grant event: {envelope.event_type}")
 
 
@@ -1532,7 +1646,7 @@ class CanonicalConversationProjection:
 
     name = "canonical_conversations"
     # Agent ownership and runtime sponsorship project from explicit authority events.
-    version = 29
+    version = 30
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -1547,8 +1661,22 @@ class CanonicalConversationProjection:
             "parent_run_id",
         ):
             await connection.execute("UPDATE runs SET parent_run_id = NULL")
+        if "messages" in existing_tables and await _table_has_column(
+            connection,
+            "messages",
+            "collaboration_grant_id",
+        ):
+            # Collaboration messages point back to the run whose active
+            # attempt authored them, while every run points to its inbound
+            # message. Break only those derived attribution links before the
+            # deterministic event replay restores them.
+            await connection.execute(
+                "UPDATE messages SET agent_definition_revision_id = NULL, run_id = NULL, "
+                "run_attempt_id = NULL, collaboration_grant_id = NULL, collaboration_operation = NULL"
+            )
         for table in (
             "deliveries",
+            "collaboration_publication_receipts",
             "artifacts",
             "agent_delegations",
             "message_reactions",
@@ -1594,6 +1722,7 @@ class CanonicalConversationProjection:
             WorkshopEventType.COLLABORATION_GRANT_REVOKED,
             WorkshopEventType.COLLABORATION_OPERATION_DECIDED,
             WorkshopEventType.COLLABORATION_REACTION_RECORDED,
+            WorkshopEventType.COLLABORATION_PUBLICATION_RECORDED,
         }:
             await _apply_collaboration_grant_event(connection, event)
             return
@@ -2174,10 +2303,18 @@ class CanonicalConversationProjection:
                 or envelope.aggregate_type != "agent_definition_revision"
             ):
                 raise ValueError("Workshop agent revision creation requires a typed revision aggregate")
-            _require_exact_payload(
-                payload,
-                {"definition_id", "revision_number", "purpose", "instructions", "capabilities"},
-            )
+            if envelope.event_version not in {1, 2}:
+                raise ValueError("Unsupported Workshop agent revision event version")
+            revision_keys = {
+                "definition_id",
+                "revision_number",
+                "purpose",
+                "instructions",
+                "capabilities",
+            }
+            if envelope.event_version == 2:
+                revision_keys.add("collaboration_operations")
+            _require_exact_payload(payload, revision_keys)
             definition_id = AgentDefinitionId(_required_text(payload, "definition_id"))
             revision_number = payload.get("revision_number")
             if not isinstance(revision_number, int) or isinstance(revision_number, bool) or revision_number < 1:
@@ -2187,7 +2324,11 @@ class CanonicalConversationProjection:
                 payload.get("instructions"), field="instructions", maximum=MAX_AGENT_INSTRUCTIONS
             )
             capabilities = validate_agent_capabilities(payload.get("capabilities"))
-            collaboration_operations = collaboration_operations_for_capabilities(capabilities)
+            collaboration_operations = (
+                validate_collaboration_operations(payload.get("collaboration_operations"))
+                if envelope.event_version == 2
+                else collaboration_operations_for_capabilities(capabilities)
+            )
             async with connection.execute(
                 "SELECT workshop_id FROM agent_definitions WHERE id = ?", (definition_id,)
             ) as cursor:
@@ -2816,8 +2957,74 @@ class CanonicalConversationProjection:
                     (runtime_profile_id, channel_id, agent_id),
                 )
         elif envelope.event_type == WorkshopEventType.MESSAGE_CREATED:
-            if envelope.event_version not in {1, 2}:
+            if envelope.event_version not in {1, 2, 3}:
                 raise ValueError("Unsupported Workshop message creation event version")
+            collaboration_attribution: tuple[str, str, str, str, str] | None = None
+            if envelope.event_version == 3:
+                _require_exact_payload(
+                    payload,
+                    {
+                        "channel_id",
+                        "author_principal_id",
+                        "body",
+                        "mentions",
+                        "reply_to_message_id",
+                        "thread_root_id",
+                        "collaboration_operation",
+                        "collaboration_grant_id",
+                        "agent_definition_revision_id",
+                        "run_id",
+                        "run_attempt_id",
+                    },
+                )
+                operation = _required_text(payload, "collaboration_operation")
+                grant_id = CollaborationGrantId(_required_text(payload, "collaboration_grant_id"))
+                revision_id = AgentDefinitionRevisionId(_required_text(payload, "agent_definition_revision_id"))
+                run_id = RunId(_required_text(payload, "run_id"))
+                attempt_id = RunAttemptId(_required_text(payload, "run_attempt_id"))
+                if operation not in {"progress_publish", "thread_reply", "artifact_publish"}:
+                    raise ValueError("Workshop collaboration publication operation is invalid")
+                async with connection.execute(
+                    "SELECT agent_principal_id, agent_definition_revision_id, run_id, attempt_id, "
+                    "channel_id, thread_root_id FROM collaboration_grants WHERE id = ?",
+                    (grant_id,),
+                ) as cursor:
+                    grant_row = await cursor.fetchone()
+                expected_thread = str(grant_row[5]) if grant_row is not None and grant_row[5] is not None else None
+                if (
+                    grant_row is None
+                    or envelope.actor_principal_id != PrincipalId(str(grant_row[0]))
+                    or _required_text(payload, "author_principal_id") != str(grant_row[0])
+                    or revision_id != AgentDefinitionRevisionId(str(grant_row[1]))
+                    or run_id != RunId(str(grant_row[2]))
+                    or attempt_id != RunAttemptId(str(grant_row[3]))
+                    or _required_text(payload, "channel_id") != str(grant_row[4])
+                    or (operation == "progress_publish" and expected_thread is not None)
+                    or (operation == "thread_reply" and expected_thread is None)
+                    or (
+                        operation in {"thread_reply", "artifact_publish"}
+                        and expected_thread is not None
+                        and (
+                            payload.get("reply_to_message_id") != expected_thread
+                            or payload.get("thread_root_id") != expected_thread
+                        )
+                    )
+                    or (
+                        operation in {"progress_publish", "artifact_publish"}
+                        and expected_thread is None
+                        and (
+                            payload.get("reply_to_message_id") is not None or payload.get("thread_root_id") is not None
+                        )
+                    )
+                ):
+                    raise ValueError("Workshop collaboration publication does not match its grant")
+                collaboration_attribution = (
+                    str(revision_id),
+                    str(run_id),
+                    str(attempt_id),
+                    str(grant_id),
+                    operation,
+                )
             reply_to = payload.get("reply_to_message_id")
             if reply_to is not None and not isinstance(reply_to, str):
                 raise ValueError("Workshop reply_to_message_id must be a string or null")
@@ -2841,7 +3048,7 @@ class CanonicalConversationProjection:
                 channel_id,
                 body,
                 payload.get("mentions", []),
-                canonical_handles=envelope.event_version == 2,
+                canonical_handles=envelope.event_version >= 2,
             )
             await connection.execute(
                 "INSERT INTO messages "
@@ -2857,6 +3064,13 @@ class CanonicalConversationProjection:
                     occurred_at,
                 ),
             )
+            if collaboration_attribution is not None:
+                await connection.execute(
+                    "UPDATE messages SET agent_definition_revision_id = ?, run_id = ?, "
+                    "run_attempt_id = ?, collaboration_grant_id = ?, collaboration_operation = ? "
+                    "WHERE id = ?",
+                    (*collaboration_attribution, envelope.aggregate_id),
+                )
             # Empty mentions use the column default, which keeps the current
             # projection executable in migration tests frozen before schema
             # v41. Accepted mention spans require the v41 authority column.
@@ -3431,8 +3645,28 @@ class CanonicalConversationProjection:
                 if cursor.rowcount != 1:
                     raise ValueError("Workshop message reaction removal has no matching reaction")
         elif envelope.event_type == WorkshopEventType.ARTIFACT_CREATED:
-            if envelope.event_version not in {1, 2}:
+            if envelope.event_version not in {1, 2, 3}:
                 raise ValueError("Unsupported Workshop artifact event version")
+            artifact_attribution: tuple[str, str, str, str] | None = None
+            if envelope.event_version == 3:
+                expected = {
+                    "channel_id",
+                    "message_id",
+                    "created_by_principal_id",
+                    "kind",
+                    "media_type",
+                    "byte_size",
+                    "content_sha256",
+                    "original_filename",
+                    "storage_path",
+                    "source_transport",
+                    "source_unique_id",
+                    "collaboration_grant_id",
+                    "agent_definition_revision_id",
+                    "run_id",
+                    "run_attempt_id",
+                }
+                _require_exact_payload(payload, expected)
             created_by = _required_text(payload, "created_by_principal_id")
             if envelope.actor_principal_id != created_by:
                 raise ValueError("Workshop artifact actor must match created_by_principal_id")
@@ -3454,6 +3688,31 @@ class CanonicalConversationProjection:
                 expected_author_kind,
             ):
                 raise ValueError("Workshop artifact must belong to a message with the event-version author kind")
+            if envelope.event_version == 3:
+                grant_id = CollaborationGrantId(_required_text(payload, "collaboration_grant_id"))
+                revision_id = AgentDefinitionRevisionId(_required_text(payload, "agent_definition_revision_id"))
+                run_id = RunId(_required_text(payload, "run_id"))
+                attempt_id = RunAttemptId(_required_text(payload, "run_attempt_id"))
+                async with connection.execute(
+                    "SELECT agent_principal_id, agent_definition_revision_id, run_id, attempt_id, "
+                    "channel_id FROM collaboration_grants WHERE id = ?",
+                    (grant_id,),
+                ) as cursor:
+                    grant_row = await cursor.fetchone()
+                if grant_row is None or tuple(str(value) for value in grant_row) != (
+                    created_by,
+                    str(revision_id),
+                    str(run_id),
+                    str(attempt_id),
+                    channel_id,
+                ):
+                    raise ValueError("Workshop collaboration artifact does not match its grant")
+                artifact_attribution = (
+                    str(revision_id),
+                    str(run_id),
+                    str(attempt_id),
+                    str(grant_id),
+                )
             kind = _required_text(payload, "kind")
             if kind not in {"photo", "document", "voice"}:
                 raise ValueError("Workshop artifact kind is unsupported")
@@ -3511,6 +3770,12 @@ class CanonicalConversationProjection:
                     occurred_at,
                 ),
             )
+            if artifact_attribution is not None:
+                await connection.execute(
+                    "UPDATE artifacts SET agent_definition_revision_id = ?, run_id = ?, "
+                    "run_attempt_id = ?, collaboration_grant_id = ? WHERE id = ?",
+                    (*artifact_attribution, envelope.aggregate_id),
+                )
         elif envelope.event_type in {
             WorkshopEventType.DELIVERY_SUCCEEDED,
             WorkshopEventType.DELIVERY_FAILED,

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 69
+WORKSHOP_SCHEMA_VERSION = 70
 
 
 @dataclass(frozen=True, slots=True)
@@ -3039,6 +3039,64 @@ _AGENT_AUTHORED_REACTION_SCHEMA = SchemaMigration(
     ),
 )
 
+_AGENT_AUTHORED_PUBLICATION_SCHEMA = SchemaMigration(
+    version=70,
+    name="agent_authored_collaboration_publications",
+    statements=(
+        "ALTER TABLE messages ADD COLUMN agent_definition_revision_id TEXT "
+        "REFERENCES agent_definition_revisions(id) ON DELETE RESTRICT",
+        "ALTER TABLE messages ADD COLUMN run_id TEXT REFERENCES runs(id) ON DELETE RESTRICT",
+        "ALTER TABLE messages ADD COLUMN run_attempt_id TEXT REFERENCES run_attempts(id) ON DELETE RESTRICT",
+        "ALTER TABLE messages ADD COLUMN collaboration_grant_id TEXT "
+        "REFERENCES collaboration_grants(id) ON DELETE RESTRICT",
+        "ALTER TABLE messages ADD COLUMN collaboration_operation TEXT CHECK "
+        "(collaboration_operation IN ('progress_publish', 'thread_reply', 'artifact_publish'))",
+        "CREATE INDEX messages_collaboration_run_idx ON messages "
+        "(run_id, run_attempt_id, created_event_position) WHERE collaboration_grant_id IS NOT NULL",
+        "ALTER TABLE artifacts ADD COLUMN agent_definition_revision_id TEXT "
+        "REFERENCES agent_definition_revisions(id) ON DELETE RESTRICT",
+        "ALTER TABLE artifacts ADD COLUMN run_id TEXT REFERENCES runs(id) ON DELETE RESTRICT",
+        "ALTER TABLE artifacts ADD COLUMN run_attempt_id TEXT REFERENCES run_attempts(id) ON DELETE RESTRICT",
+        "ALTER TABLE artifacts ADD COLUMN collaboration_grant_id TEXT "
+        "REFERENCES collaboration_grants(id) ON DELETE RESTRICT",
+        "CREATE INDEX artifacts_collaboration_run_idx ON artifacts "
+        "(run_id, run_attempt_id, created_event_position) WHERE collaboration_grant_id IS NOT NULL",
+        """
+        CREATE TABLE collaboration_publication_receipts (
+            grant_id TEXT NOT NULL REFERENCES collaboration_grants(id) ON DELETE CASCADE,
+            operation TEXT NOT NULL CHECK (
+                operation IN ('progress_publish', 'thread_reply', 'artifact_publish')
+            ),
+            idempotency_key TEXT NOT NULL,
+            request_hash TEXT NOT NULL CHECK (length(request_hash) = 64),
+            outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'denied')),
+            denial_code TEXT,
+            message_id TEXT REFERENCES messages(id) ON DELETE RESTRICT,
+            artifact_id TEXT REFERENCES artifacts(id) ON DELETE RESTRICT,
+            agent_principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
+            agent_definition_revision_id TEXT NOT NULL
+                REFERENCES agent_definition_revisions(id) ON DELETE RESTRICT,
+            run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE RESTRICT,
+            run_attempt_id TEXT NOT NULL REFERENCES run_attempts(id) ON DELETE RESTRICT,
+            recorded_at TEXT NOT NULL,
+            recorded_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            PRIMARY KEY (grant_id, operation, idempotency_key),
+            CHECK (
+                (outcome = 'succeeded' AND denial_code IS NULL AND message_id IS NOT NULL
+                    AND ((operation = 'artifact_publish' AND artifact_id IS NOT NULL)
+                        OR (operation != 'artifact_publish' AND artifact_id IS NULL)))
+                OR
+                (outcome = 'denied' AND denial_code IS NOT NULL
+                    AND message_id IS NULL AND artifact_id IS NULL)
+            )
+        )
+        """,
+        "CREATE INDEX collaboration_publication_receipts_run_idx ON "
+        "collaboration_publication_receipts (run_id, recorded_event_position)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -3109,6 +3167,7 @@ _MIGRATIONS = (
     _ATTEMPT_SCOPED_COLLABORATION_AUTHORITY_SCHEMA,
     _COLLABORATION_OPERATION_DECISION_SCHEMA,
     _AGENT_AUTHORED_REACTION_SCHEMA,
+    _AGENT_AUTHORED_PUBLICATION_SCHEMA,
 )
 
 

--- a/tests/test_webhook_api.py
+++ b/tests/test_webhook_api.py
@@ -27,7 +27,9 @@ from kai.webhook import (
     WORKSHOP_INTEGRATION_NOTIFICATIONS_KEY,
     WORKSHOP_PRINCIPAL_STORAGE_KEY,
     _handle_agent_delegation,
+    _handle_collaboration_artifact,
     _handle_collaboration_context,
+    _handle_collaboration_message,
     _handle_collaboration_reaction,
     _handle_delete_job,
     _handle_generic,
@@ -229,6 +231,10 @@ def mock_request(tmp_path):
                 agent_delegation=SimpleNamespace(delegate=AsyncMock()),
                 collaboration_context=SimpleNamespace(read=AsyncMock()),
                 collaboration_reactions=SimpleNamespace(react=AsyncMock()),
+                collaboration_publications=SimpleNamespace(
+                    publish_message=AsyncMock(),
+                    publish_artifact=AsyncMock(),
+                ),
                 runtime_pool=SimpleNamespace(
                     get_effective_workspace=AsyncMock(return_value=tmp_path),
                 ),
@@ -428,6 +434,57 @@ class TestCollaborationReaction:
             response = await _handle_collaboration_reaction(mock_request)
             assert response.status == 400
         service.react.assert_not_awaited()
+
+
+class TestCollaborationPublication:
+    async def test_message_credential_binds_context_and_forwards_no_destination(self, mock_request):
+        service = mock_request.app[CORE_HOST_KEY].services.collaboration_publications
+        message_id = MessageId.new()
+        service.publish_message.return_value = SimpleNamespace(
+            message_id=message_id,
+            event_position=81,
+            replayed=False,
+        )
+        mock_request.headers = {
+            "X-Webhook-Secret": "test-secret",
+            "X-Kai-Collaboration-Proof": "attempt-proof-000000000000000000000000000001",
+        }
+        mock_request.json = AsyncMock(
+            return_value={
+                "kind": "progress",
+                "body": "Working on it",
+                "idempotency_key": "progress-one",
+            }
+        )
+
+        response = await _handle_collaboration_message(mock_request)
+
+        assert response.status == 200
+        assert json.loads(response.body.decode()) == {
+            "version": 1,
+            "message_id": str(message_id),
+            "event_position": 81,
+            "replayed": False,
+        }
+        identity = service.publish_message.await_args.args[0]
+        assert identity.principal_id == _internal_api_context(123).principal_id
+        assert identity.channel_id == _internal_api_context(123).channel_id
+        assert service.publish_message.await_args.kwargs == {
+            "proof": mock_request.headers["X-Kai-Collaboration-Proof"],
+            "kind": "progress",
+            "body": "Working on it",
+            "idempotency_key": "progress-one",
+        }
+
+    async def test_message_rejects_every_destination_selector(self, mock_request):
+        service = mock_request.app[CORE_HOST_KEY].services.collaboration_publications
+        mock_request.headers = {"X-Webhook-Secret": "test-secret"}
+        base = {"kind": "progress", "body": "No routing", "idempotency_key": "selector"}
+        for selector in ("channel_id", "thread_root_id", "principal_id", "run_id", "agent_id"):
+            mock_request.json = AsyncMock(return_value={**base, selector: "forbidden"})
+            response = await _handle_collaboration_message(mock_request)
+            assert response.status == 400
+        service.publish_message.assert_not_awaited()
 
 
 # ── POST /api/schedule ────────────────────────────────────────────────
@@ -3801,6 +3858,8 @@ _NON_OBJECT_HANDLERS = [
     pytest.param(_handle_agent_delegation, lambda r: None, id="agent_delegation"),
     pytest.param(_handle_collaboration_context, lambda r: None, id="collaboration_context"),
     pytest.param(_handle_collaboration_reaction, lambda r: None, id="collaboration_reaction"),
+    pytest.param(_handle_collaboration_message, lambda r: None, id="collaboration_message"),
+    pytest.param(_handle_collaboration_artifact, lambda r: None, id="collaboration_artifact"),
     pytest.param(
         _handle_update_job,
         lambda r: r.match_info.update({"id": "1"}),

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -418,7 +418,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 69
+        assert await upgraded.schema_version() == 70
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -529,7 +529,7 @@ class TestArtifactShadowRecordingAfterRestart:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 29
+            assert checkpoint.version == 30
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -408,7 +408,7 @@ async def test_version_sixty_seven_migrates_only_legacy_delegation_requests(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 69
+        assert await upgraded.schema_version() == 70
         async with upgraded.connection.execute(
             "SELECT id, capabilities_json, collaboration_operations_json "
             "FROM agent_definition_revisions ORDER BY revision_number"

--- a/tests/test_workshop_collaboration_publications.py
+++ b/tests/test_workshop_collaboration_publications.py
@@ -1,0 +1,435 @@
+"""Contracts for proof-bound agent-authored Workshop publications."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.artifacts import WorkshopArtifactService
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.collaboration_authority import (
+    CollaborationDenied,
+    CollaborationHostPolicy,
+    CollaborationOperation,
+    CollaborationOwnerPolicy,
+    WorkshopCollaborationAuthority,
+)
+from kai.workshop.collaboration_publications import (
+    WorkshopCollaborationPublicationService,
+)
+from kai.workshop.conversation_commands import WorkshopConversationCommandService
+from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
+from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
+from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentDefinitionRevisionId,
+    EventEnvelope,
+    RunExecutionOwnerId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.inbound import InboundMessage
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_execution_authority import RunExecutionSelection, WorkshopRunExecutionAuthority
+from kai.workshop.runtime_profiles import ProtectedRuntimeProfile, WorkshopRuntimeProfileRegistry
+from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
+from kai.workshop.store import WorkshopEventStore
+from tests.test_workshop_collaboration_authority import _NOW, _base_identity
+from tests.test_workshop_wake_policy import (
+    _accepted_message_id,
+    _message,
+    _open_group_store,
+)
+from tests.workshop_profiles import profile_id, profile_registry
+
+
+class _Execution:
+    def __init__(self, authority: WorkshopCollaborationAuthority) -> None:
+        self.authority = authority
+
+    async def authorize_collaboration(self, *args, **kwargs):
+        return await self.authority.authorize(*args, **kwargs)
+
+
+async def _publication_context(path: Path):
+    runtime_profile_id = profile_id(101)
+    store = await WorkshopEventStore.open(path / "kai.db")
+    await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman(
+                "Workshop Human",
+                "admin",
+                "telegram",
+                "101",
+                "101",
+                runtime_profile_id,
+            ),
+        ),
+    )
+    async with store.connection.execute(
+        "SELECT d.id, d.workshop_id, d.active_revision_id, r.revision_number "
+        "FROM agent_definitions d JOIN agent_definition_revisions r "
+        "ON r.id = d.active_revision_id WHERE d.handle = 'kai'",
+    ) as cursor:
+        definition = await cursor.fetchone()
+    assert definition is not None
+    definition_id = AgentDefinitionId(str(definition[0]))
+    workshop_id = WorkshopId(str(definition[1]))
+    revision_id = AgentDefinitionRevisionId.derived(definition_id, "publication-revision")
+    for event in (
+        EventEnvelope.create(
+            event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED,
+            event_version=2,
+            workshop_id=workshop_id,
+            aggregate_type="agent_definition_revision",
+            aggregate_id=revision_id,
+            occurred_at=_NOW - timedelta(seconds=2),
+            payload={
+                "definition_id": definition_id,
+                "revision_number": int(definition[3]) + 1,
+                "purpose": "Publish bounded collaboration progress.",
+                "instructions": "Use only explicitly granted collaboration publication tools.",
+                "capabilities": ["text_generation"],
+                "collaboration_operations": ["artifact_publish", "progress_publish"],
+            },
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="agent_definition",
+            aggregate_id=definition_id,
+            occurred_at=_NOW - timedelta(seconds=1),
+            payload={"revision_id": revision_id},
+        ),
+    ):
+        await store.append(event)
+        await store.project_pending(CanonicalConversationProjection())
+    accepted = await WorkshopConversationCommandService(store).accept(
+        InboundMessage(
+            "telegram",
+            "publication-command",
+            "publication-message",
+            "101",
+            "101",
+            "Perform publication qualification",
+            _NOW,
+        )
+    )
+    await WorkshopConversationDeliveryAuthority(store).activate()
+    execution = WorkshopRunExecutionAuthority(
+        store,
+        selection_resolver=lambda _run: RunExecutionSelection("codex", "gpt-5.6-sol"),
+        registered_backend_ids=frozenset({"codex"}),
+    )
+    granted = await execution.grant(
+        accepted.run.run_id,
+        owner_id=RunExecutionOwnerId.new(),
+        occurred_at=_NOW + timedelta(seconds=1),
+        lease_expires_at=_NOW + timedelta(minutes=1),
+    )
+    started = await execution.start(granted.claim, occurred_at=_NOW + timedelta(seconds=2))
+    assert started.run.agent_definition_revision_id == revision_id
+    operations = frozenset(
+        {
+            CollaborationOperation.PROGRESS_PUBLISH,
+            CollaborationOperation.ARTIFACT_PUBLISH,
+        }
+    )
+    authority = WorkshopCollaborationAuthority(
+        store,
+        host_policy=CollaborationHostPolicy(
+            allowed_operations=operations,
+            quotas={operation: 4 for operation in operations},
+        ),
+        owner_policy_resolver=lambda _revision: CollaborationOwnerPolicy(
+            version=1,
+            allowed_operations=operations,
+        ),
+        token_factory=lambda: "publication-proof-00000000000000000000000001",
+    )
+    grant, invocation = await authority.issue(
+        started.claim,
+        occurred_at=_NOW + timedelta(seconds=3),
+    )
+    profiles = WorkshopRuntimeProfileRegistry(
+        (
+            ProtectedRuntimeProfile(
+                profile_id=runtime_profile_id,
+                display_name="Publication owner",
+                os_user=None,
+                backend="codex",
+                provider="openai",
+                model="gpt-5.6-sol",
+                timeout_seconds=120,
+                allowed_services=(),
+                home_workspace=None,
+                workspace_base=None,
+                allowed_workspaces=(),
+            ),
+        )
+    )
+    storage = await WorkshopPrincipalStorageRegistry.from_store(store, profiles)
+    artifacts = WorkshopArtifactService(
+        store,
+        data_dir=path,
+        principal_storage=storage,
+        runtime_profiles=profiles,
+    )
+    service = WorkshopCollaborationPublicationService(
+        store,
+        _Execution(authority),
+        artifacts,
+        data_dir=path,
+        delivery_policy=WorkshopDeliveryBindingPolicy(frozenset()),
+        clock=lambda: _NOW + timedelta(seconds=5),
+    )
+    return store, started, grant, invocation, service
+
+
+async def test_progress_and_artifact_are_attributed_idempotent_and_rebuild_safe(tmp_path: Path) -> None:
+    store, started, grant, invocation, service = await _publication_context(tmp_path)
+    identity = _base_identity(started)
+    source = tmp_path / "qualification.txt"
+    source.write_text("bounded artifact\n")
+    try:
+        progress = await service.publish_message(
+            identity,
+            proof=invocation.token,
+            kind="progress",
+            body="Bounded progress",
+            idempotency_key="progress-1",
+        )
+        replay = await service.publish_message(
+            identity,
+            proof=invocation.token,
+            kind="progress",
+            body="Bounded progress",
+            idempotency_key="progress-1",
+        )
+        assert replay == type(replay)(progress.message_id, None, progress.event_position, True)
+
+        artifact = await service.publish_artifact(
+            identity,
+            proof=invocation.token,
+            path=source,
+            caption="Qualification artifact",
+            idempotency_key="artifact-1",
+        )
+        assert artifact.artifact_id is not None
+        artifact_replay = await service.publish_artifact(
+            identity,
+            proof=invocation.token,
+            path=source,
+            caption="Qualification artifact",
+            idempotency_key="artifact-1",
+        )
+        assert artifact_replay == type(artifact_replay)(
+            artifact.message_id,
+            artifact.artifact_id,
+            artifact.event_position,
+            True,
+        )
+        async with store.connection.execute(
+            "SELECT author_principal_id, agent_definition_revision_id, run_id, run_attempt_id, "
+            "collaboration_grant_id, collaboration_operation FROM messages "
+            "WHERE id IN (?, ?) ORDER BY created_event_position",
+            (progress.message_id, artifact.message_id),
+        ) as cursor:
+            rows = tuple(await cursor.fetchall())
+        expected_prefix = (
+            str(grant.agent_principal_id),
+            str(grant.agent_definition_revision_id),
+            str(grant.run_id),
+            str(grant.attempt_id),
+            str(grant.grant_id),
+        )
+        assert tuple(str(value) for value in rows[0]) == (*expected_prefix, "progress_publish")
+        assert tuple(str(value) for value in rows[1]) == (*expected_prefix, "artifact_publish")
+        async with store.connection.execute(
+            "SELECT created_by_principal_id, agent_definition_revision_id, run_id, run_attempt_id, "
+            "collaboration_grant_id, storage_path FROM artifacts WHERE id = ?",
+            (artifact.artifact_id,),
+        ) as cursor:
+            artifact_row = await cursor.fetchone()
+        assert artifact_row is not None
+        assert tuple(str(value) for value in artifact_row[:5]) == expected_prefix
+        assert str(grant.sponsor_principal_id) in str(artifact_row[5])
+        async with store.connection.execute("SELECT COUNT(*) FROM delivery_outbox") as cursor:
+            assert int((await cursor.fetchone())[0]) == 0
+
+        await store.rebuild_projection(CanonicalConversationProjection())
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM collaboration_publication_receipts WHERE grant_id = ?",
+            (grant.grant_id,),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 2
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM messages WHERE collaboration_grant_id = ?",
+            (grant.grant_id,),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 2
+    finally:
+        await store.close()
+
+
+async def test_detached_attempt_fails_closed_after_authorization_and_records_no_message(tmp_path: Path) -> None:
+    store, started, grant, invocation, service = await _publication_context(tmp_path)
+    identity = _base_identity(started)
+    try:
+        await store.connection.execute(
+            "UPDATE channel_agents SET detached_at = ? WHERE channel_id = ? AND agent_id = ?",
+            ((_NOW + timedelta(seconds=4)).isoformat(), grant.channel_id, grant.agent_id),
+        )
+        await store.connection.commit()
+        with pytest.raises(CollaborationDenied) as denied:
+            await service.publish_message(
+                identity,
+                proof=invocation.token,
+                kind="progress",
+                body="Must not appear",
+                idempotency_key="detached-progress",
+            )
+        assert denied.value.code == "authority_detached"
+        async with store.connection.execute(
+            "SELECT decision, denial_code FROM collaboration_operation_decisions "
+            "WHERE grant_id = ? AND idempotency_key = 'detached-progress'",
+            (grant.grant_id,),
+        ) as cursor:
+            assert tuple(await cursor.fetchone()) == ("denied", "authority_detached")
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM messages WHERE collaboration_grant_id = ?",
+            (grant.grant_id,),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 0
+    finally:
+        await store.close()
+
+
+async def test_thread_reply_derives_root_notifies_human_and_never_wakes_mentioned_agent(
+    tmp_path: Path,
+) -> None:
+    store, human_id, group_id, agent_ids = await _open_group_store(tmp_path / "thread.db")
+    try:
+        async with store.connection.execute(
+            "SELECT d.id, d.workshop_id, r.revision_number FROM agent_definitions d "
+            "JOIN agent_definition_revisions r ON r.id = d.active_revision_id WHERE d.agent_id = ?",
+            (agent_ids[0],),
+        ) as cursor:
+            definition = await cursor.fetchone()
+        assert definition is not None
+        definition_id = AgentDefinitionId(str(definition[0]))
+        workshop_id = WorkshopId(str(definition[1]))
+        revision_id = AgentDefinitionRevisionId.derived(definition_id, "thread-publication")
+        for event in (
+            EventEnvelope.create(
+                event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ADDED,
+                event_version=2,
+                workshop_id=workshop_id,
+                aggregate_type="agent_definition_revision",
+                aggregate_id=revision_id,
+                occurred_at=_NOW - timedelta(seconds=2),
+                payload={
+                    "definition_id": definition_id,
+                    "revision_number": int(definition[2]) + 1,
+                    "purpose": "Publish bounded thread replies.",
+                    "instructions": "Reply only in the exact granted thread.",
+                    "capabilities": ["text_generation"],
+                    "collaboration_operations": ["thread_reply"],
+                },
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.AGENT_DEFINITION_REVISION_ACTIVATED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="agent_definition",
+                aggregate_id=definition_id,
+                occurred_at=_NOW - timedelta(seconds=1),
+                payload={"revision_id": revision_id},
+            ),
+        ):
+            await store.append(event)
+            await store.project_pending(CanonicalConversationProjection())
+        commands = WorkshopConversationCommandService(store)
+        root = await commands.accept_client(_message(human_id, group_id, "root", "Root", _NOW))
+        root_id = _accepted_message_id(root)
+        accepted = await commands.accept_client(
+            _message(
+                human_id,
+                group_id,
+                "thread-command",
+                "@kai work in this thread",
+                _NOW + timedelta(seconds=1),
+                thread_root_id=root_id,
+            )
+        )
+        assert len(accepted.command.runs) == 1
+        run = accepted.command.runs[0]
+        await WorkshopConversationDeliveryAuthority(store).activate()
+        execution = WorkshopRunExecutionAuthority(
+            store,
+            selection_resolver=lambda _run: RunExecutionSelection("codex", "gpt-5.6-sol"),
+            registered_backend_ids=frozenset({"codex"}),
+        )
+        granted = await execution.grant(
+            run.run_id,
+            owner_id=RunExecutionOwnerId.new(),
+            occurred_at=_NOW + timedelta(seconds=2),
+            lease_expires_at=_NOW + timedelta(minutes=1),
+        )
+        started = await execution.start(granted.claim, occurred_at=_NOW + timedelta(seconds=3))
+        operations = frozenset({CollaborationOperation.THREAD_REPLY})
+        authority = WorkshopCollaborationAuthority(
+            store,
+            host_policy=CollaborationHostPolicy(
+                allowed_operations=operations,
+                quotas={CollaborationOperation.THREAD_REPLY: 2},
+            ),
+            owner_policy_resolver=lambda _revision: CollaborationOwnerPolicy(1, operations),
+            token_factory=lambda: "thread-publication-proof-000000000000000000001",
+        )
+        grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=4),
+        )
+        profiles = profile_registry(101, 202)
+        storage = await WorkshopPrincipalStorageRegistry.from_store(store, profiles)
+        service = WorkshopCollaborationPublicationService(
+            store,
+            _Execution(authority),
+            WorkshopArtifactService(
+                store,
+                data_dir=tmp_path,
+                principal_storage=storage,
+                runtime_profiles=profiles,
+            ),
+            data_dir=tmp_path,
+            delivery_policy=WorkshopDeliveryBindingPolicy(frozenset()),
+            clock=lambda: _NOW + timedelta(seconds=5),
+        )
+        result = await service.publish_message(
+            _base_identity(started),
+            proof=invocation.token,
+            kind="thread_reply",
+            body="@Daniel bounded reply; @Nova is not activated.",
+            idempotency_key="thread-reply-1",
+        )
+        async with store.connection.execute(
+            "SELECT reply_to_message_id, thread_root_id FROM messages WHERE id = ?",
+            (result.message_id,),
+        ) as cursor:
+            assert tuple(await cursor.fetchone()) == (root_id, root_id)
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM human_notifications WHERE source_message_id = ? AND recipient_principal_id = ?",
+            (result.message_id, human_id),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 1
+        from kai.workshop.wake_policy import resolve_message_wake_targets
+
+        assert (await resolve_message_wake_targets(store, result.message_id)).agent_ids == ()
+        assert grant.thread_root_id == root_id
+    finally:
+        await store.close()

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -389,7 +389,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 29
+            assert checkpoint.version == 30
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -308,7 +308,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
             after = workshop_runtime_session_status(path)
             assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
@@ -336,7 +336,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
             assert session is not None
             assert session.runtime_profile_id == _RUNTIME_PROFILE_ID

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -153,6 +153,7 @@ class TestEventEnvelope:
             "collaboration_grant.revoked",
             "collaboration_operation.decided",
             "collaboration_reaction.recorded",
+            "collaboration_publication.recorded",
         }
 
     def test_create_builds_a_versioned_transport_independent_envelope(self):
@@ -248,6 +249,7 @@ class TestWorkshopSchema:
             "agent_delegations",
             "collaboration_grants",
             "collaboration_operation_decisions",
+            "collaboration_publication_receipts",
             "principal_human_notification_policies",
             "principal_human_notification_adapter_preferences",
             "principal_channel_notification_policies",
@@ -263,7 +265,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 69
+        assert await workshop_store.schema_version() == 70
         async with workshop_store.connection.execute("PRAGMA table_info(principals)") as cursor:
             principal_columns = {str(row[1]) for row in await cursor.fetchall()}
         assert {"display_name_state_version", "display_name_event_position"} <= principal_columns
@@ -314,7 +316,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 69
+        assert await second.schema_version() == 70
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -398,7 +400,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             async with upgraded.connection.execute(
                 "SELECT reaction, created_event_position FROM message_reactions "
                 "WHERE message_id = ? AND principal_id = ?",
@@ -439,7 +441,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -467,7 +469,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -554,6 +556,7 @@ class TestWorkshopSchema:
                     67,
                     68,
                     69,
+                    70,
                 ]
         finally:
             await upgraded.close()
@@ -576,7 +579,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -617,7 +620,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -670,7 +673,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -714,7 +717,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -758,7 +761,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -802,7 +805,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -906,7 +909,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -1033,7 +1036,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -319,7 +319,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 69
+            assert await upgraded.schema_version() == 70
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -391,7 +391,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 29
+            assert checkpoint.version == 30
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -166,7 +166,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 29
+            assert checkpoint.version == 30
             assert after == before
         finally:
             await store.close()

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -178,7 +178,7 @@ class TestRuntimeAssignmentPolicy:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 29
+            assert checkpoint.version == 30
             assert await resolve_channel_runtime_profile(store, human.channel_id) == (
                 assigned.agent_id,
                 profile_id(202),


### PR DESCRIPTION
Closes #1380.

## Summary

- add proof-bound, attempt-scoped APIs for agent progress messages, current-thread replies, and artifacts
- derive every destination from the immutable collaboration grant and attribute publications to the agent revision, run, attempt, and grant
- add canonical idempotency receipts, trace records, replay-safe projection support, bounded artifact staging, and fail-closed live-authority rechecks
- preserve ordinary terminal responses and existing proactive publication while preventing default adapter fan-out and agent-mention wakeups

## Validation

- `make check`
- `make client-check` (188 tests)
- focused collaboration/webhook checks (38 passed)
- `make test` (6,504 passed)
