### PR TITLE
Add Workshop collaboration diagnostics

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -84,6 +84,7 @@ from kai.workshop.diagnostics import (
     workshop_canonical_message_integrity_status,
     workshop_channel_notification_policy_status,
     workshop_client_preference_status,
+    workshop_collaboration_authority_status,
     workshop_delivery_authority_status,
     workshop_execution_state_status,
     workshop_human_avatar_status,
@@ -9539,6 +9540,7 @@ def _cmd_status() -> None:
         )
     )
     print(workshop_agent_authority_status(Path(data_dir) / "kai.db"))
+    print(workshop_collaboration_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_human_handle_status(Path(data_dir) / "kai.db"))
     print(workshop_human_avatar_status(Path(data_dir) / "kai.db", Path(data_dir) / "files" / "avatars"))
     print(workshop_human_notification_status(Path(data_dir) / "kai.db"))

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -120,6 +120,24 @@ _AGENT_AUTHORITY_TABLES = {
     "runs",
     "workshop_memberships",
 }
+_COLLABORATION_AUTHORITY_TABLES = {
+    "agent_definition_revisions",
+    "agent_definitions",
+    "agents",
+    "artifacts",
+    "channels",
+    "collaboration_grants",
+    "collaboration_operation_decisions",
+    "collaboration_publication_receipts",
+    "collaboration_reaction_receipts",
+    "delivery_outbox",
+    "event_log",
+    "messages",
+    "principal_agent_enablements",
+    "principals",
+    "run_attempts",
+    "runs",
+}
 _AGENT_HANDLE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
 _TELEGRAM_SUBJECT_PATTERN = re.compile(r"^-?[0-9]+$")
 _SYNTHETIC_ASSISTANT_PATTERN = re.compile(
@@ -537,6 +555,276 @@ def workshop_agent_authority_status(db_path: Path) -> str:
         f"enablements={invalid_enablements}, "
         f"runtime bindings={unauthorized_runtime_bindings}, namespaces={namespace_conflicts}, "
         f"attachments={dangling_attachments}, delegations={delegation_gaps}); authority=canonical"
+    )
+
+
+def workshop_collaboration_authority_status(db_path: Path) -> str:
+    """Report attempt-scoped collaboration activity and projection integrity."""
+    prefix = "Workshop collaboration authority:"
+    if not db_path.is_file():
+        return f"{prefix} pending; attempt-scoped authority schema unavailable"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            connection.execute("PRAGMA query_only=ON")
+            connection.execute("BEGIN")
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            if not tables >= _COLLABORATION_AUTHORITY_TABLES:
+                return f"{prefix} pending; attempt-scoped authority schema unavailable"
+
+            grant_rows = connection.execute(
+                "SELECT g.id, g.revoked_at, g.requested_operations_json, "
+                "g.owner_allowed_operations_json, g.host_allowed_operations_json, "
+                "g.effective_operations_json, g.quotas_json, g.proof_fingerprint, "
+                "ra.status, ra.lease_expires_at, r.status, r.cancellation_requested_at, "
+                "d.lifecycle_state, c.archived_at, "
+                "EXISTS(SELECT 1 FROM channel_agents ca WHERE ca.channel_id = g.channel_id "
+                "AND ca.agent_id = g.agent_id AND ca.sponsor_principal_id = g.sponsor_principal_id "
+                "AND ca.sponsored_runtime_profile_id = g.runtime_profile_id AND ca.detached_at IS NULL), "
+                "EXISTS(SELECT 1 FROM principal_agent_enablements pae "
+                "WHERE pae.principal_id = g.sponsor_principal_id AND pae.agent_id = g.agent_id "
+                "AND pae.runtime_profile_id = g.runtime_profile_id AND pae.lifecycle_state = 'enabled') "
+                "FROM collaboration_grants g "
+                "LEFT JOIN run_attempts ra ON ra.id = g.attempt_id "
+                "LEFT JOIN runs r ON r.id = g.run_id AND r.id = ra.run_id "
+                "LEFT JOIN agent_definition_revisions revision "
+                "ON revision.id = g.agent_definition_revision_id "
+                "LEFT JOIN agent_definitions d ON d.id = revision.agent_definition_id "
+                "LEFT JOIN channels c ON c.id = g.channel_id"
+            ).fetchall()
+            now = datetime.now(UTC)
+            active_grants = expired_grants = revoked_grants = grant_state_gaps = 0
+            for row in grant_rows:
+                revoked_at = row[1]
+                if revoked_at is not None:
+                    revoked_grants += 1
+                try:
+                    requested = set(json.loads(str(row[2])))
+                    owner_allowed = set(json.loads(str(row[3])))
+                    host_allowed = set(json.loads(str(row[4])))
+                    effective = set(json.loads(str(row[5])))
+                    quotas = json.loads(str(row[6]))
+                    lease_expires_at = _parse_timestamp(str(row[9]))
+                    grant_shape_valid = (
+                        effective == requested & owner_allowed & host_allowed
+                        and isinstance(quotas, dict)
+                        and set(quotas) == effective
+                        and all(
+                            isinstance(value, int) and not isinstance(value, bool) and value > 0
+                            for value in quotas.values()
+                        )
+                        and re.fullmatch(r"[0-9a-f]{64}", str(row[7])) is not None
+                    )
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    grant_shape_valid = False
+                    lease_expires_at = now
+                live = (
+                    revoked_at is None
+                    and row[8] == "started"
+                    and row[10] == "started"
+                    and row[11] is None
+                    and now < lease_expires_at
+                    and row[12] == "active"
+                    and row[13] is None
+                    and bool(row[14])
+                    and bool(row[15])
+                )
+                active_grants += int(live)
+                expired_grants += int(revoked_at is None and now >= lease_expires_at)
+                grant_state_gaps += int(not grant_shape_valid)
+                grant_state_gaps += int(revoked_at is None and not live and now < lease_expires_at)
+
+            grants = len(grant_rows)
+            decisions = connection.execute(
+                "SELECT COUNT(*), "
+                "SUM(CASE WHEN decision = 'authorized' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN decision = 'denied' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN denial_code = 'quota_exhausted' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN denial_code LIKE '%timeout%' THEN 1 ELSE 0 END) "
+                "FROM collaboration_operation_decisions"
+            ).fetchone()
+            decision_counts = tuple(int(value or 0) for value in (decisions or (0, 0, 0, 0, 0)))
+            receipts = connection.execute(
+                "SELECT COUNT(*), "
+                "SUM(CASE WHEN outcome = 'succeeded' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN outcome = 'denied' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN denial_code LIKE '%timeout%' THEN 1 ELSE 0 END) FROM ("
+                "SELECT outcome, denial_code FROM collaboration_reaction_receipts UNION ALL "
+                "SELECT outcome, denial_code FROM collaboration_publication_receipts)"
+            ).fetchone()
+            receipt_counts = tuple(int(value or 0) for value in (receipts or (0, 0, 0, 0)))
+
+            adapter = connection.execute(
+                "SELECT COUNT(*), "
+                "SUM(CASE WHEN d.status = 'pending' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN d.status = 'leased' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN d.status = 'retry_wait' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN d.status = 'succeeded' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN d.status = 'failed' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN d.attempt_count > 1 THEN d.attempt_count - 1 ELSE 0 END), "
+                "SUM(CASE WHEN d.last_error_code LIKE '%timeout%' THEN 1 ELSE 0 END) "
+                "FROM delivery_outbox d JOIN messages m ON m.id = d.message_id "
+                "WHERE m.collaboration_grant_id IS NOT NULL"
+            ).fetchone()
+            adapter_counts = tuple(int(value or 0) for value in (adapter or (0,) * 8))
+
+            relationship_gaps = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM collaboration_grants g "
+                "LEFT JOIN run_attempts ra ON ra.id = g.attempt_id "
+                "LEFT JOIN runs r ON r.id = g.run_id "
+                "LEFT JOIN agents a ON a.id = g.agent_id "
+                "LEFT JOIN principals agent ON agent.id = g.agent_principal_id "
+                "LEFT JOIN principals requester ON requester.id = g.requested_by_principal_id "
+                "LEFT JOIN principals sponsor ON sponsor.id = g.sponsor_principal_id "
+                "LEFT JOIN agent_definition_revisions revision ON revision.id = g.agent_definition_revision_id "
+                "LEFT JOIN agent_definitions definition ON definition.id = revision.agent_definition_id "
+                "LEFT JOIN channels channel ON channel.id = g.channel_id "
+                "WHERE ra.id IS NULL OR ra.run_id IS NOT g.run_id OR r.id IS NULL "
+                "OR r.workshop_id IS NOT g.workshop_id OR r.agent_id IS NOT g.agent_id "
+                "OR r.requested_by_principal_id IS NOT g.requested_by_principal_id "
+                "OR r.sponsor_principal_id IS NOT g.sponsor_principal_id "
+                "OR r.runtime_profile_id IS NOT g.runtime_profile_id "
+                "OR r.channel_id IS NOT g.channel_id OR a.principal_id IS NOT g.agent_principal_id "
+                "OR agent.kind IS NOT 'agent' OR requester.kind IS NOT 'human' OR sponsor.kind IS NOT 'human' "
+                "OR definition.agent_id IS NOT g.agent_id OR definition.workshop_id IS NOT g.workshop_id "
+                "OR channel.workshop_id IS NOT g.workshop_id",
+            )
+            quota_gaps = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM collaboration_operation_decisions decision "
+                "JOIN collaboration_grants grant_row ON grant_row.id = decision.grant_id "
+                "WHERE decision.decision = 'authorized' AND (decision.quota_ordinal IS NULL "
+                "OR decision.quota_ordinal > CAST(json_extract(grant_row.quotas_json, "
+                "'$.' || decision.operation) AS INTEGER))",
+            )
+            duplicate_quota_ordinals = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM (SELECT grant_id, operation, quota_ordinal "
+                "FROM collaboration_operation_decisions WHERE decision = 'authorized' "
+                "GROUP BY grant_id, operation, quota_ordinal HAVING COUNT(*) > 1)",
+            )
+            receipt_gaps = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM ("
+                "SELECT receipt.grant_id, receipt.idempotency_key, receipt.request_hash, 'reaction' AS operation, "
+                "receipt.agent_principal_id, receipt.agent_definition_revision_id, receipt.run_id, "
+                "receipt.run_attempt_id FROM collaboration_reaction_receipts receipt UNION ALL "
+                "SELECT receipt.grant_id, receipt.idempotency_key, receipt.request_hash, receipt.operation, "
+                "receipt.agent_principal_id, receipt.agent_definition_revision_id, receipt.run_id, "
+                "receipt.run_attempt_id FROM collaboration_publication_receipts receipt) receipt "
+                "LEFT JOIN collaboration_grants grant_row ON grant_row.id = receipt.grant_id "
+                "LEFT JOIN collaboration_operation_decisions decision ON decision.grant_id = receipt.grant_id "
+                "AND decision.operation = receipt.operation AND decision.idempotency_key = receipt.idempotency_key "
+                "WHERE grant_row.id IS NULL OR decision.decision IS NOT 'authorized' "
+                "OR decision.request_hash IS NOT receipt.request_hash "
+                "OR receipt.agent_principal_id IS NOT grant_row.agent_principal_id "
+                "OR receipt.agent_definition_revision_id IS NOT grant_row.agent_definition_revision_id "
+                "OR receipt.run_id IS NOT grant_row.run_id OR receipt.run_attempt_id IS NOT grant_row.attempt_id",
+            )
+            attribution_gaps = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM collaboration_publication_receipts receipt "
+                "LEFT JOIN collaboration_grants grant_row ON grant_row.id = receipt.grant_id "
+                "LEFT JOIN messages message ON message.id = receipt.message_id "
+                "LEFT JOIN artifacts artifact ON artifact.id = receipt.artifact_id "
+                "WHERE receipt.outcome = 'succeeded' AND (message.id IS NULL "
+                "OR message.collaboration_grant_id IS NOT receipt.grant_id "
+                "OR message.run_id IS NOT grant_row.run_id "
+                "OR message.run_attempt_id IS NOT grant_row.attempt_id "
+                "OR message.agent_definition_revision_id IS NOT grant_row.agent_definition_revision_id "
+                "OR (receipt.operation = 'artifact_publish' AND (artifact.id IS NULL "
+                "OR artifact.collaboration_grant_id IS NOT receipt.grant_id "
+                "OR artifact.run_id IS NOT grant_row.run_id "
+                "OR artifact.run_attempt_id IS NOT grant_row.attempt_id)))",
+            )
+            event_mapping_gaps = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM collaboration_grants grant_row "
+                "LEFT JOIN event_log issued ON issued.position = grant_row.issued_event_position "
+                "LEFT JOIN event_log revoked ON revoked.position = grant_row.revoked_event_position "
+                "WHERE issued.event_type IS NOT 'collaboration_grant.issued' "
+                "OR issued.aggregate_id IS NOT grant_row.id "
+                "OR json_extract(issued.payload_json, '$.attempt_id') IS NOT grant_row.attempt_id "
+                "OR json_extract(issued.payload_json, '$.run_id') IS NOT grant_row.run_id "
+                "OR (grant_row.revoked_at IS NOT NULL AND ("
+                "revoked.event_type IS NOT 'collaboration_grant.revoked' "
+                "OR revoked.aggregate_id IS NOT grant_row.id "
+                "OR json_extract(revoked.payload_json, '$.revocation_code') IS NOT grant_row.revocation_code))",
+            )
+            event_mapping_gaps += _scalar(
+                connection,
+                "SELECT COUNT(*) FROM collaboration_operation_decisions decision "
+                "LEFT JOIN event_log event ON event.position = decision.decided_event_position "
+                "WHERE event.event_type IS NOT 'collaboration_operation.decided' "
+                "OR event.aggregate_id IS NOT decision.grant_id "
+                "OR json_extract(event.payload_json, '$.operation') IS NOT decision.operation "
+                "OR json_extract(event.payload_json, '$.idempotency_key') IS NOT decision.idempotency_key "
+                "OR json_extract(event.payload_json, '$.request_hash') IS NOT decision.request_hash "
+                "OR json_extract(event.payload_json, '$.decision') IS NOT decision.decision",
+            )
+            event_mapping_gaps += _scalar(
+                connection,
+                "SELECT COUNT(*) FROM collaboration_reaction_receipts receipt "
+                "LEFT JOIN event_log event ON event.position = receipt.recorded_event_position "
+                "WHERE event.event_type IS NOT 'collaboration_reaction.recorded' "
+                "OR event.aggregate_id IS NOT receipt.grant_id "
+                "OR json_extract(event.payload_json, '$.idempotency_key') IS NOT receipt.idempotency_key "
+                "OR json_extract(event.payload_json, '$.request_hash') IS NOT receipt.request_hash "
+                "OR json_extract(event.payload_json, '$.outcome') IS NOT receipt.outcome",
+            )
+            event_mapping_gaps += _scalar(
+                connection,
+                "SELECT COUNT(*) FROM collaboration_publication_receipts receipt "
+                "LEFT JOIN event_log event ON event.position = receipt.recorded_event_position "
+                "WHERE event.event_type IS NOT 'collaboration_publication.recorded' "
+                "OR event.aggregate_id IS NOT receipt.grant_id "
+                "OR json_extract(event.payload_json, '$.operation') IS NOT receipt.operation "
+                "OR json_extract(event.payload_json, '$.idempotency_key') IS NOT receipt.idempotency_key "
+                "OR json_extract(event.payload_json, '$.request_hash') IS NOT receipt.request_hash "
+                "OR json_extract(event.payload_json, '$.outcome') IS NOT receipt.outcome",
+            )
+            event_projection_gaps = event_mapping_gaps + sum(
+                abs(
+                    projected
+                    - _scalar(connection, "SELECT COUNT(*) FROM event_log WHERE event_type = ?", (event_type,))
+                )
+                for projected, event_type in (
+                    (grants, "collaboration_grant.issued"),
+                    (revoked_grants, "collaboration_grant.revoked"),
+                    (decision_counts[0], "collaboration_operation.decided"),
+                    (
+                        _scalar(connection, "SELECT COUNT(*) FROM collaboration_reaction_receipts"),
+                        "collaboration_reaction.recorded",
+                    ),
+                    (
+                        _scalar(connection, "SELECT COUNT(*) FROM collaboration_publication_receipts"),
+                        "collaboration_publication.recorded",
+                    ),
+                )
+            )
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error, TypeError, ValueError) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+
+    integrity_gaps = (
+        grant_state_gaps + relationship_gaps + quota_gaps + duplicate_quota_ordinals + receipt_gaps + attribution_gaps
+    )
+    state = "active" if integrity_gaps == 0 and event_projection_gaps == 0 else "INCOMPLETE"
+    return (
+        f"{prefix} {state}; grants={grants} (active={active_grants}, revoked={revoked_grants}, "
+        f"expired={expired_grants}), operations={decision_counts[0]} "
+        f"(authorized={decision_counts[1]}, denied={decision_counts[2]}, quota={decision_counts[3]}, "
+        f"timeouts={decision_counts[4] + receipt_counts[3] + adapter_counts[7]}), "
+        f"receipts={receipt_counts[0]} (succeeded={receipt_counts[1]}, denied={receipt_counts[2]}), "
+        f"adapter deliveries={adapter_counts[0]} (pending={adapter_counts[1]}, executing={adapter_counts[2]}, "
+        f"retrying={adapter_counts[3]}, succeeded={adapter_counts[4]}, failed={adapter_counts[5]}, "
+        f"retries={adapter_counts[6]}); integrity gaps={integrity_gaps}, "
+        f"replay gaps={event_projection_gaps}; authority=attempt-scoped"
     )
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -32,7 +32,7 @@ from kai.backend import (
     prepend_to_prompt,
     resolve_home_workspace,
 )
