### PR TITLE
Add canonical standing-agent observation inbox

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -69,6 +69,7 @@ from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
 from kai.workshop.runtime_state import WorkshopRuntimeStateWriter
 from kai.workshop.scheduler import WorkshopCanonicalScheduler
 from kai.workshop.settings_workspaces import WorkshopSettingsWorkspaceService
+from kai.workshop.standing_observation import WorkshopStandingObservationService
 from kai.workshop.standing_participation import WorkshopStandingParticipationService
 from kai.workshop.storage_namespaces import WorkshopPrincipalStorageRegistry
 from kai.workshop.store import WorkshopEventStore
@@ -219,6 +220,7 @@ class KaiCoreServices:
     collaboration_publications: WorkshopCollaborationPublicationService
     collaboration_policy: WorkshopCollaborationPolicyService
     standing_participation: WorkshopStandingParticipationService
+    standing_observation: WorkshopStandingObservationService
     delivery_policy: WorkshopDeliveryBindingPolicy
 
 
@@ -424,6 +426,10 @@ class KaiApplicationHost:
                 client_store,
                 private_execution.collaboration_authority.host_policy,
             )
+            standing_observation = WorkshopStandingObservationService(
+                client_store,
+                private_execution.collaboration_authority.host_policy,
+            )
             scheduler = await WorkshopCanonicalScheduler.open_and_start(
                 Path(self._config.session_db_path),
                 private_execution,
@@ -543,6 +549,7 @@ class KaiApplicationHost:
                 collaboration_publications=collaboration_publications,
                 collaboration_policy=collaboration_policy,
                 standing_participation=standing_participation,
+                standing_observation=standing_observation,
                 delivery_policy=delivery_policy,
             )
             self._state = KaiApplicationState.READY

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -97,6 +97,7 @@ from kai.workshop.diagnostics import (
     workshop_memory_authority_status,
     workshop_operational_state_status,
     workshop_runtime_session_status,
+    workshop_standing_observation_status,
     workshop_standing_participation_status,
     workshop_transcript_authority_status,
     workshop_transition_tooling_status,
@@ -9541,6 +9542,7 @@ def _cmd_status() -> None:
     print(workshop_agent_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_collaboration_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_standing_participation_status(Path(data_dir) / "kai.db"))
+    print(workshop_standing_observation_status(Path(data_dir) / "kai.db"))
     print(workshop_human_handle_status(Path(data_dir) / "kai.db"))
     print(workshop_human_avatar_status(Path(data_dir) / "kai.db", Path(data_dir) / "files" / "avatars"))
     print(workshop_human_notification_status(Path(data_dir) / "kai.db"))

--- a/src/kai/workshop/collaboration_authority.py
+++ b/src/kai/workshop/collaboration_authority.py
@@ -114,6 +114,8 @@ class StandingParticipationHostPolicy:
 
     enabled: bool = False
     max_agents_per_channel: int = 2
+    coalescing_grace_seconds: int = 2
+    max_messages_per_observe_run: int = 40
     quiet_expiry_seconds: int = 259_200
     max_pending_messages_per_scope: int = 500
     max_pending_age_seconds: int = 86_400
@@ -126,6 +128,7 @@ class StandingParticipationHostPolicy:
             raise TypeError("standing participation enabled must be a boolean")
         positive = (
             self.max_agents_per_channel,
+            self.max_messages_per_observe_run,
             self.max_pending_messages_per_scope,
             self.max_pending_age_seconds,
             self.max_observe_runs_per_hour,
@@ -134,6 +137,12 @@ class StandingParticipationHostPolicy:
         )
         if any(not isinstance(value, int) or isinstance(value, bool) or value < 1 for value in positive):
             raise ValueError("standing participation host limits must be positive integers")
+        if (
+            not isinstance(self.coalescing_grace_seconds, int)
+            or isinstance(self.coalescing_grace_seconds, bool)
+            or self.coalescing_grace_seconds < 0
+        ):
+            raise ValueError("standing participation coalescing grace must be a non-negative integer")
         if (
             not isinstance(self.quiet_expiry_seconds, int)
             or isinstance(self.quiet_expiry_seconds, bool)

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -148,6 +148,11 @@ _STANDING_PARTICIPATION_TABLES = {
     "channels",
     "event_log",
 }
+_STANDING_OBSERVATION_TABLES = _STANDING_PARTICIPATION_TABLES | {
+    "channel_agent_observation_states",
+    "messages",
+    "standing_participation_host_policy",
+}
 _AGENT_HANDLE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
 _TELEGRAM_SUBJECT_PATTERN = re.compile(r"^-?[0-9]+$")
 _SYNTHETIC_ASSISTANT_PATTERN = re.compile(
@@ -959,6 +964,12 @@ def workshop_standing_participation_status(
                 "AND e.event_type IN ('channel.agent_standing_started', 'channel.agent_standing_ended') "
                 "AND json_extract(e.payload_json, '$.agent_id') = s.agent_id)",
             )
+            if host_enabled is None and "standing_participation_host_policy" in tables:
+                host_row = connection.execute(
+                    "SELECT enabled FROM standing_participation_host_policy WHERE singleton = 1"
+                ).fetchone()
+                if host_row is not None:
+                    host_enabled = bool(host_row[0])
         finally:
             connection.close()
     except (OSError, sqlite3.Error, ValueError):
@@ -971,6 +982,82 @@ def workshop_standing_participation_status(
         f"{prefix} {state}; host={host_state}, channel policies={policy_count} (enabled={enabled_policies}), "
         f"subscriptions={subscription_count} (active={active}, paused overflow={paused}, ended={ended}); "
         f"integrity gaps={integrity_gaps}, replay gaps={replay_gaps}; authority=canonical"
+    )
+
+
+def workshop_standing_observation_status(db_path: Path) -> str:
+    """Report bounded standing-agent observation cursors and continuity gaps."""
+    prefix = "Workshop standing observation inbox:"
+    if not db_path.is_file():
+        return f"{prefix} pending; observation schema unavailable"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            connection.execute("PRAGMA query_only=ON")
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            if not tables >= _STANDING_OBSERVATION_TABLES:
+                return f"{prefix} pending; observation schema unavailable"
+            host = connection.execute(
+                "SELECT enabled, coalescing_grace_seconds, max_messages_per_observe_run, "
+                "max_pending_messages_per_scope, max_pending_age_seconds "
+                "FROM standing_participation_host_policy WHERE singleton = 1"
+            ).fetchone()
+            counts = connection.execute(
+                "SELECT COUNT(*), SUM(CASE WHEN lifecycle_state = 'idle' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN lifecycle_state = 'pending' THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN lifecycle_state = 'paused_overflow' THEN 1 ELSE 0 END), "
+                "SUM(pending_message_count), "
+                "SUM(CASE WHEN pending_message_count > 0 AND latest_human_anchor_message_id IS NULL "
+                "THEN 1 ELSE 0 END) FROM channel_agent_observation_states"
+            ).fetchone()
+            scopes, idle, pending, paused, pending_messages, unanchored = tuple(
+                int(value or 0) for value in (counts or (0, 0, 0, 0, 0, 0))
+            )
+            integrity_gaps = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM channel_agent_observation_states o "
+                "LEFT JOIN channel_agent_standings s ON s.channel_id = o.channel_id AND s.agent_id = o.agent_id "
+                "LEFT JOIN channels c ON c.id = o.channel_id "
+                "LEFT JOIN agents a ON a.id = o.agent_id "
+                "LEFT JOIN messages anchor ON anchor.id = o.latest_human_anchor_message_id "
+                "LEFT JOIN principals anchor_author ON anchor_author.id = anchor.author_principal_id "
+                "WHERE s.channel_id IS NULL OR c.id IS NULL OR a.id IS NULL "
+                "OR o.projection_version != 1 OR o.last_event_position != o.considered_through_event_position "
+                "OR o.delivered_through_event_position > o.pending_through_event_position "
+                "OR o.pending_through_event_position > o.considered_through_event_position "
+                "OR (o.pending_message_count = 0 AND o.oldest_pending_event_position IS NOT NULL) "
+                "OR (o.pending_message_count > 0 AND o.oldest_pending_event_position IS NULL) "
+                "OR (o.latest_human_anchor_message_id IS NULL) != "
+                "(o.latest_human_anchor_event_position IS NULL) "
+                "OR (o.latest_human_anchor_message_id IS NOT NULL AND "
+                "(anchor.id IS NULL OR anchor.channel_id != o.channel_id OR anchor_author.kind != 'human')) "
+                "OR (o.lifecycle_state = 'paused_overflow') != (o.overflowed_at IS NOT NULL)",
+            )
+            replay_gaps = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM channel_agent_observation_states o LEFT JOIN event_log e "
+                "ON e.position = o.last_event_position AND e.event_type = 'message.created' "
+                "WHERE e.position IS NULL",
+            )
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error, TypeError, ValueError):
+        return f"{prefix} INCOMPLETE; diagnostics unavailable"
+    host_state = "unknown" if host is None else ("enabled" if bool(host[0]) else "disabled")
+    limits = (
+        "limits=unknown"
+        if host is None
+        else f"grace={int(host[1])}s, batch={int(host[2])}, pending={int(host[3])}, age={int(host[4])}s"
+    )
+    state = "active" if integrity_gaps == 0 and replay_gaps == 0 else "INCOMPLETE"
+    return (
+        f"{prefix} {state}; host={host_state}, scopes={scopes} "
+        f"(idle={idle}, pending={pending}, paused overflow={paused}), "
+        f"pending messages={pending_messages}, unanchored={unanchored}; {limits}; "
+        f"integrity gaps={integrity_gaps}, replay gaps={replay_gaps}; authority=canonical-message"
     )
 
 

