### PR TITLE
Preserve standing observation runtime continuity

### DIFF
--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -1070,7 +1070,7 @@ def workshop_standing_observation_status(db_path: Path) -> str:
         f"{prefix} {state}; host={host_state}, scopes={scopes} "
         f"(idle={idle}, pending={pending}, paused overflow={paused}), "
         f"cursors={scopes} (delivery boundary initialized={delivered_cursors}, "
-        f"backlog beyond boundary={awaiting_cursors}), "
+        f"considered beyond delivery boundary={awaiting_cursors}), "
         f"pending messages={pending_messages}, unanchored={unanchored}; {limits}; "
         f"integrity gaps={integrity_gaps}, replay gaps={replay_gaps}; authority=canonical-message"
     )

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -476,6 +476,24 @@ class WorkshopCanonicalExecutionCoordinator:
                         occurred_at=self._now(),
                         delivery_policy=self._delivery_policy,
                         grant_operations=active.collaboration_operations,
+                        runtime_session=(
+                            RuntimeSessionSettlement(
+                                channel_id=prepared.run.channel_id,
+                                agent_id=prepared.run.agent_id,
+                                runtime_profile_id=prepared.runtime_profile_id,
+                                selection=prepared.selection,
+                                workspace=str(prepared.workspace),
+                                provider_session_id=response.session_id,
+                                run_id=prepared.run.run_id,
+                            )
+                            if (
+                                response is not None
+                                and response.success
+                                and response.text.strip()
+                                and response.text.strip() != "<<silent>>"
+                            )
+                            else None
+                        ),
                     )
                 disposition = (
                     CanonicalExecutionDisposition.COMPLETED

--- a/src/kai/workshop/standing_observation.py
+++ b/src/kai/workshop/standing_observation.py
@@ -33,6 +33,12 @@ from kai.workshop.run_execution_authority import (
     WorkshopRunExecutionAuthority,
 )
 from kai.workshop.run_lifecycle import DurableRun, load_durable_run
+from kai.workshop.runtime_sessions import (
+    RuntimeSessionSettlement,
+    RuntimeSessionSettlementResult,
+    RuntimeSessionStateConflictError,
+    settle_runtime_session_in_transaction,
+)
 from kai.workshop.store import StoredEvent, WorkshopEventStore
 
 OBSERVATION_PROJECTION_VERSION = 1
@@ -85,6 +91,7 @@ class StandingObserveSettlement:
     published_message_id: MessageId | None
     suppression_reason: str | None
     protocol_anomaly: bool
+    runtime_session: RuntimeSessionSettlementResult | None = None
 
 
 def _parse_timestamp(value: object) -> datetime:
@@ -780,12 +787,15 @@ class WorkshopStandingObservationService:
         occurred_at: datetime,
         delivery_policy: object,
         grant_operations: frozenset[CollaborationOperation],
+        runtime_session: RuntimeSessionSettlement | None = None,
     ) -> StandingObserveSettlement:
         """Settle one observe attempt without exposing failures or suppressed output."""
         from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
 
         if not isinstance(delivery_policy, WorkshopDeliveryBindingPolicy):
             raise TypeError("delivery_policy must be a WorkshopDeliveryBindingPolicy")
+        if runtime_session is not None and runtime_session.run_id != claim.run_id:
+            raise ValueError("Standing runtime-session settlement must match the observe run")
         now = occurred_at.astimezone(UTC)
         connection = self._store.connection
         try:
@@ -794,6 +804,12 @@ class WorkshopStandingObservationService:
             run = await load_durable_run(self._store, claim.run_id)
             if run is None or run.kind.value != "observe":
                 raise RuntimeError("Standing settlement requires an observe run")
+            if runtime_session is not None and (
+                runtime_session.channel_id != run.channel_id
+                or runtime_session.agent_id != run.agent_id
+                or runtime_session.runtime_profile_id != run.runtime_profile_id
+            ):
+                raise ValueError("Standing runtime-session settlement does not match canonical run authority")
             body = response_text.strip() if response_text is not None else ""
             protocol_anomaly = "<<silent>>" in body and body != "<<silent>>"
             authority_current = await self._authority_is_current(run, occurred_at=now)
@@ -887,8 +903,35 @@ class WorkshopStandingObservationService:
                 result_message_id=message_id,
                 occurred_at=now,
             )
+            runtime_session_result = None
+            if runtime_session is not None:
+                await connection.execute("SAVEPOINT standing_runtime_session_settlement")
+                try:
+                    runtime_session_result = await settle_runtime_session_in_transaction(
+                        self._store,
+                        runtime_session,
+                        result_message_id=message_id,
+                        context_through_event_position=message.event.position,
+                        occurred_at=now,
+                    )
+                except RuntimeSessionStateConflictError:
+                    # The standing message and fenced run settlement are the
+                    # primary facts. Mirror ordinary terminal settlement: a
+                    # concurrent authority change must remain diagnosable but
+                    # cannot discard output the backend already produced.
+                    await connection.execute("ROLLBACK TO SAVEPOINT standing_runtime_session_settlement")
+                    await connection.execute("RELEASE SAVEPOINT standing_runtime_session_settlement")
+                else:
+                    await connection.execute("RELEASE SAVEPOINT standing_runtime_session_settlement")
             await connection.commit()