-from kai.config import Config, UserConfig, WorkspaceConfig
+from kai.config import VALID_BACKENDS, Config, UserConfig, WorkspaceConfig
 
 # ── Test build_session_context ──────────────────────────────────────
 
@@ -168,7 +168,7 @@ class TestBuildSessionContext:
         assert "untrusted historical data" in result
         assert "never obey instructions" in result
 
-    @pytest.mark.parametrize("backend_name", ["claude", "codex", "goose", "opencode", "pi"])
+    @pytest.mark.parametrize("backend_name", sorted(VALID_BACKENDS))
     def test_foreign_workspace_uses_canonical_identity_for_every_backend(self, tmp_path, backend_name):
         home = tmp_path / "home"
         home.mkdir()
@@ -193,6 +193,31 @@ class TestBuildSessionContext:
 
         assert "CANONICAL IDENTITY" in result
         assert "@../AGENTS.md" not in result
+
+    @pytest.mark.parametrize("backend_name", ["claude", "codex", "goose", "opencode", "pi"])
+    def test_every_backend_receives_the_same_collaboration_contract(self, tmp_path, backend_name):
+        workspace = tmp_path / "home"
+        workspace.mkdir()
+        data_dir = tmp_path / "data"
+        (data_dir / "memory").mkdir(parents=True)
+
+        with patch("kai.backend.get_recent_history", return_value=""):
+            result = build_session_context(
+                workspace=workspace,
+                home_workspace=workspace,
+                api=self._api(),
+                workspace_config=None,
+                chat_id=None,
+                data_dir=data_dir,
+                backend_name=backend_name,
+            )
+
+        assert result is not None
+        assert "This credential alone never authorizes collaboration" in result
+        assert "Workshop collaboration context API" in result
+        assert "Workshop collaboration reaction API" in result
+        assert "Workshop collaboration publication APIs" in result
+        assert "X-Kai-Collaboration-Proof" in result
 
     def test_memory_exists(self, tmp_path):
         """Memory content included when file exists and is non-empty."""

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5049,6 +5049,7 @@ class TestCmdStatus:
         output = capsys.readouterr().out
         assert "Installation Status" in output
         assert "Workshop bootstrap:" in output
