### PR TITLE
Fix Workshop authority status drift

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -9713,12 +9713,13 @@ def _model_catalogue_status(database_path: Path, policy_path: Path) -> str:
         return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
     active = len(rows)
     succeeded = sum(str(row[0]) == "succeeded" for row in rows)
-    failed = sum(str(row[0]) not in {"succeeded", "refreshing"} for row in rows)
+    unsupported = sum(str(row[0]) == "unsupported" for row in rows)
+    failed = sum(str(row[0]) not in {"succeeded", "refreshing", "unsupported"} for row in rows)
     refreshed = sum(row[1] is not None for row in rows)
     state = "active" if active <= expected and failed == 0 else "DEGRADED"
     return (
         f"{prefix} {state}; contexts={expected}, active={active}, refreshed={refreshed}, "
-        f"succeeded={succeeded}, failed={failed}, discovered entries={entries}, "
+        f"succeeded={succeeded}, unsupported={unsupported}, failed={failed}, discovered entries={entries}, "
         f"operator entries={operator_entries}; diagnostic discovery=disabled"
     )
 
@@ -10194,8 +10195,11 @@ def _channel_lifecycle_status(db_path: Path) -> str:
                     "LEFT JOIN event_log e ON e.position = l.position "
                     "WHERE (c.kind != 'group' AND (c.archived_at IS NOT NULL "
                     "OR c.lifecycle_event_position IS NOT NULL) AND NOT ("
-                    "c.kind = 'direct' AND e.event_type = 'channel.archived' "
-                    "AND json_extract(e.metadata_json, '$.source') = 'human_provisioning_migration')) "
+                    "c.kind = 'direct' AND e.event_type IN ('channel.archived', 'channel.restored') "
+                    "AND json_extract(e.metadata_json, '$.source') = 'human_provisioning_migration' "
+                    "AND c.lifecycle_event_position = e.position "
+                    "AND ((c.archived_at IS NOT NULL AND e.event_type = 'channel.archived') "
+                    "OR (c.archived_at IS NULL AND e.event_type = 'channel.restored')))) "
                     "OR (c.kind = 'group' AND c.archived_at IS NOT NULL AND ("
                     "e.event_type IS NULL OR e.event_type != 'channel.archived' "
                     "OR c.lifecycle_event_position != e.position)) "

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -83,10 +83,23 @@ _EXECUTION_STATE_TABLES = {
     "channel_agent_execution_settings",
     "channel_agent_runtime_assignments",
     "channel_agent_workspace_settings",
+    "channel_memberships",
+    "channels",
+    "principal_agent_enablements",
     "principal_workspace_grants",
     "principal_workspace_history",
+    "principals",
     "workshop_execution_state_migrations",
 }
