### PR TITLE
Complete standing participation rollout and qualification gates

### DIFF
--- a/kai-workshop-implementation-map.md
+++ b/kai-workshop-implementation-map.md
@@ -1,8 +1,12 @@
 # Kai Workshop: Phase 0 Implementation Map
 
-**Status:** Active migration plan; first canonical conversation delivery authority live
-**Date:** 2026-08-12
+**Status:** Canonical Workshop active; standing participation implemented and pending final installed qualification
+**Date:** 2026-09-09
 **Scope:** Map and execute the current Kai implementation's migration onto the proposed Kai Workshop architecture.
+
+This document is a chronological implementation map. Earlier sections preserve
+the system state and migration decisions at their implementation dates; the
+highest-numbered sections describe the current authority.
 
 ## 1. Naming and scope
 
@@ -2274,3 +2278,50 @@ restart continuity, memory, scheduling, integration publication, and unchanged
 optional Telegram delivery. Supported backends for which the operator has no
 configured authenticated account are not falsely reported as active and do not
 block this architectural boundary.
+
+## 49. Standing agent participation
+
+**Implementation date:** 2026-09-09
+
+Workshop group channels can opt into standing participation. An eligible agent
+begins standing only after a human explicitly mentions it in an opted-in
+channel. The resulting subscription is canonical, durable, versioned, and
+separate from both transient mention engagement and the short-lived
+collaboration grant used by any individual run. Channel policy remains off by
+default, agent owners must explicitly allow the operation, and host policy
+provides the final authority and hard resource ceilings.
+
+A standing agent observes canonical messages from every adapter through one
+bounded channel or thread inbox. Messages are coalesced into immutable ordered
+batches with durable considered, pending, and delivered cursors. Backlog count
+and age limits pause a scope visibly rather than dropping unseen input; an
+authorized human can deliberately resume from the recorded boundary or dismiss
+the agent. Subscription and observation state rebuild from the event log.
+
+Observation uses the same long-lived `(channel, agent, runtime profile)` lane
+and provider session as ordinary responses. It does not create a model process
+per message. Each observe attempt receives fresh, attempt-scoped authority and
+rechecks the current subscription, definition, owner policy, channel policy,
+attachment, host policy, cancellation state, and quotas before dispatch and
+again before publication. A backend or model switch replaces an incompatible
+provider session while rebuilding context from the canonical timeline.
+
+The exact output `<<silent>>` is a successful, message-free outcome. Empty
+output is failure, and mixed sentinel text is visible and recorded as a
+protocol anomaly rather than silently altered. Inference and visible
+publication budgets are independent. At most one standing contribution per
+agent and human anchor may be published, so multiple standing agents cannot
+form an unbounded visible response loop. Respond runs take priority over
+observation work.
+
+Dismissal, quiet expiry, overflow, detachment, channel archive, definition
+archive, access or revision loss, owner-policy revocation, channel-policy
+disablement, and emergency host revocation all fail closed. Suppressed proposed
+output remains protected and is never added to the conversation. Workshop
+shows compact standing controls, subscription state, overflow recovery, and
+authorized run inspection; silent observations remain hidden by default.
+
+Installed diagnostics report subscription lifecycle, observation cursors and
+overflow, run outcomes, quota use, protected-output counts, protocol anomalies,
+and replay or integrity gaps. Final installed qualification under #1470 is the
+closure gate for this section and epic #1465.

--- a/src/kai/workshop/collaboration_authority.py
+++ b/src/kai/workshop/collaboration_authority.py
@@ -112,7 +112,11 @@ class CollaborationOwnerPolicy:
 class StandingParticipationHostPolicy:
     """Host-owned standing-participation rollout switch and hard limits."""
 
-    enabled: bool = False
+    # The staged implementation shipped fail-closed while subscription,
+    # observation, execution, and UI authority were qualified independently.
+    # The final rollout enables the completed path by default.  Supplying an
+    # explicit disabled policy remains the emergency host revocation boundary.
+    enabled: bool = True
     max_agents_per_channel: int = 2
     coalescing_grace_seconds: int = 2
     max_messages_per_observe_run: int = 40
@@ -155,7 +159,10 @@ class StandingParticipationHostPolicy:
 class CollaborationHostPolicy:
     """Server-owned maxima that no agent revision or owner can exceed."""
 
