### PR TITLE
Prevent standing observation retries from crashing Kai

### DIFF
--- a/src/kai/sessions.py
+++ b/src/kai/sessions.py
@@ -185,10 +185,10 @@ async def init_db(db_path: Path) -> None:
     Called once at startup from main.py. Uses aiosqlite.Row as the row
     factory so query results can be accessed by column name.
 
-    All DDL (CREATE TABLE, ALTER TABLE, migrations) runs inside a single
-    explicit transaction. On failure, ROLLBACK undoes everything - the
-    database is either fully initialized or completely unchanged. SQLite
-    supports transactional DDL (as does PostgreSQL; MySQL does not).
+    Workshop schema migrations run first in their own managed transactions so
+    foreign-key-sensitive table rebuilds can safely change SQLite enforcement
+    between migrations. Legacy session DDL then runs in one explicit
+    transaction and remains all-or-nothing.
 
     Args:
         db_path: Path to the SQLite database file (created if missing).
@@ -213,6 +213,7 @@ async def init_db(db_path: Path) -> None:
     _restrict_sqlite_files(db_path)
 
     try:
+        await migrate_workshop_schema(_get_db())
         # BEGIN IMMEDIATE acquires the write lock up front rather than on
         # the first write statement, preventing a deadlock if another
         # connection holds a read lock during our init sequence.
@@ -348,10 +349,6 @@ async def init_db(db_path: Path) -> None:
             await _get_db().execute("DROP TABLE workspace_history")
             await _get_db().execute("ALTER TABLE workspace_history_new RENAME TO workspace_history")
 
-        # Additive Workshop schema only. Canonical bootstrap records are
-        # created separately after the protected user configuration has
-        # loaded; no message path reads these tables yet.
-        await migrate_workshop_schema(_get_db(), manage_transaction=False)
         await _get_db().commit()
         _restrict_sqlite_files(db_path)
     except Exception:

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 74
+WORKSHOP_SCHEMA_VERSION = 75
 
 
 @dataclass(frozen=True, slots=True)
@@ -3332,6 +3332,13 @@ _STANDING_OBSERVE_EXECUTION_SCHEMA = SchemaMigration(
     ),
 )
 
