### PR TITLE
Share group-channel agent sessions across humans

### DIFF
--- a/src/kai/internal_api_auth.py
+++ b/src/kai/internal_api_auth.py
@@ -54,12 +54,13 @@ _NOTIFICATION_SCOPES = frozenset({InternalAPIScope.MESSAGES_SEND})
 class InternalAPIPrincipal:
     """Identity and authority resolved from an internal API credential."""
 
-    principal_id: PrincipalId
+    principal_id: PrincipalId | None
     channel_id: ChannelId
     agent_id: AgentId
     runtime_profile_id: RuntimeProfileId
     scopes: frozenset[InternalAPIScope]
     private_context: bool = True
+    requesting_principal_bound: bool = True
     allowed_services: frozenset[str] = frozenset()
 
     def allows(self, scope: InternalAPIScope) -> bool:
@@ -156,16 +157,25 @@ class InternalAPIAuth:
     ) -> InternalAPIPrincipal:
         """Build the persistent-agent principal for one canonical context."""
         allowed_services = self._allowed_services_by_profile.get(context.runtime_profile_id, frozenset())
-        scopes = set(_PERSISTENT_AGENT_BASE_SCOPES)
-        if not context.private_context:
-            scopes.discard(InternalAPIScope.MEMORY_READ)
-            scopes.discard(InternalAPIScope.MEMORY_ADD)
+        if context.private_context:
+            scopes = set(_PERSISTENT_AGENT_BASE_SCOPES)
+        else:
+            # A group-channel process is shared by every human who wakes the
+            # same agent in that channel.  Its persistent credential therefore
+            # cannot carry whichever human happened to start the process.
+            # Stateful collaboration is authorized by the exact-attempt proof;
+            # principal-owned memory, jobs, and legacy proactive publication
+            # fail closed instead of being attributed to the first requester.
+            scopes = {InternalAPIScope.COLLABORATION_INVOKE}
         if allowed_services:
             scopes.add(InternalAPIScope.SERVICES_CALL)
         return self._principal(
             context,
             frozenset(scopes),
             allowed_services,
+            principal_id=(context.principal_id if context.private_context else None),
+            bind_context_principal=context.private_context,
+            requesting_principal_bound=context.private_context,
         )
 
     @staticmethod
@@ -173,14 +183,19 @@ class InternalAPIAuth:
         context: WorkshopInternalAPIExecutionContext,
         scopes: frozenset[InternalAPIScope],
         allowed_services: frozenset[str] = frozenset(),
+        *,
+        principal_id: PrincipalId | None = None,
+        bind_context_principal: bool = True,
+        requesting_principal_bound: bool = True,
     ) -> InternalAPIPrincipal:
         return InternalAPIPrincipal(
-            principal_id=context.principal_id,
+            principal_id=(context.principal_id if bind_context_principal else principal_id),
             channel_id=context.channel_id,
             agent_id=context.agent_id,
             runtime_profile_id=context.runtime_profile_id,
             scopes=scopes,
             private_context=context.private_context,
+            requesting_principal_bound=requesting_principal_bound,
             allowed_services=allowed_services,
         )
 

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -43,7 +43,7 @@ from kai.config import (
 )
 from kai.goose import GooseBackend
 from kai.internal_api_auth import InternalAPIAuth
-from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.domain import AgentId, ChannelId, RuntimeProfileId
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workspace_utils import is_workspace_allowed
 
@@ -55,7 +55,25 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 type RuntimeSelector = int | RuntimeProfileId | WorkshopInternalAPIExecutionContext
-type RuntimePoolKey = int | RuntimeProfileId | WorkshopInternalAPIExecutionContext
+
+
+@dataclass(frozen=True, slots=True)
+class _CanonicalRuntimeLaneKey:
+    """One backend conversation shared by every requester in a channel."""
+
+    channel_id: ChannelId
+    agent_id: AgentId
+    runtime_profile_id: RuntimeProfileId
+
+    @classmethod
+    def from_context(
+        cls,
+        context: WorkshopInternalAPIExecutionContext,
+    ) -> _CanonicalRuntimeLaneKey:
+        return cls(context.channel_id, context.agent_id, context.runtime_profile_id)
+
+
+type RuntimePoolKey = int | RuntimeProfileId | _CanonicalRuntimeLaneKey
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,20 +125,23 @@ class PreparedBackendExecution:
         "_instance",
         "_instance_key",
         "_pool",
+        "_runtime_identity",
         "_runtime_selector",
     )
 
     def __init__(
         self,
         pool: SubprocessPool,
-        runtime_selector: RuntimePoolKey,
+        runtime_selector: RuntimeSelector,
         instance_key: RuntimeInstanceKey,
         instance: AgentBackend,
+        runtime_identity: WorkshopInternalAPIExecutionContext | None,
     ) -> None:
         self._pool = pool
         self._runtime_selector = runtime_selector
         self._instance_key = instance_key
         self._instance = instance
