### PR TITLE
Restore operational legacy provisioning channels

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -554,11 +554,12 @@ def _start() -> None:
         human_provisioning = await sessions.reconcile_workshop_human_provisioning()
         logging.info(
             "Workshop human provisioning ready (identities=%d, legacy_channels=%d, "
-            "retained=%d, archived=%d, unresolved=%d)",
+            "retained=%d, archived=%d, restored=%d, unresolved=%d)",
             human_provisioning.identities,
             human_provisioning.legacy_channels,
             human_provisioning.retained_channels,
             human_provisioning.archived_channels,
+            human_provisioning.restored_channels,
             human_provisioning.unresolved_channels,
         )
         agent_authority = await sessions.reconcile_workshop_agent_authority(runtime_profiles)

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -258,35 +258,51 @@ def workshop_human_provisioning_status(db_path: Path) -> str:
                 "AND idempotency_key LIKE 'operator:human-provisioning:%:principal'",
             )
             legacy = connection.execute(
-                "SELECT COUNT(*), "
-                "SUM(CASE WHEN pae.id IS NOT NULL THEN 1 ELSE 0 END), "
-                "SUM(CASE WHEN pae.id IS NULL AND c.archived_at IS NOT NULL THEN 1 ELSE 0 END), "
-                "SUM(CASE WHEN pae.id IS NULL AND c.archived_at IS NULL THEN 1 ELSE 0 END), "
-                "SUM(CASE WHEN c.archived_at IS NOT NULL AND (archive.position IS NULL "
-                "OR json_extract(archive.metadata_json, '$.source') != 'human_provisioning_migration') "
-                "THEN 1 ELSE 0 END) "
+                "WITH legacy AS (SELECT c.id, c.archived_at, c.lifecycle_event_position, "
+                "CASE WHEN pae.id IS NOT NULL "
+                "OR EXISTS(SELECT 1 FROM channel_agent_runtime_assignments ra "
+                "WHERE ra.channel_id = c.id) "
+                "OR EXISTS(SELECT 1 FROM messages m WHERE m.channel_id = c.id) "
+                "OR EXISTS(SELECT 1 FROM runs r WHERE r.channel_id = c.id) "
+                "OR EXISTS(SELECT 1 FROM channel_bindings cb WHERE cb.channel_id = c.id) "
+                "THEN 1 ELSE 0 END AS operational, "
+                "CASE WHEN EXISTS(SELECT 1 FROM event_log restored "
+                "WHERE restored.aggregate_id = c.id AND restored.event_type = 'channel.restored' "
+                "AND json_extract(restored.metadata_json, '$.source') = "
+                "'human_provisioning_migration') THEN 1 ELSE 0 END AS restored "
                 "FROM event_log created "
                 "JOIN channels c ON c.id = created.aggregate_id AND c.kind = 'direct' "
                 "LEFT JOIN principal_agent_enablements pae ON pae.direct_channel_id = c.id "
-                "LEFT JOIN event_log archive ON archive.position = c.lifecycle_event_position "
                 "WHERE created.event_type = 'channel.created' "
-                "AND created.idempotency_key LIKE 'operator:human-provisioning:%:direct-channel'"
+                "AND created.idempotency_key LIKE 'operator:human-provisioning:%:direct-channel') "
+                "SELECT COUNT(*), "
+                "SUM(CASE WHEN operational = 1 THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN operational = 0 AND archived_at IS NOT NULL THEN 1 ELSE 0 END), "
+                "SUM(restored), "
+                "SUM(CASE WHEN operational = 0 AND archived_at IS NULL THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN operational = 1 AND archived_at IS NOT NULL THEN 1 "
+                "WHEN operational = 0 AND archived_at IS NOT NULL AND NOT EXISTS("
+                "SELECT 1 FROM event_log lifecycle WHERE lifecycle.position = "
+                "legacy.lifecycle_event_position AND json_extract(lifecycle.metadata_json, "
+                "'$.source') = 'human_provisioning_migration') THEN 1 ELSE 0 END) FROM legacy"
             ).fetchone()
         finally:
             connection.close()
     except (OSError, sqlite3.Error) as exc:
         return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
     if legacy is None:
-        legacy = (0, 0, 0, 0, 0)
+        legacy = (0, 0, 0, 0, 0, 0)
     legacy_channels = int(legacy[0] or 0)
     retained = int(legacy[1] or 0)
     archived = int(legacy[2] or 0)