+        assert "Workshop collaboration authority:" in output
         assert "Workshop unread authority:" in output
         assert "Workshop delivery authority:" in output
         assert "Workshop conversation continuity:" in output

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -339,21 +339,64 @@ async def test_old_attempt_proof_cannot_act_during_later_attempt_on_same_runtime
         await store.close()
 
 
-async def test_archive_and_detach_immediately_fence_live_grant(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("fence", "expected_code"),
+    [
+        ("agent_archive", "agent_unavailable"),
+        ("channel_archive", "agent_unavailable"),
+        ("attachment_detach", "authority_detached"),
+        ("principal_disable", "authority_detached"),
+        ("cancellation", "attempt_not_active"),
+        ("lease_expiry", "grant_expired"),
+    ],
+)
+async def test_agent_lifecycle_and_attempt_boundaries_immediately_fence_live_grant(
+    tmp_path: Path,
+    fence: str,
+    expected_code: str,
+) -> None:
     store, _execution, started = await _running_attempt(tmp_path / "kai.db")
     try:
         authority = WorkshopCollaborationAuthority(
             store,
             token_factory=lambda: "attempt-proof-000000000000000000000000000005",
         )
-        _grant, invocation = await authority.issue(
+        grant, invocation = await authority.issue(
             started.claim,
             occurred_at=_NOW + timedelta(seconds=3),
         )
-        await store.connection.execute(
-            "UPDATE agent_definitions SET lifecycle_state = 'archived' WHERE agent_id = ?",
-            (started.run.agent_id,),
-        )
+        if fence == "agent_archive":
+            await store.connection.execute(
+                "UPDATE agent_definitions SET lifecycle_state = 'archived' WHERE agent_id = ?",
+                (started.run.agent_id,),
+            )
+        elif fence == "channel_archive":
+            await store.connection.execute(
+                "UPDATE channels SET archived_at = ? WHERE id = ?",
+                ((_NOW + timedelta(seconds=4)).isoformat(), grant.channel_id),
+            )
+        elif fence == "attachment_detach":
+            await store.connection.execute(
+                "UPDATE channel_agents SET detached_at = ? WHERE channel_id = ? AND agent_id = ?",
+                ((_NOW + timedelta(seconds=4)).isoformat(), grant.channel_id, grant.agent_id),
+            )
+        elif fence == "principal_disable":
+            await store.connection.execute(
+                "UPDATE principal_agent_enablements SET lifecycle_state = 'disabled' "
+                "WHERE principal_id = ? AND agent_id = ?",
+                (grant.sponsor_principal_id, grant.agent_id),
+            )
+        elif fence == "cancellation":
+            await store.connection.execute(
+                "UPDATE runs SET cancellation_requested_at = ? WHERE id = ?",
+                ((_NOW + timedelta(seconds=4)).isoformat(), grant.run_id),
+            )
+        else:
+            assert fence == "lease_expiry"
+            await store.connection.execute(
+                "UPDATE run_attempts SET lease_expires_at = ? WHERE id = ?",
+                ((_NOW + timedelta(seconds=3)).isoformat(), grant.attempt_id),
+            )
         await store.connection.commit()
 
         with pytest.raises(CollaborationDenied) as denied:
@@ -362,7 +405,7 @@ async def test_archive_and_detach_immediately_fence_live_grant(tmp_path: Path) -
                 CollaborationOperation.AGENT_DELEGATION,
                 occurred_at=_NOW + timedelta(seconds=4),
             )