+_PROTECTED_EXECUTION_STATE_LANES_SQL = (
+    " FROM channel_agent_runtime_assignments a "
+    "JOIN channels c ON c.id = a.channel_id AND c.kind = 'direct' AND c.archived_at IS NULL "
+    "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
+    "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
+    "LEFT JOIN principal_agent_enablements pae ON pae.direct_channel_id = c.id "
+    "AND pae.agent_id = a.agent_id "
+    "WHERE pae.id IS NULL OR pae.lifecycle_state = 'enabled'"
+)
 _MEMORY_AUTHORITY_TABLES = {
     "channel_agent_runtime_assignments",
     "channel_memberships",
@@ -97,8 +110,12 @@ _MEMORY_AUTHORITY_TABLES = {
 }
 _OPERATIONAL_STATE_TABLES = {
     "channel_agent_runtime_assignments",
+    "channel_memberships",
+    "channels",
     "jobs",
+    "principal_agent_enablements",
     "principal_github_subscriptions",
+    "principals",
     "workshop_execution_state_migrations",
     "workshop_job_owners",
     "workshop_operational_state_migrations",
@@ -1352,23 +1369,22 @@ def workshop_execution_state_status(db_path: Path) -> str:
             }
             if not tables >= _EXECUTION_STATE_TABLES:
                 return f"{prefix} pending; canonical execution-state schema unavailable"
-            profiles = _scalar(connection, "SELECT COUNT(*) FROM channel_agent_runtime_assignments")
-            migrated = _scalar(connection, "SELECT COUNT(*) FROM workshop_execution_state_migrations")
-            missing = _scalar(
+            profiles = _scalar(
                 connection,
-                "SELECT COUNT(*) FROM channel_agent_runtime_assignments a WHERE NOT EXISTS ("
-                "SELECT 1 FROM workshop_execution_state_migrations m "
-                "WHERE m.runtime_profile_id = a.runtime_profile_id AND m.channel_id = a.channel_id "
-                "AND m.agent_id = a.agent_id)",
+                "SELECT COUNT(DISTINCT a.runtime_profile_id)" + _PROTECTED_EXECUTION_STATE_LANES_SQL,
             )
+            migrated = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM workshop_execution_state_migrations m WHERE EXISTS ("
+                "SELECT 1" + _PROTECTED_EXECUTION_STATE_LANES_SQL + " "
+                "AND a.runtime_profile_id = m.runtime_profile_id)",
+            )
+            missing = max(profiles - migrated, 0)
             stale = _scalar(
                 connection,
                 "SELECT COUNT(*) FROM workshop_execution_state_migrations m WHERE NOT EXISTS ("
-                "SELECT 1 FROM channel_agent_runtime_assignments a "
-                "JOIN channels c ON c.id = a.channel_id AND c.kind = 'direct' "
-                "JOIN channel_memberships cm ON cm.channel_id = c.id AND cm.role = 'owner' "
-                "JOIN principals p ON p.id = cm.principal_id AND p.kind = 'human' "
-                "WHERE a.runtime_profile_id = m.runtime_profile_id "
+                "SELECT 1" + _PROTECTED_EXECUTION_STATE_LANES_SQL + " "
+                "AND a.runtime_profile_id = m.runtime_profile_id "
                 "AND a.channel_id = m.channel_id AND a.agent_id = m.agent_id "
                 "AND cm.principal_id = m.principal_id)",
             )
@@ -1522,24 +1538,20 @@ def workshop_operational_state_status(db_path: Path) -> str:
                 return f"{prefix} pending; canonical operational-state schema unavailable"
             profiles = _scalar(
                 connection,
-                "SELECT COUNT(*) FROM channel_agent_runtime_assignments",
+                "SELECT COUNT(DISTINCT a.runtime_profile_id)" + _PROTECTED_EXECUTION_STATE_LANES_SQL,
             )
             migrated = _scalar(
                 connection,
-                "SELECT COUNT(*) FROM workshop_operational_state_migrations",
+                "SELECT COUNT(*) FROM workshop_operational_state_migrations m WHERE EXISTS ("
+                "SELECT 1" + _PROTECTED_EXECUTION_STATE_LANES_SQL + " "
+                "AND a.runtime_profile_id = m.runtime_profile_id)",
             )
-            missing = _scalar(
-                connection,
-                "SELECT COUNT(*) FROM channel_agent_runtime_assignments a WHERE NOT EXISTS ("
-                "SELECT 1 FROM workshop_operational_state_migrations m "
-                "WHERE m.runtime_profile_id = a.runtime_profile_id "
-                "AND m.channel_id = a.channel_id AND m.agent_id = a.agent_id)",
-            )
+            missing = max(profiles - migrated, 0)
             stale = _scalar(
                 connection,
                 "SELECT COUNT(*) FROM workshop_operational_state_migrations m WHERE NOT EXISTS ("
-                "SELECT 1 FROM channel_agent_runtime_assignments a "
-                "WHERE a.runtime_profile_id = m.runtime_profile_id "
+                "SELECT 1" + _PROTECTED_EXECUTION_STATE_LANES_SQL + " "
+                "AND a.runtime_profile_id = m.runtime_profile_id "
                 "AND a.channel_id = m.channel_id AND a.agent_id = m.agent_id)",
             )
             jobs = _scalar(connection, "SELECT COUNT(*) FROM workshop_scheduled_jobs")
@@ -1548,18 +1560,18 @@ def workshop_operational_state_status(db_path: Path) -> str:
                 connection,
                 "SELECT COUNT(*) FROM workshop_scheduled_job_migrations",
             )
-            missing_job_migrations = _scalar(
+            covered_job_migrations = _scalar(
                 connection,
-                "SELECT COUNT(*) FROM channel_agent_runtime_assignments a WHERE NOT EXISTS ("
-                "SELECT 1 FROM workshop_scheduled_job_migrations m "
-                "WHERE m.runtime_profile_id = a.runtime_profile_id "
-                "AND m.channel_id = a.channel_id AND m.agent_id = a.agent_id)",
+                "SELECT COUNT(*) FROM workshop_scheduled_job_migrations m WHERE EXISTS ("
+                "SELECT 1" + _PROTECTED_EXECUTION_STATE_LANES_SQL + " "
+                "AND a.runtime_profile_id = m.runtime_profile_id)",
             )
+            missing_job_migrations = max(profiles - covered_job_migrations, 0)
             stale_job_migrations = _scalar(
                 connection,
                 "SELECT COUNT(*) FROM workshop_scheduled_job_migrations m WHERE NOT EXISTS ("
-                "SELECT 1 FROM channel_agent_runtime_assignments a "
-                "WHERE a.runtime_profile_id = m.runtime_profile_id "
+                "SELECT 1" + _PROTECTED_EXECUTION_STATE_LANES_SQL + " "
+                "AND a.runtime_profile_id = m.runtime_profile_id "
                 "AND a.channel_id = m.channel_id AND a.agent_id = m.agent_id)",
             )
             unmigrated_jobs = _scalar(
@@ -1685,13 +1697,16 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
             in {
                 WorkshopEventType.CHANNEL_CREATED,
                 WorkshopEventType.WORKSHOP_MEMBER_ADDED,
-                WorkshopEventType.CHANNEL_MEMBER_ADDED,
                 WorkshopEventType.TRANSPORT_CHANNEL_BOUND,
                 WorkshopEventType.RUNTIME_PROFILE_ASSIGNED,
             }
             and envelope.event_version != 1
         ):
             raise ValueError("Workshop event replay encountered an unsupported event version")
+        if envelope.event_type == WorkshopEventType.CHANNEL_MEMBER_ADDED and envelope.event_version not in {1, 2}:
+            raise ValueError("Workshop event replay encountered an unsupported membership version")
+        if envelope.event_type == WorkshopEventType.CHANNEL_MEMBER_REMOVED and envelope.event_version != 1:
+            raise ValueError("Workshop event replay encountered an unsupported membership version")
         if envelope.event_type == WorkshopEventType.PRINCIPAL_CREATED:
             if envelope.event_version not in {1, 2}:
                 raise ValueError("Workshop event replay encountered an unsupported principal version")
@@ -1742,6 +1757,16 @@ def _replay_state(connection: sqlite3.Connection) -> _ReplayState:
                     _required_payload_text(payload, "role"),
                 ),
             )