+        self._runtime_identity = runtime_identity
         self._fingerprint = _runtime_fingerprint(instance)
         self._consumed = False
 
@@ -183,11 +204,13 @@ class SubprocessPool:
     """
     Agent subprocess pool with canonical protected-runtime lifecycle ownership.
 
-    Each protected RuntimeProfileId gets an independent AgentBackend instance
-    running as its configured OS user. Compatibility integer selectors are
-    normalized at entry and never become protected lifecycle keys. Negative
-    Telegram group IDs and unprotected development runtimes remain explicit
-    compatibility keys until their adapter paths are retired.
+    Each protected channel-agent-runtime lane gets an independent AgentBackend
+    instance running as its configured OS user. Humans who alternate in one
+    group channel share that lane while retaining their exact per-turn identity.
+    Compatibility integer selectors are normalized at entry and never become
+    protected lifecycle keys. Negative Telegram group IDs and unprotected
+    development runtimes remain explicit compatibility keys until their adapter
+    paths are retired.
 
     Thread safety: send() for a given runtime is serialized by the
     per-channel execution lane. A short per-runtime transition lock also
@@ -302,7 +325,9 @@ class SubprocessPool:
                     profile.profile_id: internal_api_contexts.for_runtime_profile(profile.profile_id)
                     for profile in runtime_profiles.profiles
                 }
-                contexts_by_runtime.update({context: context for context in contexts})
+                contexts_by_runtime.update(
+                    {_CanonicalRuntimeLaneKey.from_context(context): context for context in contexts}
+                )
         self._internal_api_contexts = internal_api_contexts
         self._protected_internal_api_contexts = config.protected_install
         self._contexts_by_runtime = contexts_by_runtime
@@ -388,7 +413,9 @@ class SubprocessPool:
                     selected = profile.backend_option(selected).option_id
                 except WorkshopRuntimeProfileError:
                     selected = ""
-            self._selected_backends[context] = selected or profile.default_backend_option.option_id
+            self._selected_backends[_CanonicalRuntimeLaneKey.from_context(context)] = (
+                selected or profile.default_backend_option.option_id
+            )
 
     def _backend_option(self, runtime: RuntimeSelector):
         runtime_key, _legacy_key, profile = self._resolve_runtime(runtime)
@@ -418,7 +445,11 @@ class SubprocessPool:
             if primary is None or (primary.runtime_owner_principal_id != runtime.runtime_owner_principal_id):
                 raise RuntimeError("Canonical runtime lane does not own the protected profile")
             self._register_lane_state(runtime)
-            return runtime, self._runtime_profiles.legacy_runtime_key(profile.profile_id), profile
+            return (
+                _CanonicalRuntimeLaneKey.from_context(runtime),
+                self._runtime_profiles.legacy_runtime_key(profile.profile_id),
+                profile,
+            )
         if isinstance(runtime, RuntimeProfileId):
             if self._runtime_profiles is None:
                 raise RuntimeError("Runtime profile selector requires protected runtime policy")
@@ -438,19 +469,24 @@ class SubprocessPool:
         return profile.profile_id, runtime, profile
 
     def _register_lane_state(self, context: WorkshopInternalAPIExecutionContext) -> None:
-        """Register one isolated lane while inheriting only protected policy."""
-        existing = self._contexts_by_runtime.get(context)
-        if existing is not None and existing != context:
+        """Register one channel-agent lane while inheriting protected policy."""
+        lane_key = _CanonicalRuntimeLaneKey.from_context(context)
+        existing = self._contexts_by_runtime.get(lane_key)
+        if existing is not None and (
+            existing.runtime_owner_principal_id != context.runtime_owner_principal_id
+            or existing.private_context != context.private_context
+            or existing.effective_settings_channel_id != context.effective_settings_channel_id
+        ):
             raise RuntimeError("Canonical runtime lane conflicts with existing context")
-        self._contexts_by_runtime[context] = context
+        self._contexts_by_runtime.setdefault(lane_key, context)
         profile = self._runtime_profiles.resolve(context.runtime_profile_id) if self._runtime_profiles else None
         if profile is not None:
-            self._services_info_by_runtime[context] = list(self._services_info_by_runtime.get(profile.profile_id, []))
+            self._services_info_by_runtime[lane_key] = list(self._services_info_by_runtime.get(profile.profile_id, []))
             primary_backend = self._selected_backends.get(
                 profile.profile_id,
                 profile.default_backend_option.option_id,
             )
-            self._selected_backends.setdefault(context, primary_backend)
+            self._selected_backends.setdefault(lane_key, primary_backend)
 
     def register_canonical_lane(self, context: WorkshopInternalAPIExecutionContext) -> None:
         """Make a newly enabled principal-agent lane immediately executable."""
@@ -467,10 +503,11 @@ class SubprocessPool:
         # authority as soon as the canonical lane is rebound.
         self._internal_api_auth.revoke_agent_context(prior)
         await self.force_kill(prior)
-        self._contexts_by_runtime.pop(prior, None)
-        self._services_info_by_runtime.pop(prior, None)
-        self._selected_backends.pop(prior, None)
-        self._backend_transition_locks.pop(prior, None)
+        prior_key = _CanonicalRuntimeLaneKey.from_context(prior)
+        self._contexts_by_runtime.pop(prior_key, None)
+        self._services_info_by_runtime.pop(prior_key, None)
+        self._selected_backends.pop(prior_key, None)
+        self._backend_transition_locks.pop(prior_key, None)
         self.register_canonical_lane(replacement)
 
     async def suspend_canonical_lane(self, context: WorkshopInternalAPIExecutionContext) -> None:
@@ -488,6 +525,17 @@ class SubprocessPool:
         # circular for some first-import orders.
         return self._resolve_runtime(runtime)[2]
 
+    def _runtime_identity(
+        self,
+        runtime: RuntimeSelector,
+        runtime_key: RuntimePoolKey,
+    ) -> WorkshopInternalAPIExecutionContext | None:
+        """Return this turn's identity without changing its shared lane key."""
+        if isinstance(runtime, WorkshopInternalAPIExecutionContext):
+            return runtime
+        context = self._contexts_by_runtime.get(runtime_key)
+        return context if isinstance(context, WorkshopInternalAPIExecutionContext) else None
+
     def _canonical_namespace(
         self,
         runtime: RuntimeSelector,
@@ -496,7 +544,7 @@ class SubprocessPool:
         runtime_key, _legacy_key, profile = self._resolve_runtime(runtime)
         if profile is None:
             return None
-        context = self._contexts_by_runtime.get(runtime_key)
+        context = self._runtime_identity(runtime, runtime_key)
         if context is None:
             raise RuntimeError("Protected runtime has no canonical execution context")
         from kai.workshop.execution_state import WorkshopExecutionStateNamespace
@@ -612,10 +660,11 @@ class SubprocessPool:
                     )
                 return profile.home_workspace
             runtime_key, _, _ = self._resolve_runtime(runtime)