--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -114,6 +114,7 @@ class WorkshopPrivateTextExecutionService:
             store,
             coordinator.collaboration_authority.host_policy,
         )
+        await standing_participation.synchronize_host_policy()
         service = cls(
             store,
             coordinator,

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -1646,7 +1646,7 @@ class CanonicalConversationProjection:
 
     name = "canonical_conversations"
     # Agent ownership and runtime sponsorship project from explicit authority events.
-    version = 31
+    version = 32
 
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
@@ -1675,6 +1675,7 @@ class CanonicalConversationProjection:
                 "run_attempt_id = NULL, collaboration_grant_id = NULL, collaboration_operation = NULL"
             )
         for table in (
+            "channel_agent_observation_states",
             "channel_agent_standings",
             "channel_standing_participation_policies",
             "deliveries",
@@ -3263,6 +3264,11 @@ class CanonicalConversationProjection:
                                 occurred_at,
                             ),
                         )
+            from kai.workshop.standing_observation import (
+                apply_canonical_message_to_standing_observations,
+            )
+
+            await apply_canonical_message_to_standing_observations(connection, event)
         elif envelope.event_type == WorkshopEventType.HUMAN_NOTIFICATION_CREATED:
             if not isinstance(envelope.aggregate_id, HumanNotificationId):
                 raise ValueError("Workshop human notification requires a typed notification aggregate")

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 72
+WORKSHOP_SCHEMA_VERSION = 73
 
 
 @dataclass(frozen=True, slots=True)
@@ -3180,6 +3180,89 @@ _STANDING_PARTICIPATION_AUTHORITY_SCHEMA = SchemaMigration(
     ),
 )
 