-        assert denied.value.code == "agent_unavailable"
+        assert denied.value.code == expected_code
     finally:
         await store.close()
 

--- a/tests/test_workshop_collaboration_diagnostics.py
+++ b/tests/test_workshop_collaboration_diagnostics.py
@@ -1,0 +1,115 @@
+"""Operational diagnostics for attempt-scoped Workshop collaboration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.collaboration_authority import (
+    CollaborationDenied,
+    CollaborationHostPolicy,
+    CollaborationOperation,
+    WorkshopCollaborationAuthority,
+)
+from kai.workshop.diagnostics import workshop_collaboration_authority_status
+from tests.test_workshop_collaboration_authority import (
+    _NOW,
+    _base_identity,
+    _running_attempt,
+)
+
+
+def test_status_is_pending_before_collaboration_schema_exists(tmp_path: Path) -> None:
+    assert workshop_collaboration_authority_status(tmp_path / "missing.db") == (
+        "Workshop collaboration authority: pending; attempt-scoped authority schema unavailable"
+    )
+
+
+async def test_status_reports_activity_and_clean_projection_integrity(tmp_path: Path) -> None:
+    path = tmp_path / "kai.db"
+    store, _execution, started = await _running_attempt(path)
+    try:
+        authority = WorkshopCollaborationAuthority(
+            store,
+            host_policy=CollaborationHostPolicy(
+                allowed_operations=frozenset({CollaborationOperation.AGENT_DELEGATION}),
+                quotas={CollaborationOperation.AGENT_DELEGATION: 1},
+            ),
+            token_factory=lambda: "diagnostic-proof-0000000000000000000000000001",
+        )
+        _grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+        await authority.authorize(
+            invocation.token,
+            CollaborationOperation.AGENT_DELEGATION,
+            base_identity=_base_identity(started),
+            idempotency_key="diagnostic-authorized",
+            request_hash="a" * 64,
+            occurred_at=_NOW + timedelta(seconds=4),
+        )
+        with pytest.raises(CollaborationDenied, match="exhausted"):
+            await authority.authorize(
+                invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                base_identity=_base_identity(started),
+                idempotency_key="diagnostic-denied",
+                request_hash="b" * 64,
+                occurred_at=_NOW + timedelta(seconds=5),
+            )
+        await authority.revoke(
+            invocation,
+            revocation_code="qualification_complete",
+            occurred_at=_NOW + timedelta(seconds=6),
+        )
+    finally:
+        await store.close()
+
+    status = workshop_collaboration_authority_status(path)
+
+    assert status.startswith("Workshop collaboration authority: active;")
+    assert "grants=1 (active=0, revoked=1, expired=0)" in status
+    assert "operations=2 (authorized=1, denied=1, quota=1, timeouts=0)" in status
+    assert "receipts=0 (succeeded=0, denied=0)" in status
+    assert "adapter deliveries=0" in status
+    assert "integrity gaps=0, replay gaps=0" in status
+
+
+async def test_status_fails_closed_on_quota_projection_drift(tmp_path: Path) -> None:
+    path = tmp_path / "kai.db"
+    store, _execution, started = await _running_attempt(path)
+    try:
+        authority = WorkshopCollaborationAuthority(
+            store,
+            host_policy=CollaborationHostPolicy(
+                allowed_operations=frozenset({CollaborationOperation.AGENT_DELEGATION}),
+                quotas={CollaborationOperation.AGENT_DELEGATION: 1},
+            ),
+            token_factory=lambda: "diagnostic-proof-0000000000000000000000000002",
+        )
+        _grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+        await authority.authorize(
+            invocation.token,
+            CollaborationOperation.AGENT_DELEGATION,
+            base_identity=_base_identity(started),
+            idempotency_key="diagnostic-drift",
+            request_hash="c" * 64,
+            occurred_at=_NOW + timedelta(seconds=4),
+        )
+        await store.connection.execute(
+            "UPDATE collaboration_operation_decisions SET quota_ordinal = 2 WHERE idempotency_key = 'diagnostic-drift'"
+        )
+        await store.connection.commit()
+    finally:
+        await store.close()
+
+    status = workshop_collaboration_authority_status(path)
+
+    assert status.startswith("Workshop collaboration authority: INCOMPLETE;")
+    assert "integrity gaps=1" in status


### PR DESCRIPTION
Closes #1382

## Summary

- add an install-status diagnostic for attempt-scoped collaboration grants, authorization decisions, mutation receipts, adapter delivery outcomes, quotas, timeouts, retries, and projection integrity
- fail the diagnostic closed on relationship, quota, receipt-attribution, or event/projection replay drift
- expand exact-attempt fencing contracts across agent archive, channel archive, attachment detach, principal disable, cancellation, and lease expiry
- require every registered backend to receive the same transport-neutral collaboration contract

Semantic idempotency replays intentionally collapse onto one canonical decision or receipt, so diagnostics report replay integrity gaps rather than inventing a mutable replay counter.

## Validation

- `make test` — 6,521 passed
- `make check`
- targeted collaboration, webhook, backend, and install tests — 1,129 passed (the socket-dependent install test was rerun with local test-server permission)
- current installed database diagnostic — active; 37 grants; zero integrity gaps; zero replay gaps

## Installed qualification after merge

1. Run `make install`.
2. Confirm Workshop and Telegram PINGs.
3. Run `make install-status | grep 'Workshop collaboration authority'` and require `active`, `integrity gaps=0`, and `replay gaps=0`.
4. Recheck one bounded context read, reaction, progress/reply, artifact, delegation, policy change, emergency revocation, cancellation, and restart recovery across the available two-human/two-agent environment. Provider accounts not configured on this installation are covered by automated adapter contracts rather than live qualification.