-    unresolved = int(legacy[3] or 0)
-    invalid = int(legacy[4] or 0)
+    restored = int(legacy[3] or 0)
+    unresolved = int(legacy[4] or 0)
+    invalid = int(legacy[5] or 0)
     state = "active" if unresolved == 0 and invalid == 0 else "INCOMPLETE"
     return (
         f"{prefix} {state}; identities={identities}, legacy channels={legacy_channels} "
-        f"(retained={retained}, archived={archived}, unresolved={unresolved}), "
+        f"(retained={retained}, archived={archived}, restored={restored}, "
+        f"unresolved={unresolved}), "
         f"integrity gaps={invalid}; authority=identity-only"
     )
 

--- a/src/kai/workshop/human_provisioning_migration.py
+++ b/src/kai/workshop/human_provisioning_migration.py
@@ -16,13 +16,14 @@ class WorkshopHumanProvisioningMigration:
     legacy_channels: int
     retained_channels: int
     archived_channels: int
+    restored_channels: int
     unresolved_channels: int
 
 
 async def reconcile_legacy_human_provisioning_channels(
     store: WorkshopEventStore,
 ) -> WorkshopHumanProvisioningMigration:
-    """Archive provisioner-created direct channels that never became enablements."""
+    """Retain operational legacy lanes and archive only truly empty ones."""
     async with store.connection.execute(
         "SELECT COUNT(*) FROM event_log WHERE event_type = 'principal.created' "
         "AND idempotency_key LIKE 'operator:human-provisioning:%:principal'"
@@ -33,8 +34,16 @@ async def reconcile_legacy_human_provisioning_channels(
     async with store.connection.execute(
         "SELECT c.workshop_id, c.id, cm.principal_id, c.archived_at, "
         "CASE WHEN pae.id IS NULL THEN 0 ELSE 1 END, "
-        "CASE WHEN EXISTS(SELECT 1 FROM runs r WHERE r.channel_id = c.id "
-        "AND r.status IN ('accepted', 'started')) THEN 1 ELSE 0 END "
+        "CASE WHEN EXISTS(SELECT 1 FROM channel_agent_runtime_assignments ra "
+        "WHERE ra.channel_id = c.id) "
+        "OR EXISTS(SELECT 1 FROM messages m WHERE m.channel_id = c.id) "
+        "OR EXISTS(SELECT 1 FROM runs r WHERE r.channel_id = c.id) "
+        "OR EXISTS(SELECT 1 FROM channel_bindings cb WHERE cb.channel_id = c.id) "
+        "THEN 1 ELSE 0 END, "
+        "CASE WHEN EXISTS(SELECT 1 FROM event_log restored "
+        "WHERE restored.aggregate_id = c.id AND restored.event_type = 'channel.restored' "
+        "AND json_extract(restored.metadata_json, '$.source') = 'human_provisioning_migration') "
+        "THEN 1 ELSE 0 END "
         "FROM event_log e JOIN channels c ON c.id = e.aggregate_id AND c.kind = 'direct' "
         "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
         "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
@@ -47,6 +56,7 @@ async def reconcile_legacy_human_provisioning_channels(
 
     retained = 0
     archived = 0
+    restored = 0
     unresolved = 0
     connection = store.connection
     try:
@@ -55,14 +65,33 @@ async def reconcile_legacy_human_provisioning_channels(
             workshop_id = WorkshopId(str(row[0]))
             channel_id = ChannelId(str(row[1]))
             principal_id = PrincipalId(str(row[2]))
-            if bool(row[4]):
+            operational = bool(row[4]) or bool(row[5])
+            if operational:
                 retained += 1
+                if row[3] is not None:
+                    result = await store.append_in_transaction(
+                        EventEnvelope.create(
+                            event_type=WorkshopEventType.CHANNEL_RESTORED,
+                            event_version=1,
+                            workshop_id=workshop_id,
+                            aggregate_type="channel",
+                            aggregate_id=channel_id,
+                            actor_principal_id=principal_id,
+                            occurred_at=datetime.now(UTC),
+                            idempotency_key=(f"human-provisioning-migration:{channel_id}:restore-operational"),
+                            payload={},
+                            metadata={
+                                "source": "human_provisioning_migration",
+                                "reason": "operational_authority",
+                            },
+                        )
+                    )
+                    restored += int(result.inserted)
+                elif bool(row[6]):
+                    restored += 1
                 continue
             if row[3] is not None:
                 archived += 1
-                continue
-            if bool(row[5]):
-                unresolved += 1
                 continue
             result = await store.append_in_transaction(
                 EventEnvelope.create(
@@ -89,5 +118,6 @@ async def reconcile_legacy_human_provisioning_channels(
         len(rows),
         retained,
         archived,
+        restored,
         unresolved,
     )

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -2036,9 +2036,8 @@ class CanonicalConversationProjection:
             if envelope.actor_principal_id is None:
                 raise ValueError("Workshop channel lifecycle events require a human actor")
             archived = envelope.event_type == WorkshopEventType.CHANNEL_ARCHIVED
-            legacy_provisioning_retirement = (
-                archived and envelope.metadata.get("source") == "human_provisioning_migration"
-            )
+            legacy_provisioning_lifecycle = envelope.metadata.get("source") == "human_provisioning_migration"
+            legacy_provisioning_retirement = archived and legacy_provisioning_lifecycle
             if archived:
                 async with connection.execute(
                     "SELECT 1 FROM runs WHERE channel_id = ? AND status IN ('accepted', 'started') LIMIT 1",
@@ -2055,17 +2054,22 @@ class CanonicalConversationProjection:
                 "WHERE owner.channel_id = channels.id AND owner.principal_id = ? "
                 "AND owner.role = 'owner') "
                 "AND (? = 0 OR NOT EXISTS (SELECT 1 FROM principal_agent_enablements pae "
-                "WHERE pae.direct_channel_id = channels.id))",
+                "WHERE pae.direct_channel_id = channels.id)) "
+                "AND (? = 0 OR EXISTS (SELECT 1 FROM event_log created "
+                "WHERE created.aggregate_id = channels.id AND created.event_type = 'channel.created' "
+                "AND created.idempotency_key LIKE "
+                "'operator:human-provisioning:%:direct-channel'))",
                 (
                     occurred_at if archived else None,
                     event.position,
                     envelope.aggregate_id,
                     envelope.workshop_id,
-                    int(legacy_provisioning_retirement),
+                    int(legacy_provisioning_lifecycle),
                     int(archived),
                     int(archived),
                     envelope.actor_principal_id,
                     int(legacy_provisioning_retirement),
+                    int(legacy_provisioning_lifecycle),
                 ),
             )
             if cursor.rowcount != 1:

--- a/tests/test_workshop_human_provisioning_migration.py
+++ b/tests/test_workshop_human_provisioning_migration.py
@@ -14,13 +14,15 @@ from kai.workshop.domain import (
     ChannelMembershipId,
     EventEnvelope,
     PrincipalId,
+    RuntimeAssignmentId,
     WorkshopEventType,
 )
 from kai.workshop.human_provisioning import WorkshopHumanProvisioner
 from kai.workshop.human_provisioning_migration import reconcile_legacy_human_provisioning_channels
 from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
 from kai.workshop.store import WorkshopEventStore
-from tests.workshop_profiles import profile_id
+from tests.workshop_profiles import profile_id, profile_registry
 
 
 async def test_orphaned_legacy_provisioner_channel_is_archived_and_replay_safe(
@@ -110,6 +112,7 @@ async def test_orphaned_legacy_provisioner_channel_is_archived_and_replay_safe(
 
         assert migration.legacy_channels == 1
         assert migration.archived_channels == 1
+        assert migration.restored_channels == 0
         assert migration.unresolved_channels == 0
         assert replay.archived_channels == 1
         assert retried_human.created is False
@@ -126,7 +129,143 @@ async def test_orphaned_legacy_provisioner_channel_is_archived_and_replay_safe(
             assert (await cursor.fetchone())[0] is not None
         assert workshop_human_provisioning_status(path).startswith(
             "Workshop human provisioning: active; identities=1, legacy channels=1 "
-            "(retained=0, archived=1, unresolved=0), integrity gaps=0"
+            "(retained=0, archived=1, restored=0, unresolved=0), integrity gaps=0"
+        )
+    finally:
+        await store.close()
+
+
+async def test_operational_legacy_channel_is_restored_after_prior_retirement(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "kai.db"
+    store = await WorkshopEventStore.open(path)
+    await bootstrap_default_workshop(
+        store,
+        (BootstrapHuman("Alice", "admin", "telegram", "101", "101", profile_id(101)),),
+    )
+    try:
+        human = await WorkshopHumanProvisioner(store).provision("charlie", "Charlie", "member")
+        async with store.connection.execute(
+            "SELECT a.id, a.principal_id FROM agents a WHERE a.workshop_id = ? AND a.name = 'Kai'",
+            (human.workshop_id,),
+        ) as cursor:
+            agent_row = await cursor.fetchone()
+        assert agent_row is not None
+        agent_id = AgentId(str(agent_row[0]))
+        agent_principal_id = PrincipalId(str(agent_row[1]))
+        channel_id = ChannelId.derived(human.workshop_id, "operator-human:charlie:direct-channel")
+        now = datetime.now(UTC)
+        events = (
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_CREATED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="channel",
+                aggregate_id=channel_id,
+                occurred_at=now,
+                idempotency_key=f"operator:human-provisioning:{human.principal_id}:direct-channel",
+                payload={"kind": "direct", "name": "Direct"},
+                metadata={"source": "operator_cli"},
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="channel_membership",
+                aggregate_id=ChannelMembershipId.derived(channel_id, f"human:{human.principal_id}"),
+                actor_principal_id=human.principal_id,
+                occurred_at=now,
+                idempotency_key=f"legacy-operational:{channel_id}:human",
+                payload={"channel_id": channel_id, "principal_id": human.principal_id, "role": "owner"},
+                metadata={"source": "operator_cli"},
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="channel_membership",
+                aggregate_id=ChannelMembershipId.derived(channel_id, f"agent:{agent_principal_id}"),
+                actor_principal_id=human.principal_id,
+                occurred_at=now,
+                idempotency_key=f"legacy-operational:{channel_id}:agent",
+                payload={"channel_id": channel_id, "principal_id": agent_principal_id, "role": "participant"},
+                metadata={"source": "operator_cli"},
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_AGENT_ATTACHED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="channel_agent",
+                aggregate_id=ChannelAgentId.derived(channel_id, f"agent:{agent_id}"),
+                actor_principal_id=human.principal_id,
+                occurred_at=now,
+                idempotency_key=f"legacy-operational:{channel_id}:attachment",
+                payload={"channel_id": channel_id, "agent_id": agent_id},
+                metadata={"source": "operator_cli"},
+            ),
+            EventEnvelope.create(
+                event_type=WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="runtime_assignment",
+                aggregate_id=RuntimeAssignmentId.derived(channel_id, f"runtime-profile:{agent_id}"),
+                actor_principal_id=human.principal_id,
+                occurred_at=now,
+                idempotency_key=f"legacy-operational:{channel_id}:runtime",
+                payload={
+                    "channel_id": channel_id,
+                    "agent_id": agent_id,
+                    "runtime_profile_id": profile_id(202),
+                },
+                metadata={"source": "operator_cli"},
+            ),
+        )
+        for event in events:
+            await store.append(event)
+        await store.project_pending(CanonicalConversationProjection())
+        await store.append(
+            EventEnvelope.create(
+                event_type=WorkshopEventType.CHANNEL_ARCHIVED,
+                event_version=1,
+                workshop_id=human.workshop_id,
+                aggregate_type="channel",
+                aggregate_id=channel_id,
+                actor_principal_id=human.principal_id,
+                occurred_at=now,
+                idempotency_key=f"human-provisioning-migration:{channel_id}:archive",
+                payload={},
+                metadata={"source": "human_provisioning_migration"},
+            )
+        )
+        await store.project_pending(CanonicalConversationProjection())
+
+        migration = await reconcile_legacy_human_provisioning_channels(store)
+        replay = await reconcile_legacy_human_provisioning_channels(store)
+
+        assert migration.retained_channels == 1
+        assert migration.archived_channels == 0
+        assert migration.restored_channels == 1
+        assert replay.restored_channels == 1
+        async with store.connection.execute(
+            "SELECT archived_at FROM channels WHERE id = ?",
+            (channel_id,),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] is None
+        storage = await WorkshopPrincipalStorageRegistry.from_store(
+            store,
+            profile_registry(101, 202),
+        )
+        assert storage.for_runtime_profile(profile_id(202)).principal_id == human.principal_id
+        await store.rebuild_projection(CanonicalConversationProjection())
+        async with store.connection.execute(
+            "SELECT archived_at FROM channels WHERE id = ?",
+            (channel_id,),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] is None
+        assert workshop_human_provisioning_status(path).startswith(
+            "Workshop human provisioning: active; identities=1, legacy channels=1 "
+            "(retained=1, archived=0, restored=1, unresolved=0), integrity gaps=0"
         )
     finally:
         await store.close()


### PR DESCRIPTION
## Summary
- retain legacy provisioner channels carrying runtime assignments, messages, runs, transport bindings, or enablements
- restore operational channels already archived by the #1452 migration before storage authority loads
- keep truly empty legacy channels archived and report retained, archived, and restored counts
- permit only migration-authored lifecycle repair for legacy direct channels

## Deployed regression
The affected production channel carries one runtime assignment, 14 messages, and 7 runs. #1452 archived it because it lacked an enablement row, removing the protected runtime profile's sole storage owner and preventing startup.

## Validation
- recovery against a temporary backup of the deployed database: `legacy=1 retained=1 restored=1 archived_runtime_lanes=0`
- `make test` — 6528 passed
- `make check`
- `make typecheck`
- `make client-check` — 191 passed

Closes #1453