### PR TITLE
Fix shared-channel routing preparation

### DIFF
--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -504,6 +504,7 @@ class WorkshopCanonicalExecutionCoordinator:
                     workspace=str(active.prepared.workspace) if active.prepared is not None else None,
                     selection=active.prepared.selection if active.prepared is not None else None,
                 )
+            log.exception("Workshop run %s preparation deferred", run.run_id)
             return CanonicalExecutionResult(
                 CanonicalExecutionDisposition.PREPARATION_DEFERRED, await self._run(run.run_id)
             )

--- a/src/kai/workshop/routing_eligibility.py
+++ b/src/kai/workshop/routing_eligibility.py
@@ -264,7 +264,14 @@ class WorkshopRoutingEligibilityService:
             authority.channel_id,
             authority.agent_id,
             authority.runtime_profile_id,
-            private_context=not sponsored_channel,
+            # Sponsored-channel eligibility reads the agent owner's canonical
+            # runtime settings through the owner's direct settings lane.  It
+            # must therefore use that lane's real private identity here.  The
+            # eventual group-channel execution is prepared separately with a
+            # requester-neutral, non-private context; marking this settings
+            # lookup non-private would instead collide with an already-live
+            # owner direct lane that has the same channel/agent/profile key.
+            private_context=True,
         )
         workspace = await self._runtime_pool.get_effective_workspace(runtime_authority)
         selected_backend, selected_provider = self._runtime_pool.get_backend_provider(runtime_authority)

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -699,7 +699,7 @@ class TestCanonicalExecutionCoordinator:
         finally:
             await store.close()
 
-    async def test_runtime_drift_leaves_retryable_grant_until_expiry(self, tmp_path: Path):
+    async def test_runtime_drift_leaves_retryable_grant_until_expiry(self, tmp_path: Path, caplog):
         store, run = await _accepted(tmp_path / "kai.db")
         prepared = _Prepared(run)
         prepared.reject_validation = True
@@ -709,6 +709,8 @@ class TestCanonicalExecutionCoordinator:
             deferred = await coordinator.execute(run.run_id)
             assert deferred.disposition == CanonicalExecutionDisposition.PREPARATION_DEFERRED
             assert (await WorkshopRunLifecycle(store).state(run.run_id)).status == RunStatus.ACCEPTED
+            assert f"Workshop run {run.run_id} preparation deferred" in caplog.text
+            assert "runtime drift" in caplog.text
 
             recovered = await coordinator.recover_expired(occurred_at=_NOW + timedelta(seconds=16))
             assert recovered.expired_before_dispatch == 1

--- a/tests/test_workshop_routing_eligibility.py
+++ b/tests/test_workshop_routing_eligibility.py
@@ -155,23 +155,34 @@ class _Catalogue:
 
 
 class _RuntimePool:
-    def __init__(self, workspace: Path) -> None:
+    def __init__(self, workspace: Path, namespace: WorkshopExecutionStateNamespace) -> None:
         self.workspace = workspace
+        self.namespace = namespace
         self.selection_reads = 0
         self.selected_backend = ("claude", "anthropic")
         self.authorities: list[object] = []
 
-    async def get_effective_workspace(self, runtime_authority):
+    def _record(self, runtime_authority) -> None:
+        if (
+            getattr(runtime_authority, "channel_id", None) == self.namespace.channel_id
+            and getattr(runtime_authority, "agent_id", None) == self.namespace.agent_id
+            and getattr(runtime_authority, "runtime_profile_id", None) == self.namespace.runtime_profile_id
+            and getattr(runtime_authority, "private_context", None) is not True
+        ):
+            raise RuntimeError("runtime lane conflicts with registered owner direct lane")
         self.authorities.append(runtime_authority)
+
+    async def get_effective_workspace(self, runtime_authority):
+        self._record(runtime_authority)
         return self.workspace
 
     async def get_effective_model(self, runtime_authority):
-        self.authorities.append(runtime_authority)
+        self._record(runtime_authority)
         self.selection_reads += 1
         return "selected-model"
 
     def get_backend_provider(self, runtime_authority):
-        self.authorities.append(runtime_authority)
+        self._record(runtime_authority)
         return self.selected_backend
 
     def runtime_profile(self, _runtime_profile_id):
@@ -182,7 +193,7 @@ def _service(tmp_path: Path, lanes: tuple[object, ...], snapshots: dict[str, Mod
     namespace = _namespace(1)
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    pool = _RuntimePool(workspace)
+    pool = _RuntimePool(workspace, namespace)
     catalogue = _Catalogue(snapshots)
     service = WorkshopRoutingEligibilityService(
         execution_state=WorkshopExecutionStateRegistry((namespace,)),
@@ -348,7 +359,7 @@ async def test_cross_principal_authority_and_unknown_task_fail_closed(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_sponsored_channel_uses_profile_owner_without_private_lane_access(
+async def test_sponsored_channel_reads_profile_owner_settings_through_real_direct_lane(
     tmp_path: Path,
 ) -> None:
     namespace = _namespace(1)
@@ -358,12 +369,12 @@ async def test_sponsored_channel_uses_profile_owner_without_private_lane_access(
         (lane,),
         {lane.option_id: _snapshot(namespace, lane, image_input=True)},
     )
-    group_channel = _id(ChannelId, 20)
-    group_agent = _id(AgentId, 21)
+    owner_channel = namespace.channel_id
+    owned_agent = namespace.agent_id
     authority = service.authority_for_sponsored_channel(
         namespace.principal_id,
-        group_channel,
-        group_agent,
+        owner_channel,
+        owned_agent,
         namespace.runtime_profile_id,
     )
 
@@ -373,18 +384,19 @@ async def test_sponsored_channel_uses_profile_owner_without_private_lane_access(
     )
 
     assert report.principal_id == namespace.principal_id
-    assert report.channel_id == group_channel
-    assert report.agent_id == group_agent
+    assert report.channel_id == owner_channel
+    assert report.agent_id == owned_agent
     assert report.runtime_profile_id == namespace.runtime_profile_id
     assert pool.authorities
-    assert all(getattr(item, "private_context", None) is False for item in pool.authorities)
-    with pytest.raises(RoutingEligibilityAccessDenied):
-        await service.inspect(authority, RoutingTaskClass.CONVERSATION)
+    # This authority is used only to inspect the owner's policy-bounded
+    # settings.  The eventual group execution receives its own non-private
+    # authority from protected preparation.
+    assert all(getattr(item, "private_context", None) is True for item in pool.authorities)
     with pytest.raises(RoutingEligibilityAccessDenied):
         service.authority_for_sponsored_channel(
             _id(PrincipalId, 2),
-            group_channel,
-            group_agent,
+            owner_channel,
+            owned_agent,
             namespace.runtime_profile_id,
         )
 


### PR DESCRIPTION
Closes #1450.

## Summary

- read sponsored-agent runtime settings through the owner direct lane's real private identity
- keep the eventual shared-channel execution requester-neutral and non-private
- log unexpected preparation deferrals with the run ID and underlying exception
- add production-shaped collision and diagnostic regression coverage

## Validation

- focused Workshop routing/execution tests: 35 passed
- make check
- make typecheck
- make test: 6525 tests, exit 0
