### PR TITLE
Repair restarted standing observation cursors

### DIFF
--- a/src/kai/workshop/private_text_execution.py
+++ b/src/kai/workshop/private_text_execution.py
@@ -44,6 +44,7 @@ from kai.workshop.store import WorkshopEventStore
 from kai.workshop.transcript_export import CanonicalTranscriptProjection
 
 _RECOVERY_INTERVAL_SECONDS = 1.0
+_RECOVERY_ERROR_INTERVAL_SECONDS = 30.0
 log = logging.getLogger(__name__)
 
 
@@ -126,6 +127,12 @@ class WorkshopPrivateTextExecutionService:
             store,
             coordinator.collaboration_authority.host_policy,
         )
+        repaired_observation_scopes = await standing_observation.reconcile_subscription_boundaries()
+        if repaired_observation_scopes:
+            log.warning(
+                "Rebased %d standing observation scope(s) retained from an ended subscription",
+                repaired_observation_scopes,
+            )
         service = cls(
             store,
             coordinator,
@@ -374,12 +381,33 @@ class WorkshopPrivateTextExecutionService:
 
     async def _recovery_loop(self) -> None:
         while True:
-            await self._recover_and_dispatch_observations()
+            recovery_failed = False
             try:
-                await asyncio.wait_for(self._stop_event.wait(), timeout=_RECOVERY_INTERVAL_SECONDS)
+                await self._recover_and_dispatch_observations()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                recovery_failed = True
+                log.exception("Standing observation recovery failed; the service remains available")
+            delay = _RECOVERY_ERROR_INTERVAL_SECONDS if recovery_failed else _RECOVERY_INTERVAL_SECONDS
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=delay)
                 return
             except TimeoutError:
-                await self._coordinator.recover_expired()
+                try:
+                    await self._coordinator.recover_expired()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    log.exception("Canonical execution recovery failed; the service remains available")
+                    try:
+                        await asyncio.wait_for(
+                            self._stop_event.wait(),
+                            timeout=_RECOVERY_ERROR_INTERVAL_SECONDS,
+                        )
+                        return
+                    except TimeoutError:
+                        pass
 
     async def _recover_and_dispatch_observations(self) -> None:
         finished = [run_id for run_id, task in self._observation_tasks.items() if task.done()]

--- a/src/kai/workshop/standing_observation.py
+++ b/src/kai/workshop/standing_observation.py
@@ -445,6 +445,45 @@ class WorkshopStandingObservationService:
             await connection.rollback()
             raise
 