+            continue
+        if envelope.event_type == WorkshopEventType.CHANNEL_MEMBER_REMOVED:
+            expected = (
+                _required_payload_text(payload, "channel_id"),
+                _required_payload_text(payload, "principal_id"),
+                _required_payload_text(payload, "role"),
+            )
+            if channel_memberships.get(aggregate_id) != expected:
+                raise ValueError("Workshop membership removal has no matching replayed membership")
+            del channel_memberships[aggregate_id]
             continue
         if envelope.event_type == WorkshopEventType.RUNTIME_PROFILE_ASSIGNED:
             _insert_replayed_fact(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5386,14 +5386,17 @@ class TestCmdStatus:
             "aggregate_type TEXT, event_type TEXT, metadata_json TEXT);"
             "INSERT INTO channels VALUES "
             "('chn_active','wsp_one','group','Active',NULL,NULL,NULL),"
-            "('chn_archived','wsp_one','group','Archived','2026-08-30T15:00:00Z',7,NULL);"
+            "('chn_archived','wsp_one','group','Archived','2026-08-30T15:00:00Z',7,NULL),"
+            "('chn_restored','wsp_one','direct','Restored',NULL,8,NULL);"
             "INSERT INTO principals VALUES ('prn_one','human'),('prn_two','human');"
             "INSERT INTO channel_memberships VALUES "
             "('chn_active','prn_one','owner'),('chn_archived','prn_two','owner');"
             "INSERT INTO workshop_memberships VALUES ('wsp_one','prn_one'),('wsp_one','prn_two');"
             "INSERT INTO human_handles VALUES ('wsp_one','prn_one'),('wsp_one','prn_two');"
             "INSERT INTO event_log VALUES "
-            "(7,'chn_archived','channel','channel.archived','{}');"
+            "(7,'chn_archived','channel','channel.archived','{}'),"
+            "(8,'chn_restored','channel','channel.restored','{\"source\":\"human_provisioning_migration\"}');"
+            "INSERT INTO channel_bindings VALUES ('chn_restored');"
         )
         connection.commit()
         connection.close()