+
+_RUN_KIND_SCOPED_IDENTITY_SCHEMA = SchemaMigration(
+    version=75,
+    name="run_kind_scoped_identity",
+    statements=(),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -3407,7 +3414,136 @@ _MIGRATIONS = (
     _STANDING_PARTICIPATION_AUTHORITY_SCHEMA,
     _STANDING_OBSERVATION_INBOX_SCHEMA,
     _STANDING_OBSERVE_EXECUTION_SCHEMA,
+    _RUN_KIND_SCOPED_IDENTITY_SCHEMA,
 )
+
+
+_RUN_KIND_SCOPED_IDENTITY_STATEMENTS = (
+    "ALTER TABLE runs RENAME TO runs_v74",
+    """
+    CREATE TABLE runs (
+        id TEXT PRIMARY KEY,
+        workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+        channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+        requested_by_principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
+        agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE RESTRICT,
+        inbound_message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE RESTRICT,
+        status TEXT NOT NULL CHECK (
+            status IN ('accepted', 'started', 'completed', 'failed', 'cancelled')
+        ),
+        accepted_at TEXT NOT NULL,
+        started_at TEXT,
+        terminal_at TEXT,
+        terminal_code TEXT,
+        last_event_position INTEGER NOT NULL UNIQUE
+            REFERENCES event_log(position) ON DELETE RESTRICT,
+        cancellation_requested_at TEXT,
+        cancellation_code TEXT,
+        result_message_id TEXT REFERENCES messages(id) ON DELETE RESTRICT,
+        agent_definition_revision_id TEXT
+            REFERENCES agent_definition_revisions(id) ON DELETE RESTRICT,
+        runtime_profile_id TEXT,
+        sponsor_principal_id TEXT REFERENCES principals(id) ON DELETE RESTRICT,
+        parent_run_id TEXT REFERENCES runs(id) ON DELETE RESTRICT,
+        delegation_id TEXT,
+        kind TEXT NOT NULL DEFAULT 'respond' CHECK (kind IN ('respond', 'observe')),
+        observation_scope_kind TEXT CHECK (
+            observation_scope_kind IS NULL OR observation_scope_kind IN ('channel', 'thread')
+        ),
+        observation_scope_id TEXT,
+        observed_from_event_position INTEGER REFERENCES event_log(position) ON DELETE RESTRICT,
+        observed_through_event_position INTEGER REFERENCES event_log(position) ON DELETE RESTRICT,
+        observed_message_ids_json TEXT CHECK (
+            observed_message_ids_json IS NULL OR (
+                json_valid(observed_message_ids_json)
+                AND json_type(observed_message_ids_json) = 'array'
+            )
+        ),
+        human_anchor_message_id TEXT REFERENCES messages(id) ON DELETE RESTRICT,
+        standing_subscription_started_event_position INTEGER
+            REFERENCES event_log(position) ON DELETE RESTRICT,
+        standing_outcome TEXT CHECK (
+            standing_outcome IS NULL OR standing_outcome IN (
+                'spoke', 'silent', 'publication_suppressed'
+            )
+        ),
+        CHECK (
+            (status = 'accepted' AND started_at IS NULL
+                AND terminal_at IS NULL AND terminal_code IS NULL)
+            OR (status = 'started' AND started_at IS NOT NULL
+                AND terminal_at IS NULL AND terminal_code IS NULL)
+            OR (status = 'completed' AND started_at IS NOT NULL
+                AND terminal_at IS NOT NULL AND terminal_code IS NULL)
+            OR (status = 'failed' AND started_at IS NOT NULL
+                AND terminal_at IS NOT NULL AND terminal_code IS NOT NULL)
+            OR (status = 'cancelled' AND terminal_at IS NOT NULL
+                AND terminal_code IS NOT NULL)
+        )
+    )
+    """,
+    """
+    INSERT INTO runs (
+        id, workshop_id, channel_id, requested_by_principal_id, agent_id,
+        inbound_message_id, status, accepted_at, started_at, terminal_at,
+        terminal_code, last_event_position, cancellation_requested_at,
+        cancellation_code, result_message_id, agent_definition_revision_id,
+        runtime_profile_id, sponsor_principal_id, parent_run_id, delegation_id,
+        kind, observation_scope_kind, observation_scope_id,
+        observed_from_event_position, observed_through_event_position,
+        observed_message_ids_json, human_anchor_message_id,
+        standing_subscription_started_event_position, standing_outcome
+    ) SELECT
+        id, workshop_id, channel_id, requested_by_principal_id, agent_id,
+        inbound_message_id, status, accepted_at, started_at, terminal_at,
+        terminal_code, last_event_position, cancellation_requested_at,
+        cancellation_code, result_message_id, agent_definition_revision_id,
+        runtime_profile_id, sponsor_principal_id, parent_run_id, delegation_id,
+        kind, observation_scope_kind, observation_scope_id,
+        observed_from_event_position, observed_through_event_position,
+        observed_message_ids_json, human_anchor_message_id,
+        standing_subscription_started_event_position, standing_outcome
+    FROM runs_v74
+    """,
+    "DROP TABLE runs_v74",
+    "CREATE INDEX runs_channel_status_idx ON runs (channel_id, status, accepted_at)",
+    "CREATE INDEX runs_agent_status_idx ON runs (agent_id, status, accepted_at)",
+    "CREATE INDEX runs_agent_definition_revision_idx ON runs (agent_definition_revision_id, accepted_at)",
+    "CREATE UNIQUE INDEX runs_delegation_idx ON runs (delegation_id) WHERE delegation_id IS NOT NULL",
+    "CREATE INDEX runs_parent_run_idx ON runs (parent_run_id, accepted_at) WHERE parent_run_id IS NOT NULL",
+    "CREATE INDEX runs_kind_status_idx ON runs (kind, status, accepted_at)",
+    "CREATE UNIQUE INDEX runs_respond_inbound_agent_idx ON runs (inbound_message_id, agent_id) WHERE kind = 'respond'",
+    "CREATE UNIQUE INDEX runs_observe_batch_idx ON runs "
+    "(channel_id, agent_id, observation_scope_id, observed_from_event_position, "
+    "observed_through_event_position) WHERE kind = 'observe' "
+    "AND status IN ('accepted', 'started')",
+)
+
+
+async def _migrate_run_kind_scoped_identity(connection: aiosqlite.Connection) -> None:
+    """Replace the legacy all-run input constraint outside foreign-key mode."""
+    if connection.in_transaction:
+        raise RuntimeError("Run identity migration requires no active transaction")
+    await connection.execute("PRAGMA foreign_keys=OFF")
+    await connection.execute("PRAGMA legacy_alter_table=ON")
+    try:
+        await connection.execute("BEGIN IMMEDIATE")
+        for statement in _RUN_KIND_SCOPED_IDENTITY_STATEMENTS:
+            await connection.execute(statement)
+        async with connection.execute("PRAGMA foreign_key_check") as cursor:
+            foreign_key_gaps = list(await cursor.fetchall())
+        if foreign_key_gaps:
+            raise RuntimeError("Run identity migration created foreign-key gaps")
+        await connection.execute(
+            "INSERT INTO workshop_schema_migrations (version, name) VALUES (?, ?)",
+            (_RUN_KIND_SCOPED_IDENTITY_SCHEMA.version, _RUN_KIND_SCOPED_IDENTITY_SCHEMA.name),
+        )
+        await connection.commit()
+    except Exception:
+        await connection.rollback()
+        raise
+    finally:
+        await connection.execute("PRAGMA legacy_alter_table=OFF")
+        await connection.execute("PRAGMA foreign_keys=ON")
 
 
 async def migrate_workshop_schema(
@@ -3438,6 +3574,13 @@ async def migrate_workshop_schema(
 
         for migration in _MIGRATIONS:
             if migration.version in applied:
+                continue
+            if migration == _RUN_KIND_SCOPED_IDENTITY_SCHEMA:
+                if not manage_transaction:
+                    raise RuntimeError("Run identity migration requires managed transactions")
+                await connection.commit()
+                await _migrate_run_kind_scoped_identity(connection)
+                applied.add(migration.version)
                 continue
             for statement in migration.statements:
                 await connection.execute(statement)

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -579,7 +579,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 74
+        assert await upgraded.schema_version() == 75
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -451,7 +451,7 @@ async def test_version_sixty_seven_migrates_only_legacy_delegation_requests(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 74
+        assert await upgraded.schema_version() == 75
         async with upgraded.connection.execute(
             "SELECT id, capabilities_json, collaboration_operations_json "
             "FROM agent_definition_revisions ORDER BY revision_number"

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -412,7 +412,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
             after = workshop_runtime_session_status(path)
             assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
@@ -440,7 +440,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
             assert session is not None
             assert session.runtime_profile_id == _RUNTIME_PROFILE_ID

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -273,7 +273,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 74
+        assert await workshop_store.schema_version() == 75
         async with workshop_store.connection.execute("PRAGMA table_info(principals)") as cursor:
             principal_columns = {str(row[1]) for row in await cursor.fetchall()}
         assert {"display_name_state_version", "display_name_event_position"} <= principal_columns
@@ -297,6 +297,9 @@ class TestWorkshopSchema:
         async with workshop_store.connection.execute("PRAGMA table_info(runs)") as cursor:
             run_columns = {str(row[1]) for row in await cursor.fetchall()}
         assert {"runtime_profile_id", "sponsor_principal_id"} <= run_columns
+        async with workshop_store.connection.execute("PRAGMA index_list(runs)") as cursor:
+            run_indexes = {str(row[1]): (bool(row[2]), bool(row[4])) for row in await cursor.fetchall()}
+        assert run_indexes["runs_respond_inbound_agent_idx"] == (True, True)
         async with workshop_store.connection.execute("PRAGMA index_list(messages)") as cursor:
             message_indexes = {str(row[1]) for row in await cursor.fetchall()}
         assert "messages_channel_thread_position_idx" in message_indexes
@@ -324,7 +327,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 74
+        assert await second.schema_version() == 75
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -408,7 +411,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             async with upgraded.connection.execute(
                 "SELECT reaction, created_event_position FROM message_reactions "
                 "WHERE message_id = ? AND principal_id = ?",
@@ -449,7 +452,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -477,7 +480,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -569,6 +572,7 @@ class TestWorkshopSchema:
                     72,
                     73,
                     74,
+                    75,
                 ]
         finally:
             await upgraded.close()
@@ -591,7 +595,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -632,7 +636,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -685,7 +689,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -729,7 +733,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -773,7 +777,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -817,7 +821,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -921,7 +925,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -1048,7 +1052,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -319,7 +319,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 74
+            assert await upgraded.schema_version() == 75
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),

--- a/tests/test_workshop_standing_execution.py
+++ b/tests/test_workshop_standing_execution.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
+
 from kai.backend import AgentResponse
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.diagnostics import (
@@ -19,6 +21,7 @@ from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.run_lifecycle import RunKind, RunStatus
 from kai.workshop.runtime_sessions import load_runtime_session
 from kai.workshop.standing_observation import StandingObserveSettlement, WorkshopStandingObservationService
+from kai.workshop.store import WorkshopEventStore
 from tests.test_workshop_execution_coordinator import (
     _Preparation,
     _PreparationByRun,
@@ -36,14 +39,14 @@ from tests.test_workshop_standing_participation import _message
 from tests.workshop_delivery import TELEGRAM_DELIVERY_POLICY
 
 
-def _coordinator(store, prepared, policy):
+def _coordinator(store, prepared, policy, *, offset_seconds: float = 30):
     assert prepared.run.runtime_profile_id is not None
     prepared.runtime_profile_id = prepared.run.runtime_profile_id
     return WorkshopCanonicalExecutionCoordinator(
         store,
         _Preparation(prepared),
         registered_backend_ids=frozenset({"codex"}),
-        clock=lambda: _NOW + timedelta(seconds=30),
+        clock=lambda: _NOW + timedelta(seconds=offset_seconds),
         delivery_policy=TELEGRAM_DELIVERY_POLICY,
         collaboration_host_policy=policy,
     )
@@ -180,6 +183,67 @@ async def test_empty_observe_response_fails_silently_and_defers_retry(tmp_path: 
         assert str(state[1]) == (_NOW + timedelta(seconds=90)).isoformat()
     finally:
         await store.close()
+
+
+async def test_failed_observe_batch_retries_after_run_identity_upgrade(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kai.workshop import schema
+
+    path = tmp_path / "kai.db"
+    policy = _host_policy()
+    with monkeypatch.context() as migration_context:
+        migration_context.setattr(schema, "WORKSHOP_SCHEMA_VERSION", 74)
+        migration_context.setattr(schema, "_MIGRATIONS", schema._MIGRATIONS[:74])
+        store, human_id, channel_id, _agent_id, _standing = await _observation_authority(path)
+        observation = WorkshopStandingObservationService(store, policy)
+        try:
+            await observation.synchronize_host_policy()
+            await _append_message(store, channel_id, human_id, "observe-existing", offset_seconds=1)
+            existing = await observation.accept_next_ready(occurred_at=_NOW + timedelta(seconds=4))
+            assert existing is not None
+            spoken = _Prepared(existing.run, response=AgentResponse(success=True, text="Existing output"))
+            result = await _coordinator(store, spoken, policy).execute(existing.run.run_id)
+            assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+            existing_result_message_id = result.run.result_message_id
+            assert existing_result_message_id is not None
+
+            await _append_message(store, channel_id, human_id, "observe-retry", offset_seconds=40)
+            failed_acceptance = await observation.accept_next_ready(occurred_at=_NOW + timedelta(seconds=43))
+            assert failed_acceptance is not None
+            failed = _Prepared(failed_acceptance.run, response=AgentResponse(success=True, text=""))
+            result = await _coordinator(store, failed, policy, offset_seconds=60).execute(failed_acceptance.run.run_id)
+            assert result.disposition == CanonicalExecutionDisposition.FAILED
+        finally:
+            await store.close()
+
+    upgraded = await WorkshopEventStore.open(path)
+    observation = WorkshopStandingObservationService(upgraded, policy)
+    try:
+        assert await upgraded.schema_version() == schema.WORKSHOP_SCHEMA_VERSION
+        retry = await observation.accept_next_ready(occurred_at=_NOW + timedelta(seconds=125))
+        assert retry is not None
+        assert retry.run.run_id != failed_acceptance.run.run_id
+        assert retry.run.inbound_message_id == failed_acceptance.run.inbound_message_id
+        silent = _Prepared(retry.run, response=AgentResponse(success=True, text="<<silent>>"))
+        result = await _coordinator(upgraded, silent, policy, offset_seconds=150).execute(retry.run.run_id)
+        assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+        assert result.run.standing_outcome == "silent"
+        async with upgraded.connection.execute(
+            "SELECT COUNT(*) FROM runs WHERE inbound_message_id = ? AND agent_id = ?",
+            (failed_acceptance.run.inbound_message_id, failed_acceptance.run.agent_id),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 2
+        async with upgraded.connection.execute(
+            "SELECT COUNT(*) FROM standing_observation_publications WHERE run_id = ? AND result_message_id = ?",
+            (existing.run.run_id, existing_result_message_id),
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 1
+        async with upgraded.connection.execute("PRAGMA foreign_key_check") as cursor:
+            assert await cursor.fetchall() == []
+    finally:
+        await upgraded.close()
 
 
 async def test_host_disable_after_acceptance_fails_closed_before_backend_dispatch(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1477

## Summary
- scope run-input uniqueness to response runs while retaining active observation-batch fencing
- migrate schema 74 safely while preserving run relationships and verifying foreign-key integrity
- qualify failed standing retries and independent Workshop migration startup

## Validation
- `.venv/bin/python -m pytest tests/test_workshop_foundation.py tests/test_workshop_standing_execution.py tests/test_sessions.py -q` (198 passed)
- `make check`
- `make client-check`
- `make test` (6574 passed)