### PR TITLE
Resolve deployment mode once at startup

### DIFF
--- a/src/kai/backend_registry.py
+++ b/src/kai/backend_registry.py
@@ -23,7 +23,7 @@ from kai.protected_config import ProtectedConfigError, validate_protected_file_m
 
 DEFAULT_BACKENDS_YAML = Path("/etc/kai/backends.yaml")
 BACKENDS_YAML_ENV = "KAI_BACKENDS_YAML"
-INSTALL_DIR_ENV = "KAI_INSTALL_DIR"
+DEPLOYMENT_MODE_ENV = "KAI_DEPLOYMENT_MODE"
 
 _BACKEND_ENV_VARS: dict[str, str] = {
     "claude": "CLAUDE_BIN",
@@ -33,6 +33,11 @@ _BACKEND_ENV_VARS: dict[str, str] = {
 }
 _SUPPORTED_BACKENDS = frozenset((*_BACKEND_ENV_VARS, "pi"))
 _SUPPORTED_RUNTIME = "local_process"
+
+
+def _protected_deployment() -> bool:
+    """Return the startup-resolved protected-mode authority."""
+    return os.environ.get(DEPLOYMENT_MODE_ENV, "").strip() == "protected"
 
 
 class BackendRegistryError(Exception):
@@ -64,14 +69,14 @@ def backend_registry_exists(path: Path | None = None) -> bool:
         return path.is_file()
     if os.environ.get(BACKENDS_YAML_ENV, "").strip():
         return backend_registry_path().is_file()
-    if not os.environ.get(INSTALL_DIR_ENV, "").strip():
+    if not _protected_deployment():
         return False
     return backend_registry_path().is_file()
 
 
 def backend_registry_required() -> bool:
     """Return whether this process must use the backend registry."""
-    return bool(os.environ.get(BACKENDS_YAML_ENV, "").strip() or os.environ.get(INSTALL_DIR_ENV, "").strip())
+    return bool(os.environ.get(BACKENDS_YAML_ENV, "").strip() or _protected_deployment())
 
 
 def backend_registry_is_authoritative() -> bool:
@@ -88,7 +93,8 @@ def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistry
     registry, is a configuration error because runtime and sudoers path
     decisions must not silently fall back to unrelated binaries.
     """
-    explicit_path = path is not None or backend_registry_required()
+    explicit_override = path is not None or bool(os.environ.get(BACKENDS_YAML_ENV, "").strip())
+    explicit_path = explicit_override or backend_registry_required()
     registry_path = path or backend_registry_path()
     if not registry_path.is_file():
         if explicit_path:
@@ -98,7 +104,7 @@ def load_backend_registry(path: Path | None = None) -> dict[str, BackendRegistry
         validate_protected_file_metadata(
             registry_path,
             max_mode=0o644,
-            require_root_owner=bool(os.environ.get(INSTALL_DIR_ENV, "").strip()),
+            require_root_owner=_protected_deployment() and not explicit_override,
         )
     except ProtectedConfigError as e:
         raise BackendRegistryError(str(e)) from e

--- a/src/kai/bot.py
+++ b/src/kai/bot.py
@@ -4847,6 +4847,9 @@ async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> boo
     returns False; the user then types their code as a text message, which
     handle_message processes.
     """
+    totp_cfg: Config = context.bot_data["config"]
+    if not totp_cfg.protected_install:
+        return True
     try:
         if not await asyncio.to_thread(is_totp_configured):
             return True
@@ -4861,7 +4864,6 @@ async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> boo
         log.error("TOTP challenge denied: Telegram update has no effective message")
         return False
 
-    totp_cfg: Config = context.bot_data["config"]
     session_min = totp_cfg.totp_session_minutes
     auth_time = context.user_data.get("totp_authenticated_at", 0)
     totp_expired = time.time() - auth_time > session_min * 60
@@ -4888,6 +4890,9 @@ async def _check_totp(update: Update, context: ContextTypes.DEFAULT_TYPE) -> boo
 
 async def _check_totp_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> bool:
     """Run the complete text-message TOTP challenge and verification flow."""
+    totp_cfg: Config = context.bot_data["config"]
+    if not totp_cfg.protected_install:
+        return True
     try:
         if not await asyncio.to_thread(is_totp_configured):
             return True
@@ -4897,7 +4902,6 @@ async def _check_totp_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -
         assert update.message is not None
 
         principal_id = _user_id(update)
-        totp_cfg: Config = context.bot_data["config"]
         auth_time = context.user_data.get("totp_authenticated_at", 0)
         totp_expired = time.time() - auth_time > totp_cfg.totp_session_minutes * 60
 

--- a/src/kai/config.py
+++ b/src/kai/config.py
@@ -13,6 +13,7 @@ derived from this file's location in the source tree: src/kai/config.py -> proje
 """
 
 import ipaddress
+import json
 import logging
 import os
 import pwd
@@ -96,6 +97,16 @@ VALID_BACKENDS = {"claude", "goose", "codex", "opencode", "pi"}
 # deployment so upgrades do not silently disable Telegram.
 VALID_CLIENT_ADAPTERS: frozenset[str] = frozenset({"telegram", "workshop"})
 DEFAULT_CLIENT_ADAPTERS: frozenset[str] = VALID_CLIENT_ADAPTERS
+
+
+class DeploymentMode(StrEnum):
+    """One startup-wide authority for protected versus single-user paths."""
+
+    PROTECTED = "protected"
+    SINGLE_USER = "single_user"
+
+
+DEPLOYMENT_MODE_ENV = "KAI_DEPLOYMENT_MODE"
 
 
 def parse_enabled_adapters(value: str | None) -> frozenset[str]:
@@ -1574,11 +1585,9 @@ class Config:
     workshop_lan_host: str = ""
     github_webhook_secret: str = ""
     generic_webhook_secret: str = ""
-    # True when load_config() populated secrets from the protected
-    # installation env file (/etc/kai/env). Runtime code uses this to
-    # tighten boundaries that would break local single-user installs if
-    # enforced unconditionally.
-    protected_install: bool = False
+    # Resolved once at startup from installer-owned policy. Runtime code must
+    # branch on this value rather than probing individual /etc/kai files.
+    deployment_mode: DeploymentMode = DeploymentMode.SINGLE_USER
 
     # Voice input (speech-to-text via whisper-cpp)
     voice_enabled: bool = False
@@ -1787,6 +1796,11 @@ class Config:
         """
         return self.workspace_configs.get(workspace.resolve())
 
+    @property
+    def protected_install(self) -> bool:
+        """Compatibility spelling backed by the canonical deployment mode."""
+        return self.deployment_mode is DeploymentMode.PROTECTED
+
     def get_user_config(self, user_id: int) -> UserConfig | None:
         """Get per-user config by Telegram user ID, or None if not configured."""
         return self.user_configs.get(user_id)
@@ -1887,7 +1901,7 @@ def _xdg_config_home() -> Path:
     return Path.home() / ".config"
 
 
-def _resolve_users_yaml_path(protected_env_was_loaded: bool) -> Path:
+def _resolve_users_yaml_path(deployment_mode: DeploymentMode) -> Path:
     """Resolve the canonical users.yaml path for this deployment.
 
     Resolution order, first match wins:
@@ -1895,12 +1909,9 @@ def _resolve_users_yaml_path(protected_env_was_loaded: bool) -> Path:
          only; the README does not document this as a normal operator
          path. Lets tests pin a tmp path without faking
          protected-env-loaded state.
-      2. `/etc/kai/users.yaml` when `protected_env_was_loaded` is True.
-         The signal is "_read_protected_file('/etc/kai/env') returned
-         non-empty content during this load_config call." Ambient env
-         vars like `KAI_INSTALL_DIR` and `KAI_DATA_DIR` deliberately
-         do NOT participate: they are path overrides for data and
-         install layout but do not imply protected deployment mode.
+      2. `/etc/kai/users.yaml` in protected deployment mode. Ambient
+         path variables like `KAI_INSTALL_DIR` and `KAI_DATA_DIR`
+         deliberately do NOT participate in deployment-mode resolution.
       3. `${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml` otherwise.
          The single-user repo install lives entirely under the
          operator's home; no `/etc/kai/` writes, no sudo at startup.
@@ -1912,7 +1923,7 @@ def _resolve_users_yaml_path(protected_env_was_loaded: bool) -> Path:
     override = os.environ.get("KAI_USERS_YAML", "").strip()
     if override:
         return Path(override).expanduser()
-    if protected_env_was_loaded:
+    if deployment_mode is DeploymentMode.PROTECTED:
         return Path("/etc/kai/users.yaml")
     return _xdg_config_home() / "kai" / "users.yaml"
 
@@ -1998,7 +2009,76 @@ def parse_env_file(path: Path) -> dict[str, str]:
     return env
 
 
-def _load_workspace_configs() -> dict[Path, WorkspaceConfig]:
+def _deployment_mode_value(value: object, *, source: str) -> DeploymentMode:
+    """Validate one recorded deployment-mode value with source context."""
+    try:
+        return DeploymentMode(str(value).strip())
+    except ValueError:
+        choices = ", ".join(mode.value for mode in DeploymentMode)
+        raise SystemExit(f"{source} must be one of: {choices}") from None
+
+
+def _recorded_local_deployment_mode() -> DeploymentMode | None:
+    """Read installer-recorded local mode without loading local secrets.
+
+    A protected source checkout commonly retains ``install.conf`` but has no
+    local ``.env``. Requiring the local runtime file before consulting that
+    installer artifact prevents an unrelated checkout from overriding a
+    protected daemon. Existing single-user installs have both files, so their
+    top-level ``deployment_mode`` remains a migration source even before the
+    next wizard run writes the explicit runtime marker.
+    """
+    local_env_path = PROJECT_ROOT / ".env"
+    if not local_env_path.is_file():
+        return None
+    local_mode_raw = parse_env_file(local_env_path).get(DEPLOYMENT_MODE_ENV, "").strip()
+    local_mode = (
+        _deployment_mode_value(local_mode_raw, source=f"{local_env_path} {DEPLOYMENT_MODE_ENV}")
+        if local_mode_raw
+        else None
+    )
+
+    install_conf_path = PROJECT_ROOT / "install.conf"
+    install_mode: DeploymentMode | None = None
+    if install_conf_path.is_file():
+        try:
+            document = json.loads(install_conf_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SystemExit(f"Could not read deployment mode from {install_conf_path}: {exc}") from exc
+        if not isinstance(document, dict):
+            raise SystemExit(f"{install_conf_path} must contain a JSON object")
+        install_mode_raw = document.get("deployment_mode")
+        if install_mode_raw is not None:
+            install_mode = _deployment_mode_value(
+                install_mode_raw,
+                source=f"{install_conf_path} deployment_mode",
+            )
+
+    if local_mode is not None and install_mode is not None and local_mode is not install_mode:
+        raise SystemExit(
+            f"Deployment mode disagrees between {local_env_path} ({local_mode.value}) "
+            f"and {install_conf_path} ({install_mode.value}); re-run 'make config'"
+        )
+    return local_mode or install_mode
+
+
+def _resolve_deployment_mode() -> tuple[DeploymentMode, str | None]:
+    """Resolve deployment mode once and return any protected env already read."""
+    explicit = os.environ.get(DEPLOYMENT_MODE_ENV, "").strip()
+    recorded = (
+        _deployment_mode_value(explicit, source=DEPLOYMENT_MODE_ENV) if explicit else _recorded_local_deployment_mode()
+    )
+    if recorded is DeploymentMode.SINGLE_USER:
+        return recorded, None
+
+    protected_env = _read_protected_file("/etc/kai/env")
+    resolved = recorded or (DeploymentMode.PROTECTED if protected_env else DeploymentMode.SINGLE_USER)
+    return resolved, protected_env
+
+
+def _load_workspace_configs(
+    deployment_mode: DeploymentMode | None = None,
+) -> dict[Path, WorkspaceConfig]:
     """
     Load per-workspace configs from workspaces.yaml.
 
@@ -2012,7 +2092,7 @@ def _load_workspace_configs() -> dict[Path, WorkspaceConfig]:
     # protected file stops loading entirely rather than silently
     # falling through to a local file (which could contain stale
     # or dev config on a production system).
-    data = _read_protected_yaml("workspaces.yaml")
+    data = _read_protected_yaml("workspaces.yaml") if deployment_mode is not DeploymentMode.SINGLE_USER else None
     if data is _YAML_MALFORMED:
         # Fail open: return empty dict so the system continues without
         # workspace overrides. Workspace config is convenience, not
@@ -2165,7 +2245,9 @@ def _load_workspace_configs() -> dict[Path, WorkspaceConfig]:
     return configs
 
 
-def _load_memory_project_configs() -> dict[str, MemoryProjectConfig]:
+def _load_memory_project_configs(
+    deployment_mode: DeploymentMode | None = None,
+) -> dict[str, MemoryProjectConfig]:
     """
     Load the memory project registry from memory-projects.yaml.
 
@@ -2198,7 +2280,7 @@ def _load_memory_project_configs() -> dict[str, MemoryProjectConfig]:
     # through to the local file (avoid silently using dev config on
     # a production system); fail closed with an empty registry
     # instead.
-    data = _read_protected_yaml("memory-projects.yaml")
+    data = _read_protected_yaml("memory-projects.yaml") if deployment_mode is not DeploymentMode.SINGLE_USER else None
     if data is _YAML_MALFORMED:
         log.warning("Skipping memory project registry: /etc/kai/memory-projects.yaml is malformed or empty")
         return {}
@@ -2551,7 +2633,7 @@ def _load_user_configs(
             Defaults to `/etc/kai/users.yaml` to preserve protected-install
             ergonomics for tests that do not exercise XDG resolution.
             Production callers in `load_config` pass the result of
-            `_resolve_users_yaml_path(protected_env_was_loaded)`.
+            `_resolve_users_yaml_path(deployment_mode)`.
 
     Returns a dict keyed by telegram_id for O(1) lookup.
     """
@@ -3119,12 +3201,13 @@ def load_config() -> Config:
     Raises:
         SystemExit: If required environment variables are missing or invalid.
     """
-    # Try protected config first (/etc/kai/env, root-owned). In a protected
-    # installation, secrets live here instead of .env. Falls back to local
-    # .env for development. Uses setdefault so explicitly set env vars
-    # (e.g., from the launchd plist) take precedence - same as load_dotenv().
-    protected_env = _read_protected_file("/etc/kai/env")
-    if protected_env:
+    # Resolve the deployment boundary once. Every later protected-path
+    # decision consumes this authority; single-user startup never probes
+    # individual /etc/kai files merely because leftovers exist on the host.
+    deployment_mode, protected_env = _resolve_deployment_mode()
+    if deployment_mode is DeploymentMode.PROTECTED:
+        if protected_env is None:
+            raise SystemExit("Protected deployment mode requires readable /etc/kai/env")
         for line in protected_env.splitlines():
             line = line.strip()
             if line and not line.startswith("#") and "=" in line:
@@ -3583,7 +3666,7 @@ def load_config() -> Config:
 
     # Per-workspace configuration. Loaded after ALLOWED_WORKSPACES so
     # YAML-defined workspaces can be merged into the allowed set.
-    workspace_configs = _load_workspace_configs()
+    workspace_configs = _load_workspace_configs(deployment_mode)
 
     # Merge YAML workspace paths into allowed_workspaces. Workspaces
     # defined in the config file are implicitly allowed.
@@ -3600,7 +3683,7 @@ def load_config() -> Config:
     # workspace permissions still gate which workspaces the operator
     # can enter; the registry only describes the memory boundary of
     # workspaces the user is otherwise allowed to enter.
-    memory_projects = _load_memory_project_configs()
+    memory_projects = _load_memory_project_configs(deployment_mode)
 
     # Telegram identity and compatibility configuration. users.yaml is
     # mandatory only while the Telegram adapter is enabled. A disabled
@@ -3608,18 +3691,14 @@ def load_config() -> Config:
     # because its dormant configuration is stale, unreadable, or malformed.
     # The legacy ALLOWED_USER_IDS authorization fallback is gone.
     #
-    # The path resolves based on whether `/etc/kai/env` had readable
-    # content at the top of this load_config call (protected install)
-    # or not (single-user install reads from PROJECT_ROOT/.env and
-    # places users.yaml under XDG config home). KAI_USERS_YAML is an
-    # explicit override for tests and ad-hoc development; the operator
-    # path is always one of the two resolved defaults.
-    users_yaml_path = _resolve_users_yaml_path(bool(protected_env))
+    # The path resolves from the one startup-wide deployment authority.
+    # KAI_USERS_YAML remains an explicit test/development override.
+    users_yaml_path = _resolve_users_yaml_path(deployment_mode)
     if telegram_enabled:
         user_configs = _load_user_configs(default_backend, default_provider, users_yaml_path)
     else:
         user_configs = {}
-    if protected_env and user_configs:
+    if deployment_mode is DeploymentMode.PROTECTED and user_configs:
         # A protected install gives the outer service account narrowly
         # scoped sudo access to root-owned Kai configuration.  A persistent
         # conversational agent running as that same account would inherit
@@ -3866,7 +3945,7 @@ def load_config() -> Config:
         workshop_lan_host=workshop_lan_host,
         github_webhook_secret=github_webhook_secret,
         generic_webhook_secret=generic_webhook_secret,
-        protected_install=bool(protected_env),
+        deployment_mode=deployment_mode,
         voice_enabled=os.environ.get("VOICE_ENABLED", "").lower() in ("1", "true", "yes"),
         tts_enabled=os.environ.get("TTS_ENABLED", "").lower() in ("1", "true", "yes"),
         workspace_base=workspace_base,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -54,6 +54,7 @@ from kai.config import (
     CLAUDE_MODELS,
     CODEX_EFFORT_LEVELS,
     CODEX_MODELS,
+    DEPLOYMENT_MODE_ENV,
     EFFORT_LEVELS,
     MODEL_REGISTRY,
     ONESHOT_REASONER_BACKENDS,
@@ -2008,28 +2009,6 @@ def _cmd_config() -> None:
         print("  Telegram is disabled; the bot token will be omitted from the generated configuration.")
     print()
 
-    # Migration safety: if the operator picks single_user but a
-    # readable `/etc/kai/env` exists from a previous protected install,
-    # the runtime predicate in `config._resolve_users_yaml_path` will
-    # still see the protected env as authoritative and route at
-    # `/etc/kai/users.yaml`, silently bypassing the single-user
-    # artifacts we are about to write. The runtime cannot tell which
-    # is the operator's intent; the wizard refuses up front so the
-    # operator removes the protected leftovers before reaching that
-    # ambiguous state. A protected install on a host whose operator
-    # has the sudoers cat rule from a prior `sudo make install` is
-    # the typical trigger.
-    if deployment_mode == "single_user" and _read_protected_file("/etc/kai/env"):
-        raise SystemExit(
-            "single_user mode was selected, but /etc/kai/env is readable from a "
-            "previous protected install. The runtime would still boot from the "
-            "protected files, silently ignoring the single-user artifacts. "
-            "Remove the protected install before retrying:\n"
-            "    sudo rm -rf /etc/kai\n"
-            "    sudo rm -f /etc/sudoers.d/kai\n"
-            "Then re-run 'make config' and pick single_user."
-        )
-
     # In single-user mode the install location, data directory,
     # service user, and platform service manager are not relevant:
     # Kai runs from the cloned repo under the operator's account.
@@ -3458,7 +3437,9 @@ def _cmd_config() -> None:
         # we restrict the mode to 0600 because the file holds the same
         # secrets (bot token, webhook secret).
         env_path = PROJECT_ROOT / ".env"
-        env_path.write_text(_generate_env_file(env))
+        runtime_env = dict(env)
+        runtime_env[DEPLOYMENT_MODE_ENV] = "single_user"
+        env_path.write_text(_generate_env_file(runtime_env))
         os.chmod(env_path, 0o600)
         print(f"Wrote runtime env to {env_path}")
         if users_yaml_exists or telegram_enabled:
@@ -4813,6 +4794,8 @@ def _generate_launchd_plist(install_dir: str, data_dir: str, service_user: str) 
                 <string>{data_dir}</string>
                 <key>KAI_INSTALL_DIR</key>
                 <string>{install_dir}</string>
+                <key>{DEPLOYMENT_MODE_ENV}</key>
+                <string>protected</string>
             </dict>
 
             <key>StandardErrorPath</key>
@@ -4876,6 +4859,7 @@ def _generate_systemd_unit(install_dir: str, data_dir: str, service_user: str) -
         Environment=PATH={user_home}/.local/bin:/usr/local/bin:/usr/bin:/bin
         Environment=KAI_DATA_DIR={data_dir}
         Environment=KAI_INSTALL_DIR={install_dir}
+        Environment={DEPLOYMENT_MODE_ENV}=protected
 
         [Install]
         WantedBy=multi-user.target

--- a/src/kai/main.py
+++ b/src/kai/main.py
@@ -486,7 +486,7 @@ def _start() -> None:
 
     # Load external service definitions. In a protected installation, services.yaml
     # lives in /etc/kai/ (root-owned). Falls back to PROJECT_ROOT for development.
-    protected_yaml = _read_protected_file("/etc/kai/services.yaml")
+    protected_yaml = _read_protected_file("/etc/kai/services.yaml") if config.protected_install else None
     if protected_yaml is not None:
         loaded = services.load_services_from_string(protected_yaml)
     else:

--- a/src/kai/workshop/runtime_profiles.py
+++ b/src/kai/workshop/runtime_profiles.py
@@ -33,7 +33,6 @@ _PROFILE_DERIVATION_DOMAIN = b"kai-workshop-runtime-profile:v1\0"
 _V1_LEGACY_KEY_DERIVATION_DOMAIN = b"kai-workshop-runtime-compatibility-key:v1\0"
 DEFAULT_RUNTIME_PROFILES_YAML = Path("/etc/kai/runtime-profiles.yaml")
 RUNTIME_PROFILES_YAML_ENV = "KAI_RUNTIME_PROFILES_YAML"
-INSTALL_DIR_ENV = "KAI_INSTALL_DIR"
 _OS_USER_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 RUNTIME_KEY_ARCHIVE_REMOVAL_GATE = "canonical_runtime_state_v1"
 DEFAULT_MAXIMUM_TIMEOUT_SECONDS = 600
@@ -281,10 +280,10 @@ def _positive_legacy_key(value: object, *, profile_id: RuntimeProfileId) -> int:
     return value
 
 
-def _policy_text(path: Path) -> str:
+def _policy_text(path: Path, *, protected: bool) -> str:
     """Read an explicit/dev file directly or the canonical protected file via sudo."""
     canonical = path == DEFAULT_RUNTIME_PROFILES_YAML and not os.environ.get(RUNTIME_PROFILES_YAML_ENV, "").strip()
-    if canonical:
+    if canonical and protected:
         content = _read_protected_file(str(path))
         if content is None:
             raise WorkshopRuntimeProfileError(f"Protected runtime policy {path} is missing or unreadable")
@@ -722,10 +721,13 @@ class WorkshopRuntimeProfileRegistry:
         """Load installed policy, failing closed when protected policy is absent."""
         policy_path = path or runtime_profiles_path()
         explicit = path is not None or bool(os.environ.get(RUNTIME_PROFILES_YAML_ENV, "").strip())
-        protected = bool(os.environ.get(INSTALL_DIR_ENV, "").strip())
+        protected = config.protected_install
         if not explicit and not protected:
             return cls.from_config(config)
-        registry = cls.from_yaml(_policy_text(policy_path), backend_registry=load_backend_registry())
+        registry = cls.from_yaml(
+            _policy_text(policy_path, protected=protected),
+            backend_registry=load_backend_registry(),
+        )
         if protected:
             service_uid = os.geteuid()
             try:

--- a/templates/.env
+++ b/templates/.env
@@ -1,3 +1,10 @@
+# ── Deployment mode ─────────────────────────────────────
+
+# Installer-managed startup authority: "protected" or "single_user".
+# Protected services set this in their service definition; make config writes
+# it here for single-user runs. Do not infer it from KAI_INSTALL_DIR.
+#KAI_DEPLOYMENT_MODE=single_user
+
 # ── Client adapters and initial Workshop identity ────────────────
 
 # Enabled client adapters: telegram,workshop; workshop; or telegram.

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -32,7 +32,7 @@ from kai.backend import (
     prepend_to_prompt,
     resolve_home_workspace,
 )
-from kai.config import VALID_BACKENDS, Config, UserConfig, WorkspaceConfig
+from kai.config import VALID_BACKENDS, Config, DeploymentMode, UserConfig, WorkspaceConfig
 
 # ── Test build_session_context ──────────────────────────────────────
 
@@ -1143,7 +1143,7 @@ class TestResolveHomeWorkspace:
             allowed_user_ids={1},
             default_backend="codex",
             user_configs=user_configs if user_configs is not None else {},
-            protected_install=protected_install,
+            deployment_mode=(DeploymentMode.PROTECTED if protected_install else DeploymentMode.SINGLE_USER),
         )
 
     def test_prefers_users_yaml(self, tmp_path):

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -243,7 +243,7 @@ def test_installed_registry_file_must_be_root_owned(tmp_path, monkeypatch):
     """Installed mode treats the registry as an admin-owned capability map."""
     registry = tmp_path / "backends.yaml"
     registry.write_text("version: 1\nbackends: {}\n")
-    monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
+    monkeypatch.setenv("KAI_DEPLOYMENT_MODE", "protected")
     monkeypatch.setattr("kai.backend_registry.DEFAULT_BACKENDS_YAML", registry)
     real_stat = Path.stat
 
@@ -265,7 +265,7 @@ def test_explicit_dev_registry_does_not_require_root_owner(tmp_path, monkeypatch
     registry.write_text("version: 1\nbackends: {}\n")
     registry.chmod(0o644)
     monkeypatch.setenv("KAI_BACKENDS_YAML", str(registry))
-    monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)
+    monkeypatch.setenv("KAI_DEPLOYMENT_MODE", "single_user")
 
     assert load_backend_registry() == {}
 
@@ -300,7 +300,7 @@ def test_registry_command_must_not_be_group_or_world_writable(tmp_path, monkeypa
 
 def test_default_missing_registry_uses_legacy_path_resolution(monkeypatch):
     monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
-    monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)
+    monkeypatch.setenv("KAI_DEPLOYMENT_MODE", "single_user")
     monkeypatch.delenv("CLAUDE_BIN", raising=False)
     monkeypatch.setattr("kai.backend_registry.DEFAULT_BACKENDS_YAML", Path("/does/not/exist"))
     monkeypatch.setattr("kai.backend_registry.shutil.which", lambda name: f"/fake/{name}")
@@ -310,7 +310,7 @@ def test_default_missing_registry_uses_legacy_path_resolution(monkeypatch):
 
 def test_installed_mode_missing_registry_fails(monkeypatch):
     monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
-    monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
+    monkeypatch.setenv("KAI_DEPLOYMENT_MODE", "protected")
     monkeypatch.setenv("CLAUDE_BIN", "/tmp/legacy-claude")
     monkeypatch.setattr("kai.backend_registry.DEFAULT_BACKENDS_YAML", Path("/does/not/exist"))
 
@@ -330,12 +330,25 @@ def test_pi_dev_resolution_uses_path_and_has_no_pi_bin_override(tmp_path, monkey
     real_pi = _exe(tmp_path / "pi")
     attacker_pi = _exe(tmp_path / "attacker-pi")
     monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
-    monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)
+    monkeypatch.setenv("KAI_DEPLOYMENT_MODE", "single_user")
     monkeypatch.setenv("PI_BIN", str(attacker_pi))
     monkeypatch.setenv("PATH", str(tmp_path))
 
     assert resolve_backend_command("pi") == str(real_pi)
     assert resolve_backend_command("pi", allow_bare_fallback=True) == "pi"
+
+
+def test_single_user_ignores_ambient_install_dir(monkeypatch, tmp_path):
+    """A stale protected layout variable cannot activate registry authority."""
+    monkeypatch.delenv("KAI_BACKENDS_YAML", raising=False)
+    monkeypatch.setenv("KAI_DEPLOYMENT_MODE", "single_user")
+    monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
+    claude = _exe(tmp_path / "local-claude")
+    monkeypatch.setenv("CLAUDE_BIN", str(claude))
+    monkeypatch.setattr("kai.backend_registry.DEFAULT_BACKENDS_YAML", Path("/does/not/exist"))
+
+    assert not backend_registry_is_authoritative()
+    assert resolve_backend_command("claude") == str(claude)
 
 
 def test_render_backend_registry_is_stable():

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -79,6 +79,7 @@ from kai.bot import (
 from kai.config import (
     PROVIDER_MODELS,
     Config,
+    DeploymentMode,
     ModelRole,
     UserConfig,
     get_default_model_for_backend,
@@ -4096,7 +4097,7 @@ class TestHandleSettings:
     async def test_show_settings_ignores_invalid_protected_model_override(self):
         """The display matches the model that protected execution will use."""
         update = _make_update(text="/settings")
-        config = _make_config(protected_install=True)
+        config = _make_config(deployment_mode=DeploymentMode.PROTECTED)
         pool = _make_mock_claude()
         pool.get_runtime_profile.return_value = profile_registry(12345).profile_for_legacy_runtime_key(12345)
         pool.get_backend_provider.return_value = ("codex", "openai")
@@ -5972,7 +5973,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update()
         config = _make_config(
-            protected_install=True,
+            deployment_mode=DeploymentMode.PROTECTED,
             user_configs={
                 1: UserConfig(
                     telegram_id=1,
@@ -6465,7 +6466,7 @@ class TestHandleReviewCommand:
         monkeypatch.setattr("kai.bot._REVIEW_TMP_DIR", tmp_path)
         update = _make_update(user_id=1)
         config = _make_config(
-            protected_install=True,
+            deployment_mode=DeploymentMode.PROTECTED,
             allowed_user_ids={1},
             user_configs={
                 1: UserConfig(

--- a/tests/test_bot_totp.py
+++ b/tests/test_bot_totp.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from kai.bot import (
+    _check_totp,
     _require_sensitive_authentication,
     handle_document,
     handle_message,
@@ -94,6 +95,18 @@ def _downstream_patches() -> dict:
 
 
 # ── Common sensitive-handler middleware ─────────────────────────────
+
+
+async def test_single_user_gate_never_probes_protected_totp_state():
+    update = _make_update()
+    ctx = _make_context()
+    ctx.bot_data["config"].protected_install = False
+
+    with patch(
+        "kai.bot.is_totp_configured",
+        side_effect=AssertionError("single-user mode probed protected TOTP state"),
+    ):
+        assert await _check_totp(update, ctx)
 
 
 async def test_sensitive_middleware_requires_authorization_before_totp():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,18 +14,96 @@ from kai.config import (
     MODEL_REGISTRY,
     ONESHOT_REASONER_BACKENDS,
     Config,
+    DeploymentMode,
     ModelRole,
     UserConfig,
     _check_model_registry_complete,
     _load_memory_project_configs,
+    _load_workspace_configs,
     _read_protected_file,
+    _resolve_deployment_mode,
     get_model_for,
     load_config,
     resolve_claude_user,
 )
 
+
+class TestDeploymentModeResolution:
+    """Pins the one startup-wide authority and mixed-host boundary."""
+
+    def test_recorded_single_user_never_reads_protected_state(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        monkeypatch.delenv("KAI_DEPLOYMENT_MODE", raising=False)
+        (tmp_path / ".env").write_text("KAI_DEPLOYMENT_MODE=single_user\n")
+        monkeypatch.setattr(
+            "kai.config._read_protected_file",
+            lambda path: pytest.fail(f"single-user startup probed protected file {path}"),
+        )
+        monkeypatch.setattr(
+            "kai.config._read_protected_yaml",
+            lambda name: pytest.fail(f"single-user startup probed protected YAML {name}"),
+        )
+
+        mode, protected_env = _resolve_deployment_mode()
+
+        assert mode is DeploymentMode.SINGLE_USER
+        assert protected_env is None
+        assert _load_memory_project_configs(mode) == {}
+        assert _load_workspace_configs(mode) == {}
+
+    def test_install_conf_migrates_existing_single_user_env(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        monkeypatch.delenv("KAI_DEPLOYMENT_MODE", raising=False)
+        (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=local\n")
+        (tmp_path / "install.conf").write_text('{"deployment_mode":"single_user"}\n')
+        monkeypatch.setattr(
+            "kai.config._read_protected_file",
+            lambda path: pytest.fail(f"single-user startup probed protected file {path}"),
+        )
+
+        mode, protected_env = _resolve_deployment_mode()
+
+        assert mode is DeploymentMode.SINGLE_USER
+        assert protected_env is None
+
+    def test_legacy_install_falls_back_to_protected_env_probe(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        monkeypatch.delenv("KAI_DEPLOYMENT_MODE", raising=False)
+        monkeypatch.setattr(
+            "kai.config._read_protected_file",
+            lambda path: "TOKEN=protected\n" if path == "/etc/kai/env" else None,
+        )
+
+        mode, protected_env = _resolve_deployment_mode()
+
+        assert mode is DeploymentMode.PROTECTED
+        assert protected_env == "TOKEN=protected\n"
+        assert "KAI_DEPLOYMENT_MODE" not in os.environ
+
+    def test_explicit_protected_mode_does_not_fall_back_to_local_env(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        monkeypatch.setenv("KAI_DEPLOYMENT_MODE", "protected")
+        (tmp_path / ".env").write_text("TELEGRAM_BOT_TOKEN=must-not-load\n")
+        monkeypatch.setattr("kai.config._read_protected_file", lambda _path: None)
+
+        with pytest.raises(SystemExit, match="requires readable /etc/kai/env"):
+            load_config()
+
+        assert os.environ.get("TELEGRAM_BOT_TOKEN") != "must-not-load"
+
+    def test_conflicting_local_records_fail_closed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("kai.config.PROJECT_ROOT", tmp_path)
+        monkeypatch.delenv("KAI_DEPLOYMENT_MODE", raising=False)
+        (tmp_path / ".env").write_text("KAI_DEPLOYMENT_MODE=single_user\n")
+        (tmp_path / "install.conf").write_text('{"deployment_mode":"protected"}\n')
+
+        with pytest.raises(SystemExit, match="Deployment mode disagrees"):
+            _resolve_deployment_mode()
+
+
 # All env vars that load_config reads
 _CONFIG_ENV_VARS = [
+    "KAI_DEPLOYMENT_MODE",
     "KAI_ENABLED_ADAPTERS",
     "KAI_WORKSHOP_BOOTSTRAP",
     "TELEGRAM_BOT_TOKEN",

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -21,6 +21,7 @@ import pytest
 import yaml
 
 import kai.install
+from kai.config import DeploymentMode
 from kai.install import (
     _LAUNCHD_LABEL,
     ServiceStartError,
@@ -1184,6 +1185,11 @@ class TestGenerateLaunchdPlist:
         result = _generate_launchd_plist("/opt/kai", "/var/lib/kai", "kai")
         assert "KAI_DATA_DIR" in result
 
+    def test_sets_protected_deployment_mode(self):
+        result = _generate_launchd_plist("/opt/kai", "/var/lib/kai", "kai")
+        assert "<key>KAI_DEPLOYMENT_MODE</key>" in result
+        assert "<string>protected</string>" in result
+
     def test_valid_xml_structure(self):
         result = _generate_launchd_plist("/opt/kai", "/var/lib/kai", "kai")
         assert result.startswith("<?xml")
@@ -1230,6 +1236,10 @@ class TestGenerateSystemdUnit:
     def test_contains_data_dir_env(self):
         result = _generate_systemd_unit("/opt/kai", "/var/lib/kai", "kai")
         assert "KAI_DATA_DIR=/var/lib/kai" in result
+
+    def test_sets_protected_deployment_mode(self):
+        result = _generate_systemd_unit("/opt/kai", "/var/lib/kai", "kai")
+        assert "Environment=KAI_DEPLOYMENT_MODE=protected" in result
 
     def test_network_dependency(self):
         result = _generate_systemd_unit("/opt/kai", "/var/lib/kai", "kai")
@@ -11713,7 +11723,7 @@ class TestResolveUsersYamlPath:
     the XDG single-user path. The spec carves three rules:
 
       1. KAI_USERS_YAML wins outright when set (test / development override).
-      2. Otherwise, protected_env_was_loaded -> /etc/kai/users.yaml.
+      2. Otherwise, protected mode -> /etc/kai/users.yaml.
       3. Otherwise -> ${XDG_CONFIG_HOME:-$HOME/.config}/kai/users.yaml.
 
     `KAI_INSTALL_DIR` and `KAI_DATA_DIR` deliberately do NOT participate
@@ -11725,7 +11735,7 @@ class TestResolveUsersYamlPath:
         from kai.config import _resolve_users_yaml_path
 
         monkeypatch.delenv("KAI_USERS_YAML", raising=False)
-        assert _resolve_users_yaml_path(True) == Path("/etc/kai/users.yaml")
+        assert _resolve_users_yaml_path(DeploymentMode.PROTECTED) == Path("/etc/kai/users.yaml")
 
     def test_no_protected_env_routes_xdg(self, monkeypatch, tmp_path):
         from kai.config import _resolve_users_yaml_path
@@ -11733,7 +11743,7 @@ class TestResolveUsersYamlPath:
         monkeypatch.delenv("KAI_USERS_YAML", raising=False)
         monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
         monkeypatch.setenv("HOME", str(tmp_path))
-        assert _resolve_users_yaml_path(False) == tmp_path / ".config" / "kai" / "users.yaml"
+        assert _resolve_users_yaml_path(DeploymentMode.SINGLE_USER) == tmp_path / ".config" / "kai" / "users.yaml"
 
     def test_xdg_config_home_overrides_home(self, monkeypatch, tmp_path):
         from kai.config import _resolve_users_yaml_path
@@ -11741,15 +11751,15 @@ class TestResolveUsersYamlPath:
         monkeypatch.delenv("KAI_USERS_YAML", raising=False)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
         monkeypatch.setenv("HOME", str(tmp_path / "should-not-be-used"))
-        assert _resolve_users_yaml_path(False) == tmp_path / "xdg" / "kai" / "users.yaml"
+        assert _resolve_users_yaml_path(DeploymentMode.SINGLE_USER) == tmp_path / "xdg" / "kai" / "users.yaml"
 
     def test_explicit_override_wins_in_both_modes(self, monkeypatch, tmp_path):
         from kai.config import _resolve_users_yaml_path
 
         override = tmp_path / "explicit-users.yaml"
         monkeypatch.setenv("KAI_USERS_YAML", str(override))
-        assert _resolve_users_yaml_path(True) == override
-        assert _resolve_users_yaml_path(False) == override
+        assert _resolve_users_yaml_path(DeploymentMode.PROTECTED) == override
+        assert _resolve_users_yaml_path(DeploymentMode.SINGLE_USER) == override
 
     def test_kai_install_dir_does_not_route_protected(self, monkeypatch, tmp_path):
         """Pins the spec's blast-radius rule: a single-user host with
@@ -11763,9 +11773,7 @@ class TestResolveUsersYamlPath:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
         monkeypatch.setenv("KAI_DATA_DIR", "/var/lib/kai")
-        # protected_env_was_loaded is False (no /etc/kai/env content);
-        # the env vars above must NOT override that decision.
-        assert _resolve_users_yaml_path(False) == tmp_path / ".config" / "kai" / "users.yaml"
+        assert _resolve_users_yaml_path(DeploymentMode.SINGLE_USER) == tmp_path / ".config" / "kai" / "users.yaml"
 
 
 # ── Single-user wizard branch ─────────────────────────────────────────
@@ -11874,14 +11882,8 @@ class TestCmdConfigSingleUserMode:
         # business consuming.
         assert "users_yaml_staging_path" not in conf
 
-    def test_refuses_single_user_when_protected_env_is_readable(self, tmp_path, monkeypatch):
-        """Migration guard: a host with a previous protected install
-        leaves /etc/kai/env readable through the sudoers rule. The
-        runtime's resolver would still see that as authoritative and
-        boot from the protected artifacts, silently ignoring the
-        single-user files the wizard is about to write. The wizard
-        refuses up front with an actionable removal recipe.
-        """
+    def test_single_user_records_authority_despite_readable_protected_env(self, tmp_path, monkeypatch):
+        """Leftover protected state does not prevent explicit single-user mode."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("kai.install.INSTALL_CONF", tmp_path / "install.conf")
         monkeypatch.setattr("kai.install.PROJECT_ROOT", tmp_path)
@@ -11893,13 +11895,13 @@ class TestCmdConfigSingleUserMode:
             lambda path: "TELEGRAM_BOT_TOKEN=leftover\n" if path == "/etc/kai/env" else None,
         )
 
-        # Only the deployment_mode prompt is reached before the refusal
-        # fires; the rest of the chain is unused but kept here so the
-        # test does not depend on prompt-count specifics.
-        inputs = iter(["single_user", "hybrid"] + ["x"] * 50)
+        inputs = iter(self._single_user_inputs())
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
-        with pytest.raises(SystemExit, match="single_user mode was selected"):
-            _cmd_config()
+        _cmd_config()
+
+        conf = json.loads((tmp_path / "install.conf").read_text())
+        assert conf["deployment_mode"] == "single_user"
+        assert 'KAI_DEPLOYMENT_MODE="single_user"' in (tmp_path / ".env").read_text()
 
     def test_protected_mode_unaffected_by_protected_env_check(self, tmp_path, monkeypatch):
         """Protected mode does not consult the single-user refusal

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -617,7 +617,7 @@ class TestStartCrashExit:
     """Unexpected runtime crashes must not look like clean process exits."""
 
     @staticmethod
-    def _patch_minimal_config(monkeypatch):
+    def _patch_minimal_config(monkeypatch, *, protected_install: bool = True):
         monkeypatch.setattr(
             "kai.main.load_config",
             lambda: SimpleNamespace(
@@ -626,6 +626,7 @@ class TestStartCrashExit:
                 telegram_enabled=False,
                 telegram_webhook_url=None,
                 session_db_path=":memory:",
+                protected_install=protected_install,
             ),
         )
 
@@ -689,6 +690,26 @@ class TestStartCrashExit:
         monkeypatch.setattr(
             "kai.main.services.load_services_from_string",
             lambda text: calls.append(("protected", text)) or {},
+        )
+        monkeypatch.setattr(
+            "kai.main.services.load_services",
+            lambda path: calls.append(("local", str(path))) or {},
+        )
+        self._patch_asyncio_crash(monkeypatch)
+
+        with pytest.raises(SystemExit):
+            _start()
+
+        assert calls == [("local", str(Path(__file__).resolve().parents[1] / "services.yaml"))]
+
+    def test_single_user_services_never_probe_protected_path(self, monkeypatch):
+        from kai.main import _start
+
+        calls: list[tuple[str, str]] = []
+        self._patch_minimal_config(monkeypatch, protected_install=False)
+        monkeypatch.setattr(
+            "kai.main._read_protected_file",
+            lambda path: pytest.fail(f"single-user startup probed protected file {path}"),
         )
         monkeypatch.setattr(
             "kai.main.services.load_services",

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from kai.backend import AgentResponse, StreamEvent
-from kai.config import Config, ModelRole, UserConfig, WorkspaceConfig, get_model_for
+from kai.config import Config, DeploymentMode, ModelRole, UserConfig, WorkspaceConfig, get_model_for
 from kai.goose import GooseBackend
 from kai.internal_api_auth import InternalAPIScope
 from kai.pool import SubprocessPool
@@ -89,7 +89,7 @@ class TestInstanceCreation:
             match="Protected runtime requires canonical internal API execution contexts",
         ):
             SubprocessPool(
-                config=_make_config(protected_install=True),
+                config=_make_config(deployment_mode=DeploymentMode.PROTECTED),
                 services_info=[],
             )
 
@@ -654,7 +654,7 @@ class TestPerUserBackendRouting:
         for chat_id in users:
             (tmp_path / "home" / str(chat_id)).mkdir(parents=True)
         config = _make_config(
-            protected_install=True,
+            deployment_mode=DeploymentMode.PROTECTED,
             allowed_user_ids=set(users),
             user_configs=users,
         )

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from kai.backend import AgentResponse, StreamEvent
-from kai.config import Config, UserConfig
+from kai.config import Config, DeploymentMode, UserConfig
 from kai.internal_api_auth import InternalAPIScope
 from kai.workshop.domain import RuntimeProfileId
 from kai.workshop.internal_api_contexts import (
@@ -350,7 +350,7 @@ def test_unavailable_explicit_profile_home_fails_only_that_runtime(tmp_path, mon
         default_backend="codex",
         default_provider="openai",
         default_model="gpt-5.6-sol",
-        protected_install=True,
+        deployment_mode=DeploymentMode.PROTECTED,
         session_db_path=tmp_path / "kai.db",
         user_configs={},
     )
@@ -393,7 +393,7 @@ def test_profile_only_canonical_home_error_has_actionable_remediation(tmp_path, 
         default_backend="codex",
         default_provider="openai",
         default_model="gpt-5.6-sol",
-        protected_install=True,
+        deployment_mode=DeploymentMode.PROTECTED,
         user_configs={},
     )
     runtime_profile_id = RuntimeProfileId("rtp_58585858585858585858585858585858")

--- a/tests/test_workshop_runtime_profiles.py
+++ b/tests/test_workshop_runtime_profiles.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 
 from kai.backend_registry import BackendRegistryEntry
-from kai.config import Config, UserConfig
+from kai.config import Config, DeploymentMode, UserConfig
 from kai.workshop.domain import RuntimeProfileId
 from kai.workshop.runtime_profiles import (
     ProtectedRuntimeProfile,
@@ -18,13 +18,14 @@ from kai.workshop.runtime_profiles import (
 )
 
 
-def _config() -> Config:
+def _config(*, protected: bool = False) -> Config:
     return Config(
         telegram_bot_token="test",
         allowed_user_ids={101, 202},
         default_backend="codex",
         default_provider="openai",
         default_model="gpt-5.6-sol",
+        deployment_mode=(DeploymentMode.PROTECTED if protected else DeploymentMode.SINGLE_USER),
         user_configs={
             101: UserConfig(
                 telegram_id=101,
@@ -1015,7 +1016,6 @@ runtime_profiles:
 
 
 def test_uninstalled_development_without_policy_uses_compatibility_projection(monkeypatch):
-    monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)
     monkeypatch.delenv("KAI_RUNTIME_PROFILES_YAML", raising=False)
     monkeypatch.setattr(
         "kai.workshop.runtime_profiles.runtime_profiles_path",
@@ -1028,7 +1028,6 @@ def test_uninstalled_development_without_policy_uses_compatibility_projection(mo
 
 
 def test_uninstalled_development_ignores_existing_canonical_policy(monkeypatch):
-    monkeypatch.delenv("KAI_INSTALL_DIR", raising=False)
     monkeypatch.delenv("KAI_RUNTIME_PROFILES_YAML", raising=False)
     monkeypatch.setattr(
         "kai.workshop.runtime_profiles._policy_text",
@@ -1041,12 +1040,11 @@ def test_uninstalled_development_ignores_existing_canonical_policy(monkeypatch):
 
 
 def test_protected_startup_fails_closed_when_policy_is_unreadable(monkeypatch):
-    monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
     monkeypatch.delenv("KAI_RUNTIME_PROFILES_YAML", raising=False)
     monkeypatch.setattr("kai.workshop.runtime_profiles._read_protected_file", lambda _path: None)
 
     with pytest.raises(WorkshopRuntimeProfileError, match="missing or unreadable"):
-        WorkshopRuntimeProfileRegistry.load(_config())
+        WorkshopRuntimeProfileRegistry.load(_config(protected=True))
 
 
 def test_protected_startup_validates_runtime_profile_execution_account(tmp_path, monkeypatch):
@@ -1065,7 +1063,6 @@ runtime_profiles:
     allowed_workspaces: []
 """
     )
-    monkeypatch.setenv("KAI_INSTALL_DIR", "/opt/kai")
     monkeypatch.setattr(
         "kai.workshop.runtime_profiles.load_backend_registry",
         lambda: {"codex": {}},
@@ -1076,4 +1073,4 @@ runtime_profiles:
     )
 
     with pytest.raises(WorkshopRuntimeProfileError, match="maps to service account"):
-        WorkshopRuntimeProfileRegistry.load(_config(), path=policy)
+        WorkshopRuntimeProfileRegistry.load(_config(protected=True), path=policy)


### PR DESCRIPTION
Closes #1439

## Summary
- resolve protected versus single-user mode once into a typed `Config.deployment_mode` authority
- record explicit mode for single-user env files and protected service definitions while preserving the legacy `/etc/kai/env` fallback
- route users, workspace, memory-project, runtime-profile, service, backend-registry, and TOTP decisions through the resolved authority
- remove the single-user wizard refusal caused by the old per-file probing behavior
- cover mixed hosts, protected fail-closed behavior, legacy installs, service definitions, and stale path variables

## Validation
- `make test` — 6539 passed
- `make check`
- `make typecheck`
- focused deployment-mode regression tests — 8 passed