@@ -10369,7 +10372,47 @@ backends:
 
         assert status == (
             "Workshop model catalogue: active; contexts=1, active=1, refreshed=1, "
-            "succeeded=1, failed=0, discovered entries=2, operator entries=1; "
+            "succeeded=1, unsupported=0, failed=0, discovered entries=2, operator entries=1; "
+            "diagnostic discovery=disabled"
+        )
+
+    def test_model_catalogue_status_treats_unsupported_discovery_as_expected(self, tmp_path):
+        profile_id = str(kai.install.runtime_profile_id_for_config_id(101))
+        policy = tmp_path / "runtime-profiles.yaml"
+        policy.write_text(
+            yaml.safe_dump(
+                {
+                    "version": 1,
+                    "runtime_profiles": {
+                        profile_id: {
+                            "display_name": "Daniel",
+                            "compatibility_runtime_config_id": 101,
+                            "backend": "claude",
+                            "provider": "anthropic",
+                            "model": "sonnet",
+                            "timeout_seconds": 120,
+                            "allowed_services": [],
+                            "home_workspace": None,
+                            "workspace_base": None,
+                            "allowed_workspaces": [],
+                        }
+                    },
+                }
+            )
+        )
+        database = tmp_path / "kai.db"
+        with sqlite3.connect(database) as connection:
+            connection.execute(
+                "CREATE TABLE workshop_model_catalogue_refreshes "
+                "(status TEXT, last_successful_refresh_at TEXT, active INTEGER)"
+            )
+            connection.execute("CREATE TABLE workshop_model_catalogue_discovered_entries (status TEXT)")
+            connection.execute("CREATE TABLE workshop_model_catalogue_operator_entries (active INTEGER)")
+            connection.execute("INSERT INTO workshop_model_catalogue_refreshes VALUES ('unsupported', NULL, 1)")
+
+        assert _model_catalogue_status(database, policy) == (
+            "Workshop model catalogue: active; contexts=1, active=1, refreshed=0, "
+            "succeeded=0, unsupported=1, failed=0, discovered entries=0, operator entries=0; "
             "diagnostic discovery=disabled"
         )
 

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -61,7 +61,11 @@ from kai.workshop.collaboration_policy import (
     WorkshopCollaborationPolicyAccessDenied,
 )
 from kai.workshop.conversation_commands import ConversationCommandDisposition