+_STANDING_OBSERVATION_INBOX_SCHEMA = SchemaMigration(
+    version=73,
+    name="standing_observation_inbox",
+    statements=(
+        """
+        CREATE TABLE standing_participation_host_policy (
+            singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+            host_policy_version INTEGER NOT NULL CHECK (host_policy_version > 0),
+            enabled INTEGER NOT NULL CHECK (enabled IN (0, 1)),
+            coalescing_grace_seconds INTEGER NOT NULL CHECK (coalescing_grace_seconds >= 0),
+            max_messages_per_observe_run INTEGER NOT NULL CHECK (max_messages_per_observe_run > 0),
+            max_pending_messages_per_scope INTEGER NOT NULL CHECK (max_pending_messages_per_scope > 0),
+            max_pending_age_seconds INTEGER NOT NULL CHECK (max_pending_age_seconds > 0),
+            updated_at TEXT NOT NULL
+        )
+        """,
+        """
+        CREATE TABLE channel_agent_observation_states (
+            channel_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            scope_kind TEXT NOT NULL CHECK (scope_kind IN ('channel', 'thread')),
+            scope_id TEXT NOT NULL,
+            delivered_through_event_position INTEGER NOT NULL
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            pending_through_event_position INTEGER NOT NULL
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            considered_through_event_position INTEGER NOT NULL
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            oldest_pending_event_position INTEGER
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            pending_message_count INTEGER NOT NULL CHECK (pending_message_count >= 0),
+            latest_human_anchor_message_id TEXT REFERENCES messages(id) ON DELETE RESTRICT,
+            latest_human_anchor_event_position INTEGER
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            not_before TEXT,
+            lifecycle_state TEXT NOT NULL CHECK (
+                lifecycle_state IN ('idle', 'pending', 'paused_overflow')
+            ),
+            overflowed_at TEXT,
+            overflow_reason TEXT CHECK (
+                overflow_reason IS NULL OR overflow_reason IN ('pending_count', 'pending_age', 'retention')
+            ),
+            overflow_from_event_position INTEGER
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            overflow_through_event_position INTEGER
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            projection_version INTEGER NOT NULL CHECK (projection_version = 1),
+            state_version INTEGER NOT NULL CHECK (state_version > 0),
+            last_event_position INTEGER NOT NULL
+                REFERENCES event_log(position) ON DELETE RESTRICT,
+            PRIMARY KEY (channel_id, agent_id, scope_id),
+            FOREIGN KEY (channel_id, agent_id)
+                REFERENCES channel_agent_standings(channel_id, agent_id) ON DELETE CASCADE,
+            CHECK (delivered_through_event_position <= pending_through_event_position),
+            CHECK (pending_through_event_position <= considered_through_event_position),
+            CHECK (
+                (pending_message_count = 0 AND oldest_pending_event_position IS NULL AND not_before IS NULL)
+                OR
+                (pending_message_count > 0 AND oldest_pending_event_position IS NOT NULL AND not_before IS NOT NULL)
+            ),
+            CHECK (
+                (latest_human_anchor_message_id IS NULL AND latest_human_anchor_event_position IS NULL)
+                OR
+                (latest_human_anchor_message_id IS NOT NULL AND latest_human_anchor_event_position IS NOT NULL)
+            ),
+            CHECK (
+                (lifecycle_state = 'paused_overflow' AND overflowed_at IS NOT NULL
+                    AND overflow_reason IS NOT NULL AND overflow_from_event_position IS NOT NULL
+                    AND overflow_through_event_position IS NOT NULL)
+                OR
+                (lifecycle_state != 'paused_overflow' AND overflowed_at IS NULL
+                    AND overflow_reason IS NULL AND overflow_from_event_position IS NULL
+                    AND overflow_through_event_position IS NULL)
+            )
+        )
+        """,
+        "CREATE INDEX channel_agent_observation_ready_idx ON "
+        "channel_agent_observation_states (lifecycle_state, not_before, oldest_pending_event_position)",
+        "CREATE INDEX channel_agent_observation_channel_idx ON "
+        "channel_agent_observation_states (channel_id, agent_id, considered_through_event_position)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -3253,6 +3336,7 @@ _MIGRATIONS = (
     _AGENT_AUTHORED_PUBLICATION_SCHEMA,
     _AGENT_COLLABORATION_OWNER_POLICY_SCHEMA,
     _STANDING_PARTICIPATION_AUTHORITY_SCHEMA,
+    _STANDING_OBSERVATION_INBOX_SCHEMA,
 )
 
 

--- a/src/kai/workshop/standing_observation.py
+++ b/src/kai/workshop/standing_observation.py
@@ -1,0 +1,515 @@
+"""Canonical, adapter-neutral observation inbox for standing Workshop agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+
+from kai.workshop.collaboration_authority import CollaborationHostPolicy, StandingParticipationHostPolicy
+from kai.workshop.domain import AgentId, ChannelId, MessageId, WorkshopEventType
+from kai.workshop.store import StoredEvent, WorkshopEventStore
+
+OBSERVATION_PROJECTION_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class StandingObservationState:
+    channel_id: ChannelId
+    agent_id: AgentId
+    scope_kind: str
+    scope_id: str
+    delivered_through_event_position: int
+    pending_through_event_position: int
+    considered_through_event_position: int
+    oldest_pending_event_position: int | None
+    pending_message_count: int
+    latest_human_anchor_message_id: MessageId | None
+    latest_human_anchor_event_position: int | None
+    not_before: datetime | None
+    lifecycle_state: str
+    overflowed_at: datetime | None
+    overflow_reason: str | None
+    overflow_from_event_position: int | None
+    overflow_through_event_position: int | None
+    state_version: int
+    last_event_position: int
+
+
+@dataclass(frozen=True, slots=True)
+class StandingObservationBatch:
+    channel_id: ChannelId
+    agent_id: AgentId
+    scope_id: str
+    from_event_position: int
+    through_event_position: int
+    message_ids: tuple[MessageId, ...]
+
+
+def _parse_timestamp(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("Standing observation timestamp is malformed")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("Standing observation timestamp must be timezone-aware")
+    return parsed.astimezone(UTC)
+
+
+async def _table_exists(connection: aiosqlite.Connection, table: str) -> bool:
+    async with connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ) as cursor:
+        return await cursor.fetchone() is not None
+
+
+async def synchronize_standing_observation_host_policy_in_transaction(
+    connection: aiosqlite.Connection,
+    host_policy: CollaborationHostPolicy,
+    *,
+    occurred_at: datetime,
+) -> None:
+    """Publish the process-owned observation limits for universal projection use."""
+    if not connection.in_transaction:
+        raise RuntimeError("Standing observation host-policy synchronization requires a transaction")
+    policy = host_policy.standing_participation
+    await connection.execute(
+        "INSERT INTO standing_participation_host_policy "
+        "(singleton, host_policy_version, enabled, coalescing_grace_seconds, "
+        "max_messages_per_observe_run, max_pending_messages_per_scope, "
+        "max_pending_age_seconds, updated_at) VALUES (1, ?, ?, ?, ?, ?, ?, ?) "
+        "ON CONFLICT(singleton) DO UPDATE SET host_policy_version = excluded.host_policy_version, "
+        "enabled = excluded.enabled, coalescing_grace_seconds = excluded.coalescing_grace_seconds, "
+        "max_messages_per_observe_run = excluded.max_messages_per_observe_run, "
+        "max_pending_messages_per_scope = excluded.max_pending_messages_per_scope, "
+        "max_pending_age_seconds = excluded.max_pending_age_seconds, updated_at = excluded.updated_at",
+        (
+            host_policy.version,
+            int(policy.enabled),
+            policy.coalescing_grace_seconds,
+            policy.max_messages_per_observe_run,
+            policy.max_pending_messages_per_scope,
+            policy.max_pending_age_seconds,
+            occurred_at.astimezone(UTC).isoformat(),
+        ),
+    )
+
+
+async def _current_host_policy(
+    connection: aiosqlite.Connection,
+) -> tuple[int, StandingParticipationHostPolicy] | None:
+    if not await _table_exists(connection, "standing_participation_host_policy"):
+        return None
+    async with connection.execute(
+        "SELECT host_policy_version, enabled, coalescing_grace_seconds, "
+        "max_messages_per_observe_run, max_pending_messages_per_scope, max_pending_age_seconds "
+        "FROM standing_participation_host_policy WHERE singleton = 1"
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row is None:
+        return None
+    return (
+        int(row[0]),
+        StandingParticipationHostPolicy(
+            enabled=bool(row[1]),
+            coalescing_grace_seconds=int(row[2]),
+            max_messages_per_observe_run=int(row[3]),
+            max_pending_messages_per_scope=int(row[4]),
+            max_pending_age_seconds=int(row[5]),
+        ),
+    )
+
+
+async def apply_canonical_message_to_standing_observations(
+    connection: aiosqlite.Connection,
+    event: StoredEvent,
+) -> None:
+    """Advance every eligible standing inbox once from one canonical message."""
+    if event.envelope.event_type != WorkshopEventType.MESSAGE_CREATED:
+        return
+    if not await _table_exists(connection, "channel_agent_observation_states"):
+        return
+    configured = await _current_host_policy(connection)
+    if configured is None or not configured[1].enabled:
+        return
+    _host_version, policy = configured
+    message_id = MessageId(str(event.envelope.aggregate_id))
+    async with connection.execute(
+        "SELECT m.channel_id, m.author_principal_id, m.thread_root_id, c.kind, c.archived_at, "
+        "p.kind, a.id FROM messages m JOIN channels c ON c.id = m.channel_id "
+        "JOIN principals p ON p.id = m.author_principal_id "
+        "LEFT JOIN agents a ON a.principal_id = p.id WHERE m.id = ?",
+        (message_id,),
+    ) as cursor:
+        message = await cursor.fetchone()
+    if message is None or str(message[3]) != "group" or message[4] is not None:
+        return
+    channel_id = ChannelId(str(message[0]))
+    author_kind = str(message[5])
+    author_agent_id = AgentId(str(message[6])) if message[6] is not None else None
+    thread_root = str(message[2]) if message[2] is not None else None
+    scope_kind = "thread" if thread_root is not None else "channel"
+    scope_id = thread_root or str(channel_id)
+    occurred_at = event.envelope.occurred_at.astimezone(UTC)
+    async with connection.execute(
+        "SELECT s.agent_id, s.started_event_position, s.started_at, s.started_by_message_id, "
+        "starter.created_event_position, starter.thread_root_id FROM channel_agent_standings s "
+        "JOIN messages starter ON starter.id = s.started_by_message_id "
+        "WHERE s.channel_id = ? AND s.lifecycle_state = 'active' AND s.started_event_position < ? "
+        "ORDER BY s.started_event_position, s.agent_id",
+        (channel_id, event.position),
+    ) as cursor:
+        subscriptions = list(await cursor.fetchall())
+    for subscription in subscriptions:
+        agent_id = AgentId(str(subscription[0]))
+        starting_scope_id = str(subscription[5]) if subscription[5] is not None else str(channel_id)
+        initial_anchor_id = MessageId(str(subscription[3])) if starting_scope_id == scope_id else None
+        initial_anchor_position = int(subscription[4]) if initial_anchor_id is not None else None
+        async with connection.execute(
+            "SELECT 1 FROM channel_agent_dismissals WHERE channel_id = ? AND agent_id = ? "
+            "AND dismissed_at >= ? AND (thread_root_message_id IS NULL OR thread_root_message_id = ?) LIMIT 1",
+            (channel_id, agent_id, str(subscription[2]), thread_root),
+        ) as cursor:
+            if await cursor.fetchone() is not None:
+                continue
+        await _advance_observation_state(
+            connection,
+            event_position=event.position,
+            occurred_at=occurred_at,
+            channel_id=channel_id,
+            agent_id=agent_id,
+            scope_kind=scope_kind,
+            scope_id=scope_id,
+            subscription_start_position=int(subscription[1]),
+            message_id=message_id,
+            author_kind=author_kind,
+            own_message=author_agent_id == agent_id,
+            initial_human_anchor_message_id=initial_anchor_id,
+            initial_human_anchor_event_position=initial_anchor_position,
+            policy=policy,
+        )
+
+
+async def _advance_observation_state(
+    connection: aiosqlite.Connection,
+    *,
+    event_position: int,
+    occurred_at: datetime,
+    channel_id: ChannelId,
+    agent_id: AgentId,
+    scope_kind: str,
+    scope_id: str,
+    subscription_start_position: int,
+    message_id: MessageId,
+    author_kind: str,
+    own_message: bool,
+    initial_human_anchor_message_id: MessageId | None,
+    initial_human_anchor_event_position: int | None,
+    policy: StandingParticipationHostPolicy,
+) -> None:
+    async with connection.execute(
+        "SELECT delivered_through_event_position, pending_through_event_position, "
+        "considered_through_event_position, oldest_pending_event_position, pending_message_count, "
+        "latest_human_anchor_message_id, latest_human_anchor_event_position, not_before, "
+        "lifecycle_state, overflowed_at, overflow_reason, overflow_from_event_position, "
+        "overflow_through_event_position, state_version, last_event_position "
+        "FROM channel_agent_observation_states WHERE channel_id = ? AND agent_id = ? AND scope_id = ?",
+        (channel_id, agent_id, scope_id),
+    ) as cursor:
+        current = await cursor.fetchone()
+    human_anchor_id = message_id if author_kind == "human" else initial_human_anchor_message_id
+    human_anchor_position = event_position if author_kind == "human" else initial_human_anchor_event_position
+    if current is None:
+        if own_message:
+            values = (
+                subscription_start_position,
+                subscription_start_position,
+                event_position,
+                None,
+                0,
+                human_anchor_id,
+                human_anchor_position,
+                None,
+                "idle",
+            )
+        else:
+            values = (
+                subscription_start_position,
+                event_position,
+                event_position,
+                event_position,
+                1,
+                human_anchor_id,
+                human_anchor_position,
+                (occurred_at + timedelta(seconds=policy.coalescing_grace_seconds)).isoformat(),
+                "pending",
+            )
+        await connection.execute(
+            "INSERT INTO channel_agent_observation_states "
+            "(channel_id, agent_id, scope_kind, scope_id, delivered_through_event_position, "
+            "pending_through_event_position, considered_through_event_position, "
+            "oldest_pending_event_position, pending_message_count, latest_human_anchor_message_id, "
+            "latest_human_anchor_event_position, not_before, lifecycle_state, overflowed_at, "
+            "overflow_reason, overflow_from_event_position, overflow_through_event_position, "
+            "projection_version, state_version, last_event_position) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, 1, ?)",
+            (
+                channel_id,
+                agent_id,
+                scope_kind,
+                scope_id,
+                *values,
+                OBSERVATION_PROJECTION_VERSION,
+                event_position,
+            ),
+        )
+        return
+    if int(current[14]) >= event_position:
+        return
+    anchor_id = human_anchor_id or current[5]
+    anchor_position = human_anchor_position or current[6]
+    if own_message:
+        await connection.execute(
+            "UPDATE channel_agent_observation_states SET considered_through_event_position = ?, "
+            "latest_human_anchor_message_id = ?, latest_human_anchor_event_position = ?, "
+            "state_version = state_version + 1, last_event_position = ? "
+            "WHERE channel_id = ? AND agent_id = ? AND scope_id = ?",
+            (event_position, anchor_id, anchor_position, event_position, channel_id, agent_id, scope_id),
+        )
+        return
+    if str(current[8]) == "paused_overflow":
+        await connection.execute(
+            "UPDATE channel_agent_observation_states SET considered_through_event_position = ?, "
+            "latest_human_anchor_message_id = ?, latest_human_anchor_event_position = ?, "
+            "overflow_through_event_position = ?, state_version = state_version + 1, "
+            "last_event_position = ? WHERE channel_id = ? AND agent_id = ? AND scope_id = ?",
+            (
+                event_position,
+                anchor_id,
+                anchor_position,
+                event_position,
+                event_position,
+                channel_id,
+                agent_id,
+                scope_id,
+            ),
+        )
+        return
+    pending_count = int(current[4])
+    oldest_pending = int(current[3]) if current[3] is not None else event_position
+    overflow_reason: str | None = None
+    overflow_from = event_position
+    if pending_count + 1 > policy.max_pending_messages_per_scope:
+        overflow_reason = "pending_count"
+    elif pending_count:
+        async with connection.execute(
+            "SELECT occurred_at FROM event_log WHERE position = ? AND event_type = ?",
+            (oldest_pending, WorkshopEventType.MESSAGE_CREATED.value),
+        ) as cursor:
+            oldest = await cursor.fetchone()
+        if oldest is None:
+            overflow_reason = "retention"
+            overflow_from = oldest_pending
+        elif occurred_at - _parse_timestamp(oldest[0]) > timedelta(seconds=policy.max_pending_age_seconds):
+            overflow_reason = "pending_age"
+            overflow_from = oldest_pending
+    if overflow_reason is not None:
+        await connection.execute(
+            "UPDATE channel_agent_observation_states SET considered_through_event_position = ?, "
+            "latest_human_anchor_message_id = ?, latest_human_anchor_event_position = ?, "
+            "lifecycle_state = 'paused_overflow', overflowed_at = ?, overflow_reason = ?, "
+            "overflow_from_event_position = ?, overflow_through_event_position = ?, "
+            "state_version = state_version + 1, last_event_position = ? "
+            "WHERE channel_id = ? AND agent_id = ? AND scope_id = ?",
+            (
+                event_position,
+                anchor_id,
+                anchor_position,
+                occurred_at.isoformat(),
+                overflow_reason,
+                overflow_from,
+                event_position,
+                event_position,
+                channel_id,
+                agent_id,
+                scope_id,
+            ),
+        )
+        return
+    not_before = current[7]
+    if pending_count == 0:
+        not_before = (occurred_at + timedelta(seconds=policy.coalescing_grace_seconds)).isoformat()
+    await connection.execute(
+        "UPDATE channel_agent_observation_states SET pending_through_event_position = ?, "
+        "considered_through_event_position = ?, oldest_pending_event_position = ?, "
+        "pending_message_count = ?, latest_human_anchor_message_id = ?, "
+        "latest_human_anchor_event_position = ?, not_before = ?, lifecycle_state = 'pending', "
+        "state_version = state_version + 1, last_event_position = ? "
+        "WHERE channel_id = ? AND agent_id = ? AND scope_id = ?",
+        (
+            event_position,
+            event_position,
+            oldest_pending,
+            pending_count + 1,
+            anchor_id,
+            anchor_position,
+            not_before,
+            event_position,
+            channel_id,
+            agent_id,
+            scope_id,
+        ),
+    )
+
+
+class WorkshopStandingObservationService:
+    """Inspect bounded observation work without accepting or dispatching runs."""
+
+    def __init__(self, store: WorkshopEventStore, host_policy: CollaborationHostPolicy) -> None:
+        self._store = store
+        self._host_policy = host_policy
+
+    async def synchronize_host_policy(self) -> None:
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            await synchronize_standing_observation_host_policy_in_transaction(
+                connection,
+                self._host_policy,
+                occurred_at=datetime.now(UTC),
+            )
+            await connection.commit()
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def inspect(
+        self,
+        channel_id: ChannelId,
+        agent_id: AgentId,
+        *,
+        current_at: datetime | None = None,
+    ) -> tuple[StandingObservationState, ...]:
+        await self._reconcile_age(channel_id, agent_id, current_at=current_at or datetime.now(UTC))
+        async with self._store.connection.execute(
+            "SELECT scope_kind, scope_id, delivered_through_event_position, "
+            "pending_through_event_position, considered_through_event_position, "
+            "oldest_pending_event_position, pending_message_count, latest_human_anchor_message_id, "
+            "latest_human_anchor_event_position, not_before, lifecycle_state, overflowed_at, "
+            "overflow_reason, overflow_from_event_position, overflow_through_event_position, "
+            "state_version, last_event_position FROM channel_agent_observation_states "
+            "WHERE channel_id = ? AND agent_id = ? ORDER BY oldest_pending_event_position, scope_id",
+            (channel_id, agent_id),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        return tuple(self._state(channel_id, agent_id, row) for row in rows)
+
+    async def pending_batches(self, state: StandingObservationState) -> tuple[StandingObservationBatch, ...]:
+        if state.pending_message_count == 0:
+            return ()
+        scope_clause = "m.thread_root_id IS NULL" if state.scope_kind == "channel" else "m.thread_root_id = ?"
+        parameters: list[object] = [state.agent_id, state.channel_id]
+        if state.scope_kind == "thread":
+            parameters.append(state.scope_id)
+        parameters.extend((state.delivered_through_event_position, state.pending_through_event_position))
+        async with self._store.connection.execute(
+            "SELECT m.id, m.created_event_position FROM messages m "
+            "WHERE m.author_principal_id != (SELECT principal_id FROM agents WHERE id = ?) "
+            "AND m.channel_id = ? AND "
+            + scope_clause
+            + " AND m.created_event_position > ? AND m.created_event_position <= ? "
+            "ORDER BY m.created_event_position, m.id",
+            tuple(parameters),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        limit = self._host_policy.standing_participation.max_messages_per_observe_run
+        batches: list[StandingObservationBatch] = []
+        for offset in range(0, len(rows), limit):
+            chunk = rows[offset : offset + limit]
+            batches.append(
+                StandingObservationBatch(
+                    state.channel_id,
+                    state.agent_id,
+                    state.scope_id,
+                    int(chunk[0][1]),
+                    int(chunk[-1][1]),
+                    tuple(MessageId(str(row[0])) for row in chunk),
+                )
+            )
+        return tuple(batches)
+
+    async def _reconcile_age(
+        self,
+        channel_id: ChannelId,
+        agent_id: AgentId,
+        *,
+        current_at: datetime,
+    ) -> None:
+        if current_at.tzinfo is None or current_at.utcoffset() is None:
+            raise ValueError("current_at must be timezone-aware")
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            async with connection.execute(
+                "SELECT scope_id, oldest_pending_event_position, considered_through_event_position "
+                "FROM channel_agent_observation_states WHERE channel_id = ? AND agent_id = ? "
+                "AND lifecycle_state = 'pending' AND pending_message_count > 0",
+                (channel_id, agent_id),
+            ) as cursor:
+                rows = list(await cursor.fetchall())
+            maximum_age = timedelta(seconds=self._host_policy.standing_participation.max_pending_age_seconds)
+            for row in rows:
+                async with connection.execute(
+                    "SELECT occurred_at FROM event_log WHERE position = ? AND event_type = ?",
+                    (int(row[1]), WorkshopEventType.MESSAGE_CREATED.value),
+                ) as cursor:
+                    source = await cursor.fetchone()
+                reason = "retention" if source is None else None
+                if source is not None and current_at.astimezone(UTC) - _parse_timestamp(source[0]) > maximum_age:
+                    reason = "pending_age"
+                if reason is None:
+                    continue
+                await connection.execute(
+                    "UPDATE channel_agent_observation_states SET lifecycle_state = 'paused_overflow', "
+                    "overflowed_at = ?, overflow_reason = ?, overflow_from_event_position = ?, "
+                    "overflow_through_event_position = ?, state_version = state_version + 1 "
+                    "WHERE channel_id = ? AND agent_id = ? AND scope_id = ? AND lifecycle_state = 'pending'",
+                    (
+                        current_at.astimezone(UTC).isoformat(),
+                        reason,
+                        int(row[1]),
+                        int(row[2]),
+                        channel_id,
+                        agent_id,
+                        str(row[0]),
+                    ),
+                )
+            await connection.commit()
+        except Exception:
+            await connection.rollback()
+            raise
+
+    @staticmethod
+    def _state(channel_id: ChannelId, agent_id: AgentId, row: aiosqlite.Row) -> StandingObservationState:
+        return StandingObservationState(
+            channel_id=channel_id,
+            agent_id=agent_id,
+            scope_kind=str(row[0]),
+            scope_id=str(row[1]),
+            delivered_through_event_position=int(row[2]),
+            pending_through_event_position=int(row[3]),
+            considered_through_event_position=int(row[4]),
+            oldest_pending_event_position=int(row[5]) if row[5] is not None else None,
+            pending_message_count=int(row[6]),
+            latest_human_anchor_message_id=MessageId(str(row[7])) if row[7] is not None else None,
+            latest_human_anchor_event_position=int(row[8]) if row[8] is not None else None,
+            not_before=_parse_timestamp(row[9]) if row[9] is not None else None,
+            lifecycle_state=str(row[10]),
+            overflowed_at=_parse_timestamp(row[11]) if row[11] is not None else None,
+            overflow_reason=str(row[12]) if row[12] is not None else None,
+            overflow_from_event_position=int(row[13]) if row[13] is not None else None,
+            overflow_through_event_position=int(row[14]) if row[14] is not None else None,
+            state_version=int(row[15]),
+            last_event_position=int(row[16]),
+        )

--- a/src/kai/workshop/standing_participation.py
+++ b/src/kai/workshop/standing_participation.py
@@ -346,6 +346,25 @@ class WorkshopStandingParticipationService:
         self._store = store
         self._host_policy = host_policy
 
+    async def synchronize_host_policy(self) -> None:
+        """Publish current host limits for the universal message projection."""
+        from kai.workshop.standing_observation import (
+            synchronize_standing_observation_host_policy_in_transaction,
+        )
+
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            await synchronize_standing_observation_host_policy_in_transaction(
+                connection,
+                self._host_policy,
+                occurred_at=datetime.now(UTC),
+            )
+            await connection.commit()
+        except Exception:
+            await connection.rollback()
+            raise
+
     @staticmethod
     def _projection() -> Projection:
         from kai.workshop.projection import CanonicalConversationProjection
@@ -424,6 +443,15 @@ class WorkshopStandingParticipationService:
         digest = _request_hash(request)
         try:
             await connection.execute("BEGIN IMMEDIATE")
+            from kai.workshop.standing_observation import (
+                synchronize_standing_observation_host_policy_in_transaction,
+            )
+
+            await synchronize_standing_observation_host_policy_in_transaction(
+                connection,
+                self._host_policy,
+                occurred_at=datetime.now(UTC),
+            )
             workshop_id, can_manage = await self._channel_access_row(principal_id, channel_id)
             if not can_manage:
                 raise WorkshopStandingParticipationAccessDenied("Only a channel owner may change this policy")
@@ -493,6 +521,15 @@ class WorkshopStandingParticipationService:
         *,
         occurred_at: datetime,
     ) -> None:
+        from kai.workshop.standing_observation import (
+            synchronize_standing_observation_host_policy_in_transaction,
+        )
+
+        await synchronize_standing_observation_host_policy_in_transaction(
+            self._store.connection,
+            self._host_policy,
+            occurred_at=occurred_at,
+        )
         if CollaborationOperation.STANDING_PARTICIPATION not in self._host_policy.effective_allowed_operations:
             return
         async with self._store.connection.execute(

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -579,7 +579,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 72
+        assert await upgraded.schema_version() == 73
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_artifacts.py
+++ b/tests/test_workshop_artifacts.py
@@ -529,7 +529,7 @@ class TestArtifactShadowRecordingAfterRestart:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 31
+            assert checkpoint.version == 32
             async with store.connection.execute(
                 "SELECT id, kind, media_type FROM artifacts WHERE message_id = ?",
                 (message_id,),

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -451,7 +451,7 @@ async def test_version_sixty_seven_migrates_only_legacy_delegation_requests(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 72
+        assert await upgraded.schema_version() == 73
         async with upgraded.connection.execute(
             "SELECT id, capabilities_json, collaboration_operations_json "
             "FROM agent_definition_revisions ORDER BY revision_number"

--- a/tests/test_workshop_conversation_commands.py
+++ b/tests/test_workshop_conversation_commands.py
@@ -389,7 +389,7 @@ class TestConversationCommandReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await WorkshopRunLifecycle(store).state(before.run.run_id)
 
-            assert checkpoint.version == 31
+            assert checkpoint.version == 32
             assert after == before.run
             async with store.connection.execute("SELECT body FROM messages") as cursor:
                 assert str((await cursor.fetchone())[0]) == _message().body

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -412,7 +412,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
             after = workshop_runtime_session_status(path)
             assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
@@ -440,7 +440,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
             assert session is not None
             assert session.runtime_profile_id == _RUNTIME_PROFILE_ID

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -253,6 +253,8 @@ class TestWorkshopSchema:
             "agent_delegations",
             "collaboration_grants",
             "agent_collaboration_owner_policies",
+            "channel_agent_observation_states",
+            "standing_participation_host_policy",
             "collaboration_operation_decisions",
             "collaboration_publication_receipts",
             "principal_human_notification_policies",
@@ -270,7 +272,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 72
+        assert await workshop_store.schema_version() == 73
         async with workshop_store.connection.execute("PRAGMA table_info(principals)") as cursor:
             principal_columns = {str(row[1]) for row in await cursor.fetchall()}
         assert {"display_name_state_version", "display_name_event_position"} <= principal_columns
@@ -321,7 +323,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 72
+        assert await second.schema_version() == 73
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -405,7 +407,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             async with upgraded.connection.execute(
                 "SELECT reaction, created_event_position FROM message_reactions "
                 "WHERE message_id = ? AND principal_id = ?",
@@ -446,7 +448,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -474,7 +476,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -564,6 +566,7 @@ class TestWorkshopSchema:
                     70,
                     71,
                     72,
+                    73,
                 ]
         finally:
             await upgraded.close()
@@ -586,7 +589,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -627,7 +630,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -680,7 +683,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -724,7 +727,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -768,7 +771,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -812,7 +815,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -916,7 +919,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -1043,7 +1046,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -319,7 +319,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 72
+            assert await upgraded.schema_version() == 73
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),

--- a/tests/test_workshop_run_execution_authority.py
+++ b/tests/test_workshop_run_execution_authority.py
@@ -391,7 +391,7 @@ class TestRunExecutionRecovery:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 31
+            assert checkpoint.version == 32
             assert (await authority.attempt(started.claim.attempt_id)).status == RunAttemptStatus.STARTED
             assert (await WorkshopRunLifecycle(store).state(accepted.run.run_id)).status == RunStatus.STARTED
         finally:

--- a/tests/test_workshop_run_lifecycle.py
+++ b/tests/test_workshop_run_lifecycle.py
@@ -166,7 +166,7 @@ class TestDurableRunReplay:
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
             after = await lifecycle.state(before.run_id)
 
-            assert checkpoint.version == 31
+            assert checkpoint.version == 32
             assert after == before
         finally:
             await store.close()

--- a/tests/test_workshop_runtime_assignments.py
+++ b/tests/test_workshop_runtime_assignments.py
@@ -255,7 +255,7 @@ class TestRuntimeAssignmentPolicy:
 
             checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
 
-            assert checkpoint.version == 31
+            assert checkpoint.version == 32
             assert await resolve_channel_runtime_profile(store, channel_id) == (
                 assigned.agent_id,
                 profile_id(202),

--- a/tests/test_workshop_standing_observation.py
+++ b/tests/test_workshop_standing_observation.py
@@ -1,0 +1,424 @@
+"""Contracts for the canonical standing-agent observation inbox."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from pathlib import Path
+
+from kai.workshop.agent_lifecycle import WorkshopAgentLifecycleService
+from kai.workshop.channel_lifecycle import WorkshopChannelLifecycleService
+from kai.workshop.collaboration_authority import CollaborationHostPolicy, StandingParticipationHostPolicy
+from kai.workshop.conversation_commands import WorkshopConversationCommandService
+from kai.workshop.diagnostics import workshop_standing_observation_status
+from kai.workshop.domain import (
+    AgentId,
+    ChannelId,
+    EventEnvelope,
+    EventId,
+    MessageId,
+    PrincipalId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.standing_observation import WorkshopStandingObservationService
+from kai.workshop.standing_participation import WorkshopStandingParticipationService
+from kai.workshop.store import AppendResult, WorkshopEventStore
+from kai.workshop.wake_policy import EngagementScope, dismiss_channel_agent
+from tests.test_workshop_standing_participation import _NOW, _eligible_authority, _message
+
+
+def _host_policy(**overrides: object) -> CollaborationHostPolicy:
+    return CollaborationHostPolicy(
+        standing_participation=StandingParticipationHostPolicy(enabled=True, **overrides),
+    )
+
+
+async def _append_message(
+    store: WorkshopEventStore,
+    channel_id: ChannelId,
+    author_id: PrincipalId,
+    identity: str,
+    *,
+    source: str = "workshop_client",
+    offset_seconds: float = 1,
+    thread_root_id: MessageId | None = None,
+) -> AppendResult:
+    async with store.connection.execute("SELECT workshop_id FROM channels WHERE id = ?", (channel_id,)) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    message_id = MessageId.derived(channel_id, identity)
+    payload: dict[str, object] = {
+        "channel_id": channel_id,
+        "author_principal_id": author_id,
+        "body": identity,
+        "mentions": [],
+    }
+    if thread_root_id is not None:
+        payload["reply_to_message_id"] = thread_root_id
+        payload["thread_root_id"] = thread_root_id
+    event = EventEnvelope.create(
+        event_id=EventId.derived(message_id, "created"),
+        event_type=WorkshopEventType.MESSAGE_CREATED,
+        event_version=2,
+        workshop_id=WorkshopId(str(row[0])),
+        aggregate_type="message",
+        aggregate_id=message_id,
+        actor_principal_id=author_id,
+        occurred_at=_NOW + timedelta(seconds=offset_seconds),
+        idempotency_key=f"standing-observation:{identity}",
+        payload=payload,
+        metadata={"source": source},
+    )
+    connection = store.connection
+    try:
+        await connection.execute("BEGIN IMMEDIATE")
+        result = await store.append_in_transaction(event)
+        await store.project_pending_in_transaction(CanonicalConversationProjection())
+        await connection.commit()
+        return result
+    except Exception:
+        await connection.rollback()
+        raise
+
+
+async def _other_agent_principal(store: WorkshopEventStore, owner_id: PrincipalId) -> PrincipalId:
+    draft = await WorkshopAgentLifecycleService(store).create_draft(
+        owner_id,
+        idempotency_key="standing-observation-peer",
+        handle="observation_peer",
+        display_name="Observation peer",
+        description="Produces canonical agent messages for observation tests.",
+        presentation={"avatar": "O"},
+        purpose="Provide another canonical agent author.",
+        instructions="Publish only test messages.",
+        capabilities=["text_generation"],
+        collaboration_operations=[],
+    )
+    async with store.connection.execute(
+        "SELECT principal_id FROM agents WHERE id = ?",
+        (draft.agent_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return PrincipalId(str(row[0]))
+
+
+async def _observation_authority(
+    path: Path,
+) -> tuple[
+    WorkshopEventStore,
+    PrincipalId,
+    ChannelId,
+    AgentId,
+    WorkshopStandingParticipationService,
+]:
+    store, human_id, channel_id, agent_id, standing = await _eligible_authority(path)
+    await WorkshopConversationCommandService(store, standing_participation=standing).accept_client(
+        _message(human_id, channel_id, "standing-observation-start")
+    )
+    return store, human_id, channel_id, agent_id, standing
+
+
+async def test_every_canonical_message_source_uses_one_coalesced_observation_trigger(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, _standing = await _observation_authority(tmp_path / "kai.db")
+    observation = WorkshopStandingObservationService(store, _host_policy())
+    try:
+        await observation.synchronize_host_policy()
+        async with store.connection.execute("SELECT COUNT(*) FROM runs") as cursor:
+            initial_runs = int((await cursor.fetchone())[0])
+        sources = (
+            "workshop_client",
+            "telegram",
+            "scheduled_job",
+            "github",
+            "workshop_collaboration_publication",
+            "internal_api",
+            "future_adapter",
+        )
+        results = [
+            await _append_message(
+                store,
+                channel_id,
+                human_id,
+                f"source-{index}",
+                source=source,
+                offset_seconds=1 + index / 10,
+            )
+            for index, source in enumerate(sources)
+        ]
+
+        states = await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=2))
+        assert len(states) == 1
+        state = states[0]
+        assert state.scope_kind == "channel"
+        assert state.pending_message_count == len(sources)
+        assert state.oldest_pending_event_position == results[0].event.position
+        assert state.pending_through_event_position == results[-1].event.position
+        assert state.considered_through_event_position == results[-1].event.position
+        assert state.latest_human_anchor_message_id == results[-1].event.envelope.aggregate_id
+        assert state.not_before == results[0].event.envelope.occurred_at + timedelta(seconds=2)
+        batches = await observation.pending_batches(state)
+        assert len(batches) == 1
+        assert batches[0].message_ids == tuple(result.event.envelope.aggregate_id for result in results)
+        async with store.connection.execute("SELECT COUNT(*) FROM runs") as cursor:
+            assert int((await cursor.fetchone())[0]) == initial_runs
+    finally:
+        await store.close()
+
+
+async def test_own_output_advances_considered_cursor_without_pending_work(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, _standing = await _observation_authority(tmp_path / "kai.db")
+    observation = WorkshopStandingObservationService(store, _host_policy())
+    try:
+        await observation.synchronize_host_policy()
+        async with store.connection.execute("SELECT principal_id FROM agents WHERE id = ?", (agent_id,)) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        own = await _append_message(
+            store,
+            channel_id,
+            PrincipalId(str(row[0])),
+            "own-agent-output",
+            source="agent",
+        )
+        own_state = (await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=2)))[0]
+        assert own_state.lifecycle_state == "idle"
+        assert own_state.pending_message_count == 0
+        assert own_state.considered_through_event_position == own.event.position
+        assert own_state.latest_human_anchor_message_id is not None
+        assert own_state.latest_human_anchor_message_id != own.event.envelope.aggregate_id
+
+        human = await _append_message(store, channel_id, human_id, "human-after-own-output", offset_seconds=2)
+        pending = (await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=3)))[0]
+        assert pending.pending_message_count == 1
+        assert pending.latest_human_anchor_message_id == human.event.envelope.aggregate_id
+        assert (await observation.pending_batches(pending))[0].message_ids == (human.event.envelope.aggregate_id,)
+    finally:
+        await store.close()
+
+
+async def test_channel_and_thread_scopes_keep_independent_cursors_and_anchors(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, _standing = await _observation_authority(tmp_path / "kai.db")
+    observation = WorkshopStandingObservationService(store, _host_policy())
+    try:
+        await observation.synchronize_host_policy()
+        root = await _append_message(store, channel_id, human_id, "scope-root", offset_seconds=1)
+        reply = await _append_message(
+            store,
+            channel_id,
+            human_id,
+            "scope-reply",
+            offset_seconds=2,
+            thread_root_id=MessageId(str(root.event.envelope.aggregate_id)),
+        )
+
+        states = await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=3))
+        by_kind = {state.scope_kind: state for state in states}
+        assert set(by_kind) == {"channel", "thread"}
+        assert by_kind["channel"].scope_id == str(channel_id)
+        assert by_kind["channel"].pending_message_count == 1
+        assert by_kind["channel"].latest_human_anchor_message_id == root.event.envelope.aggregate_id
+        assert by_kind["thread"].scope_id == str(root.event.envelope.aggregate_id)
+        assert by_kind["thread"].pending_message_count == 1
+        assert by_kind["thread"].latest_human_anchor_message_id == reply.event.envelope.aggregate_id
+    finally:
+        await store.close()
+
+
+async def test_thread_dismissal_prevents_later_thread_observation(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, _standing = await _observation_authority(tmp_path / "kai.db")
+    observation = WorkshopStandingObservationService(store, _host_policy())
+    try:
+        await observation.synchronize_host_policy()
+        root = await _append_message(store, channel_id, human_id, "dismissed-thread-root", offset_seconds=1)
+        root_id = MessageId(str(root.event.envelope.aggregate_id))
+        await dismiss_channel_agent(
+            store,
+            principal_id=human_id,
+            scope=EngagementScope(channel_id, root_id),
+            agent_id=agent_id,
+            client_dismissal_id="standing-observation-thread-dismissal",
+            occurred_at=_NOW + timedelta(seconds=2),
+        )
+        await _append_message(
+            store,
+            channel_id,
+            human_id,
+            "dismissed-thread-reply",
+            offset_seconds=3,
+            thread_root_id=root_id,
+        )
+
+        states = await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=4))
+        assert [state.scope_kind for state in states] == ["channel"]
+        assert states[0].pending_message_count == 1
+        assert states[0].latest_human_anchor_message_id == root_id
+    finally:
+        await store.close()
+
+
+async def test_pending_range_retains_multiple_future_batches_without_cursor_gap(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, _standing = await _observation_authority(tmp_path / "kai.db")
+    policy = _host_policy(max_messages_per_observe_run=2)
+    observation = WorkshopStandingObservationService(store, policy)
+    try:
+        await observation.synchronize_host_policy()
+        results = [
+            await _append_message(store, channel_id, human_id, f"batch-{index}", offset_seconds=index + 1)
+            for index in range(5)
+        ]
+        state = (await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=6)))[0]
+        batches = await observation.pending_batches(state)
+
+        assert [len(batch.message_ids) for batch in batches] == [2, 2, 1]
+        assert tuple(message_id for batch in batches for message_id in batch.message_ids) == tuple(
+            result.event.envelope.aggregate_id for result in results
+        )
+        assert batches[0].from_event_position == results[0].event.position
+        assert batches[-1].through_event_position == results[-1].event.position
+        assert state.delivered_through_event_position < batches[0].from_event_position
+    finally:
+        await store.close()
+
+
+async def test_overflow_pauses_explicitly_and_retains_inspectable_omitted_range(tmp_path: Path) -> None:
+    path = tmp_path / "kai.db"
+    store, human_id, channel_id, agent_id, _standing = await _observation_authority(path)
+    policy = _host_policy(max_pending_messages_per_scope=2)
+    observation = WorkshopStandingObservationService(store, policy)
+    try:
+        await observation.synchronize_host_policy()
+        results = [
+            await _append_message(store, channel_id, human_id, f"overflow-{index}", offset_seconds=index + 1)
+            for index in range(4)
+        ]
+        state = (await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=5)))[0]
+
+        assert state.lifecycle_state == "paused_overflow"
+        assert state.pending_message_count == 2
+        assert state.pending_through_event_position == results[1].event.position
+        assert state.considered_through_event_position == results[3].event.position
+        assert state.overflow_reason == "pending_count"
+        assert state.overflow_from_event_position == results[2].event.position
+        assert state.overflow_through_event_position == results[3].event.position
+        assert [len(batch.message_ids) for batch in await observation.pending_batches(state)] == [2]
+        assert "paused overflow=1" in workshop_standing_observation_status(path)
+        assert "integrity gaps=0, replay gaps=0" in workshop_standing_observation_status(path)
+    finally:
+        await store.close()
+
+
+async def test_pending_age_reconciliation_pauses_without_advancing_delivery(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, _standing = await _observation_authority(tmp_path / "kai.db")
+    policy = _host_policy(max_pending_age_seconds=5)
+    observation = WorkshopStandingObservationService(store, policy)
+    try:
+        await observation.synchronize_host_policy()
+        source = await _append_message(store, channel_id, human_id, "aged-pending", offset_seconds=1)
+        before = (await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=2)))[0]
+        after = (await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=7)))[0]
+
+        assert before.lifecycle_state == "pending"
+        assert after.lifecycle_state == "paused_overflow"
+        assert after.overflow_reason == "pending_age"
+        assert after.overflow_from_event_position == source.event.position
+        assert after.delivered_through_event_position == before.delivered_through_event_position
+    finally:
+        await store.close()
+
+
+async def test_retry_rollback_rebuild_and_cross_channel_isolation_are_exact(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, _standing = await _observation_authority(tmp_path / "kai.db")
+    observation = WorkshopStandingObservationService(store, _host_policy())
+    try:
+        await observation.synchronize_host_policy()
+        source = await _append_message(store, channel_id, human_id, "durable-source", offset_seconds=1)
+        before = await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=2))
+
+        await store.connection.execute("BEGIN IMMEDIATE")
+        replay = await store.append_in_transaction(source.event.envelope)
+        await store.project_pending_in_transaction(CanonicalConversationProjection())
+        await store.connection.commit()
+        assert replay.inserted is False
+        assert await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=2)) == before
+
+        rolled_back_id = MessageId.derived(channel_id, "rolled-back-source")
+        await store.connection.execute("BEGIN IMMEDIATE")
+        rolled_back = await store.append_in_transaction(
+            EventEnvelope.create(
+                event_id=EventId.derived(rolled_back_id, "created"),
+                event_type=WorkshopEventType.MESSAGE_CREATED,
+                event_version=2,
+                workshop_id=source.event.envelope.workshop_id,
+                aggregate_type="message",
+                aggregate_id=rolled_back_id,
+                actor_principal_id=human_id,
+                occurred_at=_NOW + timedelta(seconds=2),
+                idempotency_key="standing-observation:rolled-back-source",
+                payload={
+                    "channel_id": channel_id,
+                    "author_principal_id": human_id,
+                    "body": "rolled back",
+                    "mentions": [],
+                },
+                metadata={"source": "workshop_client"},
+            )
+        )
+        await store.project_pending_in_transaction(CanonicalConversationProjection())
+        await store.connection.rollback()
+        assert await store.event_by_idempotency_key("standing-observation:rolled-back-source") is None
+        assert await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=2)) == before
+        assert rolled_back.inserted is True
+
+        other = await WorkshopChannelLifecycleService(store).create_group(
+            human_id,
+            name="No standing",
+            agent_ids=[agent_id],
+        )
+        await _append_message(store, other.channel_id, human_id, "other-channel", offset_seconds=3)
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM channel_agent_observation_states WHERE channel_id = ?",
+            (other.channel_id,),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 0
+
+        checkpoint = await store.rebuild_projection(CanonicalConversationProjection())
+        assert checkpoint.version == 32
+        rebuilt = await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=2))
+        assert rebuilt == before
+    finally:
+        await store.close()
+
+
+async def test_other_agent_output_is_observed_but_never_creates_a_human_anchor(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, _standing = await _observation_authority(tmp_path / "kai.db")
+    observation = WorkshopStandingObservationService(store, _host_policy())
+    try:
+        await observation.synchronize_host_policy()
+        peer_principal = await _other_agent_principal(store, human_id)
+        root = await _append_message(
+            store,
+            channel_id,
+            human_id,
+            "peer-thread-root",
+            offset_seconds=1,
+        )
+        output = await _append_message(
+            store,
+            channel_id,
+            peer_principal,
+            "peer-agent-output",
+            source="agent",
+            offset_seconds=2,
+            thread_root_id=MessageId(str(root.event.envelope.aggregate_id)),
+        )
+        states = await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=3))
+        state = next(item for item in states if item.scope_kind == "thread")
+
+        assert state.pending_message_count == 1
+        assert state.pending_through_event_position == output.event.position
+        assert state.latest_human_anchor_message_id is None
+        assert state.latest_human_anchor_event_position is None
+    finally:
+        await store.close()


### PR DESCRIPTION
Closes #1467
Parent: #1465

## Summary
- add a canonical, producer-neutral standing-agent observation projection for committed group-channel messages
- track independent bounded channel/thread scopes with coalescing, human anchors, own-output suppression, dismissal fencing, and explicit overflow state
- expose observation batches without invoking a backend and add install-status integrity/replay diagnostics

## Validation
- make check
- make typecheck
- make test (6555 passed)
- focused producer/schema sweep (912 passed)