+    async def reconcile_subscription_boundaries(self) -> int:
+        """Repair observation cursors retained from an ended subscription."""
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            await self._store.project_pending_in_transaction(CanonicalConversationProjection())
+            await synchronize_standing_observation_host_policy_in_transaction(
+                connection,
+                self._host_policy,
+                occurred_at=datetime.now(UTC),
+            )
+            async with connection.execute(
+                "SELECT o.channel_id, o.agent_id, o.scope_id, s.started_event_position "
+                "FROM channel_agent_observation_states o "
+                "JOIN channel_agent_standings s ON s.channel_id = o.channel_id "
+                "AND s.agent_id = o.agent_id AND s.lifecycle_state = 'active' "
+                "WHERE o.delivered_through_event_position < s.started_event_position "
+                "ORDER BY s.started_event_position, o.channel_id, o.agent_id, o.scope_id"
+            ) as cursor:
+                stale = list(await cursor.fetchall())
+            if not stale:
+                await connection.commit()
+                return 0
+            for row in stale:
+                await connection.execute(
+                    "DELETE FROM channel_agent_observation_states "
+                    "WHERE channel_id = ? AND agent_id = ? AND scope_id = ?",
+                    (str(row[0]), str(row[1]), str(row[2])),
+                )
+            earliest_start = min(int(row[3]) for row in stale)
+            for event in await self._store.read_events(after_position=earliest_start):
+                if event.envelope.event_type == WorkshopEventType.MESSAGE_CREATED:
+                    await apply_canonical_message_to_standing_observations(connection, event)
+            await connection.commit()
+            return len(stale)
+        except Exception:
+            await connection.rollback()
+            raise
+
     async def inspect(
         self,
         channel_id: ChannelId,

--- a/src/kai/workshop/standing_participation.py
+++ b/src/kai/workshop/standing_participation.py
@@ -316,6 +316,13 @@ async def apply_standing_participation_event(
             or "standing_participation" not in validate_collaboration_operations(json.loads(str(owner_policy[1])))
         ):
             raise ValueError("Standing owner-policy evidence is not current")
+        # Observation cursors belong to one standing-subscription generation.
+        # A renewed subscription must never inherit pending work, anchors, or
+        # delivery boundaries from the generation that just ended.
+        await connection.execute(
+            "DELETE FROM channel_agent_observation_states WHERE channel_id = ? AND agent_id = ?",
+            (channel_id, agent_id),
+        )
         await connection.execute(
             "INSERT INTO channel_agent_standings "
             "(channel_id, agent_id, agent_definition_id, agent_definition_revision_id, "

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import kai.workshop.private_text_execution as private_text_execution_module
 from kai.backend import AgentResponse, StreamEvent
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop, bootstrap_human_principal_id
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
@@ -201,6 +202,28 @@ def _message(*, suffix: str = "1") -> InboundMessage:
         body=f"Canonical prompt {suffix}",
         occurred_at=_NOW,
     )
+
+
+async def test_standing_recovery_failure_isolated_from_service_lifecycle(monkeypatch) -> None:
+    service = object.__new__(WorkshopPrivateTextExecutionService)
+    service._stop_event = asyncio.Event()
+    service._coordinator = SimpleNamespace(recover_expired=AsyncMock())
+    attempts = 0
+
+    async def recover() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ValueError("malformed standing observation")
+        service._stop_event.set()
+
+    service._recover_and_dispatch_observations = recover  # type: ignore[method-assign]
+    monkeypatch.setattr(private_text_execution_module, "_RECOVERY_ERROR_INTERVAL_SECONDS", 0.001)
+
+    await asyncio.wait_for(service._recovery_loop(), timeout=1)
+
+    assert attempts == 2
+    service._coordinator.recover_expired.assert_awaited_once()
 
 
 async def test_owner_accepts_executes_and_atomically_enqueues_terminal_reply(tmp_path: Path):

--- a/tests/test_workshop_standing_observation.py
+++ b/tests/test_workshop_standing_observation.py
@@ -25,7 +25,12 @@ from kai.workshop.standing_observation import WorkshopStandingObservationService
 from kai.workshop.standing_participation import WorkshopStandingParticipationService
 from kai.workshop.store import AppendResult, WorkshopEventStore
 from kai.workshop.wake_policy import EngagementScope, dismiss_channel_agent
-from tests.test_workshop_standing_participation import _NOW, _eligible_authority, _message
+from tests.test_workshop_standing_participation import (
+    _NOW,
+    _eligible_authority,
+    _message,
+    _start_without_run,
+)
 
 
 def _host_policy(**overrides: object) -> CollaborationHostPolicy:
@@ -163,6 +168,103 @@ async def test_every_canonical_message_source_uses_one_coalesced_observation_tri
         assert batches[0].message_ids == tuple(result.event.envelope.aggregate_id for result in results)
         async with store.connection.execute("SELECT COUNT(*) FROM runs") as cursor:
             assert int((await cursor.fetchone())[0]) == initial_runs
+    finally:
+        await store.close()
+
+
+async def test_restarted_subscription_rebases_observation_and_repairs_installed_stale_cursor(
+    tmp_path: Path,
+) -> None:
+    store, human_id, channel_id, agent_id, standing = await _observation_authority(tmp_path / "kai.db")
+    observation = WorkshopStandingObservationService(store, _host_policy())
+    try:
+        await observation.synchronize_host_policy()
+        old_message = await _append_message(
+            store,
+            channel_id,
+            human_id,
+            "before-standing-restart",
+            offset_seconds=1,
+        )
+        disabled = await standing.set_channel_policy(
+            human_id,
+            channel_id,
+            enabled=False,
+            expected_policy_version=1,
+            client_operation_id="observation-restart-disable",
+        )
+        enabled = await standing.set_channel_policy(
+            human_id,
+            channel_id,
+            enabled=True,
+            expected_policy_version=disabled.snapshot.policy.policy_version,
+            client_operation_id="observation-restart-enable",
+        )
+        assert enabled.snapshot.policy.enabled is True
+        await _start_without_run(
+            store,
+            standing,
+            human_id,
+            channel_id,
+            agent_id,
+            "observation-restart-mention",
+            occurred_at=_NOW + timedelta(seconds=2),
+        )
+        after_restart = await _append_message(
+            store,
+            channel_id,
+            human_id,
+            "after-standing-restart",
+            offset_seconds=3,
+        )
+
+        snapshot = await standing.inspect(human_id, channel_id)
+        assert any(item.lifecycle_state == "active" for item in snapshot.subscriptions)
+        async with store.connection.execute(
+            "SELECT started_event_position FROM channel_agent_standings "
+            "WHERE channel_id = ? AND agent_id = ? AND lifecycle_state = 'active'",
+            (channel_id, agent_id),
+        ) as cursor:
+            started_row = await cursor.fetchone()
+        assert started_row is not None
+        started_event_position = int(started_row[0])
+        expected = await observation.inspect(channel_id, agent_id, current_at=_NOW + timedelta(seconds=4))
+        assert len(expected) == 1
+        assert expected[0].delivered_through_event_position == started_event_position
+        assert expected[0].pending_message_count == 1
+        assert (await observation.pending_batches(expected[0]))[0].message_ids == (
+            after_restart.event.envelope.aggregate_id,
+        )
+        assert (
+            old_message.event.envelope.aggregate_id
+            not in (await observation.pending_batches(expected[0]))[0].message_ids
+        )
+
+        await store.connection.execute(
+            "UPDATE channel_agent_observation_states SET delivered_through_event_position = ? "
+            "WHERE channel_id = ? AND agent_id = ?",
+            (started_event_position - 1, channel_id, agent_id),
+        )
+        await store.connection.commit()
+        assert await observation.reconcile_subscription_boundaries() == 1
+        assert (
+            await observation.inspect(
+                channel_id,
+                agent_id,
+                current_at=_NOW + timedelta(seconds=4),
+            )
+            == expected
+        )
+
+        await store.rebuild_projection(CanonicalConversationProjection())
+        assert (
+            await observation.inspect(
+                channel_id,
+                agent_id,
+                current_at=_NOW + timedelta(seconds=4),
+            )
+            == expected
+        )
     finally:
         await store.close()
 


### PR DESCRIPTION
## Summary

- reset derived standing-observation state whenever a new subscription generation starts
- repair already-installed pre-subscription cursors from canonical message events before recovery begins
- isolate and back off standing/canonical recovery failures so they cannot terminate the Kai host
- cover the exact disable, re-enable, re-mention, pending-message, restart failure sequence

## Validation

- `make check`
- `.venv/bin/python -m pytest tests/test_workshop_standing_observation.py tests/test_workshop_standing_participation.py tests/test_workshop_private_text_execution.py -q` (26 passed)
- `make test` with local test-server permission (6576 passed)
- production database backup rehearsal: `stale_before=3 repaired=3 stale_after=0 accept_ready=True`

Fixes #1481