-from kai.workshop.diagnostics import workshop_human_avatar_status
+from kai.workshop.diagnostics import (
+    workshop_canonical_message_integrity_status,
+    workshop_human_avatar_status,
+    workshop_legacy_jsonl_archive_status,
+)
 from kai.workshop.domain import (
     AgentDefinitionId,
     AgentId,
@@ -2753,6 +2757,9 @@ class TestWorkshopChannelLifecycleHTTPContract:
             assert retried_payload["changed"] is False
             assert added_payload["state_version"] == retried_payload["state_version"]
             membership_version = added_payload["state_version"]
+            assert workshop_canonical_message_integrity_status(tmp_path / "kai.db").startswith(
+                "Workshop canonical message integrity: clean;"
+            )
 
             bob_members = await client.get(path, headers={"Authorization": "Bearer bob"})
             assert bob_members.status == 200
@@ -2831,6 +2838,38 @@ class TestWorkshopChannelLifecycleHTTPContract:
             replayed = await client.get(path, headers={"Authorization": "Bearer alice"})
             assert replayed.status == 200
             assert [item["display_name"] for item in (await replayed.json())["members"]] == ["Alice"]
+            assert workshop_canonical_message_integrity_status(tmp_path / "kai.db").startswith(
+                "Workshop canonical message integrity: clean;"
+            )
+            assert workshop_legacy_jsonl_archive_status(
+                tmp_path / "kai.db",
+                tmp_path / "history",
+            ).startswith("Workshop legacy JSONL archive: classified;")
+            async with store.connection.execute(
+                "SELECT workshop_id FROM channels WHERE id = ?",
+                (channel_id,),
+            ) as cursor:
+                workshop_row = await cursor.fetchone()
+            assert workshop_row is not None
+            await store.append(
+                EventEnvelope.create(
+                    event_type=WorkshopEventType.CHANNEL_MEMBER_ADDED,
+                    event_version=3,
+                    workshop_id=WorkshopId(str(workshop_row[0])),
+                    aggregate_type="channel_membership",
+                    aggregate_id=ChannelMembershipId.new(),
+                    actor_principal_id=alice_id,
+                    occurred_at=_NOW,
+                    payload={
+                        "channel_id": channel_id,
+                        "principal_id": bob_id,
+                        "role": "participant",
+                    },
+                )
+            )
+            assert workshop_canonical_message_integrity_status(tmp_path / "kai.db").startswith(
+                "Workshop canonical message integrity: NOT VERIFIED"
+            )
         finally:
             await client.close()
             await store.close()

--- a/tests/test_workshop_operational_state.py
+++ b/tests/test_workshop_operational_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,12 +10,14 @@ import pytest
 
 from kai import sessions
 from kai.workshop.bootstrap import BootstrapHuman
-from kai.workshop.diagnostics import workshop_operational_state_status
+from kai.workshop.diagnostics import workshop_execution_state_status, workshop_operational_state_status
+from kai.workshop.domain import ChannelAgentId, ChannelId, EventEnvelope, RuntimeAssignmentId, WorkshopId
 from kai.workshop.execution_state import (
     WorkshopExecutionStateNamespace,
     WorkshopExecutionStateRegistry,
 )
 from kai.workshop.operational_state import WorkshopOperationalStateError
+from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id, profile_registry
 
 
@@ -390,6 +393,56 @@ class TestCanonicalOperationalStateWrites:
 
 
 class TestCanonicalOperationalStateDiagnostic:
+    async def test_additional_group_lane_does_not_require_protected_migration_receipts(self, database: Path):
+        registry = await _bootstrap(101)
+        await sessions.initialize_workshop_operational_state(registry, _config(101))
+        namespace = registry.namespaces[0]
+        connection = sessions._get_db()
+        async with connection.execute(
+            "SELECT workshop_id FROM channels WHERE id = ?", (namespace.channel_id,)
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        workshop_id = WorkshopId(str(row[0]))
+        group_id = ChannelId.new()
+        event = await WorkshopEventStore.from_initialized_connection(connection).append(
+            EventEnvelope.create(
+                event_type="qualification.runtime_assigned",
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="channel",
+                aggregate_id=group_id,
+                occurred_at=datetime.now(UTC),
+                payload={},
+            )
+        )
+        created_at = event.event.envelope.occurred_at.isoformat()
+        await connection.execute(
+            "INSERT INTO channels (id, workshop_id, kind, name, created_at) VALUES (?, ?, 'group', ?, ?)",
+            (group_id, workshop_id, "Additional lane", created_at),
+        )
+        await connection.execute(
+            "INSERT INTO channel_agents (id, channel_id, agent_id, created_at) VALUES (?, ?, ?, ?)",
+            (ChannelAgentId.new(), group_id, namespace.agent_id, created_at),
+        )
+        await connection.execute(
+            "INSERT INTO channel_agent_runtime_assignments "
+            "(id, channel_id, agent_id, runtime_profile_id, created_at, created_event_position) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                RuntimeAssignmentId.new(),
+                group_id,
+                namespace.agent_id,
+                namespace.runtime_profile_id,
+                created_at,
+                event.event.position,
+            ),
+        )
+        await connection.commit()
+
+        assert "active; profiles=1, migrated=1, missing=0, stale=0" in workshop_execution_state_status(database)
+        assert "active; profiles=1, migrated=1, missing=0, stale=0" in workshop_operational_state_status(database)
+
     async def test_reports_clean_authority_and_detects_unowned_job(self, database: Path):
         registry = await _bootstrap(101)
         await sessions.initialize_workshop_operational_state(registry, _config(101))


### PR DESCRIPTION
Closes #1483

## Summary

- replay canonical human membership additions/removals across their supported event versions
- validate retained provisioning-migration direct-channel archive and restore state
- measure execution and operational migration coverage per protected runtime profile instead of per collaboration lane
- distinguish expected unsupported model discovery from actual catalogue failures

## Verification

- `make check`
- affected test files: 839 passed
- full suite: 6578 passed in 218.20s
- production database read-only rehearsal: canonical replay clean with 0 mismatches; legacy archive classified; channel lifecycle active with 0 gaps; execution and operational state active with 3/3 protected profiles migrated