### PR TITLE
Retire archived agent runtime lanes

### DIFF
--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -564,10 +564,13 @@ def _start() -> None:
         )
         agent_authority = await sessions.reconcile_workshop_agent_authority(runtime_profiles)
         logging.info(
-            "Workshop agent authority ready (definitions=%d, owners=%d, runtimes=%d)",
+            "Workshop agent authority ready (definitions=%d, owners=%d, runtimes=%d, "
+            "retired_attachments=%d, retired_sessions=%d)",
             agent_authority.definitions,
             agent_authority.assigned_owners,
             agent_authority.assigned_runtimes,
+            agent_authority.retired_attachments,
+            agent_authority.retired_sessions,
         )
         principal_storage = await sessions.load_workshop_principal_storage_registry(runtime_profiles)
         from kai.backend import configure_principal_storage_namespaces

--- a/src/kai/workshop/agent_authority.py
+++ b/src/kai/workshop/agent_authority.py
@@ -29,6 +29,8 @@ class WorkshopAgentAuthorityReconciliation:
     definitions: int
     assigned_owners: int
     assigned_runtimes: int
+    retired_attachments: int
+    retired_sessions: int
 
 
 async def reconcile_single_owner_agent_authority(
@@ -40,6 +42,8 @@ async def reconcile_single_owner_agent_authority(
     captured = 0
     owners = 0
     runtimes = 0
+    retired_attachments = 0
+    retired_sessions = 0
     try:
         await connection.execute("BEGIN IMMEDIATE")
         for profile in runtime_profiles.profiles:
@@ -67,6 +71,8 @@ async def reconcile_single_owner_agent_authority(
                     (profile.profile_id, str(owner_rows[0][0])),
                 )
                 captured += 1
+
+        retired_attachments, retired_sessions = await _retire_archived_agent_lanes(store)
 
         async with connection.execute(
             "SELECT d.id, d.workshop_id, d.owner_principal_id, e.actor_principal_id "
@@ -172,7 +178,39 @@ async def reconcile_single_owner_agent_authority(
         definitions=len(definitions),
         assigned_owners=owners,
         assigned_runtimes=runtimes,
+        retired_attachments=retired_attachments,
+        retired_sessions=retired_sessions,
     )
+
+
+async def _retire_archived_agent_lanes(store: WorkshopEventStore) -> tuple[int, int]:
+    """Converge live-state residue for definitions archived by canonical events."""
+    connection = store.connection
+    async with connection.execute(
+        "SELECT d.agent_id, e.occurred_at, e.position FROM agent_definitions d "
+        "JOIN event_log e ON e.aggregate_id = d.id "
+        "AND e.event_type = 'agent_definition.archived' "
+        "WHERE d.lifecycle_state = 'archived' ORDER BY d.agent_id, e.position"
+    ) as cursor:
+        rows = list(await cursor.fetchall())
+    archived = {str(row[0]): (str(row[1]), int(row[2])) for row in rows}
+    retired_attachments = 0
+    retired_sessions = 0
+    for agent_id, (archived_at, event_position) in archived.items():
+        attachment_cursor = await connection.execute(
+            "UPDATE channel_agents SET detached_at = ?, detached_event_position = ? "
+            "WHERE agent_id = ? AND detached_at IS NULL AND EXISTS ("
+            "SELECT 1 FROM channels c WHERE c.id = channel_agents.channel_id "
+            "AND c.kind = 'group')",
+            (archived_at, event_position, agent_id),
+        )
+        retired_attachments += attachment_cursor.rowcount
+        session_cursor = await connection.execute(
+            "DELETE FROM channel_agent_runtime_sessions WHERE agent_id = ?",
+            (agent_id,),
+        )
+        retired_sessions += session_cursor.rowcount
+    return retired_attachments, retired_sessions
 
 
 async def _resolve_initial_owner(

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -2492,7 +2492,7 @@ class CanonicalConversationProjection:
                 raise ValueError("Workshop agent archival requires a typed definition aggregate")
             _require_exact_payload(payload, set())
             async with connection.execute(
-                "SELECT workshop_id, lifecycle_state FROM agent_definitions WHERE id = ?",
+                "SELECT workshop_id, lifecycle_state, agent_id FROM agent_definitions WHERE id = ?",
                 (envelope.aggregate_id,),
             ) as cursor:
                 definition_row = await cursor.fetchone()
@@ -2510,6 +2510,18 @@ class CanonicalConversationProjection:
                 "UPDATE principal_agent_enablements SET lifecycle_state = 'disabled', "
                 "updated_at = ? WHERE agent_definition_id = ? AND lifecycle_state = 'enabled'",
                 (occurred_at, envelope.aggregate_id),
+            )
+            agent_id = AgentId(str(definition_row[2]))
+            await connection.execute(
+                "UPDATE channel_agents SET detached_at = ?, detached_event_position = ? "
+                "WHERE agent_id = ? AND detached_at IS NULL AND EXISTS ("
+                "SELECT 1 FROM channels c WHERE c.id = channel_agents.channel_id "
+                "AND c.kind = 'group')",
+                (occurred_at, event.position, agent_id),
+            )
+            await connection.execute(
+                "DELETE FROM channel_agent_runtime_sessions WHERE agent_id = ?",
+                (agent_id,),
             )
         elif envelope.event_type == WorkshopEventType.AGENT_DEFINITION_AUTHORITY_ASSIGNED:
             if (

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -21,9 +21,10 @@ from kai.workshop.agent_lifecycle import (
     WorkshopAgentLifecycleService,
 )
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.channel_lifecycle import WorkshopChannelLifecycleService
 from kai.workshop.client_api import _read_agent_lifecycle_events
 from kai.workshop.conversation_runs import resolve_canonical_conversation_run
-from kai.workshop.diagnostics import workshop_agent_authority_status
+from kai.workshop.diagnostics import workshop_agent_authority_status, workshop_runtime_session_status
 from kai.workshop.domain import AgentDefinitionId, AgentEnablementId, ChannelId, MessageId, PrincipalId, RunId
 from kai.workshop.execution_state import WorkshopExecutionStateRegistry
 from kai.workshop.inbound import InboundMessage, record_inbound_message
@@ -317,6 +318,44 @@ async def test_archival_retires_runtime_lane_but_preserves_direct_channel(tmp_pa
             idempotency_key="archive-runtime-enable",
         )
         assert enabled.direct_channel_id is not None
+        group = await WorkshopChannelLifecycleService(store).create_group(
+            daniel,
+            name="Archive cleanup qualification",
+            agent_ids=[enabled.agent_id],
+            origin_channel_id=enabled.direct_channel_id,
+        )
+        async with store.connection.execute("SELECT MAX(position) FROM event_log") as cursor:
+            context_position = int((await cursor.fetchone())[0])
+        for index, channel_id in enumerate(
+            (enabled.direct_channel_id, group.channel_id),
+            start=1,
+        ):
+            await store.connection.execute("BEGIN IMMEDIATE")
+            await settle_runtime_session_in_transaction(
+                store,
+                RuntimeSessionSettlement(
+                    channel_id=channel_id,
+                    agent_id=enabled.agent_id,
+                    runtime_profile_id=profile_id(101),
+                    selection=RunExecutionSelection("codex", "gpt-5.6-sol", "openai"),
+                    workspace="/private/tmp/archive-cleanup",
+                    provider_session_id=f"archive-provider-session-{index}",
+                    run_id=RunId.new(),
+                ),
+                result_message_id=MessageId.new(),
+                context_through_event_position=context_position,
+                occurred_at=datetime.now(UTC),
+            )
+            await store.connection.commit()
+        async with store.connection.execute(
+            "SELECT channel_id, agent_id, runtime_profile_id, backend, provider, model, "
+            "workspace, provider_session_id, last_run_id, last_result_message_id, "
+            "context_through_event_position, created_at, updated_at "
+            "FROM channel_agent_runtime_sessions WHERE agent_id = ? ORDER BY channel_id",
+            (enabled.agent_id,),
+        ) as cursor:
+            archived_session_rows = [tuple(row) for row in await cursor.fetchall()]
+        assert len(archived_session_rows) == 2
         current = await WorkshopAgentLifecycleService(store).get_visible(daniel, definition_id)
 
         archived = await WorkshopAgentLifecycleService(store).archive(
@@ -331,6 +370,8 @@ async def test_archival_retires_runtime_lane_but_preserves_direct_channel(tmp_pa
         assert runtime_pool.suspended[-1].channel_id == enabled.direct_channel_id
         assert execution.maybe_for_principal_channel(daniel, enabled.direct_channel_id) is None
         assert all(context.channel_id != enabled.direct_channel_id for context in contexts.contexts)
+        assert await load_runtime_session(store, enabled.direct_channel_id, enabled.agent_id) is None
+        assert await load_runtime_session(store, group.channel_id, enabled.agent_id) is None
         async with store.connection.execute(
             "SELECT lifecycle_state FROM principal_agent_enablements "
             "WHERE agent_definition_id = ? AND principal_id = ?",
@@ -343,6 +384,45 @@ async def test_archival_retires_runtime_lane_but_preserves_direct_channel(tmp_pa
             (enabled.direct_channel_id,),
         ) as cursor:
             assert int((await cursor.fetchone())[0]) == 1
+        async with store.connection.execute(
+            "SELECT detached_at FROM channel_agents WHERE channel_id = ? AND agent_id = ?",
+            (enabled.direct_channel_id, enabled.agent_id),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] is None
+        async with store.connection.execute(
+            "SELECT detached_at FROM channel_agents WHERE channel_id = ? AND agent_id = ?",
+            (group.channel_id, enabled.agent_id),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] is not None
+
+        await store.connection.execute(
+            "UPDATE channel_agents SET detached_at = NULL, detached_event_position = NULL "
+            "WHERE channel_id = ? AND agent_id = ?",
+            (group.channel_id, enabled.agent_id),
+        )
+        await store.connection.executemany(
+            "INSERT INTO channel_agent_runtime_sessions ("
+            "channel_id, agent_id, runtime_profile_id, backend, provider, model, workspace, "
+            "provider_session_id, last_run_id, last_result_message_id, "
+            "context_through_event_position, created_at, updated_at"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            archived_session_rows,
+        )
+        await store.connection.commit()
+
+        reconciliation = await reconcile_single_owner_agent_authority(
+            store,
+            profile_registry(101, 202),
+        )
+        assert reconciliation.retired_attachments == 1
+        assert reconciliation.retired_sessions == 2
+        assert await load_runtime_session(store, enabled.direct_channel_id, enabled.agent_id) is None
+        assert await load_runtime_session(store, group.channel_id, enabled.agent_id) is None
+        async with store.connection.execute(
+            "SELECT detached_at FROM channel_agents WHERE channel_id = ? AND agent_id = ?",
+            (group.channel_id, enabled.agent_id),
+        ) as cursor:
+            assert (await cursor.fetchone())[0] is not None
 
         restarted_execution = await WorkshopExecutionStateRegistry.from_store(
             store,
@@ -357,6 +437,9 @@ async def test_archival_retires_runtime_lane_but_preserves_direct_channel(tmp_pa
         authority_status = workshop_agent_authority_status(tmp_path / "kai.db")
         assert authority_status.startswith("Workshop agent authority: active;")
         assert "owner runtimes=0" in authority_status.split("integrity gaps=", 1)[1]
+        assert workshop_runtime_session_status(tmp_path / "kai.db").startswith(
+            "Workshop conversation continuity: active; successful lanes=0, sessions=0"
+        )
     finally:
         await store.close()
 


### PR DESCRIPTION
Closes #1457.

## Summary

- make canonical agent archival detach the definition from every group channel while preserving its direct conversation history
- retire all runtime sessions belonging to the archived definition in the same projection transaction
- reconcile the same live-state residue at startup for agents archived before this correction
- report reconciliation counts in startup logging
- cover immediate archival cleanup and startup repair of deliberately recreated legacy residue

## Verification

- 23 agent definition/enablement tests passed
- 19 execution/continuity tests passed
- 2 relevant client API archival tests passed
- `make check`
- `make typecheck`
- read-only deployed database copied to temporary storage and reconciled there:
  - retired attachments: 1
  - retired sessions: 3
  - `Workshop agent authority: active`, integrity gaps 0
  - `Workshop conversation continuity: active`, missing 0, stale 0

The deployed database itself was not modified.