-    version: int = 2
+    # Version 3 is the production standing-participation rollout.  Existing
+    # subscription evidence keeps its recorded version while every new start
+    # records the enabled-by-default host policy.
+    version: int = 3
     allowed_operations: frozenset[CollaborationOperation] = frozenset(CollaborationOperation)
     quotas: Mapping[CollaborationOperation, int] = field(
         default_factory=lambda: {

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -1023,6 +1023,12 @@ def workshop_standing_observation_status(db_path: Path) -> str:
             scopes, idle, pending, paused, pending_messages, unanchored = tuple(
                 int(value or 0) for value in (counts or (0, 0, 0, 0, 0, 0))
             )
+            cursor_counts = connection.execute(
+                "SELECT SUM(CASE WHEN delivered_through_event_position > 0 THEN 1 ELSE 0 END), "
+                "SUM(CASE WHEN considered_through_event_position > delivered_through_event_position "
+                "THEN 1 ELSE 0 END) FROM channel_agent_observation_states"
+            ).fetchone()
+            delivered_cursors, awaiting_cursors = tuple(int(value or 0) for value in (cursor_counts or (0, 0)))
             integrity_gaps = _scalar(
                 connection,
                 "SELECT COUNT(*) FROM channel_agent_observation_states o "
@@ -1063,6 +1069,8 @@ def workshop_standing_observation_status(db_path: Path) -> str:
     return (
         f"{prefix} {state}; host={host_state}, scopes={scopes} "
         f"(idle={idle}, pending={pending}, paused overflow={paused}), "
+        f"cursors={scopes} (delivery boundary initialized={delivered_cursors}, "
+        f"backlog beyond boundary={awaiting_cursors}), "
         f"pending messages={pending_messages}, unanchored={unanchored}; {limits}; "
         f"integrity gaps={integrity_gaps}, replay gaps={replay_gaps}; authority=canonical-message"
     )
@@ -1101,6 +1109,7 @@ def workshop_standing_observe_execution_status(db_path: Path) -> str:
             )
             protected = _scalar(connection, "SELECT COUNT(*) FROM standing_observation_suppressed_outputs")
             anomalies = _scalar(connection, "SELECT COUNT(*) FROM standing_observation_protocol_anomalies")
+            publications = _scalar(connection, "SELECT COUNT(*) FROM standing_observation_publications")
             integrity_gaps = _scalar(
                 connection,
                 "SELECT COUNT(*) FROM runs r LEFT JOIN standing_observation_publications p ON p.run_id = r.id "
@@ -1136,6 +1145,7 @@ def workshop_standing_observe_execution_status(db_path: Path) -> str:
     return (
         f"{prefix} {state}; host={host_state}, runs={total} (nonterminal={nonterminal}, "
         f"spoke={spoke}, silent={silent}, suppressed={suppressed}, failed={failed}), "
+        f"quota ledger=(inferences={total}, publications={publications}), "
         f"protected outputs={protected}, protocol anomalies={anomalies}; {limits}; "
         f"integrity gaps={integrity_gaps}, replay gaps={replay_gaps}; "
         "authority=canonical/attempt-scoped"

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -1026,7 +1026,7 @@ async def test_standing_participation_api_is_principal_scoped_versioned_and_repl
             "policy_version": 0,
             "can_manage": True,
             "host_enabled": True,
-            "host_policy_version": 2,
+            "host_policy_version": 3,
             "max_agents_per_channel": 2,
             "coalescing_grace_seconds": 2,
             "max_messages_per_observe_run": 40,

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -122,7 +122,7 @@ async def test_grant_snapshots_revision_owner_host_context_and_limits(tmp_path: 
         )
         assert grant.effective_operations == frozenset({CollaborationOperation.AGENT_DELEGATION})
         assert grant.owner_policy_version == 7
-        assert grant.host_policy_version == 2
+        assert grant.host_policy_version == 3
         assert grant.quotas[CollaborationOperation.AGENT_DELEGATION] == 12
         assert grant.proof_fingerprint != invocation.token
         assert invocation.token not in repr(invocation)

--- a/tests/test_workshop_standing_execution.py
+++ b/tests/test_workshop_standing_execution.py
@@ -91,6 +91,7 @@ async def test_ready_batch_becomes_immutable_observe_run_and_exact_silence_advan
     status = workshop_standing_observe_execution_status(database)
     assert status.startswith("Workshop standing observe execution: active;")
     assert "runs=1 (nonterminal=0, spoke=0, silent=1, suppressed=0, failed=0)" in status
+    assert "quota ledger=(inferences=1, publications=0)" in status
 
 
 async def test_standing_publication_is_once_per_human_anchor_and_suppressed_text_is_protected(

--- a/tests/test_workshop_standing_observation.py
+++ b/tests/test_workshop_standing_observation.py
@@ -304,6 +304,10 @@ async def test_overflow_pauses_explicitly_and_retains_inspectable_omitted_range(
         assert state.overflow_through_event_position == results[3].event.position
         assert [len(batch.message_ids) for batch in await observation.pending_batches(state)] == [2]
         assert "paused overflow=1" in workshop_standing_observation_status(path)
+        assert (
+            "cursors=1 (delivery boundary initialized=1, backlog beyond boundary=1)"
+            in workshop_standing_observation_status(path)
+        )
         assert "integrity gaps=0, replay gaps=0" in workshop_standing_observation_status(path)
     finally:
         await store.close()

--- a/tests/test_workshop_standing_participation.py
+++ b/tests/test_workshop_standing_participation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -17,11 +17,21 @@ from kai.workshop.collaboration_authority import (
 from kai.workshop.collaboration_policy import WorkshopCollaborationPolicyService
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.diagnostics import workshop_standing_participation_status
-from kai.workshop.domain import AgentId, ChannelId, PrincipalId
+from kai.workshop.domain import (
+    AgentId,
+    ChannelId,
+    EventEnvelope,
+    EventId,
+    MessageId,
+    PrincipalId,
+    WorkshopEventType,
+    WorkshopId,
+)
 from kai.workshop.inbound import ClientInboundMessage
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.standing_participation import WorkshopStandingParticipationService
 from kai.workshop.store import WorkshopEventStore
+from kai.workshop.wake_policy import EngagementScope, dismiss_channel_agent
 from tests.workshop_profiles import profile_id
 
 _NOW = datetime(2026, 9, 9, 12, 0, tzinfo=UTC)
@@ -134,6 +144,71 @@ def _message(principal_id: PrincipalId, channel_id: ChannelId, identity: str) ->
     )
 
 
+async def _start_without_run(
+    store: WorkshopEventStore,
+    standing: WorkshopStandingParticipationService,
+    human_id: PrincipalId,
+    channel_id: ChannelId,
+    agent_id: AgentId,
+    identity: str,
+    *,
+    occurred_at: datetime = _NOW,
+) -> MessageId:
+    """Start standing from a canonical mention without leaving a respond run."""
+    async with store.connection.execute(
+        "SELECT c.workshop_id, a.principal_id, d.handle FROM channels c "
+        "JOIN agents a ON a.id = ? JOIN agent_definitions d ON d.agent_id = a.id "
+        "WHERE c.id = ?",
+        (agent_id, channel_id),
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    workshop_id = WorkshopId(str(row[0]))
+    agent_principal_id = PrincipalId(str(row[1]))
+    handle = str(row[2])
+    body = f"@{handle} qualify standing lifecycle"
+    message_id = MessageId.derived(channel_id, identity)
+    event = EventEnvelope.create(
+        event_id=EventId.derived(message_id, "created"),
+        event_type=WorkshopEventType.MESSAGE_CREATED,
+        event_version=2,
+        workshop_id=workshop_id,
+        aggregate_type="message",
+        aggregate_id=message_id,
+        actor_principal_id=human_id,
+        occurred_at=occurred_at,
+        idempotency_key=f"standing-qualification:{identity}",
+        payload={
+            "channel_id": channel_id,
+            "author_principal_id": human_id,
+            "body": body,
+            "mentions": [
+                {
+                    "principal_id": agent_principal_id,
+                    "kind": "agent",
+                    "start": 0,
+                    "length": len(handle) + 1,
+                }
+            ],
+        },
+        metadata={"source": "qualification"},
+    )
+    await store.connection.execute("BEGIN IMMEDIATE")
+    try:
+        await store.append_in_transaction(event)
+        await store.project_pending_in_transaction(CanonicalConversationProjection())
+        await standing.start_from_message_in_transaction(
+            message_id,
+            (agent_id,),
+            occurred_at=occurred_at,
+        )
+        await store.connection.commit()
+    except Exception:
+        await store.connection.rollback()
+        raise
+    return message_id
+
+
 async def test_explicit_mention_starts_one_replayable_subscription_without_replacing_response(
     tmp_path: Path,
 ) -> None:
@@ -151,7 +226,7 @@ async def test_explicit_mention_starts_one_replayable_subscription_without_repla
         assert [item.agent_id for item in active] == [agent_id]
         assert active[0].owner_policy_version == 1
         assert active[0].channel_policy_version == 1
-        assert active[0].host_policy_version == 2
+        assert active[0].host_policy_version == 3
         async with store.connection.execute("SELECT COUNT(*) FROM collaboration_grants") as cursor:
             grants = await cursor.fetchone()
         assert grants is not None and int(grants[0]) == 0
@@ -173,7 +248,12 @@ async def test_host_revocation_is_fenced_lazily_and_diagnostics_report_clean_sta
         await WorkshopConversationCommandService(store, standing_participation=standing).accept_client(
             _message(human_id, channel_id, "standing-host-revocation")
         )
-        disabled_host = WorkshopStandingParticipationService(store, CollaborationHostPolicy())
+        disabled_host = WorkshopStandingParticipationService(
+            store,
+            CollaborationHostPolicy(
+                standing_participation=StandingParticipationHostPolicy(enabled=False),
+            ),
+        )
 
         fenced = await disabled_host.inspect(human_id, channel_id)
 
@@ -254,7 +334,12 @@ async def test_channel_policy_disable_ends_subscription_and_rebuild_preserves_te
 async def test_host_rollout_disabled_keeps_mention_response_without_subscription(tmp_path: Path) -> None:
     store, human_id, channel_id, _agent_id = await _base_group_store(tmp_path / "kai.db")
     try:
-        standing = WorkshopStandingParticipationService(store, CollaborationHostPolicy())
+        standing = WorkshopStandingParticipationService(
+            store,
+            CollaborationHostPolicy(
+                standing_participation=StandingParticipationHostPolicy(enabled=False),
+            ),
+        )
         accepted = await WorkshopConversationCommandService(store, standing_participation=standing).accept_client(
             _message(human_id, channel_id, "standing-host-off")
         )
@@ -262,3 +347,157 @@ async def test_host_rollout_disabled_keeps_mention_response_without_subscription
         assert (await standing.inspect(human_id, channel_id)).subscriptions == ()
     finally:
         await store.close()
+
+
+async def test_production_host_policy_enables_standing_by_default() -> None:
+    host = CollaborationHostPolicy()
+
+    assert host.version == 3
+    assert host.standing_participation.enabled is True
+    assert "standing_participation" in host.effective_allowed_operations
+
+
+async def test_channel_dismissal_ends_subscription_immediately_and_replays(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, standing = await _eligible_authority(tmp_path / "dismiss.db")
+    try:
+        await _start_without_run(store, standing, human_id, channel_id, agent_id, "dismiss-start")
+        first = await dismiss_channel_agent(
+            store,
+            principal_id=human_id,
+            scope=EngagementScope(channel_id, None),
+            agent_id=agent_id,
+            client_dismissal_id="standing-dismiss",
+            occurred_at=_NOW + timedelta(seconds=1),
+        )
+        replay = await dismiss_channel_agent(
+            store,
+            principal_id=human_id,
+            scope=EngagementScope(channel_id, None),
+            agent_id=agent_id,
+            client_dismissal_id="standing-dismiss",
+            occurred_at=_NOW + timedelta(seconds=1),
+        )
+
+        snapshot = await standing.inspect(human_id, channel_id)
+        assert first.inserted is True
+        assert replay.inserted is False
+        assert snapshot.subscriptions[0].lifecycle_state == "ended"
+        assert snapshot.subscriptions[0].end_reason == "dismissed"
+    finally:
+        await store.close()
+
+
+async def test_definition_archive_ends_subscription_immediately(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, standing = await _eligible_authority(tmp_path / "definition.db")
+    try:
+        await _start_without_run(store, standing, human_id, channel_id, agent_id, "definition-start")
+        lifecycle = WorkshopAgentLifecycleService(store)
+        definition = next(item for item in await lifecycle.list_visible(human_id) if item.agent_id == agent_id)
+        await lifecycle.archive(
+            human_id,
+            definition.definition_id,
+            idempotency_key="standing-definition-archive",
+            expected_version=definition.state_version,
+        )
+
+        snapshot = await standing.inspect(human_id, channel_id)
+        assert snapshot.subscriptions[0].lifecycle_state == "ended"
+        assert snapshot.subscriptions[0].end_reason == "definition_archived"
+    finally:
+        await store.close()
+
+
+async def test_channel_archive_ends_subscription_immediately(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, standing = await _eligible_authority(tmp_path / "channel.db")
+    try:
+        await _start_without_run(store, standing, human_id, channel_id, agent_id, "channel-start")
+        await WorkshopChannelLifecycleService(store).archive(
+            human_id,
+            channel_id,
+            client_operation_id="standing-channel-archive",
+        )
+
+        async with store.connection.execute(
+            "SELECT lifecycle_state, end_reason FROM channel_agent_standings WHERE channel_id = ?",
+            (channel_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None and tuple(row) == ("ended", "channel_archived")
+    finally:
+        await store.close()
+
+
+async def test_owner_revocation_ends_subscription_immediately(tmp_path: Path) -> None:
+    store, human_id, channel_id, agent_id, standing = await _eligible_authority(tmp_path / "owner.db")
+    try:
+        await _start_without_run(store, standing, human_id, channel_id, agent_id, "owner-start")
+        lifecycle = WorkshopAgentLifecycleService(store)
+        definition = next(item for item in await lifecycle.list_visible(human_id) if item.agent_id == agent_id)
+        policy = WorkshopCollaborationPolicyService(
+            store,
+            cast(Any, _PrivateExecution(WorkshopCollaborationAuthority(store))),
+        )
+        await policy.set_allowed(
+            human_id,
+            definition.definition_id,
+            allowed_operations=[],
+            expected_policy_version=1,
+            client_operation_id="standing-owner-revoke",
+        )
+
+        snapshot = await standing.inspect(human_id, channel_id)
+        assert snapshot.subscriptions[0].lifecycle_state == "ended"
+        assert snapshot.subscriptions[0].end_reason == "owner_policy_revoked"
+    finally:
+        await store.close()
+
+
+async def test_revision_loss_and_quiet_expiry_fail_closed_lazily(tmp_path: Path) -> None:
+    revision_store, human_id, channel_id, agent_id, standing = await _eligible_authority(tmp_path / "revision.db")
+    try:
+        await _start_without_run(revision_store, standing, human_id, channel_id, agent_id, "revision-start")
+        lifecycle = WorkshopAgentLifecycleService(revision_store)
+        definition = next(item for item in await lifecycle.list_visible(human_id) if item.agent_id == agent_id)
+        revised = await lifecycle.add_revision(
+            human_id,
+            definition.definition_id,
+            idempotency_key="standing-nonparticipating-revision",
+            expected_version=definition.state_version,
+            purpose="Respond only when explicitly mentioned.",
+            instructions="Do not participate as a standing agent.",
+            capabilities=["text_generation"],
+            collaboration_operations=[],
+        )
+        await lifecycle.activate_revision(
+            human_id,
+            definition.definition_id,
+            revision_id=revised.revisions[-1].revision_id,
+            idempotency_key="standing-nonparticipating-activate",
+            expected_version=revised.state_version,
+        )
+        snapshot = await standing.inspect(human_id, channel_id)
+        assert snapshot.subscriptions[0].end_reason == "access_removed"
+    finally:
+        await revision_store.close()
+
+    expiry_store, human_id, channel_id, agent_id, _standing = await _eligible_authority(tmp_path / "expiry.db")
+    expiry_policy = CollaborationHostPolicy(
+        standing_participation=StandingParticipationHostPolicy(enabled=True, quiet_expiry_seconds=1),
+    )
+    expiry = WorkshopStandingParticipationService(expiry_store, expiry_policy)
+    try:
+        started_at = datetime.now(UTC) - timedelta(seconds=2)
+        await _start_without_run(
+            expiry_store,
+            expiry,
+            human_id,
+            channel_id,
+            agent_id,
+            "expiry-start",
+            occurred_at=started_at,
+        )
+        snapshot = await expiry.inspect(human_id, channel_id)
+        assert snapshot.subscriptions[0].lifecycle_state == "ended"
+        assert snapshot.subscriptions[0].end_reason == "quiet_expired"
+    finally:
+        await expiry_store.close()


### PR DESCRIPTION
## Summary

- enable the standing-participation host policy by default while retaining the explicit emergency-disable boundary
- complete adversarial lifecycle coverage for dismissal, agent/channel archival, owner-policy revocation, access/revision loss, and quiet expiry
- expose accurate observation-cursor and quota-ledger diagnostics
- reconcile the public Workshop implementation map with the implemented long-lived standing-agent design

## Validation

- `make check`
- `make client-check` (194 tests)
- `make test` (6,573 tests)

Implements the code and automated-qualification portion of #1470. The issue remains open for installed qualification and final epic reconciliation.
