### PR TITLE
Make Workshop human provisioning identity-only

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -76,6 +76,7 @@ from kai.config import (
 from kai.named_access import replace_named_inherited_read_access, replace_named_read_access
 from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
+from kai.workshop.agent_enablement import initial_kai_enablement_ids
 from kai.workshop.bootstrap import bootstrap_human_principal_id
 from kai.workshop.diagnostics import (
     workshop_agent_authority_status,
@@ -90,6 +91,7 @@ from kai.workshop.diagnostics import (
     workshop_human_avatar_status,
     workshop_human_handle_status,
     workshop_human_notification_status,
+    workshop_human_provisioning_status,
     workshop_legacy_jsonl_archive_status,
     workshop_memory_authority_status,
     workshop_operational_state_status,
@@ -923,7 +925,7 @@ async def _provision_single_user_workshop(
         )
         return await sessions.issue_workshop_enrollment(
             provisioned.principal_id,
-            provisioned.channel_id,
+            provisioned.direct_channel_id,
         )
     finally:
         await sessions.close_db()
@@ -5605,7 +5607,7 @@ def _runtime_profile_principal_names(
             rows = connection.execute(
                 "SELECT ra.runtime_profile_id, cm.principal_id "
                 "FROM channel_agent_runtime_assignments ra "
-                "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+                "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
                 "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
                 "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
                 "ORDER BY ra.runtime_profile_id, cm.principal_id"
@@ -5681,7 +5683,7 @@ def _runtime_storage_targets(
                     provisioned_human_ids(
                         initial_plan.workshop_id,
                         initial_plan.provisioning_key,
-                    )[0]
+                    )
                 )
             elif runtime_config_id is None or runtime_config_id not in compatibility_ids:
                 raise RuntimeError(
@@ -6788,10 +6790,11 @@ def _issue_installed_initial_enrollment(
     service_user: str,
 ) -> str:
     """Issue the staged first browser enrollment as the database owner."""
-    principal_id, channel_id = provisioned_human_ids(
+    principal_id = provisioned_human_ids(
         plan.workshop_id,
         plan.provisioning_key,
     )
+    _enablement_id, channel_id = initial_kai_enablement_ids(plan.workshop_id, principal_id)
     command = [
         "sudo",
         "-H",
@@ -9539,6 +9542,7 @@ def _cmd_status() -> None:
             expected_humans=expected_humans,
         )
     )
+    print(workshop_human_provisioning_status(Path(data_dir) / "kai.db"))
     print(workshop_agent_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_collaboration_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_human_handle_status(Path(data_dir) / "kai.db"))
@@ -10189,7 +10193,9 @@ def _channel_lifecycle_status(db_path: Path) -> str:
                     "LEFT JOIN latest l ON l.aggregate_id = c.id "
                     "LEFT JOIN event_log e ON e.position = l.position "
                     "WHERE (c.kind != 'group' AND (c.archived_at IS NOT NULL "
-                    "OR c.lifecycle_event_position IS NOT NULL)) "
+                    "OR c.lifecycle_event_position IS NOT NULL) AND NOT ("
+                    "c.kind = 'direct' AND e.event_type = 'channel.archived' "
+                    "AND json_extract(e.metadata_json, '$.source') = 'human_provisioning_migration')) "
                     "OR (c.kind = 'group' AND c.archived_at IS NOT NULL AND ("
                     "e.event_type IS NULL OR e.event_type != 'channel.archived' "
                     "OR c.lifecycle_event_position != e.position)) "
@@ -10327,7 +10333,7 @@ def _internal_api_authority_status(db_path: Path) -> str:
                     "SELECT COUNT(*) FROM ("
                     "SELECT ra.runtime_profile_id, ra.channel_id, ra.agent_id, cm.principal_id "
                     "FROM channel_agent_runtime_assignments ra "
-                    "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+                    "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
                     "JOIN agents a ON a.id = ra.agent_id AND a.workshop_id = c.workshop_id "
                     "JOIN channel_agents ca ON ca.channel_id = c.id AND ca.agent_id = a.id "
                     "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -551,6 +551,16 @@ def _start() -> None:
             workshop_bootstrap.created_events,
             workshop_bootstrap.existing_events,
         )
+        human_provisioning = await sessions.reconcile_workshop_human_provisioning()
+        logging.info(
+            "Workshop human provisioning ready (identities=%d, legacy_channels=%d, "
+            "retained=%d, archived=%d, unresolved=%d)",
+            human_provisioning.identities,
+            human_provisioning.legacy_channels,
+            human_provisioning.retained_channels,
+            human_provisioning.archived_channels,
+            human_provisioning.unresolved_channels,
+        )
         agent_authority = await sessions.reconcile_workshop_agent_authority(runtime_profiles)
         logging.info(
             "Workshop agent authority ready (definitions=%d, owners=%d, runtimes=%d)",

--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -45,6 +45,10 @@ from typing import TYPE_CHECKING, TypedDict
 import aiosqlite
 
 from kai.job_types import JOB_TYPE_AGENT, LEGACY_JOB_TYPE_AGENT, normalize_job_type
+from kai.workshop.agent_enablement import (
+    InitialAgentEnablement,
+    enable_initial_workshop_agent,
+)
 from kai.workshop.artifacts import InboundArtifact, record_inbound_artifact
 from kai.workshop.bootstrap import (
     BootstrapHuman,
@@ -71,9 +75,10 @@ from kai.workshop.execution_state import (
     WorkshopExecutionStateRegistry,
     reconcile_legacy_execution_state,
 )
-from kai.workshop.human_provisioning import (
-    ProvisionedWorkshopHuman,
-    WorkshopHumanProvisioner,
+from kai.workshop.human_provisioning import WorkshopHumanProvisioner
+from kai.workshop.human_provisioning_migration import (
+    WorkshopHumanProvisioningMigration,
+    reconcile_legacy_human_provisioning_channels,
 )
 from kai.workshop.inbound import InboundMessage, record_inbound_message
 from kai.workshop.initial_provisioning import WorkshopInitialProvisioning
@@ -109,7 +114,6 @@ from kai.workshop.transport_linking import WorkshopTransportLinker
 
 if TYPE_CHECKING:
     from kai.config import Config, WorkspaceConfig
-from kai.workshop.runtime_assignments import WorkshopRuntimeAssignmentService
 from kai.workshop.runtime_key_cutover import (
     WorkshopRuntimeKeyCutover,
     reconcile_workshop_runtime_key_cutover,
@@ -394,8 +398,8 @@ async def bootstrap_workshop_foundation(
 async def reconcile_initial_workshop_human(
     plan: WorkshopInitialProvisioning,
     runtime_profiles: WorkshopRuntimeProfileRegistry,
-) -> ProvisionedWorkshopHuman:
-    """Idempotently provision and assign the first transport-free human."""
+) -> InitialAgentEnablement:
+    """Idempotently provision the first human and enable canonical Kai."""
     if _workshop_event_lock is None:
         raise RuntimeError("Database not initialized - call init_db() first")
     runtime_profiles.resolve(plan.runtime_profile_id)
@@ -407,12 +411,21 @@ async def reconcile_initial_workshop_human(
             plan.role,
             workshop_id=plan.workshop_id,
         )
-        await WorkshopRuntimeAssignmentService(store, runtime_profiles).assign(
+        return await enable_initial_workshop_agent(
+            store,
+            runtime_profiles,
             provisioned.principal_id,
-            provisioned.channel_id,
             plan.runtime_profile_id,
         )
-        return provisioned
+
+
+async def reconcile_workshop_human_provisioning() -> WorkshopHumanProvisioningMigration:
+    """Retire direct channels emitted by the legacy identity provisioner."""
+    if _workshop_event_lock is None:
+        raise RuntimeError("Database not initialized - call init_db() first")
+    async with _workshop_event_lock:
+        store = WorkshopEventStore.from_initialized_connection(_get_db())
+        return await reconcile_legacy_human_provisioning_channels(store)
 
 
 async def link_workshop_transport_profile(

--- a/src/kai/workshop/agent_authority.py
+++ b/src/kai/workshop/agent_authority.py
@@ -51,7 +51,7 @@ async def reconcile_single_owner_agent_authority(
             if owner_row is None:
                 async with connection.execute(
                     "SELECT DISTINCT cm.principal_id FROM channel_agent_runtime_assignments ra "
-                    "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+                    "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
                     "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
                     "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
                     "WHERE ra.runtime_profile_id = ? ORDER BY cm.principal_id",

--- a/src/kai/workshop/agent_enablement.py
+++ b/src/kai/workshop/agent_enablement.py
@@ -83,6 +83,276 @@ class PrincipalAgentEnablement:
     conversation_started: bool = False
 
 
+@dataclass(frozen=True, slots=True)
+class InitialAgentEnablement:
+    """Canonical direct lane created for the first Workshop administrator."""
+
+    principal_id: PrincipalId
+    definition_id: AgentDefinitionId
+    agent_id: AgentId
+    direct_channel_id: ChannelId
+    runtime_profile_id: RuntimeProfileId
+    created: bool
+
+
+def principal_agent_enablement_ids(
+    definition_id: AgentDefinitionId,
+    principal_id: PrincipalId,
+) -> tuple[AgentEnablementId, ChannelId]:
+    """Return the canonical enablement and direct-channel identities."""
+    enablement_id = AgentEnablementId.derived(definition_id, f"principal:{principal_id}")
+    return enablement_id, ChannelId.derived(enablement_id, "direct-channel")
+
+
+def initial_kai_enablement_ids(
+    workshop_id: WorkshopId,
+    principal_id: PrincipalId,
+) -> tuple[AgentEnablementId, ChannelId]:
+    """Return the bootstrap Kai enablement identities without database access."""
+    agent_id = AgentId.derived(workshop_id, "agent:kai")
+    definition_id = AgentDefinitionId.derived(agent_id, "definition")
+    return principal_agent_enablement_ids(definition_id, principal_id)
+
+
+def _agent_enablement_event(
+    workshop_id: WorkshopId,
+    principal_id: PrincipalId,
+    definition_id: AgentDefinitionId,
+    agent_id: AgentId,
+    enablement_id: AgentEnablementId,
+    channel_id: ChannelId,
+    runtime_profile_id: RuntimeProfileId,
+    now: datetime,
+    operation_key: str,
+    metadata: dict[str, str],
+) -> EventEnvelope:
+    return EventEnvelope.create(
+        event_type=WorkshopEventType.PRINCIPAL_AGENT_ENABLED,
+        event_version=1,
+        workshop_id=workshop_id,
+        aggregate_type="agent_enablement",
+        aggregate_id=enablement_id,
+        actor_principal_id=principal_id,
+        occurred_at=now,
+        idempotency_key=operation_key,
+        payload={
+            "principal_id": principal_id,
+            "agent_definition_id": definition_id,
+            "agent_id": agent_id,
+            "direct_channel_id": channel_id,
+            "runtime_profile_id": runtime_profile_id,
+        },
+        metadata=metadata,
+    )
+
+
+def agent_enablement_creation_events(
+    workshop_id: WorkshopId,
+    principal_id: PrincipalId,
+    definition_id: AgentDefinitionId,
+    agent_id: AgentId,
+    agent_principal_id: PrincipalId,
+    display_name: str,
+    enablement_id: AgentEnablementId,
+    channel_id: ChannelId,
+    runtime_profile_id: RuntimeProfileId,
+    now: datetime,
+    operation_key: str,
+    metadata: dict[str, str],
+) -> list[EventEnvelope]:
+    """Build the one canonical event shape for a new agent access lane."""
+    assignment_id = RuntimeAssignmentId.derived(channel_id, f"runtime-profile:{agent_id}")
+    return [
+        EventEnvelope.create(
+            event_type=WorkshopEventType.CHANNEL_CREATED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="channel",
+            aggregate_id=channel_id,
+            actor_principal_id=principal_id,
+            occurred_at=now,
+            idempotency_key=f"{operation_key}:channel",
+            payload={"kind": "direct", "name": display_name},
+            metadata=metadata,
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="channel_membership",
+            aggregate_id=ChannelMembershipId.derived(channel_id, f"human:{principal_id}"),
+            actor_principal_id=principal_id,
+            occurred_at=now,
+            idempotency_key=f"{operation_key}:human",
+            payload={"channel_id": channel_id, "principal_id": principal_id, "role": "owner"},
+            metadata=metadata,
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="channel_membership",
+            aggregate_id=ChannelMembershipId.derived(channel_id, f"agent:{agent_principal_id}"),
+            actor_principal_id=principal_id,
+            occurred_at=now,
+            idempotency_key=f"{operation_key}:agent-member",
+            payload={
+                "channel_id": channel_id,
+                "principal_id": agent_principal_id,
+                "role": "participant",
+            },
+            metadata=metadata,
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="channel_agent",
+            aggregate_id=ChannelAgentId.derived(channel_id, f"agent:{agent_id}"),
+            actor_principal_id=principal_id,
+            occurred_at=now,
+            idempotency_key=f"{operation_key}:attachment",
+            payload={"channel_id": channel_id, "agent_id": agent_id},
+            metadata=metadata,
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="runtime_assignment",
+            aggregate_id=assignment_id,
+            actor_principal_id=principal_id,
+            occurred_at=now,
+            idempotency_key=f"{operation_key}:assignment",
+            payload={
+                "channel_id": channel_id,
+                "agent_id": agent_id,
+                "runtime_profile_id": runtime_profile_id,
+            },
+            metadata=metadata,
+        ),
+        _agent_enablement_event(
+            workshop_id,
+            principal_id,
+            definition_id,
+            agent_id,
+            enablement_id,
+            channel_id,
+            runtime_profile_id,
+            now,
+            operation_key,
+            metadata,
+        ),
+    ]
+
+
+async def enable_initial_workshop_agent(
+    store: WorkshopEventStore,
+    runtime_profiles: WorkshopRuntimeProfileRegistry,
+    principal_id: PrincipalId,
+    runtime_profile_id: RuntimeProfileId,
+) -> InitialAgentEnablement:
+    """Enable canonical Kai for the first transport-free administrator."""
+    runtime_profiles.resolve(runtime_profile_id)
+    async with store.connection.execute(
+        "SELECT wm.workshop_id FROM workshop_memberships wm JOIN principals p "
+        "ON p.id = wm.principal_id AND p.kind = 'human' "
+        "WHERE wm.principal_id = ? AND wm.role = 'admin'",
+        (principal_id,),
+    ) as cursor:
+        membership_rows = list(await cursor.fetchall())
+    if len(membership_rows) != 1:
+        raise WorkshopAgentEnablementAccessDenied("Initial agent enablement requires one Workshop administrator")
+    workshop_id = WorkshopId(str(membership_rows[0][0]))
+    async with store.connection.execute(
+        "SELECT d.id, d.agent_id, a.principal_id, d.display_name "
+        "FROM agent_definitions d JOIN agents a ON a.id = d.agent_id "
+        "WHERE d.workshop_id = ? AND d.handle = 'kai' COLLATE NOCASE "
+        "AND d.lifecycle_state = 'active' AND d.active_revision_id IS NOT NULL",
+        (workshop_id,),
+    ) as cursor:
+        definition_rows = list(await cursor.fetchall())
+    if len(definition_rows) != 1:
+        raise WorkshopAgentEnablementAccessDenied("Canonical Kai agent definition is unavailable")
+    definition_id = AgentDefinitionId(str(definition_rows[0][0]))
+    agent_id = AgentId(str(definition_rows[0][1]))
+    agent_principal_id = PrincipalId(str(definition_rows[0][2]))
+    display_name = str(definition_rows[0][3])
+    enablement_id, channel_id = principal_agent_enablement_ids(definition_id, principal_id)
+    operation_key = f"initial-agent-enablement:{workshop_id}:{principal_id}:{definition_id}"
+    metadata = {
+        "source": "initial_workshop_provisioning",
+        "operation": "enable",
+        "definition_id": str(definition_id),
+    }
+    created = False
+    connection = store.connection
+    try:
+        await connection.execute("BEGIN IMMEDIATE")
+        async with connection.execute(
+            "SELECT direct_channel_id, runtime_profile_id, lifecycle_state, conversation_started_at "
+            "FROM principal_agent_enablements WHERE id = ?",
+            (enablement_id,),
+        ) as cursor:
+            existing = await cursor.fetchone()
+        if existing is None:
+            now = datetime.now(UTC)
+            for event in agent_enablement_creation_events(
+                workshop_id,
+                principal_id,
+                definition_id,
+                agent_id,
+                agent_principal_id,
+                display_name,
+                enablement_id,
+                channel_id,
+                runtime_profile_id,
+                now,
+                operation_key,
+                metadata,
+            ):
+                await store.append_in_transaction(event)
+            created = True
+            conversation_started = False
+        else:
+            if (
+                str(existing[0]) != str(channel_id)
+                or str(existing[1]) != str(runtime_profile_id)
+                or str(existing[2]) != "enabled"
+            ):
+                raise WorkshopAgentEnablementConflict("Initial agent enablement conflicts with canonical state")
+            conversation_started = existing[3] is not None
+            now = datetime.now(UTC)
+        if not conversation_started:
+            await store.append_in_transaction(
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.PRINCIPAL_AGENT_CONVERSATION_STARTED,
+                    event_version=1,
+                    workshop_id=workshop_id,
+                    aggregate_type="agent_enablement",
+                    aggregate_id=enablement_id,
+                    actor_principal_id=principal_id,
+                    occurred_at=now,
+                    idempotency_key=f"{operation_key}:conversation",
+                    payload={},
+                    metadata=metadata,
+                )
+            )
+        await store.project_pending_in_transaction(CanonicalConversationProjection())
+        await connection.commit()
+    except Exception:
+        await connection.rollback()
+        raise
+    return InitialAgentEnablement(
+        principal_id,
+        definition_id,
+        agent_id,
+        channel_id,
+        runtime_profile_id,
+        created,
+    )
+
+
 class WorkshopAgentEnablementService:
     """Enable an active agent in an isolated direct lane owned by one human."""
 
@@ -175,8 +445,7 @@ class WorkshopAgentEnablementService:
             }
             if current.enablement_id is None:
                 created = True
-                enablement_id = AgentEnablementId.derived(definition_id, f"principal:{principal_id}")
-                channel_id = ChannelId.derived(enablement_id, "direct-channel")
+                enablement_id, channel_id = principal_agent_enablement_ids(definition_id, principal_id)
                 events = self._creation_events(
                     workshop_id,
                     principal_id,
@@ -517,7 +786,7 @@ class WorkshopAgentEnablementService:
     ) -> tuple[EligibleAgentRuntime, ...]:
         async with self._store.connection.execute(
             "SELECT ra.runtime_profile_id FROM channel_agent_runtime_assignments ra "
-            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
             "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
             "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
             "GROUP BY ra.runtime_profile_id HAVING COUNT(DISTINCT cm.principal_id) = 1 "
@@ -636,89 +905,20 @@ class WorkshopAgentEnablementService:
         metadata: dict[str, str],
     ) -> list[EventEnvelope]:
         agent_id, agent_principal_id, _handle, display_name, _owner, _owner_runtime, _owner_channel = definition
-        assignment_id = RuntimeAssignmentId.derived(channel_id, f"runtime-profile:{agent_id}")
-        return [
-            EventEnvelope.create(
-                event_type=WorkshopEventType.CHANNEL_CREATED,
-                event_version=1,
-                workshop_id=workshop_id,
-                aggregate_type="channel",
-                aggregate_id=channel_id,
-                actor_principal_id=principal_id,
-                occurred_at=now,
-                idempotency_key=f"{operation_key}:channel",
-                payload={"kind": "direct", "name": display_name},
-                metadata=metadata,
-            ),
-            EventEnvelope.create(
-                event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
-                event_version=1,
-                workshop_id=workshop_id,
-                aggregate_type="channel_membership",
-                aggregate_id=ChannelMembershipId.derived(channel_id, f"human:{principal_id}"),
-                actor_principal_id=principal_id,
-                occurred_at=now,
-                idempotency_key=f"{operation_key}:human",
-                payload={"channel_id": channel_id, "principal_id": principal_id, "role": "owner"},
-                metadata=metadata,
-            ),
-            EventEnvelope.create(
-                event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
-                event_version=1,
-                workshop_id=workshop_id,
-                aggregate_type="channel_membership",
-                aggregate_id=ChannelMembershipId.derived(channel_id, f"agent:{agent_principal_id}"),
-                actor_principal_id=principal_id,
-                occurred_at=now,
-                idempotency_key=f"{operation_key}:agent-member",
-                payload={
-                    "channel_id": channel_id,
-                    "principal_id": agent_principal_id,
-                    "role": "participant",
-                },
-                metadata=metadata,
-            ),
-            EventEnvelope.create(
-                event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
-                event_version=1,
-                workshop_id=workshop_id,
-                aggregate_type="channel_agent",
-                aggregate_id=ChannelAgentId.derived(channel_id, f"agent:{agent_id}"),
-                actor_principal_id=principal_id,
-                occurred_at=now,
-                idempotency_key=f"{operation_key}:attachment",
-                payload={"channel_id": channel_id, "agent_id": agent_id},
-                metadata=metadata,
-            ),
-            EventEnvelope.create(
-                event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
-                event_version=1,
-                workshop_id=workshop_id,
-                aggregate_type="runtime_assignment",
-                aggregate_id=assignment_id,
-                actor_principal_id=principal_id,
-                occurred_at=now,
-                idempotency_key=f"{operation_key}:assignment",
-                payload={
-                    "channel_id": channel_id,
-                    "agent_id": agent_id,
-                    "runtime_profile_id": runtime_profile_id,
-                },
-                metadata=metadata,
-            ),
-            self._enablement_event(
-                workshop_id,
-                principal_id,
-                definition_id,
-                agent_id,
-                enablement_id,
-                channel_id,
-                runtime_profile_id,
-                now,
-                operation_key,
-                metadata,
-            ),
-        ]
+        return agent_enablement_creation_events(
+            workshop_id,
+            principal_id,
+            definition_id,
+            agent_id,
+            agent_principal_id,
+            display_name,
+            enablement_id,
+            channel_id,
+            runtime_profile_id,
+            now,
+            operation_key,
+            metadata,
+        )
 
     @staticmethod
     def _enablement_event(
@@ -733,23 +933,17 @@ class WorkshopAgentEnablementService:
         operation_key: str,
         metadata: dict[str, str],
     ) -> EventEnvelope:
-        return EventEnvelope.create(
-            event_type=WorkshopEventType.PRINCIPAL_AGENT_ENABLED,
-            event_version=1,
-            workshop_id=workshop_id,
-            aggregate_type="agent_enablement",
-            aggregate_id=enablement_id,
-            actor_principal_id=principal_id,
-            occurred_at=now,
-            idempotency_key=operation_key,
-            payload={
-                "principal_id": principal_id,
-                "agent_definition_id": definition_id,
-                "agent_id": agent_id,
-                "direct_channel_id": channel_id,
-                "runtime_profile_id": runtime_profile_id,
-            },
-            metadata=metadata,
+        return _agent_enablement_event(
+            workshop_id,
+            principal_id,
+            definition_id,
+            agent_id,
+            enablement_id,
+            channel_id,
+            runtime_profile_id,
+            now,
+            operation_key,
+            metadata,
         )
 
     async def _replayed(

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -4083,7 +4083,7 @@ async def _handle_client_navigation(
         "AND sponsored.lifecycle_state = 'enabled' "
         "LEFT JOIN principal_direct_message_archives dma "
         "ON dma.principal_id = cm.principal_id AND dma.channel_id = c.id "
-        "WHERE cm.principal_id = ? "
+        "WHERE cm.principal_id = ? AND (c.kind != 'direct' OR c.archived_at IS NULL) "
         "ORDER BY c.workshop_id, "
         "CASE c.kind WHEN 'direct' THEN 0 WHEN 'group' THEN 1 "
         "WHEN 'notification' THEN 2 ELSE 3 END, lower(coalesce(c.name, '')), c.id, a.name, a.id",
@@ -4106,7 +4106,7 @@ async def _handle_client_navigation(
         "LEFT JOIN agent_definitions ad ON ad.agent_id = peer_agent.id "
         "LEFT JOIN channel_agents active_agent ON active_agent.channel_id = c.id "
         "AND active_agent.agent_id = peer_agent.id AND active_agent.detached_at IS NULL "
-        "WHERE own_cm.principal_id = ? "
+        "WHERE own_cm.principal_id = ? AND (c.kind != 'direct' OR c.archived_at IS NULL) "
         "AND (peer.kind != 'agent' OR active_agent.id IS NOT NULL) "
         "ORDER BY c.workshop_id, c.id, lower(peer.display_name), peer.id",
         (principal_id,),

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -244,6 +244,53 @@ def workshop_bootstrap_status(db_path: Path, *, expected_humans: int | None) -> 
     )
 
 
+def workshop_human_provisioning_status(db_path: Path) -> str:
+    """Report identity-only provisioning and legacy direct-channel retirement."""
+    prefix = "Workshop human provisioning:"
+    if not db_path.is_file():
+        return f"{prefix} NOT VERIFIED (database unavailable)"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            identities = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM event_log WHERE event_type = 'principal.created' "
+                "AND idempotency_key LIKE 'operator:human-provisioning:%:principal'",
+            )
+            legacy = connection.execute(
+                "SELECT COUNT(*), "
+                "SUM(CASE WHEN pae.id IS NOT NULL THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN pae.id IS NULL AND c.archived_at IS NOT NULL THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN pae.id IS NULL AND c.archived_at IS NULL THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN c.archived_at IS NOT NULL AND (archive.position IS NULL "
+                "OR json_extract(archive.metadata_json, '$.source') != 'human_provisioning_migration') "
+                "THEN 1 ELSE 0 END) "
+                "FROM event_log created "
+                "JOIN channels c ON c.id = created.aggregate_id AND c.kind = 'direct' "
+                "LEFT JOIN principal_agent_enablements pae ON pae.direct_channel_id = c.id "
+                "LEFT JOIN event_log archive ON archive.position = c.lifecycle_event_position "
+                "WHERE created.event_type = 'channel.created' "
+                "AND created.idempotency_key LIKE 'operator:human-provisioning:%:direct-channel'"
+            ).fetchone()
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+    if legacy is None:
+        legacy = (0, 0, 0, 0, 0)
+    legacy_channels = int(legacy[0] or 0)
+    retained = int(legacy[1] or 0)
+    archived = int(legacy[2] or 0)
+    unresolved = int(legacy[3] or 0)
+    invalid = int(legacy[4] or 0)
+    state = "active" if unresolved == 0 and invalid == 0 else "INCOMPLETE"
+    return (
+        f"{prefix} {state}; identities={identities}, legacy channels={legacy_channels} "
+        f"(retained={retained}, archived={archived}, unresolved={unresolved}), "
+        f"integrity gaps={invalid}; authority=identity-only"
+    )
+
+
 def workshop_agent_authority_status(db_path: Path) -> str:
     """Describe canonical multi-agent authority and integrity without exposing content."""
     prefix = "Workshop agent authority:"
@@ -394,6 +441,7 @@ def workshop_agent_authority_status(db_path: Path) -> str:
                 "OR d.active_revision_id IS NULL OR d.agent_id != e.agent_id "
                 "OR d.workshop_id != e.workshop_id OR a.workshop_id != e.workshop_id "
                 "OR ap.kind IS NULL OR ap.kind != 'agent' OR c.kind IS NULL OR c.kind != 'direct' "
+                "OR c.archived_at IS NOT NULL "
                 "OR c.workshop_id != e.workshop_id OR (SELECT COUNT(*) FROM channel_memberships cm "
                 "WHERE cm.channel_id = e.direct_channel_id) != 2 "
                 "OR NOT EXISTS (SELECT 1 FROM channel_memberships cm WHERE "
@@ -411,7 +459,7 @@ def workshop_agent_authority_status(db_path: Path) -> str:
                 "WITH runtime_owners AS (SELECT ra.runtime_profile_id, "
                 "COUNT(DISTINCT owner.principal_id) AS owner_count, "
                 "MIN(owner.principal_id) AS owner_id FROM channel_agent_runtime_assignments ra "
-                "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+                "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
                 "JOIN channel_memberships owner ON owner.channel_id = c.id AND owner.role = 'owner' "
                 "JOIN principals p ON p.id = owner.principal_id AND p.kind = 'human' "
                 "GROUP BY ra.runtime_profile_id) SELECT COUNT(*) "
@@ -423,7 +471,8 @@ def workshop_agent_authority_status(db_path: Path) -> str:
                 connection,
                 "SELECT COUNT(*) FROM (SELECT ra.runtime_profile_id FROM "
                 "channel_agent_runtime_assignments ra JOIN channels c ON c.id = ra.channel_id "
-                "AND c.kind = 'direct' JOIN channel_memberships owner ON owner.channel_id = c.id "
+                "AND c.kind = 'direct' AND c.archived_at IS NULL "
+                "JOIN channel_memberships owner ON owner.channel_id = c.id "
                 "AND owner.role = 'owner' JOIN principals p ON p.id = owner.principal_id "
                 "AND p.kind = 'human' GROUP BY ra.runtime_profile_id "
                 "HAVING COUNT(DISTINCT owner.principal_id) > 1)",

--- a/src/kai/workshop/execution_state.py
+++ b/src/kai/workshop/execution_state.py
@@ -105,7 +105,7 @@ class WorkshopExecutionStateRegistry:
             "SELECT ra.runtime_profile_id, ra.channel_id, ra.agent_id, cm.principal_id, "
             "ra.created_event_position "
             "FROM channel_agent_runtime_assignments ra "
-            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
             "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
             "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
             "LEFT JOIN principal_agent_enablements pae ON pae.direct_channel_id = c.id "

--- a/src/kai/workshop/human_provisioning.py
+++ b/src/kai/workshop/human_provisioning.py
@@ -7,10 +7,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from kai.workshop.domain import (
-    AgentId,
-    ChannelAgentId,
-    ChannelId,
-    ChannelMembershipId,
     EventEnvelope,
     PrincipalId,
     WorkshopEventType,
@@ -30,7 +26,6 @@ class WorkshopHumanProvisioningError(RuntimeError):
 class ProvisionedWorkshopHuman:
     workshop_id: WorkshopId
     principal_id: PrincipalId
-    channel_id: ChannelId
     display_name: str
     role: str
     provisioning_key: str
@@ -44,14 +39,11 @@ _PROVISIONING_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 def provisioned_human_ids(
     workshop_id: WorkshopId,
     provisioning_key: str,
-) -> tuple[PrincipalId, ChannelId]:
-    """Return the stable principal/direct-channel IDs for operator provisioning."""
+) -> PrincipalId:
+    """Return the stable principal ID for operator provisioning."""
     normalized_key = _normalize_provisioning_key(provisioning_key)
     stable_prefix = f"operator-human:{normalized_key}"
-    return (
-        PrincipalId.derived(workshop_id, stable_prefix),
-        ChannelId.derived(workshop_id, f"{stable_prefix}:direct-channel"),
-    )
+    return PrincipalId.derived(workshop_id, stable_prefix)
 
 
 def _normalize_display_name(value: object) -> str:
@@ -106,9 +98,8 @@ class WorkshopHumanProvisioner:
         try:
             await connection.execute("BEGIN IMMEDIATE")
             resolved_workshop_id = await self._resolve_workshop(workshop_id)
-            agent_id, agent_principal_id = await self._resolve_kai_agent(resolved_workshop_id)
             stable_prefix = f"operator-human:{normalized_key}"
-            principal_id, channel_id = provisioned_human_ids(
+            principal_id = provisioned_human_ids(
                 resolved_workshop_id,
                 normalized_key,
             )
@@ -121,26 +112,11 @@ class WorkshopHumanProvisioner:
                 resolved_workshop_id,
                 f"{stable_prefix}:workshop-membership",
             )
-            human_channel_membership_id = ChannelMembershipId.derived(
-                resolved_workshop_id,
-                f"{stable_prefix}:human-channel-membership",
-            )
-            agent_channel_membership_id = ChannelMembershipId.derived(
-                resolved_workshop_id,
-                f"{stable_prefix}:agent-channel-membership",
-            )
-            channel_agent_id = ChannelAgentId.derived(
-                resolved_workshop_id,
-                f"{stable_prefix}:channel-agent",
-            )
             principal_event_key = f"operator:human-provisioning:{principal_id}:principal"
             if await self._store.event_by_idempotency_key(principal_event_key) is not None:
                 if not await self._matches_existing_provisioning(
                     resolved_workshop_id,
                     principal_id,
-                    channel_id,
-                    agent_id,
-                    agent_principal_id,
                     normalized_name,
                     normalized_role,
                     normalized_handle,
@@ -152,7 +128,6 @@ class WorkshopHumanProvisioner:
                 return ProvisionedWorkshopHuman(
                     resolved_workshop_id,
                     principal_id,
-                    channel_id,
                     normalized_name,
                     normalized_role,
                     normalized_key,
@@ -186,58 +161,6 @@ class WorkshopHumanProvisioner:
                     payload={"principal_id": principal_id, "role": normalized_role},
                     metadata={"source": "operator_cli"},
                 ),
-                EventEnvelope.create(
-                    event_type=WorkshopEventType.CHANNEL_CREATED,
-                    event_version=1,
-                    workshop_id=resolved_workshop_id,
-                    aggregate_type="channel",
-                    aggregate_id=channel_id,
-                    occurred_at=now,
-                    idempotency_key=f"operator:human-provisioning:{principal_id}:direct-channel",
-                    payload={"kind": "direct", "name": "Direct"},
-                    metadata={"source": "operator_cli"},
-                ),
-                EventEnvelope.create(
-                    event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
-                    event_version=1,
-                    workshop_id=resolved_workshop_id,
-                    aggregate_type="channel_membership",
-                    aggregate_id=human_channel_membership_id,
-                    occurred_at=now,
-                    idempotency_key=f"operator:human-provisioning:{principal_id}:human-channel-membership",
-                    payload={
-                        "channel_id": channel_id,
-                        "principal_id": principal_id,
-                        "role": "owner",
-                    },
-                    metadata={"source": "operator_cli"},
-                ),
-                EventEnvelope.create(
-                    event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
-                    event_version=1,
-                    workshop_id=resolved_workshop_id,
-                    aggregate_type="channel_membership",
-                    aggregate_id=agent_channel_membership_id,
-                    occurred_at=now,
-                    idempotency_key=f"operator:human-provisioning:{principal_id}:agent-channel-membership",
-                    payload={
-                        "channel_id": channel_id,
-                        "principal_id": agent_principal_id,
-                        "role": "participant",
-                    },
-                    metadata={"source": "operator_cli"},
-                ),
-                EventEnvelope.create(
-                    event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
-                    event_version=1,
-                    workshop_id=resolved_workshop_id,
-                    aggregate_type="channel_agent",
-                    aggregate_id=channel_agent_id,
-                    occurred_at=now,
-                    idempotency_key=f"operator:human-provisioning:{principal_id}:channel-agent",
-                    payload={"channel_id": channel_id, "agent_id": agent_id},
-                    metadata={"source": "operator_cli"},
-                ),
             )
             inserted_states: set[bool] = set()
             for event in events:
@@ -258,7 +181,6 @@ class WorkshopHumanProvisioner:
         return ProvisionedWorkshopHuman(
             resolved_workshop_id,
             principal_id,
-            channel_id,
             normalized_name,
             normalized_role,
             normalized_key,
@@ -270,9 +192,6 @@ class WorkshopHumanProvisioner:
         self,
         workshop_id: WorkshopId,
         principal_id: PrincipalId,
-        channel_id: ChannelId,
-        agent_id: AgentId,
-        agent_principal_id: PrincipalId,
         display_name: str,
         role: str,
         handle: str,
@@ -283,21 +202,11 @@ class WorkshopHumanProvisioner:
             "AND wm.workshop_id = ? AND wm.role = ? "
             "JOIN human_handles hh ON hh.workshop_id = wm.workshop_id "
             "AND hh.principal_id = p.id AND hh.handle = ? COLLATE NOCASE "
-            "JOIN channels c ON c.id = ? AND c.workshop_id = wm.workshop_id "
-            "AND c.kind = 'direct' "
-            "JOIN channel_memberships human_cm ON human_cm.channel_id = c.id "
-            "AND human_cm.principal_id = p.id AND human_cm.role = 'owner' "
-            "JOIN channel_agents ca ON ca.channel_id = c.id AND ca.agent_id = ? "
-            "JOIN channel_memberships agent_cm ON agent_cm.channel_id = c.id "
-            "AND agent_cm.principal_id = ? AND agent_cm.role = 'participant' "
             "WHERE p.id = ? AND p.kind = 'human' AND p.display_name = ? LIMIT 1",
             (
                 workshop_id,
                 role,
                 handle,
-                channel_id,
-                agent_id,
-                agent_principal_id,
                 principal_id,
                 display_name,
             ),
@@ -310,7 +219,10 @@ class WorkshopHumanProvisioner:
             (f"operator:human-provisioning:{principal_id}:%",),
         ) as cursor:
             count_row = await cursor.fetchone()
-        return count_row is not None and int(count_row[0]) == 6
+        # Legacy releases emitted four additional Kai/channel events. They do
+        # not change the identity semantics of a safe retry and are reconciled
+        # separately during startup.
+        return count_row is not None and int(count_row[0]) in {2, 6}
 
     async def _require_available_handle(
         self,
@@ -348,17 +260,3 @@ class WorkshopHumanProvisioner:
         if not exists:
             raise WorkshopHumanProvisioningError("Workshop is unavailable")
         return workshop_id
-
-    async def _resolve_kai_agent(self, workshop_id: WorkshopId) -> tuple[AgentId, PrincipalId]:
-        async with self._store.connection.execute(
-            "SELECT a.id, a.principal_id FROM agents a "
-            "JOIN principals p ON p.id = a.principal_id AND p.kind = 'agent' "
-            "JOIN workshop_memberships wm ON wm.workshop_id = a.workshop_id "
-            "AND wm.principal_id = a.principal_id AND wm.role = 'agent' "
-            "WHERE a.workshop_id = ? AND a.name = 'Kai'",
-            (workshop_id,),
-        ) as cursor:
-            rows = list(await cursor.fetchall())
-        if len(rows) != 1:
-            raise WorkshopHumanProvisioningError("Workshop does not contain exactly one canonical Kai agent")
-        return AgentId(str(rows[0][0])), PrincipalId(str(rows[0][1]))

--- a/src/kai/workshop/human_provisioning_migration.py
+++ b/src/kai/workshop/human_provisioning_migration.py
@@ -1,0 +1,93 @@
+"""Retire direct channels created by the legacy human provisioner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from kai.workshop.domain import ChannelId, EventEnvelope, PrincipalId, WorkshopEventType, WorkshopId
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import WorkshopEventStore
+
+
+@dataclass(frozen=True, slots=True)
+class WorkshopHumanProvisioningMigration:
+    identities: int
+    legacy_channels: int
+    retained_channels: int
+    archived_channels: int
+    unresolved_channels: int
+
+
+async def reconcile_legacy_human_provisioning_channels(
+    store: WorkshopEventStore,
+) -> WorkshopHumanProvisioningMigration:
+    """Archive provisioner-created direct channels that never became enablements."""
+    async with store.connection.execute(
+        "SELECT COUNT(*) FROM event_log WHERE event_type = 'principal.created' "
+        "AND idempotency_key LIKE 'operator:human-provisioning:%:principal'"
+    ) as cursor:
+        identity_row = await cursor.fetchone()
+    assert identity_row is not None
+    identities = int(identity_row[0])
+    async with store.connection.execute(
+        "SELECT c.workshop_id, c.id, cm.principal_id, c.archived_at, "
+        "CASE WHEN pae.id IS NULL THEN 0 ELSE 1 END, "
+        "CASE WHEN EXISTS(SELECT 1 FROM runs r WHERE r.channel_id = c.id "
+        "AND r.status IN ('accepted', 'started')) THEN 1 ELSE 0 END "
+        "FROM event_log e JOIN channels c ON c.id = e.aggregate_id AND c.kind = 'direct' "
+        "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
+        "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+        "LEFT JOIN principal_agent_enablements pae ON pae.direct_channel_id = c.id "
+        "WHERE e.event_type = 'channel.created' "
+        "AND e.idempotency_key LIKE 'operator:human-provisioning:%:direct-channel' "
+        "ORDER BY c.id"
+    ) as cursor:
+        rows = list(await cursor.fetchall())
+
+    retained = 0
+    archived = 0
+    unresolved = 0
+    connection = store.connection
+    try:
+        await connection.execute("BEGIN IMMEDIATE")
+        for row in rows:
+            workshop_id = WorkshopId(str(row[0]))
+            channel_id = ChannelId(str(row[1]))
+            principal_id = PrincipalId(str(row[2]))
+            if bool(row[4]):
+                retained += 1
+                continue
+            if row[3] is not None:
+                archived += 1
+                continue
+            if bool(row[5]):
+                unresolved += 1
+                continue
+            result = await store.append_in_transaction(
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.CHANNEL_ARCHIVED,
+                    event_version=1,
+                    workshop_id=workshop_id,
+                    aggregate_type="channel",
+                    aggregate_id=channel_id,
+                    actor_principal_id=principal_id,
+                    occurred_at=datetime.now(UTC),
+                    idempotency_key=f"human-provisioning-migration:{channel_id}:archive",
+                    payload={},
+                    metadata={"source": "human_provisioning_migration"},
+                )
+            )
+            archived += int(result.inserted)
+        await store.project_pending_in_transaction(CanonicalConversationProjection())
+        await connection.commit()
+    except Exception:
+        await connection.rollback()
+        raise
+    return WorkshopHumanProvisioningMigration(
+        identities,
+        len(rows),
+        retained,
+        archived,
+        unresolved,
+    )

--- a/src/kai/workshop/internal_api_contexts.py
+++ b/src/kai/workshop/internal_api_contexts.py
@@ -89,7 +89,7 @@ class WorkshopInternalAPIContextRegistry:
             "SELECT ra.runtime_profile_id, cm.principal_id, ra.channel_id, ra.agent_id, "
             "ra.created_event_position "
             "FROM channel_agent_runtime_assignments ra "
-            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
             "JOIN agents a ON a.id = ra.agent_id AND a.workshop_id = c.workshop_id "
             "JOIN channel_agents ca ON ca.channel_id = c.id AND ca.agent_id = a.id "
             "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -2036,6 +2036,9 @@ class CanonicalConversationProjection:
             if envelope.actor_principal_id is None:
                 raise ValueError("Workshop channel lifecycle events require a human actor")
             archived = envelope.event_type == WorkshopEventType.CHANNEL_ARCHIVED
+            legacy_provisioning_retirement = (
+                archived and envelope.metadata.get("source") == "human_provisioning_migration"
+            )
             if archived:
                 async with connection.execute(
                     "SELECT 1 FROM runs WHERE channel_id = ? AND status IN ('accepted', 'started') LIMIT 1",
@@ -2045,19 +2048,24 @@ class CanonicalConversationProjection:
                         raise ValueError("Workshop channel cannot be archived with a nonterminal run")
             cursor = await connection.execute(
                 "UPDATE channels SET archived_at = ?, lifecycle_event_position = ? "
-                "WHERE id = ? AND workshop_id = ? AND kind = 'group' "
+                "WHERE id = ? AND workshop_id = ? "
+                "AND (kind = 'group' OR (? = 1 AND kind = 'direct')) "
                 "AND ((? = 1 AND archived_at IS NULL) OR (? = 0 AND archived_at IS NOT NULL)) "
                 "AND EXISTS (SELECT 1 FROM channel_memberships owner "
                 "WHERE owner.channel_id = channels.id AND owner.principal_id = ? "
-                "AND owner.role = 'owner')",
+                "AND owner.role = 'owner') "
+                "AND (? = 0 OR NOT EXISTS (SELECT 1 FROM principal_agent_enablements pae "
+                "WHERE pae.direct_channel_id = channels.id))",
                 (
                     occurred_at if archived else None,
                     event.position,
                     envelope.aggregate_id,
                     envelope.workshop_id,
+                    int(legacy_provisioning_retirement),
                     int(archived),
                     int(archived),
                     envelope.actor_principal_id,
+                    int(legacy_provisioning_retirement),
                 ),
             )
             if cursor.rowcount != 1:

--- a/src/kai/workshop/scheduled_jobs.py
+++ b/src/kai/workshop/scheduled_jobs.py
@@ -85,7 +85,7 @@ class WorkshopScheduledJobStore:
         """Require one complete direct-channel execution assignment."""
         async with self._store.connection.execute(
             "SELECT COUNT(*) FROM channel_agent_runtime_assignments ra "
-            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
             "JOIN agents a ON a.id = ra.agent_id AND a.workshop_id = c.workshop_id "
             "JOIN channel_agents ca ON ca.channel_id = c.id AND ca.agent_id = a.id "
             "JOIN channel_memberships cm ON cm.channel_id = c.id "

--- a/src/kai/workshop/storage_namespaces.py
+++ b/src/kai/workshop/storage_namespaces.py
@@ -80,6 +80,7 @@ class WorkshopChannelHistoryRegistry:
             "SELECT ra.runtime_profile_id, ra.channel_id, c.kind, ra.created_event_position "
             "FROM channel_agent_runtime_assignments ra "
             "JOIN channels c ON c.id = ra.channel_id "
+            "AND (c.kind != 'direct' OR c.archived_at IS NULL) "
             "ORDER BY ra.runtime_profile_id, "
             "CASE c.kind WHEN 'direct' THEN 0 ELSE 1 END, ra.created_event_position, ra.channel_id"
         ) as cursor:
@@ -205,7 +206,7 @@ class WorkshopPrincipalStorageRegistry:
         async with store.connection.execute(
             "SELECT ra.runtime_profile_id, cm.principal_id "
             "FROM channel_agent_runtime_assignments ra "
-            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
             "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
             "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
             "ORDER BY ra.runtime_profile_id, cm.principal_id"

--- a/src/kai/workshop/transport_linking.py
+++ b/src/kai/workshop/transport_linking.py
@@ -160,7 +160,7 @@ class WorkshopTransportLinker:
         async with self._store.connection.execute(
             "SELECT c.workshop_id, cm.principal_id, c.id "
             "FROM channel_agent_runtime_assignments ra "
-            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' "
+            "JOIN channels c ON c.id = ra.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
             "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
             "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
             "WHERE ra.runtime_profile_id = ?",

--- a/src/kai/workshop_cli.py
+++ b/src/kai/workshop_cli.py
@@ -77,7 +77,7 @@ def _parser() -> argparse.ArgumentParser:
     )
     provision = client_actions.add_parser(
         "provision-human",
-        help="create a canonical human and direct channel without transport or runtime access",
+        help="create a canonical human identity without transport, channel, agent, or runtime access",
     )
     provision.add_argument("--provisioning-key", required=True)
     provision.add_argument("--display-name", required=True)
@@ -520,11 +520,11 @@ async def _run(args: argparse.Namespace) -> int:
                 print(f"Handle: @{human.handle}")
                 print(f"Principal: {human.principal_id}")
                 print(f"Workshop: {human.workshop_id}")
-                print(f"Direct channel: {human.channel_id}")
                 print(f"Role: {human.role}")
                 print(f"Provisioning key: {human.provisioning_key}")
                 print(f"Status: {'created' if human.created else 'already provisioned'}")
                 print("Transport access: not assigned")
+                print("Agent access: not assigned")
                 print("Runtime access: not assigned")
                 return 0
             if args.action == "list-runtime-profiles":

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3445,9 +3445,13 @@ class TestCmdConfig:
 class TestInstalledInitialWorkshopEnrollment:
     def test_issues_as_service_user_for_the_canonical_human(self, monkeypatch):
         plan = kai.install.WorkshopInitialProvisioning.create("Daniel")
-        principal_id, channel_id = kai.install.provisioned_human_ids(
+        principal_id = kai.install.provisioned_human_ids(
             plan.workshop_id,
             plan.provisioning_key,
+        )
+        _enablement_id, channel_id = kai.install.initial_kai_enablement_ids(
+            plan.workshop_id,
+            principal_id,
         )
         completed = subprocess.CompletedProcess(
             args=[],
@@ -5360,7 +5364,7 @@ class TestCmdStatus:
             "CREATE TABLE channel_agent_runtime_assignments (channel_id TEXT);"
             "CREATE TABLE channel_bindings (channel_id TEXT);"
             "CREATE TABLE event_log (position INTEGER PRIMARY KEY, aggregate_id TEXT, "
-            "aggregate_type TEXT, event_type TEXT);"
+            "aggregate_type TEXT, event_type TEXT, metadata_json TEXT);"
             "INSERT INTO channels VALUES "
             "('chn_active','wsp_one','group','Active',NULL,NULL,NULL),"
             "('chn_archived','wsp_one','group','Archived','2026-08-30T15:00:00Z',7,NULL);"
@@ -5370,7 +5374,7 @@ class TestCmdStatus:
             "INSERT INTO workshop_memberships VALUES ('wsp_one','prn_one'),('wsp_one','prn_two');"
             "INSERT INTO human_handles VALUES ('wsp_one','prn_one'),('wsp_one','prn_two');"
             "INSERT INTO event_log VALUES "
-            "(7,'chn_archived','channel','channel.archived');"
+            "(7,'chn_archived','channel','channel.archived','{}');"
         )
         connection.commit()
         connection.close()
@@ -5419,7 +5423,7 @@ class TestCmdStatus:
         connection.executescript(
             "CREATE TABLE channel_agent_runtime_assignments "
             "(runtime_profile_id TEXT, channel_id TEXT, agent_id TEXT);"
-            "CREATE TABLE channels (id TEXT, kind TEXT, workshop_id TEXT);"
+            "CREATE TABLE channels (id TEXT, kind TEXT, workshop_id TEXT, archived_at TEXT);"
             "CREATE TABLE agents (id TEXT, workshop_id TEXT);"
             "CREATE TABLE channel_agents (channel_id TEXT, agent_id TEXT);"
             "CREATE TABLE channel_memberships (channel_id TEXT, principal_id TEXT, role TEXT);"
@@ -5430,7 +5434,7 @@ class TestCmdStatus:
             "CREATE TABLE artifacts (id TEXT);"
             "CREATE TABLE delivery_outbox (id TEXT);"
             "INSERT INTO channel_agent_runtime_assignments VALUES ('rtp_one','chn_one','agt_one');"
-            "INSERT INTO channels VALUES ('chn_one','direct','wsp_one');"
+            "INSERT INTO channels VALUES ('chn_one','direct','wsp_one',NULL);"
             "INSERT INTO agents VALUES ('agt_one','wsp_one');"
             "INSERT INTO channel_agents VALUES ('chn_one','agt_one');"
             "INSERT INTO channel_memberships VALUES ('chn_one','prn_one','owner');"

--- a/tests/test_workshop_client_access.py
+++ b/tests/test_workshop_client_access.py
@@ -284,11 +284,12 @@ class TestWorkshopClientAccessCLI:
         assert "Handle: @charlie" in output
         assert "Principal: prn_" in output
         assert "Workshop: wsp_" in output
-        assert "Direct channel: chn_" in output
+        assert "Direct channel:" not in output
         assert "Role: member" in output
         assert "Provisioning key: charlie" in output
         assert "Status: created" in output
         assert "Transport access: not assigned" in output
+        assert "Agent access: not assigned" in output
         assert "Runtime access: not assigned" in output
 
     async def test_issue_command_prints_the_token_once_with_qualification_coordinates(

--- a/tests/test_workshop_human_provisioning.py
+++ b/tests/test_workshop_human_provisioning.py
@@ -2,21 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
-from kai.workshop.authorization import CanonicalChannelAuthorizer
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
-from kai.workshop.client_access import WorkshopClientAccess
-from kai.workshop.client_sessions import WorkshopClientEnrollmentManager
-from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.human_provisioning import (
     WorkshopHumanProvisioner,
     WorkshopHumanProvisioningError,
 )
-from kai.workshop.inbound import ClientInboundMessage
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id
 
@@ -47,19 +41,17 @@ class TestWorkshopHumanProvisioner:
             assert provisioned.handle == "charlie_ops"
 
             async with store.connection.execute(
-                "SELECT p.display_name, hh.handle, wm.role, c.kind, cm.role "
+                "SELECT p.display_name, hh.handle, wm.role "
                 "FROM principals p "
                 "JOIN workshop_memberships wm ON wm.principal_id = p.id "
                 "JOIN human_handles hh ON hh.workshop_id = wm.workshop_id "
                 "AND hh.principal_id = p.id "
-                "JOIN channel_memberships cm ON cm.principal_id = p.id "
-                "JOIN channels c ON c.id = cm.channel_id AND c.workshop_id = wm.workshop_id "
-                "WHERE p.id = ? AND c.id = ?",
-                (provisioned.principal_id, provisioned.channel_id),
+                "WHERE p.id = ?",
+                (provisioned.principal_id,),
             ) as cursor:
                 row = await cursor.fetchone()
             assert row is not None
-            assert tuple(row) == ("Charlie", "charlie_ops", "member", "direct", "owner")
+            assert tuple(row) == ("Charlie", "charlie_ops", "member")
 
             async with store.connection.execute(
                 "SELECT COUNT(*) FROM external_identities WHERE principal_id = ?",
@@ -67,29 +59,31 @@ class TestWorkshopHumanProvisioner:
             ) as cursor:
                 assert (await cursor.fetchone())[0] == 0
             async with store.connection.execute(
-                "SELECT COUNT(*) FROM channel_bindings WHERE channel_id = ?",
-                (provisioned.channel_id,),
+                "SELECT COUNT(*) FROM channel_memberships WHERE principal_id = ?",
+                (provisioned.principal_id,),
             ) as cursor:
                 assert (await cursor.fetchone())[0] == 0
             async with store.connection.execute(
-                "SELECT COUNT(*) FROM channel_agents ca "
-                "JOIN agents a ON a.id = ca.agent_id AND a.name = 'Kai' "
-                "JOIN channel_memberships cm ON cm.channel_id = ca.channel_id "
-                "AND cm.principal_id = a.principal_id AND cm.role = 'participant' "
-                "WHERE ca.channel_id = ?",
-                (provisioned.channel_id,),
+                "SELECT COUNT(*) FROM principal_agent_enablements WHERE principal_id = ?",
+                (provisioned.principal_id,),
             ) as cursor:
-                assert (await cursor.fetchone())[0] == 1
+                assert (await cursor.fetchone())[0] == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_agents ca JOIN channel_memberships cm "
+                "ON cm.channel_id = ca.channel_id WHERE cm.principal_id = ?",
+                (provisioned.principal_id,),
+            ) as cursor:
+                assert (await cursor.fetchone())[0] == 0
             async with store.connection.execute(
                 "SELECT COUNT(*) FROM event_log WHERE idempotency_key LIKE ? "
                 "AND json_extract(metadata_json, '$.source') = 'operator_cli'",
                 (f"operator:human-provisioning:{provisioned.principal_id}:%",),
             ) as cursor:
-                assert (await cursor.fetchone())[0] == 6
+                assert (await cursor.fetchone())[0] == 2
         finally:
             await store.close()
 
-    async def test_provisioned_human_uses_the_shared_agent_owner_runtime(
+    async def test_provisioned_human_has_no_implicit_agent_or_runtime_authority(
         self,
         tmp_path: Path,
     ):
@@ -100,32 +94,19 @@ class TestWorkshopHumanProvisioner:
                 "Charlie",
                 "member",
             )
-            access = WorkshopClientAccess(store)
-            issued = await access.issue_enrollment(
-                provisioned.principal_id,
-                provisioned.channel_id,
-            )
-            redeemed = await WorkshopClientEnrollmentManager(store).redeem_grant(
-                issued.grant.token,
-                "Charlie's laptop",
-            )
-
-            assert redeemed.device.principal_id == provisioned.principal_id
-            assert await CanonicalChannelAuthorizer(store).can_read_channel(
-                provisioned.principal_id,
-                provisioned.channel_id,
-            )
-            accepted = await WorkshopConversationCommandService(store).accept_client(
-                ClientInboundMessage(
-                    principal_id=provisioned.principal_id,
-                    channel_id=provisioned.channel_id,
-                    client_message_id="provisioned-human-shared-agent-runtime",
-                    body="Use the shared agent owner's runtime",
-                    occurred_at=datetime.now(UTC),
-                )
-            )
-            assert accepted.runtime_profile_id == profile_id(101)
-            assert accepted.run.requested_by_principal_id == provisioned.principal_id
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channels c JOIN channel_memberships cm "
+                "ON cm.channel_id = c.id WHERE cm.principal_id = ?",
+                (provisioned.principal_id,),
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
+            async with store.connection.execute(
+                "SELECT COUNT(*) FROM channel_agent_runtime_assignments ra "
+                "JOIN channel_memberships cm ON cm.channel_id = ra.channel_id "
+                "WHERE cm.principal_id = ?",
+                (provisioned.principal_id,),
+            ) as cursor:
+                assert int((await cursor.fetchone())[0]) == 0
         finally:
             await store.close()
 
@@ -142,7 +123,6 @@ class TestWorkshopHumanProvisioner:
             assert first.created is True
             assert retried.created is False
             assert retried.principal_id == first.principal_id
-            assert retried.channel_id == first.channel_id
             async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
                 assert (await cursor.fetchone())[0] == after_first
 
@@ -177,7 +157,7 @@ class TestWorkshopHumanProvisioner:
         finally:
             await store.close()
 
-    async def test_missing_canonical_kai_agent_rolls_back_without_partial_human(
+    async def test_identity_provisioning_does_not_depend_on_a_kai_agent(
         self,
         tmp_path: Path,
     ):
@@ -186,22 +166,16 @@ class TestWorkshopHumanProvisioner:
             await store.connection.execute("DELETE FROM channel_agents")
             await store.connection.execute("DELETE FROM agents")
             await store.connection.commit()
-            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
-                before_events = (await cursor.fetchone())[0]
-            async with store.connection.execute("SELECT COUNT(*) FROM principals") as cursor:
-                before_principals = (await cursor.fetchone())[0]
-
-            with pytest.raises(WorkshopHumanProvisioningError, match="canonical Kai agent"):
-                await WorkshopHumanProvisioner(store).provision(
-                    "charlie",
-                    "Charlie",
-                    "member",
-                )
-
-            async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
-                assert (await cursor.fetchone())[0] == before_events
-            async with store.connection.execute("SELECT COUNT(*) FROM principals") as cursor:
-                assert (await cursor.fetchone())[0] == before_principals
+            provisioned = await WorkshopHumanProvisioner(store).provision(
+                "charlie",
+                "Charlie",
+                "member",
+            )
+            async with store.connection.execute(
+                "SELECT display_name FROM principals WHERE id = ?",
+                (provisioned.principal_id,),
+            ) as cursor:
+                assert tuple(await cursor.fetchone()) == ("Charlie",)
         finally:
             await store.close()
 

--- a/tests/test_workshop_human_provisioning_migration.py
+++ b/tests/test_workshop_human_provisioning_migration.py
@@ -1,0 +1,132 @@
+"""Legacy automatic-Kai channel retirement contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.diagnostics import workshop_human_provisioning_status
+from kai.workshop.domain import (
+    AgentId,
+    ChannelAgentId,
+    ChannelId,
+    ChannelMembershipId,
+    EventEnvelope,
+    PrincipalId,
+    WorkshopEventType,
+)
+from kai.workshop.human_provisioning import WorkshopHumanProvisioner
+from kai.workshop.human_provisioning_migration import reconcile_legacy_human_provisioning_channels
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id
+
+
+async def test_orphaned_legacy_provisioner_channel_is_archived_and_replay_safe(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "kai.db"
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (BootstrapHuman("Alice", "admin", "telegram", "101", "101", profile_id(101)),),
+    )
+    try:
+        human = await WorkshopHumanProvisioner(store).provision("charlie", "Charlie", "member")
+        async with store.connection.execute(
+            "SELECT a.id, a.principal_id FROM agents a WHERE a.workshop_id = ? AND a.name = 'Kai'",
+            (human.workshop_id,),
+        ) as cursor:
+            agent_row = await cursor.fetchone()
+        assert agent_row is not None
+        agent_id = AgentId(str(agent_row[0]))
+        agent_principal_id = PrincipalId(str(agent_row[1]))
+        stable_prefix = "operator-human:charlie"
+        channel_id = ChannelId.derived(human.workshop_id, f"{stable_prefix}:direct-channel")
+        now = datetime.now(UTC)
+        legacy_events = (
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_CREATED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="channel",
+                aggregate_id=channel_id,
+                occurred_at=now,
+                idempotency_key=f"operator:human-provisioning:{human.principal_id}:direct-channel",
+                payload={"kind": "direct", "name": "Direct"},
+                metadata={"source": "operator_cli"},
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="channel_membership",
+                aggregate_id=ChannelMembershipId.derived(
+                    human.workshop_id,
+                    f"{stable_prefix}:human-channel-membership",
+                ),
+                occurred_at=now,
+                idempotency_key=f"operator:human-provisioning:{human.principal_id}:human-channel-membership",
+                payload={"channel_id": channel_id, "principal_id": human.principal_id, "role": "owner"},
+                metadata={"source": "operator_cli"},
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="channel_membership",
+                aggregate_id=ChannelMembershipId.derived(
+                    human.workshop_id,
+                    f"{stable_prefix}:agent-channel-membership",
+                ),
+                occurred_at=now,
+                idempotency_key=f"operator:human-provisioning:{human.principal_id}:agent-channel-membership",
+                payload={"channel_id": channel_id, "principal_id": agent_principal_id, "role": "participant"},
+                metadata={"source": "operator_cli"},
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="channel_agent",
+                aggregate_id=ChannelAgentId.derived(
+                    human.workshop_id,
+                    f"{stable_prefix}:channel-agent",
+                ),
+                occurred_at=now,
+                idempotency_key=f"operator:human-provisioning:{human.principal_id}:channel-agent",
+                payload={"channel_id": channel_id, "agent_id": agent_id},
+                metadata={"source": "operator_cli"},
+            ),
+        )
+        for event in legacy_events:
+            await store.append(event)
+        await store.project_pending(CanonicalConversationProjection())
+
+        migration = await reconcile_legacy_human_provisioning_channels(store)
+        replay = await reconcile_legacy_human_provisioning_channels(store)
+        retried_human = await WorkshopHumanProvisioner(store).provision("charlie", "Charlie", "member")
+
+        assert migration.legacy_channels == 1
+        assert migration.archived_channels == 1
+        assert migration.unresolved_channels == 0
+        assert replay.archived_channels == 1
+        assert retried_human.created is False
+        async with store.connection.execute(
+            "SELECT archived_at FROM channels WHERE id = ?",
+            (channel_id,),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] is not None
+        await store.rebuild_projection(CanonicalConversationProjection())
+        async with store.connection.execute(
+            "SELECT archived_at FROM channels WHERE id = ?",
+            (channel_id,),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] is not None
+        assert workshop_human_provisioning_status(path).startswith(
+            "Workshop human provisioning: active; identities=1, legacy channels=1 "
+            "(retained=0, archived=1, unresolved=0), integrity gaps=0"
+        )
+    finally:
+        await store.close()

--- a/tests/test_workshop_initial_provisioning.py
+++ b/tests/test_workshop_initial_provisioning.py
@@ -6,15 +6,19 @@ from pathlib import Path
 
 import pytest
 
+from kai.workshop.agent_authority import reconcile_single_owner_agent_authority
+from kai.workshop.agent_enablement import enable_initial_workshop_agent
 from kai.workshop.bootstrap import bootstrap_default_workshop
+from kai.workshop.client_access import WorkshopClientAccess
 from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.human_provisioning import WorkshopHumanProvisioner
 from kai.workshop.initial_provisioning import (
     WorkshopInitialProvisioning,
     WorkshopInitialProvisioningError,
     parse_initial_provisioning,
 )
-from kai.workshop.runtime_assignments import WorkshopRuntimeAssignmentService
+from kai.workshop.internal_api_contexts import WorkshopInternalAPIContextRegistry
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 from kai.workshop.store import WorkshopEventStore
 from kai.workshop.transport_linking import (
@@ -54,6 +58,74 @@ def test_initial_policy_round_trips_without_transport_identity() -> None:
         parse_initial_provisioning("v1.not-base64")
 
 
+async def test_fresh_workshop_only_boot_enables_kai_through_canonical_authority(
+    tmp_path: Path,
+) -> None:
+    plan = WorkshopInitialProvisioning.create("Daniel")
+    profiles = _profiles(plan.runtime_profile_id)
+    store = await WorkshopEventStore.open(tmp_path / "kai.db")
+    try:
+        await bootstrap_default_workshop(store, (), workshop_id=plan.workshop_id)
+        human = await WorkshopHumanProvisioner(store).provision(
+            plan.provisioning_key,
+            plan.display_name,
+            plan.role,
+            workshop_id=plan.workshop_id,
+        )
+        enabled = await enable_initial_workshop_agent(
+            store,
+            profiles,
+            human.principal_id,
+            plan.runtime_profile_id,
+        )
+        async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+            event_count = int((await cursor.fetchone())[0])
+        replayed = await enable_initial_workshop_agent(
+            store,
+            profiles,
+            human.principal_id,
+            plan.runtime_profile_id,
+        )
+        async with store.connection.execute("SELECT COUNT(*) FROM event_log") as cursor:
+            assert int((await cursor.fetchone())[0]) == event_count
+        authority = await reconcile_single_owner_agent_authority(store, profiles)
+
+        assert enabled.created is True
+        assert replayed.created is False
+        assert replayed.direct_channel_id == enabled.direct_channel_id
+        async with store.connection.execute(
+            "SELECT lifecycle_state, conversation_started_at FROM principal_agent_enablements WHERE principal_id = ?",
+            (human.principal_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        assert str(row[0]) == "enabled"
+        assert row[1] is not None
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM channels c JOIN channel_memberships cm "
+            "ON cm.channel_id = c.id AND cm.principal_id = ? "
+            "WHERE c.kind = 'direct'",
+            (human.principal_id,),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 1
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM channel_agents ca JOIN channel_memberships cm "
+            "ON cm.channel_id = ca.channel_id AND cm.principal_id = ?",
+            (human.principal_id,),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 1
+        assert authority.definitions == 1
+        assert len((await WorkshopExecutionStateRegistry.from_store(store, profiles)).lanes) == 1
+        assert len((await WorkshopInternalAPIContextRegistry.from_store(store, profiles)).contexts) == 1
+        enrollment = await WorkshopClientAccess(store).issue_enrollment(
+            human.principal_id,
+            enabled.direct_channel_id,
+        )
+        assert enrollment.channel_id == enabled.direct_channel_id
+    finally:
+        await store.close()
+
+
 class TestWorkshopTransportLinking:
     async def _provision(self, path: Path):
         plan = WorkshopInitialProvisioning.create("Daniel")
@@ -66,18 +138,19 @@ class TestWorkshopTransportLinking:
             workshop_id=plan.workshop_id,
         )
         profiles = _profiles(plan.runtime_profile_id)
-        assignment = await WorkshopRuntimeAssignmentService(store, profiles).assign(
+        enablement = await enable_initial_workshop_agent(
+            store,
+            profiles,
             human.principal_id,
-            human.channel_id,
             plan.runtime_profile_id,
         )
-        return store, plan, human, profiles, assignment
+        return store, plan, human, profiles, enablement
 
     async def test_later_telegram_link_reuses_human_channel_and_assignment(
         self,
         tmp_path: Path,
     ) -> None:
-        store, plan, human, profiles, assignment = await self._provision(tmp_path / "kai.db")
+        store, plan, human, profiles, enablement = await self._provision(tmp_path / "kai.db")
         try:
             linker = WorkshopTransportLinker(store, profiles)
             linked = await linker.link_runtime_profile(
@@ -94,14 +167,14 @@ class TestWorkshopTransportLinking:
             )
 
             assert linked.principal_id == human.principal_id
-            assert linked.channel_id == human.channel_id
+            assert linked.channel_id == enablement.direct_channel_id
             assert linked.created_events == 2
             assert retried.created_events == 0
             async with store.connection.execute("SELECT COUNT(*) FROM principals WHERE kind = 'human'") as cursor:
                 assert int((await cursor.fetchone())[0]) == 1
             async with store.connection.execute(
-                "SELECT runtime_profile_id FROM channel_agent_runtime_assignments WHERE id = ?",
-                (assignment.assignment_id,),
+                "SELECT runtime_profile_id FROM channel_agent_runtime_assignments WHERE channel_id = ?",
+                (enablement.direct_channel_id,),
             ) as cursor:
                 assert str((await cursor.fetchone())[0]) == str(plan.runtime_profile_id)
         finally:
@@ -126,12 +199,13 @@ class TestWorkshopTransportLinking:
             other = await WorkshopHumanProvisioner(store).provision(
                 "other",
                 "Other",
-                "member",
+                "admin",
                 workshop_id=plan.workshop_id,
             )
-            await WorkshopRuntimeAssignmentService(store, other_profiles).assign(
+            await enable_initial_workshop_agent(
+                store,
+                other_profiles,
                 other.principal_id,
-                other.channel_id,
                 other_profile,
             )
             with pytest.raises(

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -10,7 +10,17 @@ import pytest
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.conversation_runs import resolve_canonical_conversation_run
-from kai.workshop.domain import MessageId, RuntimeProfileId
+from kai.workshop.domain import (
+    ChannelAgentId,
+    ChannelId,
+    ChannelMembershipId,
+    EventEnvelope,
+    MessageId,
+    PrincipalId,
+    RuntimeProfileId,
+    WorkshopEventType,
+    WorkshopId,
+)
 from kai.workshop.human_provisioning import WorkshopHumanProvisioner
 from kai.workshop.inbound import ClientInboundMessage
 from kai.workshop.projection import CanonicalConversationProjection
@@ -31,6 +41,68 @@ async def _store(path: Path) -> WorkshopEventStore:
         (BootstrapHuman("Alice", "admin", "telegram", "101", "101", profile_id(101)),),
     )
     return store
+
+
+async def _unassigned_direct_lane(store: WorkshopEventStore, principal_id: PrincipalId) -> ChannelId:
+    async with store.connection.execute(
+        "SELECT wm.workshop_id, a.id, a.principal_id FROM workshop_memberships wm "
+        "JOIN agents a ON a.workshop_id = wm.workshop_id AND a.name = 'Kai' "
+        "WHERE wm.principal_id = ?",
+        (principal_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    workshop_id = WorkshopId(str(row[0]))
+    agent_id = str(row[1])
+    agent_principal_id = str(row[2])
+    channel_id = ChannelId.derived(principal_id, "runtime-assignment-test")
+    now = datetime.now(UTC)
+    events = (
+        EventEnvelope.create(
+            event_type=WorkshopEventType.CHANNEL_CREATED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="channel",
+            aggregate_id=channel_id,
+            occurred_at=now,
+            idempotency_key=f"test-runtime-assignment:{principal_id}:channel",
+            payload={"kind": "direct", "name": "Direct"},
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="channel_membership",
+            aggregate_id=ChannelMembershipId.derived(channel_id, f"human:{principal_id}"),
+            occurred_at=now,
+            idempotency_key=f"test-runtime-assignment:{principal_id}:human",
+            payload={"channel_id": channel_id, "principal_id": principal_id, "role": "owner"},
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="channel_membership",
+            aggregate_id=ChannelMembershipId.derived(channel_id, f"agent:{agent_principal_id}"),
+            occurred_at=now,
+            idempotency_key=f"test-runtime-assignment:{principal_id}:agent",
+            payload={"channel_id": channel_id, "principal_id": agent_principal_id, "role": "participant"},
+        ),
+        EventEnvelope.create(
+            event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
+            event_version=1,
+            workshop_id=workshop_id,
+            aggregate_type="channel_agent",
+            aggregate_id=ChannelAgentId.derived(channel_id, f"agent:{agent_id}"),
+            occurred_at=now,
+            idempotency_key=f"test-runtime-assignment:{principal_id}:attachment",
+            payload={"channel_id": channel_id, "agent_id": agent_id},
+        ),
+    )
+    for event in events:
+        await store.append(event)
+    await store.project_pending(CanonicalConversationProjection())
+    return channel_id
 
 
 class TestRuntimeAssignmentPolicy:
@@ -60,10 +132,11 @@ class TestRuntimeAssignmentPolicy:
                 "Browser human",
                 "member",
             )
+            channel_id = await _unassigned_direct_lane(store, human.principal_id)
 
             assigned = await WorkshopRuntimeAssignmentService(store, profiles).assign(
                 human.principal_id,
-                human.channel_id,
+                channel_id,
                 runtime_profile_id,
             )
 
@@ -87,24 +160,25 @@ class TestRuntimeAssignmentPolicy:
                 "Charlie",
                 "member",
             )
+            channel_id = await _unassigned_direct_lane(store, human.principal_id)
             profiles = profile_registry(101, 202)
             service = WorkshopRuntimeAssignmentService(store, profiles)
 
             assigned = await service.assign(
                 human.principal_id,
-                human.channel_id,
+                channel_id,
                 profile_id(202),
             )
             retried = await service.assign(
                 human.principal_id,
-                human.channel_id,
+                channel_id,
                 profile_id(202),
             )
 
             assert assigned.created is True
             assert retried.created is False
             assert retried.assignment_id == assigned.assignment_id
-            assert await resolve_channel_runtime_profile(store, human.channel_id) == (
+            assert await resolve_channel_runtime_profile(store, channel_id) == (
                 assigned.agent_id,
                 profile_id(202),
             )
@@ -117,7 +191,7 @@ class TestRuntimeAssignmentPolicy:
             accepted = await WorkshopConversationCommandService(store).accept_client(
                 ClientInboundMessage(
                     principal_id=human.principal_id,
-                    channel_id=human.channel_id,
+                    channel_id=channel_id,
                     client_message_id="charlie-command-1",
                     body="Use the agent owner's runtime",
                     occurred_at=datetime.now(UTC),
@@ -149,14 +223,16 @@ class TestRuntimeAssignmentPolicy:
                 "Dana",
                 "member",
             )
+            charlie_channel = await _unassigned_direct_lane(store, charlie.principal_id)
+            dana_channel = await _unassigned_direct_lane(store, dana.principal_id)
             service = WorkshopRuntimeAssignmentService(store, profile_registry(101, 202))
 
             with pytest.raises(WorkshopRuntimeAssignmentError, match="must own"):
-                await service.assign(charlie.principal_id, dana.channel_id, profile_id(202))
+                await service.assign(charlie.principal_id, dana_channel, profile_id(202))
 
-            await service.assign(charlie.principal_id, charlie.channel_id, profile_id(202))
+            await service.assign(charlie.principal_id, charlie_channel, profile_id(202))
             with pytest.raises(WorkshopRuntimeAssignmentError, match="already assigned"):
-                await service.assign(dana.principal_id, dana.channel_id, profile_id(202))
+                await service.assign(dana.principal_id, dana_channel, profile_id(202))
         finally:
             await store.close()
 
@@ -168,9 +244,10 @@ class TestRuntimeAssignmentPolicy:
                 "Charlie",
                 "member",
             )
+            channel_id = await _unassigned_direct_lane(store, human.principal_id)
             assigned = await WorkshopRuntimeAssignmentService(store, profile_registry(101, 202)).assign(
                 human.principal_id,
-                human.channel_id,
+                channel_id,
                 profile_id(202),
             )
             await store.connection.execute("DELETE FROM channel_agent_runtime_assignments")
@@ -179,7 +256,7 @@ class TestRuntimeAssignmentPolicy:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
             assert checkpoint.version == 30
-            assert await resolve_channel_runtime_profile(store, human.channel_id) == (
+            assert await resolve_channel_runtime_profile(store, channel_id) == (
                 assigned.agent_id,
                 profile_id(202),
             )

--- a/tests/test_workshop_storage_namespaces.py
+++ b/tests/test_workshop_storage_namespaces.py
@@ -7,10 +7,10 @@ from pathlib import Path
 import pytest
 
 from kai.install import _canonical_storage_reader_users
+from kai.workshop.agent_enablement import enable_initial_workshop_agent
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.domain import ChannelId, PrincipalId
 from kai.workshop.human_provisioning import WorkshopHumanProvisioner
-from kai.workshop.runtime_assignments import WorkshopRuntimeAssignmentService
 from kai.workshop.storage_namespaces import (
     WorkshopChannelHistoryNamespace,
     WorkshopChannelHistoryRegistry,
@@ -189,11 +189,12 @@ class TestWorkshopChannelHistoryRegistry:
             human = await WorkshopHumanProvisioner(store).provision(
                 "workshop-only-human",
                 "Workshop-only human",
-                "member",
+                "admin",
             )
-            await WorkshopRuntimeAssignmentService(store, profiles).assign(
+            enabled = await enable_initial_workshop_agent(
+                store,
+                profiles,
                 human.principal_id,
-                human.channel_id,
                 profile_id(303),
             )
 
@@ -203,12 +204,12 @@ class TestWorkshopChannelHistoryRegistry:
             )
             namespace = registry.for_compatibility_chat_id(303)
 
-            assert namespace.channel_id == human.channel_id
-            assert namespace.history_directory(tmp_path) == (tmp_path / "history" / str(human.channel_id))
+            assert namespace.channel_id == enabled.direct_channel_id
+            assert namespace.history_directory(tmp_path) == (tmp_path / "history" / str(enabled.direct_channel_id))
             assert namespace.legacy_history_directory(tmp_path) == (tmp_path / "history" / "303")
             async with store.connection.execute(
                 "SELECT COUNT(*) FROM channel_bindings WHERE channel_id = ?",
-                (human.channel_id,),
+                (enabled.direct_channel_id,),
             ) as cursor:
                 assert int((await cursor.fetchone())[0]) == 0
         finally:


### PR DESCRIPTION
## Summary
- make operator human provisioning create canonical identity and Workshop membership only
- route fresh Workshop-only bootstrap through the canonical agent-enablement event shape
- archive legacy provisioner-created direct channels that were never enabled and report migration integrity
- exclude retired legacy direct lanes from runtime, navigation, storage, and authority resolution

## Validation
- `make test` — 6527 passed
- `make check`
- `make typecheck`
- `make client-check` — 191 passed
- focused provisioning/migration validation — 25 passed

Closes #1443
Closes #1438