-            context = self._contexts_by_runtime.get(runtime_key) or self._contexts_by_runtime.get(profile.profile_id)
+            context = self._runtime_identity(runtime, runtime_key) or self._contexts_by_runtime.get(profile.profile_id)
             if context is None:
                 raise RuntimeError("Protected runtime has no canonical home owner")
-            path = self._config.session_db_path.parent / "home" / str(context.principal_id)
+            home_principal_id = context.principal_id if context.private_context else context.runtime_owner_principal_id
+            path = self._config.session_db_path.parent / "home" / str(home_principal_id)
             if not path.is_dir():
                 if self._config.protected_install:
                     raise RuntimeError(
@@ -828,7 +877,7 @@ class SubprocessPool:
         # Internal API availability is independent of public webhook ingress.
         # Agents receive only their random principal credential, never an
         # external webhook signing secret.
-        internal_api_context = self._contexts_by_runtime.get(runtime_key)
+        internal_api_context = self._runtime_identity(runtime, runtime_key)
         if internal_api_context is None:
             if self._protected_internal_api_contexts:
                 raise RuntimeError("Runtime has no canonical internal API execution context")
@@ -970,9 +1019,10 @@ class SubprocessPool:
         async with self._backend_transition_lock(runtime_key):
             prepared = PreparedBackendExecution(
                 self,
-                runtime_key,
+                runtime,
                 runtime_key,
                 await self._prepare_instance(runtime),
+                self._runtime_identity(runtime, runtime_key),
             )
             # Preparation is already part of an accepted canonical run.  Hold
             # the runtime's active marker across the short stage-before-send
@@ -1042,9 +1092,10 @@ class SubprocessPool:
             self._last_activity[instance_key] = time.monotonic()
             prepared = PreparedBackendExecution(
                 self,
-                runtime_key,
+                runtime,
                 instance_key,
                 instance,
+                self._runtime_identity(runtime, runtime_key),
             )
             self._in_flight.add(instance_key)
             return prepared
@@ -1083,7 +1134,7 @@ class SubprocessPool:
             self._in_flight.add(runtime_key)
         try:
             if profile is not None:
-                runtime_identity = self._contexts_by_runtime.get(runtime_key)
+                runtime_identity = self._runtime_identity(selector, runtime_key)
                 if runtime_identity is None:
                     raise RuntimeError("Protected runtime has no canonical backend identity")
                 stream = instance.send(prompt, runtime_identity=runtime_identity)
@@ -1105,15 +1156,15 @@ class SubprocessPool:
     ) -> AsyncGenerator[StreamEvent]:
         """Dispatch through a prepared handle only while its runtime remains exact."""
         self._validate_prepared(prepared)
