### PR TITLE
Expose agent creation readiness and authorized runtime choices

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -19,6 +19,7 @@ from kai.backend_registry import (
 )
 from kai.config import Config, models_for_backend_policy
 from kai.pool import SubprocessPool
+from kai.workshop.agent_creation_options import WorkshopAgentCreationOptionsService
 from kai.workshop.agent_delegation import WorkshopAgentDelegationService
 from kai.workshop.agent_enablement import WorkshopAgentEnablementService
 from kai.workshop.appearance_preferences import WorkshopAppearancePreferenceService
@@ -209,6 +210,7 @@ class KaiCoreServices:
     client_preferences: WorkshopClientPreferenceService
     appearance_preferences: WorkshopAppearancePreferenceService
     human_avatars: WorkshopHumanAvatarService
+    agent_creation_options: WorkshopAgentCreationOptionsService
     agent_enablement: WorkshopAgentEnablementService
     proactive_publication: WorkshopProactivePublicationService
     integration_notifications: WorkshopIntegrationNotificationService
@@ -480,6 +482,11 @@ class KaiApplicationHost:
                 self._internal_api_contexts,
                 runtime_pool,
             )
+            agent_creation_options = WorkshopAgentCreationOptionsService(
+                model_discovery_inventory,
+                model_catalogue,
+                runtime_pool,
+            )
             proactive_publication = WorkshopProactivePublicationService(
                 client_store,
                 artifacts,
@@ -538,6 +545,7 @@ class KaiApplicationHost:
                 channel_notification_policy=channel_notification_policy,
                 client_preferences=client_preferences,
                 appearance_preferences=appearance_preferences,
+                agent_creation_options=agent_creation_options,
                 agent_enablement=agent_enablement,
                 proactive_publication=proactive_publication,
                 integration_notifications=integration_notifications,

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -67,6 +67,7 @@ from kai.config import (
 )
 from kai.internal_api_auth import InternalAPIAuth, InternalAPIPrincipal, InternalAPIScope
 from kai.job_types import CANONICAL_JOB_TYPES, normalize_job_type
+from kai.workshop.agent_creation_options import WorkshopAgentCreationOptionsService
 from kai.workshop.agent_delegation import (
     AgentDelegationConflict,
     AgentDelegationDenied,
@@ -2180,6 +2181,7 @@ async def _register_workshop_client_api(
     channel_notification_policy: WorkshopChannelNotificationPolicyService | None = None,
     client_preferences: WorkshopClientPreferenceService | None = None,
     appearance_preferences: WorkshopAppearancePreferenceService | None = None,
+    agent_creation_options: WorkshopAgentCreationOptionsService | None = None,
     agent_enablement: WorkshopAgentEnablementService | None = None,
     human_avatars: WorkshopHumanAvatarService | None = None,
     collaboration_policy: WorkshopCollaborationPolicyService | None = None,
@@ -2226,6 +2228,7 @@ async def _register_workshop_client_api(
             channel_notification_policy=channel_notification_policy,
             client_preferences=client_preferences,
             appearance_preferences=appearance_preferences,
+            agent_creation_options=agent_creation_options,
             agent_enablement=agent_enablement,
             human_avatars=human_avatars,
             collaboration_policy=collaboration_policy,
@@ -2317,6 +2320,7 @@ async def start(
             channel_notification_policy=getattr(core_services, "channel_notification_policy", None),
             client_preferences=getattr(core_services, "client_preferences", None),
             appearance_preferences=getattr(core_services, "appearance_preferences", None),
+            agent_creation_options=getattr(core_services, "agent_creation_options", None),
             agent_enablement=getattr(core_services, "agent_enablement", None),
             human_avatars=getattr(core_services, "human_avatars", None),
             collaboration_policy=getattr(core_services, "collaboration_policy", None),

--- a/src/kai/workshop/agent_creation_options.py
+++ b/src/kai/workshop/agent_creation_options.py
@@ -1,0 +1,264 @@
+"""Principal-scoped readiness and choices for Workshop agent creation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from kai.workshop.domain import PrincipalId, RuntimeProfileId
+from kai.workshop.model_catalogue import ModelCatalogueError, WorkshopModelCatalogueService
+from kai.workshop.model_discovery_inventory import (
+    ModelDiscoveryBackendInventory,
+    ModelDiscoveryProfileInventory,
+    ModelDiscoveryReadiness,
+    WorkshopModelDiscoveryInventoryService,
+)
+from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.settings_workspaces import MIN_SELF_SERVICE_TIMEOUT_SECONDS
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCreationBlocker:
+    """One stable, actionable reason a creation choice is not ready."""
+
+    code: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCreationModelOption:
+    """One model visible through the canonical model catalogue."""
+
+    model_id: str
+    display_name: str
+    status: str
+    selectable: bool
+    retained: bool
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCreationBackendOption:
+    """One operator-authorized backend/provider choice."""
+
+    option_id: str
+    backend: str
+    provider: str
+    current: bool
+    readiness: str
+    default_model: str
+    models: tuple[AgentCreationModelOption, ...]
+    catalogue_status: str | None
+    catalogue_stale: bool
+    blockers: tuple[AgentCreationBlocker, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCreationWorkspaceOption:
+    """One authorized workspace path and its current availability."""
+
+    path: str
+    name: str
+    default: bool
+    available: bool
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCreationRuntimeOption:
+    """One principal-owned protected runtime suitable for agent creation."""
+
+    runtime_profile_id: RuntimeProfileId
+    display_name: str
+    current_backend_option_id: str
+    default_workspace: str | None
+    default_timeout_seconds: int
+    minimum_timeout_seconds: int
+    maximum_timeout_seconds: int
+    backends: tuple[AgentCreationBackendOption, ...]
+    workspaces: tuple[AgentCreationWorkspaceOption, ...]
+    ready: bool
+    blockers: tuple[AgentCreationBlocker, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCreationOptions:
+    """Complete bounded creation readiness for one authenticated principal."""
+
+    principal_id: PrincipalId
+    ready: bool
+    runtimes: tuple[AgentCreationRuntimeOption, ...]
+    blockers: tuple[AgentCreationBlocker, ...]
+
+
+class WorkshopAgentCreationOptionsService:
+    """Project creation choices from existing canonical runtime authorities.
+
+    Inspection is deliberately side-effect free: it never refreshes model
+    discovery, starts a runtime, writes settings, or creates an agent draft.
+    """
+
+    def __init__(
+        self,
+        inventory: WorkshopModelDiscoveryInventoryService,
+        model_catalogue: WorkshopModelCatalogueService,
+        runtime_pool: WorkshopRuntimePool,
+    ) -> None:
+        self._inventory = inventory
+        self._model_catalogue = model_catalogue
+        self._runtime_pool = runtime_pool
+
+    async def inspect(self, principal_id: PrincipalId) -> AgentCreationOptions:
+        inventories = self._inventory.for_principal(principal_id)
+        runtimes = tuple([await self._runtime(item) for item in inventories])
+        blockers: tuple[AgentCreationBlocker, ...]
+        if not runtimes:
+            blockers = (
+                AgentCreationBlocker(
+                    "no_authorized_runtime_profiles",
+                    "No protected runtime profile is authorized for this principal.",
+                ),
+            )
+        elif not any(runtime.ready for runtime in runtimes):
+            blockers = (
+                AgentCreationBlocker(
+                    "no_ready_runtime_profiles",
+                    "No authorized runtime profile currently has a usable backend and default workspace.",
+                ),
+            )
+        else:
+            blockers = ()
+        return AgentCreationOptions(principal_id, not blockers, runtimes, blockers)
+
+    async def _runtime(self, inventory: ModelDiscoveryProfileInventory) -> AgentCreationRuntimeOption:
+        profile = self._runtime_pool.runtime_profile(inventory.runtime_profile_id)
+        backends = tuple(
+            [
+                await self._backend(
+                    inventory.principal_id,
+                    inventory.runtime_profile_id,
+                    item,
+                )
+                for item in inventory.backends
+            ]
+        )
+        workspaces, default_workspace = await self._workspaces(profile.profile_id, profile.workspace_base)
+        blockers: list[AgentCreationBlocker] = []
+        if not any(not backend.blockers for backend in backends):
+            blockers.append(
+                AgentCreationBlocker(
+                    "no_available_backend",
+                    "No authorized backend is currently available for this runtime profile.",
+                )
+            )
+        if default_workspace is None:
+            blockers.append(
+                AgentCreationBlocker(
+                    "default_workspace_unavailable",
+                    "The runtime profile's default workspace is unavailable.",
+                )
+            )
+        return AgentCreationRuntimeOption(
+            runtime_profile_id=profile.profile_id,
+            display_name=profile.display_name,
+            current_backend_option_id=inventory.selected_option_id,
+            default_workspace=default_workspace,
+            default_timeout_seconds=profile.timeout_seconds,
+            minimum_timeout_seconds=MIN_SELF_SERVICE_TIMEOUT_SECONDS,
+            maximum_timeout_seconds=profile.maximum_timeout_seconds,
+            backends=backends,
+            workspaces=workspaces,
+            ready=not blockers,
+            blockers=tuple(blockers),
+        )
+
+    async def _backend(
+        self,
+        principal_id: PrincipalId,
+        runtime_profile_id: RuntimeProfileId,
+        inventory: ModelDiscoveryBackendInventory,
+    ) -> AgentCreationBackendOption:
+        models: tuple[AgentCreationModelOption, ...] = ()
+        catalogue_status: str | None = None
+        catalogue_stale = True
+        try:
+            snapshot = await self._model_catalogue.inspect(
+                self._model_catalogue.authority_for_principal(principal_id),
+                runtime_profile_id,
+                inventory.option_id,
+            )
+        except ModelCatalogueError:
+            pass
+        else:
+            models = tuple(
+                AgentCreationModelOption(
+                    item.model_id,
+                    item.display_label,
+                    item.status.value,
+                    item.selectable,
+                    item.retained,
+                )
+                for item in snapshot.entries
+            )
+            catalogue_status = snapshot.refresh.status.value if snapshot.refresh is not None else None
+            catalogue_stale = snapshot.stale
+
+        blockers: tuple[AgentCreationBlocker, ...] = ()
+        if inventory.readiness == ModelDiscoveryReadiness.UNAVAILABLE:
+            blockers = (
+                AgentCreationBlocker(
+                    "backend_unavailable",
+                    "The authorized backend is not currently available.",
+                ),
+            )
+        elif inventory.readiness == ModelDiscoveryReadiness.MISCONFIGURED:
+            blockers = (
+                AgentCreationBlocker(
+                    "backend_misconfigured",
+                    "The authorized backend requires operator attention.",
+                ),
+            )
+        return AgentCreationBackendOption(
+            option_id=inventory.option_id,
+            backend=inventory.backend,
+            provider=inventory.provider,
+            current=inventory.selected,
+            readiness=inventory.readiness.value,
+            default_model=inventory.default_model,
+            models=models,
+            catalogue_status=catalogue_status,
+            catalogue_stale=catalogue_stale,
+            blockers=blockers,
+        )
+
+    async def _workspaces(
+        self,
+        runtime_profile_id: RuntimeProfileId,
+        workspace_base: Path | None,
+    ) -> tuple[tuple[AgentCreationWorkspaceOption, ...], str | None]:
+        try:
+            home = self._runtime_pool.get_home_workspace(runtime_profile_id).expanduser().resolve()
+        except RuntimeError:
+            return (), None
+        _base, allowed = await self._runtime_pool.resolve_workspace_access(runtime_profile_id)
+        candidates = {home, *(path.expanduser().resolve() for path in allowed)}
+        options = tuple(
+            AgentCreationWorkspaceOption(
+                path=str(path),
+                name=self._workspace_name(path, workspace_base, home),
+                default=path == home,
+                available=path.is_dir(),
+            )
+            for path in sorted(candidates, key=lambda item: (item != home, str(item)))
+        )
+        default_workspace = str(home) if home.is_dir() else None
+        return options, default_workspace
+
+    @staticmethod
+    def _workspace_name(path: Path, base: Path | None, home: Path) -> str:
+        if path == home:
+            return "Home"
+        if base is not None:
+            try:
+                return str(path.relative_to(base.resolve())) or path.name
+            except ValueError:
+                pass
+        return path.name

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -19,6 +19,11 @@ from urllib.parse import quote
 
 from aiohttp import BodyPartReader, web
 
+from kai.workshop.agent_creation_options import (
+    AgentCreationBlocker,
+    AgentCreationOptions,
+    WorkshopAgentCreationOptionsService,
+)
 from kai.workshop.agent_enablement import (
     PrincipalAgentEnablement,
     WorkshopAgentEnablementAccessDenied,
@@ -339,6 +344,7 @@ _CHANNEL_MEMBER_REMOVAL_PATH = "/v1/channels/{channel_id}/members/{principal_id}
 _WORKSHOP_HUMANS_PATH = "/v1/workshops/{workshop_id}/humans"
 _HUMAN_CONVERSATION_PATH = "/v1/workshops/{workshop_id}/humans/{principal_id}/conversation"
 _AGENT_DEFINITIONS_PATH = "/v1/client/agents"
+_AGENT_CREATION_OPTIONS_PATH = "/v1/client/agents/creation-options"
 _AGENT_EVENTS_PATH = "/v1/client/agents/events"
 _AGENT_DEFINITION_PATH = "/v1/client/agents/{definition_id}"
 _AGENT_REVISIONS_PATH = "/v1/client/agents/{definition_id}/revisions"
@@ -1084,6 +1090,64 @@ def _serialize_agent_definition(snapshot: AgentDefinitionSnapshot) -> dict[str, 
                 "event_position": revision.event_position,
             }
             for revision in snapshot.revisions
+        ],
+    }
+
+
+def _serialize_agent_creation_options(snapshot: AgentCreationOptions) -> dict[str, object]:
+    def blocker(item: AgentCreationBlocker) -> dict[str, str]:
+        return {"code": item.code, "detail": item.detail}
+
+    return {
+        "principal_id": str(snapshot.principal_id),
+        "ready": snapshot.ready,
+        "blockers": [blocker(item) for item in snapshot.blockers],
+        "runtimes": [
+            {
+                "runtime_profile_id": str(runtime.runtime_profile_id),
+                "display_name": runtime.display_name,
+                "current_backend_option_id": runtime.current_backend_option_id,
+                "default_workspace": runtime.default_workspace,
+                "default_timeout_seconds": runtime.default_timeout_seconds,
+                "minimum_timeout_seconds": runtime.minimum_timeout_seconds,
+                "maximum_timeout_seconds": runtime.maximum_timeout_seconds,
+                "ready": runtime.ready,
+                "blockers": [blocker(item) for item in runtime.blockers],
+                "backends": [
+                    {
+                        "option_id": backend.option_id,
+                        "backend": backend.backend,
+                        "provider": backend.provider,
+                        "current": backend.current,
+                        "readiness": backend.readiness,
+                        "default_model": backend.default_model,
+                        "catalogue_status": backend.catalogue_status,
+                        "catalogue_stale": backend.catalogue_stale,
+                        "blockers": [blocker(item) for item in backend.blockers],
+                        "models": [
+                            {
+                                "model_id": model.model_id,
+                                "display_name": model.display_name,
+                                "status": model.status,
+                                "selectable": model.selectable,
+                                "retained": model.retained,
+                            }
+                            for model in backend.models
+                        ],
+                    }
+                    for backend in runtime.backends
+                ],
+                "workspaces": [
+                    {
+                        "path": workspace.path,
+                        "name": workspace.name,
+                        "default": workspace.default,
+                        "available": workspace.available,
+                    }
+                    for workspace in runtime.workspaces
+                ],
+            }
+            for runtime in snapshot.runtimes
         ],
     }
 
@@ -5049,6 +5113,32 @@ async def _handle_agent_definition_list(
     )
 
 
+async def _handle_agent_creation_options(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentCreationOptionsService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    if request.query or request.can_read_body:
+        return _error_response(status=400, code="invalid_request", message="Invalid agent creation-options request")
+    try:
+        snapshot = await service.inspect(principal_id)
+    except Exception:
+        return _error_response(
+            status=503,
+            code="agent_creation_options_unavailable",
+            message="Agent creation options are temporarily unavailable",
+        )
+    return _json_response(
+        {"version": 1, "creation_options": _serialize_agent_creation_options(snapshot)},
+        status=200,
+    )
+
+
 async def _handle_agent_definition_detail(
     request: web.Request,
     *,
@@ -7758,6 +7848,7 @@ def register_workshop_read_routes(
     channel_notification_policy: WorkshopChannelNotificationPolicyService | None = None,
     client_preferences: WorkshopClientPreferenceService | None = None,
     appearance_preferences: WorkshopAppearancePreferenceService | None = None,
+    agent_creation_options: WorkshopAgentCreationOptionsService | None = None,
     agent_enablement: WorkshopAgentEnablementService | None = None,
     human_avatars: WorkshopHumanAvatarService | None = None,
     collaboration_policy: WorkshopCollaborationPolicyService | None = None,
@@ -7925,6 +8016,15 @@ def register_workshop_read_routes(
                 request,
                 authenticator=authenticator,
                 service=agent_lifecycle,
+            )
+
+    async def handle_agent_creation_options(request: web.Request) -> web.Response:
+        assert agent_creation_options is not None
+        async with request_lock:
+            return await _handle_agent_creation_options(
+                request,
+                authenticator=authenticator,
+                service=agent_creation_options,
             )
 
     async def handle_agent_definition_detail(request: web.Request) -> web.Response:
@@ -8214,6 +8314,8 @@ def register_workshop_read_routes(
         app.router.add_get(_CHANNEL_STANDING_PARTICIPATION_PATH, handle_channel_standing_participation)
         app.router.add_put(_CHANNEL_STANDING_PARTICIPATION_PATH, handle_channel_standing_participation)
         app.router.add_post(_CHANNEL_STANDING_OBSERVATION_RESUME_PATH, handle_standing_observation_resume)
+    if agent_creation_options is not None:
+        app.router.add_get(_AGENT_CREATION_OPTIONS_PATH, handle_agent_creation_options)
     app.router.add_get(_AGENT_DEFINITIONS_PATH, handle_agent_definition_list)
     app.router.add_post(_AGENT_DEFINITIONS_PATH, handle_agent_definition_create)
     app.router.add_get(_AGENT_EVENTS_PATH, handle_agent_event_stream)

--- a/tests/test_workshop_agent_creation_options.py
+++ b/tests/test_workshop_agent_creation_options.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from kai.backend_registry import BackendRegistryEntry
+from kai.workshop.agent_creation_options import WorkshopAgentCreationOptionsService
+from kai.workshop.domain import AgentId, ChannelId, PrincipalId, RuntimeProfileId
+from kai.workshop.execution_state import WorkshopExecutionStateNamespace, WorkshopExecutionStateRegistry
+from kai.workshop.model_catalogue import ModelCatalogueRefreshStatus, WorkshopModelCatalogueService
+from kai.workshop.model_discovery_inventory import WorkshopModelDiscoveryInventoryService
+from kai.workshop.runtime_pool import WorkshopRuntimePool
+from kai.workshop.runtime_profiles import (
+    ProtectedRuntimeBackend,
+    ProtectedRuntimeProfile,
+    WorkshopRuntimeProfileRegistry,
+)
+
+
+def _id(identifier_type, value: int):
+    return identifier_type(f"{identifier_type.prefix}_{value:032x}")
+
+
+def _executable(path: Path) -> str:
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o700)
+    return str(path)
+
+
+def _profile(
+    value: int,
+    home: Path,
+    allowed: Path,
+    *,
+    options: tuple[ProtectedRuntimeBackend, ...] | None = None,
+) -> ProtectedRuntimeProfile:
+    choices = options or (
+        ProtectedRuntimeBackend("claude", "anthropic", "claude-default"),
+        ProtectedRuntimeBackend("opencode", "openrouter", "open-default"),
+    )
+    return ProtectedRuntimeProfile(
+        profile_id=_id(RuntimeProfileId, value),
+        display_name=f"Profile {value}",
+        os_user="daniel",
+        backend="claude",
+        provider="anthropic",
+        model="claude-default",
+        timeout_seconds=300,
+        maximum_timeout_seconds=1800,
+        allowed_services=(),
+        home_workspace=home,
+        workspace_base=allowed.parent,
+        allowed_workspaces=(allowed,),
+        backend_options=choices,
+    )
+
+
+def _namespace(value: int, principal: int) -> WorkshopExecutionStateNamespace:
+    return WorkshopExecutionStateNamespace(
+        _id(PrincipalId, principal),
+        _id(ChannelId, value),
+        _id(AgentId, value),
+        _id(RuntimeProfileId, value),
+        None,
+    )
+
+
+class _RuntimePool:
+    def __init__(self, profiles: WorkshopRuntimeProfileRegistry) -> None:
+        self._profiles = profiles
+
+    def runtime_profile(self, profile_id: RuntimeProfileId) -> ProtectedRuntimeProfile:
+        return self._profiles.resolve(profile_id)
+
+    def get_home_workspace(self, profile_id: RuntimeProfileId) -> Path:
+        profile = self._profiles.resolve(profile_id)
+        assert profile.home_workspace is not None
+        if not profile.home_workspace.is_dir():
+            raise RuntimeError("unavailable")
+        return profile.home_workspace
+
+    async def resolve_workspace_access(self, profile_id: RuntimeProfileId) -> tuple[Path | None, list[Path]]:
+        profile = self._profiles.resolve(profile_id)
+        return profile.workspace_base, list(profile.allowed_workspaces)
+
+
+async def _services(
+    tmp_path: Path,
+    *,
+    profiles: tuple[ProtectedRuntimeProfile, ...],
+    namespaces: tuple[WorkshopExecutionStateNamespace, ...],
+) -> tuple[WorkshopAgentCreationOptionsService, WorkshopModelCatalogueService]:
+    registry = WorkshopRuntimeProfileRegistry(profiles)
+    execution = WorkshopExecutionStateRegistry(namespaces)
+    inventory = WorkshopModelDiscoveryInventoryService(
+        config=SimpleNamespace(codex_auth_mode="subscription"),  # type: ignore[arg-type]
+        runtime_profiles=registry,
+        execution_state=execution,
+        backend_registry={
+            backend: BackendRegistryEntry(
+                id=backend,
+                driver=backend,
+                runtime="local_process",
+                command=_executable(tmp_path / backend),
+            )
+            for backend in sorted({option.backend for profile in profiles for option in profile.backend_options})
+        },
+        selected_backend=lambda _profile_id: ("claude", "anthropic"),
+        service_os_user="kai",
+        environment={"OPENROUTER_API_KEY": "secret-not-for-output"},
+    )
+
+    async def selected_model(_profile_id: RuntimeProfileId) -> str:
+        return "claude-selected"
+
+    catalogue = await WorkshopModelCatalogueService.open(
+        tmp_path / "kai.db",
+        inventory,
+        selected_model=selected_model,
+        curated_models=(
+            lambda lane: (
+                {"claude-default": "Claude Default", "claude-new": "Claude New"} if lane.backend == "claude" else None
+            )
+        ),
+    )
+    return (
+        WorkshopAgentCreationOptionsService(
+            inventory,
+            catalogue,
+            cast(WorkshopRuntimePool, _RuntimePool(registry)),
+        ),
+        catalogue,
+    )
+
+
+async def test_projects_authorized_choices_without_mutation_and_isolates_principals(tmp_path: Path) -> None:
+    alice_home = tmp_path / "alice-home"
+    alice_repo = tmp_path / "repos" / "kai"
+    bob_home = tmp_path / "bob-home"
+    bob_repo = tmp_path / "repos" / "vox"
+    for path in (alice_home, alice_repo, bob_home, bob_repo):
+        path.mkdir(parents=True, exist_ok=True)
+    profiles = (
+        _profile(1, alice_home, alice_repo),
+        _profile(2, bob_home, bob_repo),
+    )
+    service, catalogue = await _services(
+        tmp_path,
+        profiles=profiles,
+        namespaces=(_namespace(1, 10), _namespace(2, 20)),
+    )
+    alice = _id(PrincipalId, 10)
+    try:
+        unsupported = await catalogue.refresh(
+            catalogue.authority_for_principal(alice),
+            _id(RuntimeProfileId, 1),
+            "opencode:openrouter",
+        )
+        first = await service.inspect(alice)
+        second = await service.inspect(alice)
+    finally:
+        await catalogue.close()
+
+    assert unsupported.status == ModelCatalogueRefreshStatus.UNSUPPORTED
+    assert first == second
+    assert first.ready is True
+    assert [runtime.runtime_profile_id for runtime in first.runtimes] == [_id(RuntimeProfileId, 1)]
+    runtime = first.runtimes[0]
+    assert runtime.current_backend_option_id == "claude:anthropic"
+    assert runtime.default_workspace == str(alice_home)
+    assert [(item.name, item.default, item.available) for item in runtime.workspaces] == [
+        ("Home", True, True),
+        ("kai", False, True),
+    ]
+    assert (runtime.minimum_timeout_seconds, runtime.default_timeout_seconds, runtime.maximum_timeout_seconds) == (
+        1,
+        300,
+        1800,
+    )
+    by_backend = {item.option_id: item for item in runtime.backends}
+    assert by_backend["claude:anthropic"].default_model == "claude-default"
+    assert [item.model_id for item in by_backend["claude:anthropic"].models] == [
+        "claude-default",
+        "claude-new",
+        "claude-selected",
+    ]
+    assert by_backend["claude:anthropic"].models[-1].retained is True
+    assert by_backend["opencode:openrouter"].catalogue_status == "unsupported"
+    assert by_backend["opencode:openrouter"].blockers == ()
+    assert "secret-not-for-output" not in repr(first)
+
+
+async def test_reports_actionable_readiness_without_creating_state(tmp_path: Path) -> None:
+    missing_home = tmp_path / "missing-home"
+    missing_repo = tmp_path / "missing-repo"
+    profile = _profile(1, missing_home, missing_repo)
+    service, catalogue = await _services(
+        tmp_path,
+        profiles=(profile,),
+        namespaces=(_namespace(1, 10),),
+    )
+    try:
+        snapshot = await service.inspect(_id(PrincipalId, 10))
+        unknown = await service.inspect(_id(PrincipalId, 99))
+    finally:
+        await catalogue.close()
+
+    assert snapshot.ready is False
+    assert [item.code for item in snapshot.blockers] == ["no_ready_runtime_profiles"]
+    assert [item.code for item in snapshot.runtimes[0].blockers] == ["default_workspace_unavailable"]
+    assert unknown.ready is False
+    assert unknown.runtimes == ()
+    assert [item.code for item in unknown.blockers] == ["no_authorized_runtime_profiles"]
+
+
+async def test_projects_every_supported_backend_family_in_stable_order(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    repo = tmp_path / "repo"
+    home.mkdir()
+    repo.mkdir()
+    options = (
+        ProtectedRuntimeBackend("pi", "openai-codex", "pi-default"),
+        ProtectedRuntimeBackend("goose", "ollama", "goose-default"),
+        ProtectedRuntimeBackend("opencode", "openrouter", "opencode-default"),
+        ProtectedRuntimeBackend("codex", "openai", "codex-default"),
+        ProtectedRuntimeBackend("claude", "anthropic", "claude-default"),
+    )
+    profile = _profile(1, home, repo, options=options)
+    service, catalogue = await _services(
+        tmp_path,
+        profiles=(profile,),
+        namespaces=(_namespace(1, 10),),
+    )
+    try:
+        snapshot = await service.inspect(_id(PrincipalId, 10))
+    finally:
+        await catalogue.close()
+
+    assert [item.option_id for item in snapshot.runtimes[0].backends] == [
+        "claude:anthropic",
+        "codex:openai",
+        "goose:ollama",
+        "opencode:openrouter",
+        "pi:openai-codex",
+    ]
+    assert all(item.default_model.endswith("-default") for item in snapshot.runtimes[0].backends)
+
+
+async def test_unavailable_backends_block_readiness_without_hiding_choices(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    repo = tmp_path / "repo"
+    home.mkdir()
+    repo.mkdir()
+    profile = _profile(1, home, repo)
+    service, catalogue = await _services(
+        tmp_path,
+        profiles=(profile,),
+        namespaces=(_namespace(1, 10),),
+    )
+    (tmp_path / "claude").unlink()
+    (tmp_path / "opencode").unlink()
+    try:
+        snapshot = await service.inspect(_id(PrincipalId, 10))
+    finally:
+        await catalogue.close()
+
+    runtime = snapshot.runtimes[0]
+    assert runtime.ready is False
+    assert [item.code for item in runtime.blockers] == ["no_available_backend"]
+    assert [item.code for item in snapshot.blockers] == ["no_ready_runtime_profiles"]
+    assert [item.option_id for item in runtime.backends] == [
+        "claude:anthropic",
+        "opencode:openrouter",
+    ]
+    assert all(item.blockers[0].code == "backend_unavailable" for item in runtime.backends)

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -15,6 +15,12 @@ from aiohttp import FormData, web
 from aiohttp.test_utils import TestClient, TestServer
 from PIL import Image
 
+from kai.workshop.agent_creation_options import (
+    AgentCreationBackendOption,
+    AgentCreationOptions,
+    AgentCreationRuntimeOption,
+    AgentCreationWorkspaceOption,
+)
 from kai.workshop.agent_enablement import EligibleAgentRuntime, PrincipalAgentEnablement
 from kai.workshop.appearance_preferences import (
     WORKSHOP_APPEARANCE_THEMES,
@@ -773,6 +779,49 @@ class _AgentEnablement:
         return replace(self._snapshot("enabled"), conversation_started=True)
 
 
+@dataclass
+class _AgentCreationOptions:
+    principal_id: PrincipalId
+    calls: list[PrincipalId] = field(default_factory=list)
+
+    async def inspect(self, principal_id: PrincipalId) -> AgentCreationOptions:
+        assert principal_id == self.principal_id
+        self.calls.append(principal_id)
+        return AgentCreationOptions(
+            principal_id,
+            True,
+            (
+                AgentCreationRuntimeOption(
+                    profile_id(101),
+                    "Daniel",
+                    "claude:anthropic",
+                    "/srv/daniel",
+                    300,
+                    1,
+                    1800,
+                    (
+                        AgentCreationBackendOption(
+                            "claude:anthropic",
+                            "claude",
+                            "anthropic",
+                            True,
+                            "unverified",
+                            "claude-sonnet-4-5",
+                            (),
+                            "unsupported",
+                            True,
+                            (),
+                        ),
+                    ),
+                    (AgentCreationWorkspaceOption("/srv/daniel", "Home", True, True),),
+                    True,
+                    (),
+                ),
+            ),
+            (),
+        )
+
+
 async def _identity_for(store: WorkshopEventStore, subject: str) -> tuple[PrincipalId, ChannelId]:
     async with store.connection.execute(
         "SELECT e.principal_id, b.channel_id FROM external_identities e "
@@ -899,6 +948,7 @@ async def _open_client(
     notification_preferences=None,
     client_preferences=None,
     appearance_preferences=None,
+    agent_creation_options=None,
     agent_enablement=None,
     human_avatars=None,
     collaboration_policy=None,
@@ -924,6 +974,7 @@ async def _open_client(
         notification_preferences=notification_preferences,
         client_preferences=client_preferences,
         appearance_preferences=appearance_preferences,
+        agent_creation_options=agent_creation_options,
         agent_enablement=agent_enablement,
         human_avatars=human_avatars,
         collaboration_policy=collaboration_policy,
@@ -2536,6 +2587,81 @@ class TestWorkshopAgentLifecycleHTTPContract:
 
 
 class TestWorkshopAgentEnablementHTTPContract:
+    async def test_creation_options_are_authenticated_principal_scoped_and_read_only(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, _, bob_id, _ = await _open_store(tmp_path / "kai.db")
+        service = _AgentCreationOptions(alice_id)
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id, "bob": bob_id}),
+            agent_creation_options=service,
+        )
+        try:
+            unauthenticated = await client.get("/v1/client/agents/creation-options")
+            assert unauthenticated.status == 401
+            selected = await client.get(
+                "/v1/client/agents/creation-options",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert selected.status == 200
+            payload = await selected.json()
+            assert payload == {
+                "version": 1,
+                "creation_options": {
+                    "principal_id": str(alice_id),
+                    "ready": True,
+                    "blockers": [],
+                    "runtimes": [
+                        {
+                            "runtime_profile_id": str(profile_id(101)),
+                            "display_name": "Daniel",
+                            "current_backend_option_id": "claude:anthropic",
+                            "default_workspace": "/srv/daniel",
+                            "default_timeout_seconds": 300,
+                            "minimum_timeout_seconds": 1,
+                            "maximum_timeout_seconds": 1800,
+                            "ready": True,
+                            "blockers": [],
+                            "backends": [
+                                {
+                                    "option_id": "claude:anthropic",
+                                    "backend": "claude",
+                                    "provider": "anthropic",
+                                    "current": True,
+                                    "readiness": "unverified",
+                                    "default_model": "claude-sonnet-4-5",
+                                    "catalogue_status": "unsupported",
+                                    "catalogue_stale": True,
+                                    "blockers": [],
+                                    "models": [],
+                                }
+                            ],
+                            "workspaces": [
+                                {
+                                    "path": "/srv/daniel",
+                                    "name": "Home",
+                                    "default": True,
+                                    "available": True,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+            assert service.calls == [alice_id]
+
+            selector = await client.get(
+                f"/v1/client/agents/creation-options?principal_id={bob_id}",
+                headers={"Authorization": "Bearer alice"},
+            )
+            assert selector.status == 400
+            assert service.calls == [alice_id]
+        finally:
+            await client.close()
+            await store.close()
+
     async def test_authenticated_principal_lists_and_enables_agent(self, tmp_path: Path) -> None:
         store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
         service = _AgentEnablement(alice_id)

--- a/workshop-client/src/api.test.ts
+++ b/workshop-client/src/api.test.ts
@@ -28,6 +28,7 @@ import {
   loadChannelMembers,
   loadChannelUnread,
   loadAgentDefinitions,
+  loadAgentCreationOptions,
   loadAgentEnablements,
   loadAgentCollaborationPolicy,
   loadAppearancePreferences,
@@ -273,6 +274,57 @@ function agentEnablementPayload(): Record<string, unknown> {
     conversation_started: false,
     owner_principal_id: "prn_00000000000000000000000000000001",
     owner_runtime_profile_id: runtimeProfileId,
+  };
+}
+
+function agentCreationOptionsPayload(): Record<string, unknown> {
+  return {
+    blockers: [],
+    principal_id: "prn_00000000000000000000000000000001",
+    ready: true,
+    runtimes: [
+      {
+        backends: [
+          {
+            backend: "claude",
+            blockers: [],
+            catalogue_stale: true,
+            catalogue_status: "unsupported",
+            current: true,
+            default_model: "claude-sonnet-4-5",
+            models: [
+              {
+                display_name: "Claude Sonnet 4.5",
+                model_id: "claude-sonnet-4-5",
+                retained: true,
+                selectable: false,
+                status: "not_advertised",
+              },
+            ],
+            option_id: "claude:anthropic",
+            provider: "anthropic",
+            readiness: "unverified",
+          },
+        ],
+        blockers: [],
+        current_backend_option_id: "claude:anthropic",
+        default_timeout_seconds: 300,
+        default_workspace: "/srv/workspaces/home",
+        display_name: "Daniel's runtime",
+        maximum_timeout_seconds: 1800,
+        minimum_timeout_seconds: 1,
+        ready: true,
+        runtime_profile_id: runtimeProfileId,
+        workspaces: [
+          {
+            available: true,
+            default: true,
+            name: "Home",
+            path: "/srv/workspaces/home",
+          },
+        ],
+      },
+    ],
   };
 }
 
@@ -2714,6 +2766,52 @@ describe("Workshop client API", () => {
       2,
       "/v1/client/agent-enablement",
       expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("loads strict principal-scoped agent creation options", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      creation_options: agentCreationOptionsPayload(),
+      version: 1,
+    }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const options = await loadAgentCreationOptions("session-secret");
+
+    expect(options).toEqual(expect.objectContaining({
+      principalId: "prn_00000000000000000000000000000001",
+      ready: true,
+      runtimes: [expect.objectContaining({
+        currentBackendOptionId: "claude:anthropic",
+        defaultWorkspace: "/srv/workspaces/home",
+        runtimeProfileId,
+      })],
+    }));
+    expect(options.runtimes[0]?.backends[0]).toEqual(expect.objectContaining({
+      catalogueStatus: "unsupported",
+      defaultModel: "claude-sonnet-4-5",
+      readiness: "unverified",
+    }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/client/agents/creation-options",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("rejects malformed agent creation options", async () => {
+    const malformed = agentCreationOptionsPayload();
+    const runtimes = malformed.runtimes as Record<string, unknown>[];
+    const backends = runtimes[0]?.backends as Record<string, unknown>[];
+    if (backends[0]) {
+      backends[0].readiness = "maybe";
+    }
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      creation_options: malformed,
+      version: 1,
+    }), { status: 200 })));
+
+    await expect(loadAgentCreationOptions("session-secret")).rejects.toThrow(
+      "Kai returned unsupported agent creation options.",
     );
   });
 

--- a/workshop-client/src/api.ts
+++ b/workshop-client/src/api.ts
@@ -62,6 +62,7 @@ import type {
   WorkshopAgentChangeSignal,
   WorkshopAgentDefinition,
   WorkshopAgentEnablement,
+  WorkshopAgentCreationOptions,
   WorkshopCollaborationOperation,
   WorkshopCollaborationPolicy,
   WorkshopStandingParticipation,
@@ -974,6 +975,195 @@ function parseAgentEnablement(value: unknown): WorkshopAgentEnablement | null {
   };
 }
 
+function parseAgentCreationBlockers(
+  value: unknown,
+): WorkshopAgentCreationOptions["blockers"] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const blockers = value.map((item) => {
+    if (
+      !isRecord(item) ||
+      typeof item.code !== "string" ||
+      item.code.length === 0 ||
+      typeof item.detail !== "string" ||
+      item.detail.length === 0
+    ) {
+      return null;
+    }
+    return { code: item.code, detail: item.detail };
+  });
+  return blockers.some((item) => item === null)
+    ? null
+    : blockers as WorkshopAgentCreationOptions["blockers"];
+}
+
+function parseAgentCreationOptions(value: unknown): WorkshopAgentCreationOptions | null {
+  if (
+    !isRecord(value) ||
+    typeof value.principal_id !== "string" ||
+    !PRINCIPAL_PATTERN.test(value.principal_id) ||
+    typeof value.ready !== "boolean" ||
+    !Array.isArray(value.runtimes)
+  ) {
+    return null;
+  }
+  const blockers = parseAgentCreationBlockers(value.blockers);
+  if (!blockers) {
+    return null;
+  }
+  const refreshStatuses = [
+    "refreshing",
+    "succeeded",
+    "failed",
+    "unsupported",
+    "malformed",
+    "timed_out",
+    "invalidated",
+    "superseded",
+  ];
+  const modelStatuses = ["available", "not_advertised", "unavailable", "unknown"];
+  const readinessStates = ["ready", "unverified", "unavailable", "misconfigured"];
+  const runtimes = value.runtimes.map((runtime) => {
+    if (
+      !isRecord(runtime) ||
+      typeof runtime.runtime_profile_id !== "string" ||
+      !RUNTIME_PROFILE_PATTERN.test(runtime.runtime_profile_id) ||
+      typeof runtime.display_name !== "string" ||
+      runtime.display_name.length === 0 ||
+      typeof runtime.current_backend_option_id !== "string" ||
+      runtime.current_backend_option_id.length === 0 ||
+      (runtime.default_workspace !== null && typeof runtime.default_workspace !== "string") ||
+      !Number.isSafeInteger(runtime.default_timeout_seconds) ||
+      (runtime.default_timeout_seconds as number) < 1 ||
+      !Number.isSafeInteger(runtime.minimum_timeout_seconds) ||
+      (runtime.minimum_timeout_seconds as number) < 1 ||
+      !Number.isSafeInteger(runtime.maximum_timeout_seconds) ||
+      (runtime.maximum_timeout_seconds as number) < (runtime.minimum_timeout_seconds as number) ||
+      typeof runtime.ready !== "boolean" ||
+      !Array.isArray(runtime.backends) ||
+      !Array.isArray(runtime.workspaces)
+    ) {
+      return null;
+    }
+    const runtimeBlockers = parseAgentCreationBlockers(runtime.blockers);
+    if (!runtimeBlockers) {
+      return null;
+    }
+    const backends = runtime.backends.map((backend) => {
+      if (
+        !isRecord(backend) ||
+        typeof backend.option_id !== "string" ||
+        backend.option_id.length === 0 ||
+        typeof backend.backend !== "string" ||
+        backend.backend.length === 0 ||
+        typeof backend.provider !== "string" ||
+        backend.provider.length === 0 ||
+        typeof backend.current !== "boolean" ||
+        typeof backend.readiness !== "string" ||
+        !readinessStates.includes(backend.readiness) ||
+        typeof backend.default_model !== "string" ||
+        backend.default_model.length === 0 ||
+        (backend.catalogue_status !== null &&
+          (typeof backend.catalogue_status !== "string" ||
+            !refreshStatuses.includes(backend.catalogue_status))) ||
+        typeof backend.catalogue_stale !== "boolean" ||
+        !Array.isArray(backend.models)
+      ) {
+        return null;
+      }
+      const backendBlockers = parseAgentCreationBlockers(backend.blockers);
+      if (!backendBlockers) {
+        return null;
+      }
+      const models = backend.models.map((model) => {
+        if (
+          !isRecord(model) ||
+          typeof model.model_id !== "string" ||
+          model.model_id.length === 0 ||
+          typeof model.display_name !== "string" ||
+          model.display_name.length === 0 ||
+          typeof model.status !== "string" ||
+          !modelStatuses.includes(model.status) ||
+          typeof model.selectable !== "boolean" ||
+          typeof model.retained !== "boolean"
+        ) {
+          return null;
+        }
+        return {
+          displayName: model.display_name,
+          modelId: model.model_id,
+          retained: model.retained,
+          selectable: model.selectable,
+          status: model.status,
+        };
+      });
+      if (models.some((model) => model === null)) {
+        return null;
+      }
+      return {
+        backend: backend.backend,
+        blockers: backendBlockers,
+        catalogueStale: backend.catalogue_stale,
+        catalogueStatus: backend.catalogue_status,
+        current: backend.current,
+        defaultModel: backend.default_model,
+        models,
+        optionId: backend.option_id,
+        provider: backend.provider,
+        readiness: backend.readiness,
+      };
+    });
+    const workspaces = runtime.workspaces.map((workspace) => {
+      if (
+        !isRecord(workspace) ||
+        typeof workspace.path !== "string" ||
+        workspace.path.length === 0 ||
+        typeof workspace.name !== "string" ||
+        workspace.name.length === 0 ||
+        typeof workspace.default !== "boolean" ||
+        typeof workspace.available !== "boolean"
+      ) {
+        return null;
+      }
+      return {
+        available: workspace.available,
+        default: workspace.default,
+        name: workspace.name,
+        path: workspace.path,
+      };
+    });
+    if (
+      backends.some((backend) => backend === null) ||
+      workspaces.some((workspace) => workspace === null)
+    ) {
+      return null;
+    }
+    return {
+      backends,
+      blockers: runtimeBlockers,
+      currentBackendOptionId: runtime.current_backend_option_id,
+      defaultTimeoutSeconds: runtime.default_timeout_seconds as number,
+      defaultWorkspace: runtime.default_workspace,
+      displayName: runtime.display_name,
+      maximumTimeoutSeconds: runtime.maximum_timeout_seconds as number,
+      minimumTimeoutSeconds: runtime.minimum_timeout_seconds as number,
+      ready: runtime.ready,
+      runtimeProfileId: runtime.runtime_profile_id,
+      workspaces,
+    };
+  });
+  if (runtimes.some((runtime) => runtime === null)) {
+    return null;
+  }
+  return {
+    blockers,
+    principalId: value.principal_id,
+    ready: value.ready,
+    runtimes: runtimes as WorkshopAgentCreationOptions["runtimes"],
+  };
+}
+
 async function agentMutation(
   token: string,
   path: string,
@@ -1040,6 +1230,26 @@ export async function loadAgentDefinitions(
     throw new Error("Kai returned unsupported agent definitions.");
   }
   return agents as WorkshopAgentDefinition[];
+}
+
+export async function loadAgentCreationOptions(
+  token: string,
+): Promise<WorkshopAgentCreationOptions> {
+  const response = await authorizedFetch(
+    { channelId: "", token },
+    "/v1/client/agents/creation-options",
+  );
+  const payload = await responsePayload(response);
+  if (!response.ok) {
+    throw new Error(safeErrorMessage(payload, "Could not load agent creation options."));
+  }
+  const options = isRecord(payload) && payload.version === 1
+    ? parseAgentCreationOptions(payload.creation_options)
+    : null;
+  if (!options) {
+    throw new Error("Kai returned unsupported agent creation options.");
+  }
+  return options;
 }
 
 export async function loadAgentEnablements(

--- a/workshop-client/src/types.ts
+++ b/workshop-client/src/types.ts
@@ -423,6 +423,69 @@ export interface WorkshopAgentEnablement {
   ownerRuntimeProfileId: string | null;
 }
 
+export interface WorkshopAgentCreationBlocker {
+  code: string;
+  detail: string;
+}
+
+export interface WorkshopAgentCreationModelOption {
+  displayName: string;
+  modelId: string;
+  retained: boolean;
+  selectable: boolean;
+  status: "available" | "not_advertised" | "unavailable" | "unknown";
+}
+
+export interface WorkshopAgentCreationBackendOption {
+  backend: string;
+  blockers: WorkshopAgentCreationBlocker[];
+  catalogueStale: boolean;
+  catalogueStatus:
+    | "refreshing"
+    | "succeeded"
+    | "failed"
+    | "unsupported"
+    | "malformed"
+    | "timed_out"
+    | "invalidated"
+    | "superseded"
+    | null;
+  current: boolean;
+  defaultModel: string;
+  models: WorkshopAgentCreationModelOption[];
+  optionId: string;
+  provider: string;
+  readiness: "ready" | "unverified" | "unavailable" | "misconfigured";
+}
+
+export interface WorkshopAgentCreationWorkspaceOption {
+  available: boolean;
+  default: boolean;
+  name: string;
+  path: string;
+}
+
+export interface WorkshopAgentCreationRuntimeOption {
+  backends: WorkshopAgentCreationBackendOption[];
+  blockers: WorkshopAgentCreationBlocker[];
+  currentBackendOptionId: string;
+  defaultTimeoutSeconds: number;
+  defaultWorkspace: string | null;
+  displayName: string;
+  maximumTimeoutSeconds: number;
+  minimumTimeoutSeconds: number;
+  ready: boolean;
+  runtimeProfileId: string;
+  workspaces: WorkshopAgentCreationWorkspaceOption[];
+}
+
+export interface WorkshopAgentCreationOptions {
+  blockers: WorkshopAgentCreationBlocker[];
+  principalId: string;
+  ready: boolean;
+  runtimes: WorkshopAgentCreationRuntimeOption[];
+}
+
 export interface WorkshopAgentChangeSignal {
   definitionId: string | null;
   eventPosition: number;


### PR DESCRIPTION
Closes #1487

## Summary
- add a principal-scoped, read-only agent creation-options projection and authenticated client endpoint
- expose authorized runtime profiles, backend/provider/model choices, workspaces, timeout bounds, and actionable readiness blockers
- add strict Workshop client parsing plus isolation, all-backend, retained-model, missing-authority, and HTTP contract coverage

## Validation
- make test (6593 passed)
- make client-check (196 passed)
- make check
- make typecheck
- focused Workshop creation-options and API suites (191 passed)