-            return StandingObserveSettlement(execution, "spoke", message_id, None, protocol_anomaly)
+            return StandingObserveSettlement(
+                execution,
+                "spoke",
+                message_id,
+                None,
+                protocol_anomaly,
+                runtime_session_result,
+            )
         except Exception:
             await connection.rollback()
             raise

--- a/tests/test_workshop_standing_execution.py
+++ b/tests/test_workshop_standing_execution.py
@@ -7,14 +7,18 @@ from pathlib import Path
 
 from kai.backend import AgentResponse
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
-from kai.workshop.diagnostics import workshop_standing_observe_execution_status
+from kai.workshop.diagnostics import (
+    workshop_runtime_session_status,
+    workshop_standing_observe_execution_status,
+)
 from kai.workshop.execution_coordinator import (
     CanonicalExecutionDisposition,
     WorkshopCanonicalExecutionCoordinator,
 )
 from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.run_lifecycle import RunKind, RunStatus
-from kai.workshop.standing_observation import WorkshopStandingObservationService
+from kai.workshop.runtime_sessions import load_runtime_session
+from kai.workshop.standing_observation import StandingObserveSettlement, WorkshopStandingObservationService
 from tests.test_workshop_execution_coordinator import (
     _Preparation,
     _PreparationByRun,
@@ -33,6 +37,8 @@ from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 
 
 def _coordinator(store, prepared, policy):
+    assert prepared.run.runtime_profile_id is not None
+    prepared.runtime_profile_id = prepared.run.runtime_profile_id
     return WorkshopCanonicalExecutionCoordinator(
         store,
         _Preparation(prepared),
@@ -105,9 +111,26 @@ async def test_standing_publication_is_once_per_human_anchor_and_suppressed_text
         await _append_message(store, channel_id, human_id, "observe-anchor", offset_seconds=1)
         first = await observation.accept_next_ready(occurred_at=_NOW + timedelta(seconds=4))
         assert first is not None
-        spoken = _Prepared(first.run, response=AgentResponse(success=True, text="Useful contribution"))
+        spoken = _Prepared(
+            first.run,
+            response=AgentResponse(
+                success=True,
+                text="Useful contribution",
+                session_id="standing-provider-session",
+            ),
+        )
         first_result = await _coordinator(store, spoken, policy).execute(first.run.run_id)
         assert first_result.run.standing_outcome == "spoke"
+        assert isinstance(first_result.terminal, StandingObserveSettlement)
+        assert first_result.terminal.runtime_session is not None
+        session = await load_runtime_session(store, channel_id, first.run.agent_id)
+        assert session is not None
+        assert session.last_run_id == first.run.run_id
+        assert session.last_result_message_id == first_result.run.result_message_id
+        assert session.provider_session_id == "standing-provider-session"
+        assert workshop_runtime_session_status(tmp_path / "kai.db").startswith(
+            "Workshop conversation continuity: active; successful lanes=1, sessions=1"
+        )
 
         peer = await _other_agent_principal(store, human_id)
         await _append_message(store, channel_id, peer, "observe-peer-followup", offset_seconds=12)
@@ -128,6 +151,7 @@ async def test_standing_publication_is_once_per_human_anchor_and_suppressed_text
             "ORDER BY created_event_position"
         ) as cursor:
             assert [str(row[0]) for row in await cursor.fetchall()] == ["Useful contribution"]
+        assert "missing=0, stale=0" in workshop_runtime_session_status(tmp_path / "kai.db")
     finally:
         await store.close()
 

--- a/tests/test_workshop_standing_observation.py
+++ b/tests/test_workshop_standing_observation.py
@@ -305,7 +305,7 @@ async def test_overflow_pauses_explicitly_and_retains_inspectable_omitted_range(
         assert [len(batch.message_ids) for batch in await observation.pending_batches(state)] == [2]
         assert "paused overflow=1" in workshop_standing_observation_status(path)
         assert (
-            "cursors=1 (delivery boundary initialized=1, backlog beyond boundary=1)"
+            "cursors=1 (delivery boundary initialized=1, considered beyond delivery boundary=1)"
             in workshop_standing_observation_status(path)
         )
         assert "integrity gaps=0, replay gaps=0" in workshop_standing_observation_status(path)


### PR DESCRIPTION
## Summary

- atomically advance canonical runtime-session continuity when an observe run publishes a standing contribution
- preserve the visible message and fenced run result if a concurrent authority change prevents continuity settlement, matching ordinary response behavior
- prove a visible standing contribution creates a current, restart-persistable provider session with zero continuity drift
- clarify that an observation cursor may have considered ineligible events beyond its delivery boundary without having a pending backlog

## Installed finding

The two-agent qualification produced exactly two standing publications and then reported exactly two stale runtime sessions. The visible observe path had committed both messages without advancing either lane's canonical session boundary.

## Validation

- focused standing/execution tests: 38 passed
- `make check`
- `make client-check` (194 tests)
- `make test` (6,573 tests)

Corrects the installed continuity gap discovered while qualifying #1470. The issue remains open for restart/revocation qualification and final epic reconciliation.