-        runtime_key = prepared._runtime_selector
+        runtime_selector = prepared._runtime_selector
         instance_key = prepared._instance_key
-        _, runtime_config_id, profile = self._resolve_runtime(runtime_key)
+        _, runtime_config_id, profile = self._resolve_runtime(runtime_selector)
         instance = prepared._instance
         self._last_activity[instance_key] = time.monotonic()
         self._in_flight.add(instance_key)
         try:
             if profile is not None:
-                runtime_identity = self._contexts_by_runtime.get(runtime_key)
+                runtime_identity = prepared._runtime_identity
                 if runtime_identity is None:
                     raise RuntimeError("Protected runtime has no canonical backend identity")
                 stream = instance.send(prompt, runtime_identity=runtime_identity)

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -107,6 +107,7 @@ from kai.workshop.collaboration_reactions import (
     CollaborationReactionDenied,
     CollaborationReactionValidationError,
 )
+from kai.workshop.domain import PrincipalId
 from kai.workshop.github_automation import (
     GitHubSubscriptionRoute,
     WorkshopGitHubAutomationService,
@@ -300,7 +301,7 @@ def _reject_internal_identity_selectors(payload: dict) -> None:
 
 def _scheduled_job_authority(principal: InternalAPIPrincipal) -> WorkshopScheduledJobAuthority:
     return WorkshopScheduledJobAuthority(
-        principal.principal_id,
+        _bound_principal_id(principal),
         principal.channel_id,
         principal.agent_id,
         principal.runtime_profile_id,
@@ -312,7 +313,7 @@ def _internal_execution_context(
 ) -> WorkshopInternalAPIExecutionContext:
     """Recover the exact canonical lane already bound to one credential."""
     return WorkshopInternalAPIExecutionContext(
-        principal.principal_id,
+        _bound_principal_id(principal),
         principal.channel_id,
         principal.agent_id,
         principal.runtime_profile_id,
@@ -1143,7 +1144,7 @@ async def _handle_service_call(request: web.Request, principal: InternalAPIPrinc
 
 def _proactive_authority(principal: InternalAPIPrincipal) -> ProactivePublicationAuthority:
     return ProactivePublicationAuthority(
-        principal_id=principal.principal_id,
+        principal_id=_bound_principal_id(principal),
         channel_id=principal.channel_id,
         agent_id=principal.agent_id,
         runtime_profile_id=principal.runtime_profile_id,
@@ -1255,12 +1256,7 @@ async def _handle_agent_delegation(
     try:
         proof = request.headers.get("X-Kai-Collaboration-Proof", "")
         result = await request.app[CORE_HOST_KEY].services.agent_delegation.delegate(
-            CollaborationBaseIdentity(
-                principal_id=principal.principal_id,
-                channel_id=principal.channel_id,
-                agent_id=principal.agent_id,
-                runtime_profile_id=principal.runtime_profile_id,
-            ),
+            _collaboration_base_identity(principal),
             proof=proof,
             target_handle=payload["target_handle"],
             task=payload["task"],
@@ -1334,12 +1330,7 @@ async def _handle_collaboration_context(
         return web.json_response({"error": "Missing required field: idempotency_key"}, status=400)
     try:
         result = await request.app[CORE_HOST_KEY].services.collaboration_context.read(
-            CollaborationBaseIdentity(
-                principal_id=principal.principal_id,
-                channel_id=principal.channel_id,
-                agent_id=principal.agent_id,
-                runtime_profile_id=principal.runtime_profile_id,
-            ),
+            _collaboration_base_identity(principal),
             proof=request.headers.get("X-Kai-Collaboration-Proof", ""),
             cursor=payload.get("cursor"),
             limit=payload.get("limit", 20),
@@ -1384,12 +1375,7 @@ async def _handle_collaboration_reaction(
         return web.json_response({"error": "Invalid collaboration reaction request"}, status=400)
     try:
         result = await request.app[CORE_HOST_KEY].services.collaboration_reactions.react(
-            CollaborationBaseIdentity(
-                principal_id=principal.principal_id,
-                channel_id=principal.channel_id,
-                agent_id=principal.agent_id,
-                runtime_profile_id=principal.runtime_profile_id,
-            ),
+            _collaboration_base_identity(principal),
             proof=request.headers.get("X-Kai-Collaboration-Proof", ""),
             message_id=payload["message_id"],
             reaction=payload["reaction"],
@@ -1427,11 +1413,18 @@ async def _handle_collaboration_reaction(
 
 def _collaboration_base_identity(principal: InternalAPIPrincipal) -> CollaborationBaseIdentity:
     return CollaborationBaseIdentity(
-        principal_id=principal.principal_id,
+        principal_id=(principal.principal_id if principal.requesting_principal_bound else None),
         channel_id=principal.channel_id,
         agent_id=principal.agent_id,
         runtime_profile_id=principal.runtime_profile_id,
     )
+
+
+def _bound_principal_id(principal: InternalAPIPrincipal) -> PrincipalId:
+    """Return the human identity carried only by principal-bound credentials."""
+    if principal.principal_id is None:
+        raise RuntimeError("Internal API credential is not bound to a requesting principal")
+    return principal.principal_id
 
 
 def _collaboration_publication_error(exc: Exception) -> web.Response:

--- a/src/kai/workshop/collaboration_authority.py
+++ b/src/kai/workshop/collaboration_authority.py
@@ -84,7 +84,11 @@ class CollaborationGrantConflict(CollaborationAuthorityError):
 class CollaborationBaseIdentity:
     """Stable process identity that must agree with a transient proof."""
 
-    principal_id: PrincipalId
+    # Shared group-channel processes are deliberately requester-neutral.  In
+    # that case the exact attempt proof supplies the requesting principal,
+    # while the persistent credential still has to match channel, agent, and
+    # runtime.  Direct-channel processes remain principal-bound.
+    principal_id: PrincipalId | None
     channel_id: ChannelId
     agent_id: AgentId
     runtime_profile_id: RuntimeProfileId
@@ -420,7 +424,7 @@ class WorkshopCollaborationAuthority:
         if not hmac.compare_digest(fingerprint, grant.proof_fingerprint):
             raise CollaborationProofError("Invalid collaboration proof")
         if base_identity is not None and (
-            base_identity.principal_id != grant.requested_by_principal_id
+            (base_identity.principal_id is not None and base_identity.principal_id != grant.requested_by_principal_id)
             or base_identity.channel_id != grant.channel_id
             or base_identity.agent_id != grant.agent_id
             or base_identity.runtime_profile_id != grant.runtime_profile_id
@@ -470,7 +474,7 @@ class WorkshopCollaborationAuthority:
         except CollaborationDenied as exc:
             denial = exc
         if denial is None and (
-            base_identity.principal_id != grant.requested_by_principal_id
+            (base_identity.principal_id is not None and base_identity.principal_id != grant.requested_by_principal_id)
             or base_identity.channel_id != grant.channel_id
             or base_identity.agent_id != grant.agent_id
             or base_identity.runtime_profile_id != grant.runtime_profile_id

--- a/tests/test_internal_api_auth.py
+++ b/tests/test_internal_api_auth.py
@@ -64,14 +64,16 @@ def test_persistent_agent_profile_is_explicit_and_excludes_delete_all() -> None:
     assert not principal.allows(InternalAPIScope.MEMORY_DELETE_ALL)
 
 
-def test_shared_channel_agent_credential_cannot_access_personal_memory() -> None:
+def test_shared_channel_agent_credential_is_requester_neutral_and_attempt_scoped() -> None:
     direct = _context(123)
+    requester = PrincipalId("prn_00000000000000000000000000000456")
     shared = WorkshopInternalAPIExecutionContext(
-        principal_id=direct.principal_id,
+        principal_id=requester,
         channel_id=ChannelId("chn_00000000000000000000000000000456"),
         agent_id=direct.agent_id,
         runtime_profile_id=direct.runtime_profile_id,
         private_context=False,
+        sponsor_principal_id=direct.principal_id,
     )
     auth = InternalAPIAuth.for_execution_contexts({direct, shared})
 
@@ -79,9 +81,39 @@ def test_shared_channel_agent_credential_cannot_access_personal_memory() -> None
 
     assert principal is not None
     assert principal.private_context is False
+    assert principal.requesting_principal_bound is False
+    assert principal.principal_id is None
+    assert principal.scopes == frozenset({InternalAPIScope.COLLABORATION_INVOKE})
     assert not principal.allows(InternalAPIScope.MEMORY_READ)
     assert not principal.allows(InternalAPIScope.MEMORY_ADD)
-    assert principal.allows(InternalAPIScope.MESSAGES_SEND)
+    assert not principal.allows(InternalAPIScope.JOBS_READ)
+    assert not principal.allows(InternalAPIScope.JOBS_WRITE)
+    assert not principal.allows(InternalAPIScope.MESSAGES_SEND)
+    assert not principal.allows(InternalAPIScope.FILES_SEND)
+
+
+def test_shared_channel_requesters_receive_one_lane_credential() -> None:
+    direct = _context(123)
+    channel_id = ChannelId("chn_00000000000000000000000000000456")
+    first = WorkshopInternalAPIExecutionContext(
+        principal_id=PrincipalId("prn_00000000000000000000000000000456"),
+        channel_id=channel_id,
+        agent_id=direct.agent_id,
+        runtime_profile_id=direct.runtime_profile_id,
+        private_context=False,
+        sponsor_principal_id=direct.principal_id,
+    )
+    second = WorkshopInternalAPIExecutionContext(
+        principal_id=PrincipalId("prn_00000000000000000000000000000789"),
+        channel_id=channel_id,
+        agent_id=direct.agent_id,
+        runtime_profile_id=direct.runtime_profile_id,
+        private_context=False,
+        sponsor_principal_id=direct.principal_id,
+    )
+    auth = InternalAPIAuth.for_execution_contexts({direct})
+
+    assert auth.agent_credential_for(first) == auth.agent_credential_for(second)
 
 
 def test_persistent_agent_service_scope_requires_explicit_names() -> None:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -23,7 +23,7 @@ from kai.config import Config, ModelRole, UserConfig, WorkspaceConfig, get_model
 from kai.goose import GooseBackend
 from kai.internal_api_auth import InternalAPIScope
 from kai.pool import SubprocessPool
-from kai.workshop.domain import AgentId, ChannelId
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId
 from kai.workshop.internal_api_contexts import (
     WorkshopInternalAPIContextRegistry,
     WorkshopInternalAPIExecutionContext,
@@ -151,6 +151,81 @@ class TestInstanceCreation:
         assert (
             pool.internal_api_auth.authenticate(second._api_context.webhook_secret).channel_id == secondary.channel_id
         )
+
+    @pytest.mark.asyncio
+    async def test_group_channel_requesters_share_instance_but_keep_per_turn_identity(self, tmp_path):
+        runtime_id = profile_id(111)
+        owner = WorkshopInternalAPIExecutionContext.for_unprotected_runtime(111, runtime_id)
+        channel_id = ChannelId("chn_" + "c" * 32)
+        agent_id = AgentId("agt_" + "d" * 32)
+        first = WorkshopInternalAPIExecutionContext(
+            PrincipalId("prn_" + "1" * 32),
+            channel_id,
+            agent_id,
+            runtime_id,
+            private_context=False,
+            sponsor_principal_id=owner.principal_id,
+            settings_channel_id=owner.channel_id,
+        )
+        second = WorkshopInternalAPIExecutionContext(
+            PrincipalId("prn_" + "2" * 32),
+            channel_id,
+            agent_id,
+            runtime_id,
+            private_context=False,
+            sponsor_principal_id=owner.principal_id,
+            settings_channel_id=owner.channel_id,
+        )
+        profiles = WorkshopRuntimeProfileRegistry(
+            (
+                ProtectedRuntimeProfile(
+                    profile_id=runtime_id,
+                    display_name="shared policy",
+                    os_user=None,
+                    backend="codex",
+                    provider="openai",
+                    model="gpt-5.6-sol",
+                    timeout_seconds=120,
+                    allowed_services=(),
+                    home_workspace=tmp_path,
+                    workspace_base=None,
+                    allowed_workspaces=(),
+                ),
+            ),
+            legacy_runtime_keys={runtime_id: 111},
+        )
+        pool = SubprocessPool(
+            config=_make_config(allowed_user_ids={111}),
+            services_info=[],
+            runtime_profiles=profiles,
+            internal_api_contexts=WorkshopInternalAPIContextRegistry((owner,)),
+        )
+
+        instance = pool.get(first)
+        assert pool.get(second) is instance
+        assert len(pool._pool) == 1
+        lane_principal = pool.internal_api_auth.authenticate(instance._api_context.webhook_secret)
+        assert lane_principal is not None
+        assert lane_principal.requesting_principal_bound is False
+
+        async def response_events():
+            yield StreamEvent(
+                text_so_far="done",
+                done=True,
+                response=AgentResponse(text="done", success=True),
+            )
+
+        instance.send = MagicMock(side_effect=lambda *_args, **_kwargs: response_events())
+        pool._prepare_instance = AsyncMock(return_value=instance)
+        pool._pending_workspace_restore.clear()
+        pool._pending_settings_restore.clear()
+
+        first_prepared = await pool.prepare_execution(first)
+        assert [event async for event in first_prepared.stream("first")]
+        second_prepared = await pool.prepare_execution(second)
+        assert [event async for event in second_prepared.stream("second")]
+
+        assert [call.kwargs["runtime_identity"] for call in instance.send.call_args_list] == [first, second]
 
     def test_internal_api_credential_exists_without_external_webhooks(self):
         """Disabling public ingress must not remove the agent's scoped API."""

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -21,7 +21,7 @@ from kai.workshop.collaboration_authority import (
 )
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
-from kai.workshop.domain import RunExecutionOwnerId, RuntimeProfileId
+from kai.workshop.domain import ChannelId, RunExecutionOwnerId, RuntimeProfileId
 from kai.workshop.inbound import InboundMessage
 from kai.workshop.internal_api_contexts import WorkshopInternalAPIExecutionContext
 from kai.workshop.projection import CanonicalConversationProjection
@@ -608,5 +608,54 @@ async def test_mismatched_base_identity_is_denied_and_audited(tmp_path: Path) ->
             "SELECT decision, denial_code FROM collaboration_operation_decisions"
         ) as cursor:
             assert tuple(await cursor.fetchone()) == ("denied", "base_identity_mismatch")
+    finally:
+        await store.close()
+
+
+async def test_requester_neutral_base_identity_uses_proof_principal_but_still_fences_lane(
+    tmp_path: Path,
+) -> None:
+    store, _execution, started = await _running_attempt(tmp_path / "kai.db")
+    try:
+        authority = WorkshopCollaborationAuthority(
+            store,
+            token_factory=lambda: "attempt-proof-000000000000000000000000000010",
+        )
+        _grant, invocation = await authority.issue(
+            started.claim,
+            occurred_at=_NOW + timedelta(seconds=3),
+        )
+        correct = _base_identity(started)
+        neutral = CollaborationBaseIdentity(
+            principal_id=None,
+            channel_id=correct.channel_id,
+            agent_id=correct.agent_id,
+            runtime_profile_id=correct.runtime_profile_id,
+        )
+
+        authorized = await authority.authorize(
+            invocation.token,
+            CollaborationOperation.AGENT_DELEGATION,
+            base_identity=neutral,
+            idempotency_key="requester-neutral-lane",
+            request_hash="d" * 64,
+            occurred_at=_NOW + timedelta(seconds=4),
+        )
+        assert authorized.grant.requested_by_principal_id == started.run.requested_by_principal_id
+
+        wrong_lane = CollaborationBaseIdentity(
+            principal_id=None,
+            channel_id=ChannelId.new(),
+            agent_id=correct.agent_id,
+            runtime_profile_id=correct.runtime_profile_id,
+        )
+        with pytest.raises(CollaborationDenied) as denied:
+            await authority.authenticate(
+                invocation.token,
+                CollaborationOperation.AGENT_DELEGATION,
+                base_identity=wrong_lane,
+                occurred_at=_NOW + timedelta(seconds=5),
+            )
+        assert denied.value.code == "base_identity_mismatch"
     finally:
         await store.close()

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -12,16 +12,17 @@ import pytest
 from kai.agent_failure import AgentFailureKind
 from kai.backend import AgentResponse, StreamEvent, TraceEntry
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.channel_lifecycle import WorkshopChannelLifecycleService
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.diagnostics import workshop_runtime_session_status
-from kai.workshop.domain import RunExecutionOwnerId, RuntimeProfileId
+from kai.workshop.domain import ChannelId, PrincipalId, RunExecutionOwnerId, RuntimeProfileId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
     CanonicalExecutionDisposition,
     WorkshopCanonicalExecutionCoordinator,
 )
-from kai.workshop.inbound import InboundMessage
+from kai.workshop.inbound import ClientInboundMessage, InboundMessage
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.protected_execution import ProtectedExecutionRoutingRejected
 from kai.workshop.routing_eligibility import RoutingTaskClass
@@ -113,6 +114,14 @@ class _Preparation:
         return self.prepared
 
 
+class _PreparationByRun:
+    def __init__(self, prepared: tuple[_Prepared, ...]) -> None:
+        self.prepared = {item.run.run_id: item for item in prepared}
+
+    async def prepare(self, run_id):
+        return self.prepared[run_id]
+
+
 class _RejectedPreparation:
     def __init__(self, run) -> None:
         self.run = run
@@ -167,6 +176,63 @@ async def _accepted(path: Path, *, suffix: str = "1"):
     return store, result.run
 
 
+async def _accepted_group_pair(path: Path):
+    store = await WorkshopEventStore.open(path)
+    bootstrap = await bootstrap_default_workshop(
+        store,
+        (
+            BootstrapHuman("Daniel", "admin", "desktop", "daniel", "daniel", _RUNTIME_PROFILE_ID),
+            BootstrapHuman("Scott", "member", "desktop", "scott", "scott", RuntimeProfileId.new()),
+        ),
+    )
+    async with store.connection.execute(
+        "SELECT e.external_subject, e.principal_id, cb.channel_id "
+        "FROM external_identities e JOIN channel_bindings cb "
+        "ON cb.transport = e.provider AND cb.external_channel_id = e.external_subject "
+        "ORDER BY e.external_subject"
+    ) as cursor:
+        rows = list(await cursor.fetchall())
+    identities = {str(row[0]): (PrincipalId(str(row[1])), ChannelId(str(row[2]))) for row in rows}
+    daniel_id, daniel_direct = identities["daniel"]
+    scott_id, _scott_direct = identities["scott"]
+    lifecycle = WorkshopChannelLifecycleService(store)
+    group = await lifecycle.create_group(
+        daniel_id,
+        name="Shared execution lane",
+        agent_ids=[bootstrap.agent_id],
+        origin_channel_id=daniel_direct,
+    )
+    membership = await lifecycle.human_members(daniel_id, group.channel_id)
+    await lifecycle.add_human_member(
+        daniel_id,
+        group.channel_id,
+        scott_id,
+        expected_state_version=membership.state_version,
+        client_operation_id="add-scott-to-shared-execution-lane",
+    )
+    commands = WorkshopConversationCommandService(store)
+    first = await commands.accept_client(
+        ClientInboundMessage(
+            daniel_id,
+            group.channel_id,
+            "shared-lane-daniel",
+            "@Kai first",
+            _NOW,
+        )
+    )
+    second = await commands.accept_client(
+        ClientInboundMessage(
+            scott_id,
+            group.channel_id,
+            "shared-lane-scott",
+            "@Kai second",
+            _NOW + timedelta(seconds=1),
+        )
+    )
+    await WorkshopConversationDeliveryAuthority(store).activate()
+    return store, first.command.runs[0], second.command.runs[0]
+
+
 def _coordinator(store, preparation, *, lease_seconds: int = 60):
     return WorkshopCanonicalExecutionCoordinator(
         store,
@@ -184,6 +250,44 @@ async def _terminal_bodies(store: WorkshopEventStore) -> list[str]:
 
 
 class TestCanonicalExecutionCoordinator:
+    async def test_two_humans_alternate_in_one_group_agent_lane_in_order(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, first_run, second_run = await _accepted_group_pair(tmp_path / "kai.db")
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        dispatch_order: list[PrincipalId] = []
+
+        async def start_first() -> None:
+            dispatch_order.append(first_run.requested_by_principal_id)
+            first_started.set()
+
+        async def start_second() -> None:
+            dispatch_order.append(second_run.requested_by_principal_id)
+
+        first = _Prepared(first_run, wait=release_first, on_stream=start_first)
+        second = _Prepared(second_run, on_stream=start_second)
+        coordinator = _coordinator(store, _PreparationByRun((first, second)))
+        try:
+            first_execution = asyncio.create_task(coordinator.execute(first_run.run_id))
+            await first_started.wait()
+            second_execution = asyncio.create_task(coordinator.execute(second_run.run_id))
+            await asyncio.sleep(0)
+
+            assert second.prompts == []
+            release_first.set()
+            first_result, second_result = await asyncio.gather(first_execution, second_execution)
+
+            assert first_result.disposition == CanonicalExecutionDisposition.COMPLETED
+            assert second_result.disposition == CanonicalExecutionDisposition.COMPLETED
+            assert dispatch_order == [
+                first_run.requested_by_principal_id,
+                second_run.requested_by_principal_id,
+            ]
+        finally:
+            await store.close()
+
     async def test_ineligible_explicit_route_fails_without_backend_dispatch(self, tmp_path: Path):
         store, run = await _accepted(tmp_path / "kai.db")
         try:


### PR DESCRIPTION
Closes #1446.

## Summary
- key protected backend processes by canonical channel/agent/runtime lane instead of the triggering human
- preserve the exact requesting principal as per-turn runtime identity
- issue requester-neutral group-lane credentials and require exact-attempt collaboration proofs for stateful actions
- retain principal-bound credentials and existing capabilities for direct conversations

## Security decision
A shared group-lane credential carries no human principal. It permits attempt-scoped collaboration operations and explicitly authorized stateless service calls only. Principal-owned memory, scheduling, file/message publication, and legacy proactive publication fail closed in shared lanes.

## Validation
- `make test` — 6524 passed
- focused execution/auth/coordinator suite — 435 passed
- `make check`
- `make typecheck`
- `git diff --check`