### PR TITLE
Provision ready agents through one replay-safe operation

### DIFF
--- a/src/kai/application_host.py
+++ b/src/kai/application_host.py
@@ -22,6 +22,8 @@ from kai.pool import SubprocessPool
 from kai.workshop.agent_creation_options import WorkshopAgentCreationOptionsService
 from kai.workshop.agent_delegation import WorkshopAgentDelegationService
 from kai.workshop.agent_enablement import WorkshopAgentEnablementService
+from kai.workshop.agent_lifecycle import WorkshopAgentLifecycleService
+from kai.workshop.agent_provisioning import WorkshopAgentProvisioningService
 from kai.workshop.appearance_preferences import WorkshopAppearancePreferenceService
 from kai.workshop.artifacts import WorkshopArtifactService
 from kai.workshop.channel_notification_policy import WorkshopChannelNotificationPolicyService
@@ -212,6 +214,7 @@ class KaiCoreServices:
     human_avatars: WorkshopHumanAvatarService
     agent_creation_options: WorkshopAgentCreationOptionsService
     agent_enablement: WorkshopAgentEnablementService
+    agent_provisioning: WorkshopAgentProvisioningService
     proactive_publication: WorkshopProactivePublicationService
     integration_notifications: WorkshopIntegrationNotificationService
     github_automation: WorkshopGitHubAutomationService
@@ -487,6 +490,14 @@ class KaiApplicationHost:
                 model_catalogue,
                 runtime_pool,
             )
+            agent_provisioning = WorkshopAgentProvisioningService(
+                client_store,
+                agent_creation_options,
+                WorkshopAgentLifecycleService(client_store),
+                agent_enablement,
+                settings_workspaces,
+                collaboration_policy,
+            )
             proactive_publication = WorkshopProactivePublicationService(
                 client_store,
                 artifacts,
@@ -547,6 +558,7 @@ class KaiApplicationHost:
                 appearance_preferences=appearance_preferences,
                 agent_creation_options=agent_creation_options,
                 agent_enablement=agent_enablement,
+                agent_provisioning=agent_provisioning,
                 proactive_publication=proactive_publication,
                 integration_notifications=integration_notifications,
                 github_automation=github_automation,

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -81,6 +81,7 @@ from kai.workshop.agent_enablement import initial_kai_enablement_ids
 from kai.workshop.bootstrap import bootstrap_human_principal_id
 from kai.workshop.diagnostics import (
     workshop_agent_authority_status,
+    workshop_agent_provisioning_status,
     workshop_appearance_preference_status,
     workshop_bootstrap_status,
     workshop_canonical_message_integrity_status,
@@ -9541,6 +9542,7 @@ def _cmd_status() -> None:
     )
     print(workshop_human_provisioning_status(Path(data_dir) / "kai.db"))
     print(workshop_agent_authority_status(Path(data_dir) / "kai.db"))
+    print(workshop_agent_provisioning_status(Path(data_dir) / "kai.db"))
     print(workshop_collaboration_authority_status(Path(data_dir) / "kai.db"))
     print(workshop_standing_participation_status(Path(data_dir) / "kai.db"))
     print(workshop_standing_observation_status(Path(data_dir) / "kai.db"))

--- a/src/kai/webhook.py
+++ b/src/kai/webhook.py
@@ -73,6 +73,7 @@ from kai.workshop.agent_delegation import (
     AgentDelegationDenied,
 )
 from kai.workshop.agent_enablement import WorkshopAgentEnablementService
+from kai.workshop.agent_provisioning import WorkshopAgentProvisioningService
 from kai.workshop.appearance_preferences import WorkshopAppearancePreferenceService
 from kai.workshop.artifacts import MAX_ARTIFACT_BYTES, WorkshopArtifactService
 from kai.workshop.channel_notification_policy import WorkshopChannelNotificationPolicyService
@@ -2182,6 +2183,7 @@ async def _register_workshop_client_api(
     client_preferences: WorkshopClientPreferenceService | None = None,
     appearance_preferences: WorkshopAppearancePreferenceService | None = None,
     agent_creation_options: WorkshopAgentCreationOptionsService | None = None,
+    agent_provisioning: WorkshopAgentProvisioningService | None = None,
     agent_enablement: WorkshopAgentEnablementService | None = None,
     human_avatars: WorkshopHumanAvatarService | None = None,
     collaboration_policy: WorkshopCollaborationPolicyService | None = None,
@@ -2229,6 +2231,7 @@ async def _register_workshop_client_api(
             client_preferences=client_preferences,
             appearance_preferences=appearance_preferences,
             agent_creation_options=agent_creation_options,
+            agent_provisioning=agent_provisioning,
             agent_enablement=agent_enablement,
             human_avatars=human_avatars,
             collaboration_policy=collaboration_policy,
@@ -2321,6 +2324,7 @@ async def start(
             client_preferences=getattr(core_services, "client_preferences", None),
             appearance_preferences=getattr(core_services, "appearance_preferences", None),
             agent_creation_options=getattr(core_services, "agent_creation_options", None),
+            agent_provisioning=getattr(core_services, "agent_provisioning", None),
             agent_enablement=getattr(core_services, "agent_enablement", None),
             human_avatars=getattr(core_services, "human_avatars", None),
             collaboration_policy=getattr(core_services, "collaboration_policy", None),

--- a/src/kai/workshop/agent_enablement.py
+++ b/src/kai/workshop/agent_enablement.py
@@ -650,6 +650,44 @@ class WorkshopAgentEnablementService:
             await connection.rollback()
             raise WorkshopAgentEnablementStorageError("Agent conversation could not be started") from exc
 
+    async def ensure_runtime_registered(
+        self,
+        principal_id: PrincipalId,
+        definition_id: AgentDefinitionId,
+    ) -> PrincipalAgentEnablement:
+        """Reconcile one committed enablement with the live runtime registries.
+
+        Enablement persistence deliberately commits before process-local runtime
+        registration.  A provisioning retry after interruption must therefore
+        be able to reconstruct the exact canonical lane without emitting new
+        lifecycle events or starting a conversation.
+        """
+        current = await self._snapshot(principal_id, definition_id)
+        if (
+            current.enablement_id is None
+            or current.lifecycle_state != "enabled"
+            or current.direct_channel_id is None
+            or current.runtime_profile_id is None
+        ):
+            raise WorkshopAgentEnablementConflict("Agent runtime lane is not enabled")
+        context = WorkshopInternalAPIExecutionContext(
+            principal_id,
+            current.direct_channel_id,
+            current.agent_id,
+            current.runtime_profile_id,
+        )
+        namespace = WorkshopExecutionStateNamespace(
+            context.principal_id,
+            context.channel_id,
+            context.agent_id,
+            context.runtime_profile_id,
+            None,
+        )
+        self._execution_state.register_lane(namespace)
+        self._internal_api_contexts.register_context(context)
+        self._runtime_pool.register_canonical_lane(context)
+        return current
+
     async def suspend_archived_definition(
         self,
         principal_id: PrincipalId,

--- a/src/kai/workshop/agent_provisioning.py
+++ b/src/kai/workshop/agent_provisioning.py
@@ -1,0 +1,919 @@
+"""Replay-safe orchestration for provisioning principal-owned Workshop agents."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from kai.config import canonicalize_model_for_backend
+from kai.workshop.agent_creation_options import (
+    AgentCreationBackendOption,
+    WorkshopAgentCreationOptionsService,
+)
+from kai.workshop.agent_definitions import (
+    MAX_AGENT_DESCRIPTION,
+    MAX_AGENT_DISPLAY_NAME,
+    MAX_AGENT_INSTRUCTIONS,
+    MAX_AGENT_PURPOSE,
+    normalize_agent_handle,
+    validate_agent_capabilities,
+    validate_agent_presentation,
+    validate_agent_text,
+    validate_collaboration_operations,
+)
+from kai.workshop.agent_enablement import (
+    WorkshopAgentEnablementAccessDenied,
+    WorkshopAgentEnablementConflict,
+    WorkshopAgentEnablementError,
+    WorkshopAgentEnablementService,
+)
+from kai.workshop.agent_lifecycle import (
+    WorkshopAgentLifecycleAccessDenied,
+    WorkshopAgentLifecycleConflict,
+    WorkshopAgentLifecycleError,
+    WorkshopAgentLifecycleService,
+)
+from kai.workshop.collaboration_policy import (
+    WorkshopCollaborationPolicyAccessDenied,
+    WorkshopCollaborationPolicyConflict,
+    WorkshopCollaborationPolicyError,
+    WorkshopCollaborationPolicyService,
+    WorkshopCollaborationPolicyValidationError,
+)
+from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentDefinitionRevisionId,
+    AgentEnablementId,
+    AgentId,
+    AgentProvisioningId,
+    ChannelId,
+    PrincipalId,
+    RuntimeProfileId,
+    WorkshopId,
+)
+from kai.workshop.settings_workspaces import (
+    WorkshopSettingsWorkspaceAccessDenied,
+    WorkshopSettingsWorkspaceBusy,
+    WorkshopSettingsWorkspaceError,
+    WorkshopSettingsWorkspaceService,
+    WorkshopSettingsWorkspaceValidationError,
+)
+from kai.workshop.store import WorkshopEventStore
+
+_OPERATION_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_BACKEND_OPTION_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$")
+_STAGES = (
+    "definition_created",
+    "revision_activated",
+    "enablement_created",
+    "runtime_registered",
+    "backend_selected",
+    "model_selected",
+    "workspace_selected",
+    "timeout_selected",
+    "collaboration_policy_set",
+    "ready",
+)
+
+
+class WorkshopAgentProvisioningError(RuntimeError):
+    """A ready-agent provisioning operation could not be completed."""
+
+
+class WorkshopAgentProvisioningAccessDenied(WorkshopAgentProvisioningError):
+    """The request references authority not owned by the principal."""
+
+
+class WorkshopAgentProvisioningValidationError(WorkshopAgentProvisioningError):
+    """The provisioning request is malformed or currently unavailable."""
+
+
+class WorkshopAgentProvisioningConflict(WorkshopAgentProvisioningError):
+    """An operation identity or canonical stage conflicts with prior state."""
+
+
+class WorkshopAgentProvisioningStorageError(WorkshopAgentProvisioningError):
+    """Provisioning coordination state could not be persisted."""
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProvisioningBlocker:
+    code: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class AgentProvisioningResult:
+    operation_id: AgentProvisioningId
+    client_operation_id: str
+    status: str
+    replayed: bool
+    definition_id: AgentDefinitionId | None
+    revision_id: AgentDefinitionRevisionId | None
+    agent_id: AgentId | None
+    enablement_id: AgentEnablementId | None
+    direct_channel_id: ChannelId | None
+    runtime_profile_id: RuntimeProfileId
+    completed_stages: tuple[str, ...]
+    next_stage: str | None
+    blockers: tuple[AgentProvisioningBlocker, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _NormalizedProvisioningRequest:
+    client_operation_id: str
+    handle: str
+    display_name: str
+    description: str
+    presentation: dict[str, object]
+    purpose: str
+    instructions: str
+    capabilities: tuple[str, ...]
+    collaboration_operations: tuple[str, ...]
+    runtime_profile_id: RuntimeProfileId
+    backend_option_id: str
+    model: str
+    workspace: str
+    timeout_seconds: int
+    allowed_collaboration_operations: tuple[str, ...]
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "client_operation_id": self.client_operation_id,
+            "definition": {
+                "handle": self.handle,
+                "display_name": self.display_name,
+                "description": self.description,
+                "presentation": self.presentation,
+            },
+            "revision": {
+                "purpose": self.purpose,
+                "instructions": self.instructions,
+                "capabilities": list(self.capabilities),
+                "collaboration_operations": list(self.collaboration_operations),
+            },
+            "runtime": {
+                "runtime_profile_id": str(self.runtime_profile_id),
+                "backend_option_id": self.backend_option_id,
+                "model": self.model,
+                "workspace": self.workspace,
+                "timeout_seconds": self.timeout_seconds,
+            },
+            "collaboration_policy": {
+                "allowed_operations": list(self.allowed_collaboration_operations),
+            },
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _ProvisioningOperation:
+    operation_id: AgentProvisioningId
+    workshop_id: WorkshopId
+    principal_id: PrincipalId
+    client_operation_id: str
+    request_hash: str
+    status: str
+    next_stage: str | None
+    failure_code: str | None
+    failure_detail: str | None
+    definition_id: AgentDefinitionId | None
+    revision_id: AgentDefinitionRevisionId | None
+    definition_initial_version: int | None
+    agent_id: AgentId | None
+    enablement_id: AgentEnablementId | None
+    direct_channel_id: ChannelId | None
+    runtime_profile_id: RuntimeProfileId
+
+
+class WorkshopAgentProvisioningService:
+    """Compose existing canonical authorities into one recoverable operation."""
+
+    def __init__(
+        self,
+        store: WorkshopEventStore,
+        creation_options: WorkshopAgentCreationOptionsService,
+        lifecycle: WorkshopAgentLifecycleService,
+        enablement: WorkshopAgentEnablementService,
+        settings: WorkshopSettingsWorkspaceService,
+        collaboration_policy: WorkshopCollaborationPolicyService,
+    ) -> None:
+        self._store = store
+        self._creation_options = creation_options
+        self._lifecycle = lifecycle
+        self._enablement = enablement
+        self._settings = settings
+        self._collaboration_policy = collaboration_policy
+        self._locks: dict[tuple[PrincipalId, str], asyncio.Lock] = {}
+
+    async def provision(
+        self,
+        principal_id: PrincipalId,
+        *,
+        client_operation_id: object,
+        definition: object,
+        revision: object,
+        runtime: object,
+        collaboration_policy: object,
+    ) -> AgentProvisioningResult:
+        request = self._normalize(
+            client_operation_id=client_operation_id,
+            definition=definition,
+            revision=revision,
+            runtime=runtime,
+            collaboration_policy=collaboration_policy,
+        )
+        authority = await self._lifecycle.authority_for(principal_id)
+        request_json = json.dumps(request.payload(), sort_keys=True, separators=(",", ":"))
+        request_hash = hashlib.sha256(request_json.encode()).hexdigest()
+        lock = self._locks.setdefault((principal_id, request.client_operation_id), asyncio.Lock())
+        async with lock:
+            existing = await self._operation_for_identity(
+                authority.workshop_id,
+                principal_id,
+                request.client_operation_id,
+            )
+            if existing is not None:
+                if existing.request_hash != request_hash:
+                    raise WorkshopAgentProvisioningConflict(
+                        "Operation identity was reused with different provisioning input"
+                    )
+                if existing.status == "ready":
+                    return await self._result(existing.operation_id, replayed=True)
+
+            await self._validate_authority(principal_id, request)
+            operation = existing or await self._create_operation(
+                authority.workshop_id,
+                principal_id,
+                request,
+                request_json,
+                request_hash,
+            )
+            await self._mark_running(operation.operation_id)
+            return await self._resume(operation.operation_id, principal_id, request)
+
+    async def _resume(
+        self,
+        operation_id: AgentProvisioningId,
+        principal_id: PrincipalId,
+        request: _NormalizedProvisioningRequest,
+    ) -> AgentProvisioningResult:
+        completed = set(await self._completed_stages(operation_id))
+        current_stage = next((stage for stage in _STAGES if stage not in completed), None)
+        if current_stage is None:
+            await self._record_stage(operation_id, "ready", {})
+            return await self._result(operation_id, replayed=True)
+        try:
+            operation = await self._require_operation(operation_id)
+            if "definition_created" not in completed:
+                draft = await self._lifecycle.create_draft(
+                    principal_id,
+                    idempotency_key=self._stage_key(operation_id, "definition"),
+                    handle=request.handle,
+                    display_name=request.display_name,
+                    description=request.description,
+                    presentation=request.presentation,
+                    purpose=request.purpose,
+                    instructions=request.instructions,
+                    capabilities=list(request.capabilities),
+                    collaboration_operations=list(request.collaboration_operations),
+                )
+                revision = draft.revisions[0]
+                await self._record_stage(
+                    operation_id,
+                    "definition_created",
+                    {
+                        "definition_id": str(draft.definition_id),
+                        "revision_id": str(revision.revision_id),
+                        "agent_id": str(draft.agent_id),
+                        "definition_initial_version": draft.state_version,
+                    },
+                )
+                await self._after_stage("definition_created")
+                completed.add("definition_created")
+                operation = await self._require_operation(operation_id)
+
+            definition_id, revision_id = self._definition_ids(operation)
+            if "revision_activated" not in completed:
+                if operation.definition_initial_version is None:
+                    raise WorkshopAgentProvisioningStorageError("Provisioning definition receipt is incomplete")
+                await self._lifecycle.activate_revision(
+                    principal_id,
+                    definition_id,
+                    revision_id=revision_id,
+                    idempotency_key=self._stage_key(operation_id, "activation"),
+                    expected_version=operation.definition_initial_version,
+                )
+                await self._record_stage(operation_id, "revision_activated", {})
+                await self._after_stage("revision_activated")
+                completed.add("revision_activated")
+
+            if "enablement_created" not in completed:
+                enabled = await self._enablement.enable(
+                    principal_id,
+                    definition_id,
+                    request.runtime_profile_id,
+                    idempotency_key=self._stage_key(operation_id, "enablement"),
+                )
+                if enabled.enablement_id is None or enabled.direct_channel_id is None:
+                    raise WorkshopAgentProvisioningStorageError(
+                        "Provisioning enablement did not produce a canonical runtime lane"
+                    )
+                await self._record_stage(
+                    operation_id,
+                    "enablement_created",
+                    {
+                        "enablement_id": str(enabled.enablement_id),
+                        "direct_channel_id": str(enabled.direct_channel_id),
+                    },
+                )
+                await self._after_stage("enablement_created")
+                completed.add("enablement_created")
+                operation = await self._require_operation(operation_id)
+
+            if "runtime_registered" not in completed:
+                await self._enablement.ensure_runtime_registered(principal_id, definition_id)
+                await self._record_stage(operation_id, "runtime_registered", {})
+                await self._after_stage("runtime_registered")
+                completed.add("runtime_registered")
+            else:
+                # Registration is process-local. Reconcile it on every retry,
+                # including one handled by a newly started Kai process.
+                await self._enablement.ensure_runtime_registered(principal_id, definition_id)
+
+            operation = await self._require_operation(operation_id)
+            if operation.direct_channel_id is None:
+                raise WorkshopAgentProvisioningStorageError("Provisioning runtime receipt is incomplete")
+            settings_authority = self._settings.authority_for_principal_channel(
+                principal_id,
+                operation.direct_channel_id,
+            )
+
+            if "backend_selected" not in completed:
+                await self._settings.set_backend(settings_authority, request.backend_option_id)
+                await self._record_stage(operation_id, "backend_selected", {})
+                await self._after_stage("backend_selected")
+                completed.add("backend_selected")
+
+            if "model_selected" not in completed:
+                await self._settings.set_model(settings_authority, request.model)
+                await self._record_stage(operation_id, "model_selected", {})
+                await self._after_stage("model_selected")
+                completed.add("model_selected")
+
+            if "workspace_selected" not in completed:
+                await self._settings.switch_workspace(settings_authority, request.workspace)
+                await self._record_stage(operation_id, "workspace_selected", {})
+                await self._after_stage("workspace_selected")
+                completed.add("workspace_selected")
+
+            if "timeout_selected" not in completed:
+                await self._settings.set_timeout(settings_authority, request.timeout_seconds)
+                await self._record_stage(operation_id, "timeout_selected", {})
+                await self._after_stage("timeout_selected")
+                completed.add("timeout_selected")
+
+            if "collaboration_policy_set" not in completed:
+                await self._collaboration_policy.set_allowed(
+                    principal_id,
+                    definition_id,
+                    allowed_operations=list(request.allowed_collaboration_operations),
+                    expected_policy_version=0,
+                    client_operation_id=self._stage_key(operation_id, "collaboration"),
+                )
+                await self._record_stage(operation_id, "collaboration_policy_set", {})
+                await self._after_stage("collaboration_policy_set")
+
+            await self._record_stage(operation_id, "ready", {})
+            await self._after_stage("ready")
+            return await self._result(operation_id, replayed=False)
+        except WorkshopAgentProvisioningError:
+            raise
+        except BaseException as exc:
+            # Process cancellation/crash must leave the last durable receipt
+            # untouched so a new coordinator can resume the exact next stage.
+            if not isinstance(exc, Exception):
+                raise
+            code, detail = self._failure(exc)
+            completed = set(await self._completed_stages(operation_id))
+            next_stage = next((stage for stage in _STAGES if stage not in completed), None)
+            status = (
+                "draft"
+                if "definition_created" in completed and "revision_activated" not in completed
+                else "needs_attention"
+            )
+            await self._mark_failure(operation_id, status, next_stage, code, detail)
+            return await self._result(operation_id, replayed=False)
+
+    async def _validate_authority(
+        self,
+        principal_id: PrincipalId,
+        request: _NormalizedProvisioningRequest,
+    ) -> None:
+        options = await self._creation_options.inspect(principal_id)
+        runtime = next(
+            (item for item in options.runtimes if item.runtime_profile_id == request.runtime_profile_id),
+            None,
+        )
+        if runtime is None:
+            raise WorkshopAgentProvisioningAccessDenied("Runtime profile is not authorized for this principal")
+        backend = next(
+            (item for item in runtime.backends if item.option_id == request.backend_option_id),
+            None,
+        )
+        if backend is None:
+            raise WorkshopAgentProvisioningAccessDenied("Backend option is not authorized for this runtime profile")
+        if backend.blockers:
+            raise WorkshopAgentProvisioningValidationError("The selected backend is not currently usable")
+        workspace = next(
+            (item for item in runtime.workspaces if item.path == request.workspace),
+            None,
+        )
+        if workspace is None:
+            raise WorkshopAgentProvisioningAccessDenied("Workspace is not authorized for this runtime profile")
+        if not workspace.available:
+            raise WorkshopAgentProvisioningValidationError("The selected workspace is unavailable")
+        if not runtime.minimum_timeout_seconds <= request.timeout_seconds <= runtime.maximum_timeout_seconds:
+            raise WorkshopAgentProvisioningValidationError("Timeout is outside this runtime profile's policy bounds")
+        self._validate_model(backend, request.model)
+        try:
+            self._collaboration_policy.validate_initial_allowed_operations(
+                request.collaboration_operations,
+                request.allowed_collaboration_operations,
+            )
+        except WorkshopCollaborationPolicyValidationError as exc:
+            raise WorkshopAgentProvisioningValidationError(str(exc)) from exc
+
+    @staticmethod
+    def _validate_model(backend: AgentCreationBackendOption, model: str) -> None:
+        if model == backend.default_model:
+            return
+        if not any(item.model_id == model and item.selectable for item in backend.models):
+            raise WorkshopAgentProvisioningValidationError("Model is not selectable for the authorized backend")
+
+    def _normalize(
+        self,
+        *,
+        client_operation_id: object,
+        definition: object,
+        revision: object,
+        runtime: object,
+        collaboration_policy: object,
+    ) -> _NormalizedProvisioningRequest:
+        if not isinstance(client_operation_id, str) or not _OPERATION_ID_PATTERN.fullmatch(client_operation_id):
+            raise WorkshopAgentProvisioningValidationError(
+                "client_operation_id must be 1-128 letters, digits, dots, underscores, colons, or hyphens"
+            )
+        definition_map = self._exact_object(
+            definition,
+            "definition",
+            {"handle", "display_name", "description", "presentation"},
+        )
+        revision_map = self._exact_object(
+            revision,
+            "revision",
+            {
+                "purpose",
+                "instructions",
+                "capabilities",
+                "collaboration_operations",
+            },
+        )
+        runtime_map = self._exact_object(
+            runtime,
+            "runtime",
+            {
+                "runtime_profile_id",
+                "backend_option_id",
+                "model",
+                "workspace",
+                "timeout_seconds",
+            },
+        )
+        policy_map = self._exact_object(
+            collaboration_policy,
+            "collaboration_policy",
+            {"allowed_operations"},
+        )
+        try:
+            handle = normalize_agent_handle(definition_map["handle"])
+            display_name = validate_agent_text(
+                definition_map["display_name"],
+                field="display_name",
+                maximum=MAX_AGENT_DISPLAY_NAME,
+            )
+            description = validate_agent_text(
+                definition_map["description"],
+                field="description",
+                maximum=MAX_AGENT_DESCRIPTION,
+                allow_empty=True,
+            )
+            presentation = json.loads(validate_agent_presentation(definition_map["presentation"]))
+            purpose = validate_agent_text(
+                revision_map["purpose"],
+                field="purpose",
+                maximum=MAX_AGENT_PURPOSE,
+            )
+            instructions = validate_agent_text(
+                revision_map["instructions"],
+                field="instructions",
+                maximum=MAX_AGENT_INSTRUCTIONS,
+            )
+            capabilities = validate_agent_capabilities(revision_map["capabilities"])
+            requested_operations = validate_collaboration_operations(revision_map["collaboration_operations"])
+            runtime_profile_id = RuntimeProfileId(str(runtime_map["runtime_profile_id"]))
+        except (TypeError, ValueError) as exc:
+            raise WorkshopAgentProvisioningValidationError(str(exc)) from exc
+        backend_option_id = runtime_map["backend_option_id"]
+        if not isinstance(backend_option_id, str) or not _BACKEND_OPTION_PATTERN.fullmatch(backend_option_id):
+            raise WorkshopAgentProvisioningValidationError("backend_option_id is invalid")
+        backend = backend_option_id.partition(":")[0]
+        raw_model = runtime_map["model"]
+        if not isinstance(raw_model, str):
+            raise WorkshopAgentProvisioningValidationError("model must be a string")
+        model = canonicalize_model_for_backend(raw_model.strip(), backend)
+        if not model:
+            raise WorkshopAgentProvisioningValidationError("model must be non-empty")
+        raw_workspace = runtime_map["workspace"]
+        if not isinstance(raw_workspace, str) or not Path(raw_workspace).is_absolute():
+            raise WorkshopAgentProvisioningValidationError("workspace must be an absolute path")
+        workspace = str(Path(raw_workspace).expanduser().resolve())
+        timeout = runtime_map["timeout_seconds"]
+        if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout < 1:
+            raise WorkshopAgentProvisioningValidationError("timeout_seconds must be a positive integer")
+        try:
+            allowed = validate_collaboration_operations(policy_map["allowed_operations"])
+        except ValueError as exc:
+            raise WorkshopAgentProvisioningValidationError(str(exc)) from exc
+        return _NormalizedProvisioningRequest(
+            client_operation_id,
+            handle,
+            display_name,
+            description,
+            presentation,
+            purpose,
+            instructions,
+            capabilities,
+            requested_operations,
+            runtime_profile_id,
+            backend_option_id,
+            model,
+            workspace,
+            timeout,
+            allowed,
+        )
+
+    @staticmethod
+    def _exact_object(value: object, field: str, keys: set[str]) -> dict[str, object]:
+        if not isinstance(value, dict) or set(value) != keys or any(not isinstance(key, str) for key in value):
+            raise WorkshopAgentProvisioningValidationError(f"{field} must contain exactly: {', '.join(sorted(keys))}")
+        return value
+
+    async def _create_operation(
+        self,
+        workshop_id: WorkshopId,
+        principal_id: PrincipalId,
+        request: _NormalizedProvisioningRequest,
+        request_json: str,
+        request_hash: str,
+    ) -> _ProvisioningOperation:
+        operation_id = AgentProvisioningId.derived(
+            principal_id,
+            f"{workshop_id}:{request.client_operation_id}",
+        )
+        now = datetime.now(UTC).isoformat()
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            await connection.execute(
+                "INSERT INTO agent_provisioning_operations ("
+                "id, workshop_id, principal_id, client_operation_id, request_hash, request_json, "
+                "status, next_stage, runtime_profile_id, backend_option_id, model, workspace, "
+                "timeout_seconds, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, "
+                "'provisioning', 'definition_created', ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    operation_id,
+                    workshop_id,
+                    principal_id,
+                    request.client_operation_id,
+                    request_hash,
+                    request_json,
+                    request.runtime_profile_id,
+                    request.backend_option_id,
+                    request.model,
+                    request.workspace,
+                    request.timeout_seconds,
+                    now,
+                    now,
+                ),
+            )
+            await connection.commit()
+        except Exception as exc:
+            await connection.rollback()
+            existing = await self._operation_for_identity(
+                workshop_id,
+                principal_id,
+                request.client_operation_id,
+            )
+            if existing is not None:
+                if existing.request_hash != request_hash:
+                    raise WorkshopAgentProvisioningConflict(
+                        "Operation identity was reused with different provisioning input"
+                    ) from exc
+                return existing
+            raise WorkshopAgentProvisioningStorageError("Provisioning operation could not be persisted") from exc
+        return await self._require_operation(operation_id)
+
+    async def _operation_for_identity(
+        self,
+        workshop_id: WorkshopId,
+        principal_id: PrincipalId,
+        client_operation_id: str,
+    ) -> _ProvisioningOperation | None:
+        async with self._store.connection.execute(
+            "SELECT * FROM agent_provisioning_operations WHERE workshop_id = ? "
+            "AND principal_id = ? AND client_operation_id = ?",
+            (workshop_id, principal_id, client_operation_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return self._operation(row) if row is not None else None
+
+    async def _require_operation(
+        self,
+        operation_id: AgentProvisioningId,
+    ) -> _ProvisioningOperation:
+        async with self._store.connection.execute(
+            "SELECT * FROM agent_provisioning_operations WHERE id = ?",
+            (operation_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        if row is None:
+            raise WorkshopAgentProvisioningStorageError("Provisioning operation is unavailable")
+        return self._operation(row)
+
+    @staticmethod
+    def _operation(row) -> _ProvisioningOperation:
+        return _ProvisioningOperation(
+            AgentProvisioningId(str(row["id"])),
+            WorkshopId(str(row["workshop_id"])),
+            PrincipalId(str(row["principal_id"])),
+            str(row["client_operation_id"]),
+            str(row["request_hash"]),
+            str(row["status"]),
+            str(row["next_stage"]) if row["next_stage"] is not None else None,
+            str(row["failure_code"]) if row["failure_code"] is not None else None,
+            str(row["failure_detail"]) if row["failure_detail"] is not None else None,
+            AgentDefinitionId(str(row["definition_id"])) if row["definition_id"] is not None else None,
+            AgentDefinitionRevisionId(str(row["revision_id"])) if row["revision_id"] is not None else None,
+            int(row["definition_initial_version"]) if row["definition_initial_version"] is not None else None,
+            AgentId(str(row["agent_id"])) if row["agent_id"] is not None else None,
+            AgentEnablementId(str(row["enablement_id"])) if row["enablement_id"] is not None else None,
+            ChannelId(str(row["direct_channel_id"])) if row["direct_channel_id"] is not None else None,
+            RuntimeProfileId(str(row["runtime_profile_id"])),
+        )
+
+    async def _record_stage(
+        self,
+        operation_id: AgentProvisioningId,
+        stage: str,
+        details: dict[str, object],
+    ) -> None:
+        if stage not in _STAGES:
+            raise WorkshopAgentProvisioningStorageError("Unknown provisioning stage")
+        now = datetime.now(UTC).isoformat()
+        next_stage = _STAGES[_STAGES.index(stage) + 1] if stage != "ready" else None
+        updates: dict[str, object] = {}
+        for key in (
+            "definition_id",
+            "revision_id",
+            "definition_initial_version",
+            "agent_id",
+            "enablement_id",
+            "direct_channel_id",
+        ):
+            if key in details:
+                updates[key] = details[key]
+        set_clause = [
+            "status = ?",
+            "next_stage = ?",
+            "failure_code = NULL",
+            "failure_detail = NULL",
+            "updated_at = ?",
+        ]
+        parameters: list[object] = [
+            "ready" if stage == "ready" else "provisioning",
+            next_stage,
+            now,
+        ]
+        for key, value in updates.items():
+            set_clause.append(f"{key} = ?")
+            parameters.append(value)
+        parameters.append(operation_id)
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            async with connection.execute(
+                "SELECT stage, details_json FROM agent_provisioning_stage_receipts WHERE operation_id = ?",
+                (operation_id,),
+            ) as cursor:
+                receipt_rows = list(await cursor.fetchall())
+            completed = {str(row[0]) for row in receipt_rows}
+            prior = set(_STAGES[: _STAGES.index(stage)])
+            if not prior.issubset(completed):
+                raise WorkshopAgentProvisioningStorageError("Provisioning stage receipts are out of order")
+            existing_details = next(
+                (str(row[1]) for row in receipt_rows if str(row[0]) == stage),
+                None,
+            )
+            encoded_details = json.dumps(details, sort_keys=True, separators=(",", ":"))
+            if existing_details is not None and existing_details != encoded_details:
+                raise WorkshopAgentProvisioningConflict("Provisioning stage receipt conflicts with canonical state")
+            await connection.execute(
+                "INSERT OR IGNORE INTO agent_provisioning_stage_receipts "
+                "(operation_id, stage, details_json, completed_at) VALUES (?, ?, ?, ?)",
+                (
+                    operation_id,
+                    stage,
+                    encoded_details,
+                    now,
+                ),
+            )
+            await connection.execute(
+                f"UPDATE agent_provisioning_operations SET {', '.join(set_clause)} WHERE id = ?",
+                tuple(parameters),
+            )
+            await connection.commit()
+        except WorkshopAgentProvisioningError:
+            await connection.rollback()
+            raise
+        except Exception as exc:
+            await connection.rollback()
+            raise WorkshopAgentProvisioningStorageError("Provisioning stage receipt could not be persisted") from exc
+
+    async def _completed_stages(self, operation_id: AgentProvisioningId) -> tuple[str, ...]:
+        async with self._store.connection.execute(
+            "SELECT stage FROM agent_provisioning_stage_receipts WHERE operation_id = ?",
+            (operation_id,),
+        ) as cursor:
+            found = {str(row[0]) for row in await cursor.fetchall()}
+        return tuple(stage for stage in _STAGES if stage in found)
+
+    async def _mark_running(self, operation_id: AgentProvisioningId) -> None:
+        operation = await self._require_operation(operation_id)
+        await self._update_status(
+            operation_id,
+            "provisioning",
+            operation.next_stage,
+            None,
+            None,
+        )
+
+    async def _mark_failure(
+        self,
+        operation_id: AgentProvisioningId,
+        status: str,
+        next_stage: str | None,
+        code: str,
+        detail: str,
+    ) -> None:
+        await self._update_status(operation_id, status, next_stage, code, detail)
+
+    async def _update_status(
+        self,
+        operation_id: AgentProvisioningId,
+        status: str,
+        next_stage: str | None,
+        failure_code: str | None,
+        failure_detail: str | None,
+    ) -> None:
+        try:
+            await self._store.connection.execute(
+                "UPDATE agent_provisioning_operations SET status = ?, next_stage = ?, "
+                "failure_code = ?, failure_detail = ?, updated_at = ? WHERE id = ?",
+                (
+                    status,
+                    next_stage,
+                    failure_code,
+                    failure_detail,
+                    datetime.now(UTC).isoformat(),
+                    operation_id,
+                ),
+            )
+            await self._store.connection.commit()
+        except Exception as exc:
+            await self._store.connection.rollback()
+            raise WorkshopAgentProvisioningStorageError("Provisioning status could not be persisted") from exc
+
+    async def _result(
+        self,
+        operation_id: AgentProvisioningId,
+        *,
+        replayed: bool,
+    ) -> AgentProvisioningResult:
+        operation = await self._require_operation(operation_id)
+        blockers = (
+            (
+                AgentProvisioningBlocker(
+                    operation.failure_code,
+                    operation.failure_detail,
+                ),
+            )
+            if operation.failure_code is not None and operation.failure_detail is not None
+            else ()
+        )
+        return AgentProvisioningResult(
+            operation.operation_id,
+            operation.client_operation_id,
+            operation.status,
+            replayed,
+            operation.definition_id,
+            operation.revision_id,
+            operation.agent_id,
+            operation.enablement_id,
+            operation.direct_channel_id,
+            operation.runtime_profile_id,
+            await self._completed_stages(operation_id),
+            operation.next_stage,
+            blockers,
+        )
+
+    @staticmethod
+    def _definition_ids(
+        operation: _ProvisioningOperation,
+    ) -> tuple[AgentDefinitionId, AgentDefinitionRevisionId]:
+        if operation.definition_id is None or operation.revision_id is None:
+            raise WorkshopAgentProvisioningStorageError("Provisioning definition receipt is incomplete")
+        return operation.definition_id, operation.revision_id
+
+    @staticmethod
+    def _stage_key(operation_id: AgentProvisioningId, stage: str) -> str:
+        return f"provision:{operation_id}:{stage}"
+
+    @staticmethod
+    def _failure(exc: Exception) -> tuple[str, str]:
+        if isinstance(
+            exc,
+            (
+                WorkshopAgentEnablementAccessDenied,
+                WorkshopAgentLifecycleAccessDenied,
+                WorkshopCollaborationPolicyAccessDenied,
+                WorkshopSettingsWorkspaceAccessDenied,
+            ),
+        ):
+            return (
+                "authority_changed",
+                "Provisioning authority changed. Review the requested runtime choices and retry.",
+            )
+        if isinstance(
+            exc,
+            (
+                WorkshopSettingsWorkspaceValidationError,
+                WorkshopCollaborationPolicyValidationError,
+            ),
+        ):
+            return (
+                "selection_invalidated",
+                "A selected runtime value is no longer available. Review the choices and retry.",
+            )
+        if isinstance(exc, WorkshopSettingsWorkspaceBusy):
+            return (
+                "runtime_busy",
+                "The selected runtime is busy. Retry this provisioning operation when it is idle.",
+            )
+        if isinstance(
+            exc,
+            (
+                WorkshopAgentEnablementConflict,
+                WorkshopAgentLifecycleConflict,
+                WorkshopCollaborationPolicyConflict,
+            ),
+        ):
+            return (
+                "canonical_conflict",
+                "Canonical agent state changed during provisioning. Review the agent and retry.",
+            )
+        if isinstance(
+            exc,
+            (
+                WorkshopAgentEnablementError,
+                WorkshopAgentLifecycleError,
+                WorkshopCollaborationPolicyError,
+                WorkshopSettingsWorkspaceError,
+            ),
+        ):
+            return (
+                "stage_failed",
+                "A canonical provisioning stage failed. Retry this operation to resume it.",
+            )
+        return (
+            "stage_failed",
+            "A provisioning stage failed. Retry this operation to resume it.",
+        )
+
+    async def _after_stage(self, stage: str) -> None:
+        """Test seam for simulating process interruption after a receipt."""
+        del stage

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -42,6 +42,15 @@ from kai.workshop.agent_lifecycle import (
     WorkshopAgentLifecycleStorageError,
     WorkshopAgentLifecycleValidationError,
 )
+from kai.workshop.agent_provisioning import (
+    AgentProvisioningResult,
+    WorkshopAgentProvisioningAccessDenied,
+    WorkshopAgentProvisioningConflict,
+    WorkshopAgentProvisioningError,
+    WorkshopAgentProvisioningService,
+    WorkshopAgentProvisioningStorageError,
+    WorkshopAgentProvisioningValidationError,
+)
 from kai.workshop.appearance_preferences import (
     AppearancePreferenceAuthority,
     AppearancePreferenceSnapshot,
@@ -345,6 +354,7 @@ _WORKSHOP_HUMANS_PATH = "/v1/workshops/{workshop_id}/humans"
 _HUMAN_CONVERSATION_PATH = "/v1/workshops/{workshop_id}/humans/{principal_id}/conversation"
 _AGENT_DEFINITIONS_PATH = "/v1/client/agents"
 _AGENT_CREATION_OPTIONS_PATH = "/v1/client/agents/creation-options"
+_AGENT_PROVISIONING_PATH = "/v1/client/agents/provision"
 _AGENT_EVENTS_PATH = "/v1/client/agents/events"
 _AGENT_DEFINITION_PATH = "/v1/client/agents/{definition_id}"
 _AGENT_REVISIONS_PATH = "/v1/client/agents/{definition_id}/revisions"
@@ -483,6 +493,9 @@ _AGENT_ACTIVATION_FIELDS = frozenset({"idempotency_key", "expected_version", "re
 _AGENT_ARCHIVAL_FIELDS = frozenset({"idempotency_key", "expected_version"})
 _AGENT_COLLABORATION_POLICY_FIELDS = frozenset({"allowed_operations", "expected_policy_version", "client_operation_id"})
 _AGENT_COLLABORATION_REVOKE_FIELDS = frozenset({"client_operation_id"})
+_AGENT_PROVISIONING_FIELDS = frozenset(
+    {"client_operation_id", "definition", "revision", "runtime", "collaboration_policy"}
+)
 _MAX_AGENT_LIFECYCLE_BODY_BYTES = 32_768
 _DECIMAL_INTEGER = re.compile(r"^[0-9]+$")
 _CLIENT_MESSAGE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
@@ -1149,6 +1162,24 @@ def _serialize_agent_creation_options(snapshot: AgentCreationOptions) -> dict[st
             }
             for runtime in snapshot.runtimes
         ],
+    }
+
+
+def _serialize_agent_provisioning(result: AgentProvisioningResult) -> dict[str, object]:
+    return {
+        "operation_id": str(result.operation_id),
+        "client_operation_id": result.client_operation_id,
+        "status": result.status,
+        "replayed": result.replayed,
+        "definition_id": str(result.definition_id) if result.definition_id is not None else None,
+        "revision_id": str(result.revision_id) if result.revision_id is not None else None,
+        "agent_id": str(result.agent_id) if result.agent_id is not None else None,
+        "enablement_id": str(result.enablement_id) if result.enablement_id is not None else None,
+        "direct_channel_id": (str(result.direct_channel_id) if result.direct_channel_id is not None else None),
+        "runtime_profile_id": str(result.runtime_profile_id),
+        "completed_stages": list(result.completed_stages),
+        "next_stage": result.next_stage,
+        "blockers": [{"code": blocker.code, "detail": blocker.detail} for blocker in result.blockers],
     }
 
 
@@ -5139,6 +5170,54 @@ async def _handle_agent_creation_options(
     )
 
 
+async def _handle_agent_provisioning(
+    request: web.Request,
+    *,
+    authenticator: WorkshopClientAuthenticator,
+    service: WorkshopAgentProvisioningService,
+) -> web.Response:
+    principal_id, error = await _authenticate_agent_lifecycle(request, authenticator)
+    if error is not None:
+        return error
+    assert principal_id is not None
+    payload, error = await _read_agent_lifecycle_payload(
+        request,
+        _AGENT_PROVISIONING_FIELDS,
+    )
+    if error is not None:
+        return error
+    assert payload is not None
+    try:
+        result = await service.provision(principal_id, **payload)
+    except WorkshopAgentProvisioningAccessDenied:
+        return _error_response(status=403, code="access_denied", message="Access denied")
+    except WorkshopAgentProvisioningValidationError as exc:
+        return _error_response(status=400, code="invalid_request", message=str(exc))
+    except WorkshopAgentProvisioningConflict as exc:
+        return _error_response(
+            status=409,
+            code="agent_provisioning_conflict",
+            message=str(exc),
+        )
+    except WorkshopAgentProvisioningStorageError:
+        return _error_response(
+            status=503,
+            code="agent_provisioning_unavailable",
+            message="Agent provisioning is temporarily unavailable",
+        )
+    except WorkshopAgentProvisioningError:
+        return _error_response(
+            status=409,
+            code="agent_provisioning_conflict",
+            message="Agent provisioning conflicted with current state",
+        )
+    status = 201 if result.status == "ready" and not result.replayed else 200
+    return _json_response(
+        {"version": 1, "provisioning": _serialize_agent_provisioning(result)},
+        status=status,
+    )
+
+
 async def _handle_agent_definition_detail(
     request: web.Request,
     *,
@@ -7849,6 +7928,7 @@ def register_workshop_read_routes(
     client_preferences: WorkshopClientPreferenceService | None = None,
     appearance_preferences: WorkshopAppearancePreferenceService | None = None,
     agent_creation_options: WorkshopAgentCreationOptionsService | None = None,
+    agent_provisioning: WorkshopAgentProvisioningService | None = None,
     agent_enablement: WorkshopAgentEnablementService | None = None,
     human_avatars: WorkshopHumanAvatarService | None = None,
     collaboration_policy: WorkshopCollaborationPolicyService | None = None,
@@ -8025,6 +8105,15 @@ def register_workshop_read_routes(
                 request,
                 authenticator=authenticator,
                 service=agent_creation_options,
+            )
+
+    async def handle_agent_provisioning(request: web.Request) -> web.Response:
+        assert agent_provisioning is not None
+        async with request_lock:
+            return await _handle_agent_provisioning(
+                request,
+                authenticator=authenticator,
+                service=agent_provisioning,
             )
 
     async def handle_agent_definition_detail(request: web.Request) -> web.Response:
@@ -8316,6 +8405,8 @@ def register_workshop_read_routes(
         app.router.add_post(_CHANNEL_STANDING_OBSERVATION_RESUME_PATH, handle_standing_observation_resume)
     if agent_creation_options is not None:
         app.router.add_get(_AGENT_CREATION_OPTIONS_PATH, handle_agent_creation_options)
+    if agent_provisioning is not None:
+        app.router.add_post(_AGENT_PROVISIONING_PATH, handle_agent_provisioning)
     app.router.add_get(_AGENT_DEFINITIONS_PATH, handle_agent_definition_list)
     app.router.add_post(_AGENT_DEFINITIONS_PATH, handle_agent_definition_create)
     app.router.add_get(_AGENT_EVENTS_PATH, handle_agent_event_stream)

--- a/src/kai/workshop/collaboration_policy.py
+++ b/src/kai/workshop/collaboration_policy.py
@@ -103,6 +103,25 @@ class WorkshopCollaborationPolicyService:
         self._private_execution = private_execution
         self._host_policy: CollaborationHostPolicy = private_execution.collaboration_authority.host_policy
 
+    def validate_initial_allowed_operations(
+        self,
+        requested_operations: object,
+        allowed_operations: object,
+    ) -> tuple[str, ...]:
+        """Validate creation-time owner policy without requiring a definition."""
+        try:
+            requested = validate_collaboration_operations(requested_operations)
+            allowed = validate_collaboration_operations(allowed_operations)
+        except ValueError as exc:
+            raise WorkshopCollaborationPolicyValidationError(str(exc)) from exc
+        if not set(allowed).issubset(requested):
+            raise WorkshopCollaborationPolicyValidationError(
+                "Owner policy cannot allow operations not requested by Revision 1"
+            )
+        if any(CollaborationOperation(item) not in self._host_policy.effective_allowed_operations for item in allowed):
+            raise WorkshopCollaborationPolicyValidationError("Owner policy cannot exceed host policy")
+        return allowed
+
     async def inspect(
         self,
         principal_id: PrincipalId,

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -137,6 +137,25 @@ _AGENT_AUTHORITY_TABLES = {
     "runs",
     "workshop_memberships",
 }
+_AGENT_PROVISIONING_TABLES = {
+    "agent_provisioning_operations",
+    "agent_provisioning_stage_receipts",
+    "agent_definitions",
+    "agent_definition_revisions",
+    "principal_agent_enablements",
+}
+_AGENT_PROVISIONING_STAGES = (
+    "definition_created",
+    "revision_activated",
+    "enablement_created",
+    "runtime_registered",
+    "backend_selected",
+    "model_selected",
+    "workspace_selected",
+    "timeout_selected",
+    "collaboration_policy_set",
+    "ready",
+)
 _COLLABORATION_AUTHORITY_TABLES = {
     "agent_definition_revisions",
     "agent_definitions",
@@ -659,6 +678,153 @@ def workshop_agent_authority_status(db_path: Path) -> str:
         f"enablements={invalid_enablements}, "
         f"runtime bindings={unauthorized_runtime_bindings}, namespaces={namespace_conflicts}, "
         f"attachments={dangling_attachments}, delegations={delegation_gaps}); authority=canonical"
+    )
+
+
+def workshop_agent_provisioning_status(db_path: Path) -> str:
+    """Report replay-safe provisioning outcomes and receipt integrity."""
+    prefix = "Workshop agent provisioning:"
+    if not db_path.is_file():
+        return f"{prefix} pending; replay-safe schema unavailable"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+        try:
+            connection.execute("PRAGMA query_only=ON")
+            connection.execute("BEGIN")
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            if not tables >= _AGENT_PROVISIONING_TABLES:
+                return f"{prefix} pending; replay-safe schema unavailable"
+            operations = list(
+                connection.execute("SELECT * FROM agent_provisioning_operations ORDER BY created_at, id").fetchall()
+            )
+            receipts = list(
+                connection.execute(
+                    "SELECT operation_id, stage, details_json FROM agent_provisioning_stage_receipts"
+                ).fetchall()
+            )
+            intentional_drafts = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM agent_definitions d WHERE d.lifecycle_state = 'draft' "
+                "AND NOT EXISTS (SELECT 1 FROM agent_provisioning_operations operation "
+                "WHERE operation.definition_id = d.id)",
+            )
+            status_counts = {
+                status: sum(str(row["status"]) == status for row in operations)
+                for status in ("provisioning", "draft", "needs_attention", "ready")
+            }
+            receipt_map: dict[str, dict[str, str]] = {}
+            integrity_gaps = 0
+            for receipt in receipts:
+                stage = str(receipt["stage"])
+                try:
+                    details = json.loads(str(receipt["details_json"]))
+                except (TypeError, ValueError):
+                    details = None
+                if stage not in _AGENT_PROVISIONING_STAGES or not isinstance(details, dict):
+                    integrity_gaps += 1
+                receipt_map.setdefault(str(receipt["operation_id"]), {})[stage] = str(receipt["details_json"])
+            for operation in operations:
+                operation_id = str(operation["id"])
+                completed = set(receipt_map.get(operation_id, {}))
+                prefix_length = 0
+                for stage in _AGENT_PROVISIONING_STAGES:
+                    if stage not in completed:
+                        break
+                    prefix_length += 1
+                if completed != set(_AGENT_PROVISIONING_STAGES[:prefix_length]):
+                    integrity_gaps += 1
+                expected_next = (
+                    _AGENT_PROVISIONING_STAGES[prefix_length]
+                    if prefix_length < len(_AGENT_PROVISIONING_STAGES)
+                    else None
+                )
+                status = str(operation["status"])
+                if status == "ready":
+                    if expected_next is not None or operation["next_stage"] is not None:
+                        integrity_gaps += 1
+                    if operation["failure_code"] is not None or operation["failure_detail"] is not None:
+                        integrity_gaps += 1
+                else:
+                    if operation["next_stage"] != expected_next:
+                        integrity_gaps += 1
+                    has_failure = operation["failure_code"] is not None and operation["failure_detail"] is not None
+                    if (status in {"draft", "needs_attention"}) != has_failure:
+                        integrity_gaps += 1
+                request_json = str(operation["request_json"])
+                try:
+                    request = json.loads(request_json)
+                except (TypeError, ValueError):
+                    request = None
+                if (
+                    not isinstance(request, dict)
+                    or hashlib.sha256(request_json.encode()).hexdigest() != operation["request_hash"]
+                ):
+                    integrity_gaps += 1
+                if "definition_created" in completed:
+                    relationship = connection.execute(
+                        "SELECT COUNT(*) FROM agent_definitions d "
+                        "JOIN agent_definition_revisions r ON r.id = ? AND r.agent_definition_id = d.id "
+                        "WHERE d.id = ? AND d.agent_id = ? AND d.workshop_id = ? "
+                        "AND d.owner_principal_id = ?",
+                        (
+                            operation["revision_id"],
+                            operation["definition_id"],
+                            operation["agent_id"],
+                            operation["workshop_id"],
+                            operation["principal_id"],
+                        ),
+                    ).fetchone()
+                    if relationship is None or int(relationship[0]) != 1:
+                        integrity_gaps += 1
+                if "enablement_created" in completed:
+                    relationship = connection.execute(
+                        "SELECT COUNT(*) FROM principal_agent_enablements e "
+                        "WHERE e.id = ? AND e.agent_definition_id = ? AND e.agent_id = ? "
+                        "AND e.principal_id = ? AND e.runtime_profile_id = ? "
+                        "AND e.direct_channel_id = ?",
+                        (
+                            operation["enablement_id"],
+                            operation["definition_id"],
+                            operation["agent_id"],
+                            operation["principal_id"],
+                            operation["runtime_profile_id"],
+                            operation["direct_channel_id"],
+                        ),
+                    ).fetchone()
+                    if relationship is None or int(relationship[0]) != 1:
+                        integrity_gaps += 1
+                if status == "ready":
+                    relationship = connection.execute(
+                        "SELECT COUNT(*) FROM agent_definitions d "
+                        "JOIN principal_agent_enablements e ON e.id = ? "
+                        "AND e.agent_definition_id = d.id WHERE d.id = ? "
+                        "AND d.lifecycle_state = 'active' AND d.active_revision_id = ? "
+                        "AND e.lifecycle_state = 'enabled' "
+                        "AND d.owner_runtime_profile_id = e.runtime_profile_id "
+                        "AND d.owner_direct_channel_id = e.direct_channel_id",
+                        (
+                            operation["enablement_id"],
+                            operation["definition_id"],
+                            operation["revision_id"],
+                        ),
+                    ).fetchone()
+                    if relationship is None or int(relationship[0]) != 1:
+                        integrity_gaps += 1
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error, TypeError, ValueError) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+    state = "active" if integrity_gaps == 0 else "INCOMPLETE"
+    return (
+        f"{prefix} {state}; operations={len(operations)} "
+        f"(ready={status_counts['ready']}, provisioning={status_counts['provisioning']}, "
+        f"draft={status_counts['draft']}, needs attention={status_counts['needs_attention']}), "
+        f"intentional drafts={intentional_drafts}, receipts={len(receipts)}, "
+        f"integrity gaps={integrity_gaps}; authority=canonical/replay-safe"
     )
 
 

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -179,6 +179,10 @@ class AgentEnablementId(OpaqueId):
     prefix = "aen"
 
 
+class AgentProvisioningId(OpaqueId):
+    prefix = "apv"
+
+
 class RuntimeProfileId(OpaqueId):
     prefix = "rtp"
 

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 75
+WORKSHOP_SCHEMA_VERSION = 76
 
 
 @dataclass(frozen=True, slots=True)
@@ -3339,6 +3339,76 @@ _RUN_KIND_SCOPED_IDENTITY_SCHEMA = SchemaMigration(
     statements=(),
 )
 
+
+_REPLAY_SAFE_AGENT_PROVISIONING_SCHEMA = SchemaMigration(
+    version=76,
+    name="replay_safe_agent_provisioning",
+    statements=(
+        """
+        CREATE TABLE agent_provisioning_operations (
+            id TEXT PRIMARY KEY,
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE RESTRICT,
+            client_operation_id TEXT NOT NULL,
+            request_hash TEXT NOT NULL,
+            request_json TEXT NOT NULL CHECK (
+                json_valid(request_json) AND json_type(request_json) = 'object'
+            ),
+            status TEXT NOT NULL CHECK (
+                status IN ('provisioning', 'draft', 'needs_attention', 'ready')
+            ),
+            next_stage TEXT,
+            failure_code TEXT,
+            failure_detail TEXT,
+            definition_id TEXT REFERENCES agent_definitions(id) ON DELETE RESTRICT,
+            revision_id TEXT REFERENCES agent_definition_revisions(id) ON DELETE RESTRICT,
+            definition_initial_version INTEGER CHECK (
+                definition_initial_version IS NULL OR definition_initial_version > 0
+            ),
+            agent_id TEXT REFERENCES agents(id) ON DELETE RESTRICT,
+            enablement_id TEXT REFERENCES principal_agent_enablements(id) ON DELETE RESTRICT,
+            direct_channel_id TEXT REFERENCES channels(id) ON DELETE RESTRICT,
+            runtime_profile_id TEXT NOT NULL,
+            backend_option_id TEXT NOT NULL,
+            model TEXT NOT NULL,
+            workspace TEXT NOT NULL,
+            timeout_seconds INTEGER NOT NULL CHECK (timeout_seconds > 0),
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE (workshop_id, principal_id, client_operation_id),
+            CHECK (
+                (failure_code IS NULL AND failure_detail IS NULL)
+                OR (failure_code IS NOT NULL AND failure_detail IS NOT NULL)
+            )
+        )
+        """,
+        "CREATE INDEX agent_provisioning_operations_status_idx ON agent_provisioning_operations (status, updated_at)",
+        """
+        CREATE TABLE agent_provisioning_stage_receipts (
+            operation_id TEXT NOT NULL
+                REFERENCES agent_provisioning_operations(id) ON DELETE CASCADE,
+            stage TEXT NOT NULL CHECK (stage IN (
+                'definition_created',
+                'revision_activated',
+                'enablement_created',
+                'runtime_registered',
+                'backend_selected',
+                'model_selected',
+                'workspace_selected',
+                'timeout_selected',
+                'collaboration_policy_set',
+                'ready'
+            )),
+            details_json TEXT NOT NULL CHECK (
+                json_valid(details_json) AND json_type(details_json) = 'object'
+            ),
+            completed_at TEXT NOT NULL,
+            PRIMARY KEY (operation_id, stage)
+        )
+        """,
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -3415,6 +3485,7 @@ _MIGRATIONS = (
     _STANDING_OBSERVATION_INBOX_SCHEMA,
     _STANDING_OBSERVE_EXECUTION_SCHEMA,
     _RUN_KIND_SCOPED_IDENTITY_SCHEMA,
+    _REPLAY_SAFE_AGENT_PROVISIONING_SCHEMA,
 )
 
 

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -579,7 +579,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 75
+        assert await upgraded.schema_version() == 76
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_agent_provisioning.py
+++ b/tests/test_workshop_agent_provisioning.py
@@ -1,0 +1,409 @@
+"""Replay-safe principal-owned agent provisioning contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from kai.workshop.agent_creation_options import (
+    AgentCreationBackendOption,
+    AgentCreationModelOption,
+    AgentCreationOptions,
+    AgentCreationRuntimeOption,
+    AgentCreationWorkspaceOption,
+)
+from kai.workshop.agent_enablement import WorkshopAgentEnablementService
+from kai.workshop.agent_lifecycle import WorkshopAgentLifecycleService
+from kai.workshop.agent_provisioning import (
+    WorkshopAgentProvisioningAccessDenied,
+    WorkshopAgentProvisioningConflict,
+    WorkshopAgentProvisioningService,
+)
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.diagnostics import workshop_agent_provisioning_status
+from kai.workshop.domain import PrincipalId
+from kai.workshop.execution_state import WorkshopExecutionStateRegistry
+from kai.workshop.internal_api_contexts import (
+    WorkshopInternalAPIContextRegistry,
+    WorkshopInternalAPIExecutionContext,
+)
+from kai.workshop.store import WorkshopEventStore
+from tests.workshop_profiles import profile_id, profile_registry
+
+
+class _Crash(BaseException):
+    pass
+
+
+@dataclass
+class _RuntimePool:
+    registered: list[WorkshopInternalAPIExecutionContext] = field(default_factory=list)
+
+    def register_canonical_lane(self, context: WorkshopInternalAPIExecutionContext) -> None:
+        self.registered.append(context)
+
+
+@dataclass
+class _CreationOptions:
+    principal_id: PrincipalId
+    home: Path
+
+    async def inspect(self, principal_id: PrincipalId) -> AgentCreationOptions:
+        if principal_id != self.principal_id:
+            return AgentCreationOptions(principal_id, False, (), ())
+        backend = AgentCreationBackendOption(
+            option_id="codex:openai",
+            backend="codex",
+            provider="openai",
+            current=True,
+            readiness="ready",
+            default_model="gpt-5.6-sol",
+            models=(
+                AgentCreationModelOption(
+                    "gpt-5.6-sol",
+                    "GPT-5.6 Sol",
+                    "available",
+                    True,
+                    False,
+                ),
+            ),
+            catalogue_status="succeeded",
+            catalogue_stale=False,
+            blockers=(),
+        )
+        runtime = AgentCreationRuntimeOption(
+            runtime_profile_id=profile_id(101),
+            display_name="Daniel",
+            current_backend_option_id=backend.option_id,
+            default_workspace=str(self.home),
+            default_timeout_seconds=300,
+            minimum_timeout_seconds=1,
+            maximum_timeout_seconds=1800,
+            backends=(backend,),
+            workspaces=(AgentCreationWorkspaceOption(str(self.home), "Home", True, True),),
+            ready=True,
+            blockers=(),
+        )
+        return AgentCreationOptions(principal_id, True, (runtime,), ())
+
+
+@dataclass
+class _Settings:
+    values: dict[str, object] = field(default_factory=dict)
+    fail_model_once: bool = False
+
+    def authority_for_principal_channel(self, principal_id, channel_id):
+        return principal_id, channel_id
+
+    async def set_backend(self, _authority, value):
+        self.values["backend"] = value
+
+    async def set_model(self, _authority, value):
+        if self.fail_model_once:
+            self.fail_model_once = False
+            raise RuntimeError("transient model failure")
+        self.values["model"] = value
+
+    async def switch_workspace(self, _authority, value):
+        self.values["workspace"] = value
+
+    async def set_timeout(self, _authority, value):
+        self.values["timeout"] = value
+
+
+@dataclass
+class _CollaborationPolicy:
+    values: tuple[str, ...] = ()
+
+    def validate_initial_allowed_operations(self, requested, allowed):
+        assert set(allowed).issubset(requested)
+        return tuple(allowed)
+
+    async def set_allowed(
+        self,
+        _principal_id,
+        _definition_id,
+        *,
+        allowed_operations,
+        expected_policy_version,
+        client_operation_id,
+    ):
+        assert expected_policy_version == 0
+        assert client_operation_id.startswith("provision:apv_")
+        self.values = tuple(allowed_operations)
+
+
+class _InterruptingProvisioningService(WorkshopAgentProvisioningService):
+    def __init__(self, *args, interrupt_after: str | None = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._interrupt_after = interrupt_after
+
+    async def _after_stage(self, stage: str) -> None:
+        if stage == self._interrupt_after:
+            self._interrupt_after = None
+            raise _Crash(stage)
+
+
+async def _principal(store: WorkshopEventStore) -> PrincipalId:
+    async with store.connection.execute(
+        "SELECT principal_id FROM external_identities WHERE provider = 'telegram' AND external_subject = '101'",
+    ) as cursor:
+        row = await cursor.fetchone()
+    assert row is not None
+    return PrincipalId(str(row[0]))
+
+
+async def _services(tmp_path: Path):
+    store = await WorkshopEventStore.open(tmp_path / "kai.db")
+    profiles = profile_registry(101)
+    await bootstrap_default_workshop(
+        store,
+        (BootstrapHuman("Daniel", "admin", "telegram", "101", "101", profile_id(101)),),
+    )
+    principal_id = await _principal(store)
+    execution = await WorkshopExecutionStateRegistry.from_store(store, profiles)
+    contexts = await WorkshopInternalAPIContextRegistry.from_store(store, profiles)
+    runtime_pool = _RuntimePool()
+    enablement = WorkshopAgentEnablementService(
+        store,
+        profiles,
+        execution,
+        contexts,
+        runtime_pool,  # type: ignore[arg-type]
+    )
+    settings = _Settings()
+    collaboration = _CollaborationPolicy()
+    dependencies = (
+        store,
+        _CreationOptions(principal_id, tmp_path.resolve()),
+        WorkshopAgentLifecycleService(store),
+        enablement,
+        settings,
+        collaboration,
+    )
+    return store, principal_id, dependencies, runtime_pool, settings
+
+
+def _request() -> dict[str, object]:
+    return {
+        "client_operation_id": "q1488-provision-1",
+        "definition": {
+            "handle": "builder",
+            "display_name": "Builder",
+            "description": "A bounded builder.",
+            "presentation": {"avatar": "B"},
+        },
+        "revision": {
+            "purpose": "Build carefully.",
+            "instructions": "Use the authorized workspace.",
+            "capabilities": ["text_generation"],
+            "collaboration_operations": [],
+        },
+        "runtime": {
+            "runtime_profile_id": str(profile_id(101)),
+            "backend_option_id": "codex:openai",
+            "model": "gpt-5.6-sol",
+            "workspace": str(Path.cwd()),
+            "timeout_seconds": 420,
+        },
+        "collaboration_policy": {"allowed_operations": []},
+    }
+
+
+@pytest.mark.parametrize(
+    "stage",
+    (
+        "definition_created",
+        "revision_activated",
+        "enablement_created",
+        "runtime_registered",
+        "backend_selected",
+        "model_selected",
+        "workspace_selected",
+        "timeout_selected",
+        "collaboration_policy_set",
+        "ready",
+    ),
+)
+async def test_interruption_after_every_durable_stage_resumes_exact_lane(
+    tmp_path: Path,
+    stage: str,
+) -> None:
+    store, principal_id, dependencies, _runtime_pool, settings = await _services(tmp_path)
+    request = _request()
+    request["runtime"] = {**request["runtime"], "workspace": str(tmp_path.resolve())}  # type: ignore[dict-item]
+    try:
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM event_log WHERE event_type = 'principal_agent.conversation_started'",
+        ) as cursor:
+            initial_conversation_starts = int((await cursor.fetchone())[0])
+        interrupted = _InterruptingProvisioningService(
+            *dependencies,
+            interrupt_after=stage,
+        )
+        with pytest.raises(_Crash):
+            await interrupted.provision(principal_id, **request)
+
+        restarted = WorkshopAgentProvisioningService(*dependencies)  # type: ignore[arg-type]
+        result = await restarted.provision(principal_id, **request)
+        replay = await restarted.provision(principal_id, **request)
+
+        assert result.status == "ready"
+        assert result.completed_stages[-1] == "ready"
+        assert replay.replayed is True
+        assert replay.definition_id == result.definition_id
+        assert settings.values == {
+            "backend": "codex:openai",
+            "model": "gpt-5.6-sol",
+            "workspace": str(tmp_path.resolve()),
+            "timeout": 420,
+        }
+        async with store.connection.execute(
+            "SELECT (SELECT COUNT(*) FROM agent_definitions), "
+            "(SELECT COUNT(*) FROM agent_definition_revisions WHERE agent_definition_id = ?), "
+            "(SELECT COUNT(*) FROM principal_agent_enablements WHERE agent_definition_id = ?), "
+            "(SELECT COUNT(*) FROM agent_provisioning_stage_receipts)",
+            (result.definition_id, result.definition_id),
+        ) as cursor:
+            counts = await cursor.fetchone()
+        assert counts is not None
+        # Bootstrap contributes only the predefined Kai definition.
+        assert tuple(int(value) for value in counts) == (2, 1, 1, 10)
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM event_log WHERE event_type = 'principal_agent.conversation_started'",
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == initial_conversation_starts
+        assert "Workshop agent provisioning: active; operations=1 (ready=1" in (
+            workshop_agent_provisioning_status(tmp_path / "kai.db")
+        )
+    finally:
+        await store.close()
+
+
+async def test_exact_concurrency_replays_and_conflicting_identity_fails(tmp_path: Path) -> None:
+    store, principal_id, dependencies, _runtime_pool, _settings = await _services(tmp_path)
+    request = _request()
+    request["runtime"] = {**request["runtime"], "workspace": str(tmp_path.resolve())}  # type: ignore[dict-item]
+    service = WorkshopAgentProvisioningService(*dependencies)  # type: ignore[arg-type]
+    try:
+        first, second = await asyncio.gather(
+            service.provision(principal_id, **request),
+            service.provision(principal_id, **request),
+        )
+        assert {first.replayed, second.replayed} == {False, True}
+        assert first.definition_id == second.definition_id
+
+        changed = dict(request)
+        changed["definition"] = {**request["definition"], "display_name": "Other"}  # type: ignore[dict-item]
+        with pytest.raises(WorkshopAgentProvisioningConflict, match="different"):
+            await service.provision(principal_id, **changed)
+    finally:
+        await store.close()
+
+
+async def test_conflicting_concurrent_inputs_create_only_one_agent(tmp_path: Path) -> None:
+    store, principal_id, dependencies, _runtime_pool, _settings = await _services(tmp_path)
+    first = _request()
+    first["runtime"] = {**first["runtime"], "workspace": str(tmp_path.resolve())}  # type: ignore[dict-item]
+    second = dict(first)
+    second["definition"] = {**first["definition"], "display_name": "Conflicting"}  # type: ignore[dict-item]
+    service = WorkshopAgentProvisioningService(*dependencies)  # type: ignore[arg-type]
+    try:
+        outcomes = await asyncio.gather(
+            service.provision(principal_id, **first),
+            service.provision(principal_id, **second),
+            return_exceptions=True,
+        )
+        assert sum(not isinstance(outcome, BaseException) for outcome in outcomes) == 1
+        assert sum(isinstance(outcome, WorkshopAgentProvisioningConflict) for outcome in outcomes) == 1
+        async with store.connection.execute(
+            "SELECT COUNT(*) FROM agent_definitions WHERE handle = 'builder'",
+        ) as cursor:
+            assert int((await cursor.fetchone())[0]) == 1
+    finally:
+        await store.close()
+
+
+async def test_committed_enablement_recovers_registration_after_store_reopen(
+    tmp_path: Path,
+) -> None:
+    store, principal_id, dependencies, _runtime_pool, settings = await _services(tmp_path)
+    request = _request()
+    request["runtime"] = {**request["runtime"], "workspace": str(tmp_path.resolve())}  # type: ignore[dict-item]
+    collaboration = dependencies[-1]
+    interrupted = _InterruptingProvisioningService(
+        *dependencies,
+        interrupt_after="enablement_created",
+    )
+    with pytest.raises(_Crash):
+        await interrupted.provision(principal_id, **request)
+    await store.close()
+
+    reopened = await WorkshopEventStore.open(tmp_path / "kai.db")
+    profiles = profile_registry(101)
+    execution = await WorkshopExecutionStateRegistry.from_store(reopened, profiles)
+    contexts = await WorkshopInternalAPIContextRegistry.from_store(reopened, profiles)
+    runtime_pool = _RuntimePool()
+    enablement = WorkshopAgentEnablementService(
+        reopened,
+        profiles,
+        execution,
+        contexts,
+        runtime_pool,  # type: ignore[arg-type]
+    )
+    restarted = WorkshopAgentProvisioningService(
+        reopened,
+        _CreationOptions(principal_id, tmp_path.resolve()),  # type: ignore[arg-type]
+        WorkshopAgentLifecycleService(reopened),
+        enablement,
+        settings,  # type: ignore[arg-type]
+        collaboration,  # type: ignore[arg-type]
+    )
+    try:
+        result = await restarted.provision(principal_id, **request)
+        assert result.status == "ready"
+        assert len(runtime_pool.registered) == 1
+        assert runtime_pool.registered[0].channel_id == result.direct_channel_id
+    finally:
+        await reopened.close()
+
+
+async def test_late_failure_is_bounded_and_resumable(tmp_path: Path) -> None:
+    store, principal_id, dependencies, _runtime_pool, settings = await _services(tmp_path)
+    request = _request()
+    request["runtime"] = {**request["runtime"], "workspace": str(tmp_path.resolve())}  # type: ignore[dict-item]
+    settings.fail_model_once = True
+    service = WorkshopAgentProvisioningService(*dependencies)  # type: ignore[arg-type]
+    try:
+        blocked = await service.provision(principal_id, **request)
+        assert blocked.status == "needs_attention"
+        assert blocked.next_stage == "model_selected"
+        assert [item.code for item in blocked.blockers] == ["stage_failed"]
+
+        completed = await service.provision(principal_id, **request)
+        assert completed.status == "ready"
+    finally:
+        await store.close()
+
+
+async def test_unauthorized_runtime_fails_before_agent_state(tmp_path: Path) -> None:
+    store, principal_id, dependencies, _runtime_pool, _settings = await _services(tmp_path)
+    request = _request()
+    runtime = dict(request["runtime"])  # type: ignore[arg-type]
+    runtime["runtime_profile_id"] = str(profile_id(202))
+    request["runtime"] = runtime
+    service = WorkshopAgentProvisioningService(*dependencies)  # type: ignore[arg-type]
+    try:
+        with pytest.raises(WorkshopAgentProvisioningAccessDenied):
+            await service.provision(principal_id, **request)
+        async with store.connection.execute(
+            "SELECT (SELECT COUNT(*) FROM agent_provisioning_operations), (SELECT COUNT(*) FROM agent_definitions)",
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        assert (int(row[0]), int(row[1])) == (0, 1)
+    finally:
+        await store.close()

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -22,6 +22,7 @@ from kai.workshop.agent_creation_options import (
     AgentCreationWorkspaceOption,
 )
 from kai.workshop.agent_enablement import EligibleAgentRuntime, PrincipalAgentEnablement
+from kai.workshop.agent_provisioning import AgentProvisioningResult
 from kai.workshop.appearance_preferences import (
     WORKSHOP_APPEARANCE_THEMES,
     WorkshopAppearancePreferenceService,
@@ -74,7 +75,10 @@ from kai.workshop.diagnostics import (
 )
 from kai.workshop.domain import (
     AgentDefinitionId,
+    AgentDefinitionRevisionId,
+    AgentEnablementId,
     AgentId,
+    AgentProvisioningId,
     ChannelId,
     ChannelMembershipId,
     EventEnvelope,
@@ -175,6 +179,18 @@ from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id, profile_registry
 
 _NOW = datetime(2026, 8, 11, 14, 0, tzinfo=UTC)
+_AGENT_PROVISIONING_STAGES_FOR_TEST = (
+    "definition_created",
+    "revision_activated",
+    "enablement_created",
+    "runtime_registered",
+    "backend_selected",
+    "model_selected",
+    "workspace_selected",
+    "timeout_selected",
+    "collaboration_policy_set",
+    "ready",
+)
 
 
 @dataclass
@@ -822,6 +838,31 @@ class _AgentCreationOptions:
         )
 
 
+@dataclass
+class _AgentProvisioning:
+    principal_id: PrincipalId
+    calls: list[tuple[PrincipalId, dict[str, object]]] = field(default_factory=list)
+
+    async def provision(self, principal_id: PrincipalId, **payload) -> AgentProvisioningResult:
+        assert principal_id == self.principal_id
+        self.calls.append((principal_id, payload))
+        return AgentProvisioningResult(
+            AgentProvisioningId("apv_" + "1" * 32),
+            str(payload["client_operation_id"]),
+            "ready",
+            False,
+            AgentDefinitionId("adf_" + "2" * 32),
+            AgentDefinitionRevisionId("adr_" + "3" * 32),
+            AgentId("agt_" + "4" * 32),
+            AgentEnablementId("aen_" + "5" * 32),
+            ChannelId("chn_" + "6" * 32),
+            profile_id(101),
+            _AGENT_PROVISIONING_STAGES_FOR_TEST,
+            None,
+            (),
+        )
+
+
 async def _identity_for(store: WorkshopEventStore, subject: str) -> tuple[PrincipalId, ChannelId]:
     async with store.connection.execute(
         "SELECT e.principal_id, b.channel_id FROM external_identities e "
@@ -949,6 +990,7 @@ async def _open_client(
     client_preferences=None,
     appearance_preferences=None,
     agent_creation_options=None,
+    agent_provisioning=None,
     agent_enablement=None,
     human_avatars=None,
     collaboration_policy=None,
@@ -975,6 +1017,7 @@ async def _open_client(
         client_preferences=client_preferences,
         appearance_preferences=appearance_preferences,
         agent_creation_options=agent_creation_options,
+        agent_provisioning=agent_provisioning,
         agent_enablement=agent_enablement,
         human_avatars=human_avatars,
         collaboration_policy=collaboration_policy,
@@ -2658,6 +2701,77 @@ class TestWorkshopAgentEnablementHTTPContract:
             )
             assert selector.status == 400
             assert service.calls == [alice_id]
+        finally:
+            await client.close()
+            await store.close()
+
+    async def test_provisioning_is_authenticated_and_uses_one_strict_operation(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, alice_id, _, _, _ = await _open_store(tmp_path / "kai.db")
+        service = _AgentProvisioning(alice_id)
+        client = await _open_client(
+            store,
+            _Authenticator({"alice": alice_id}),
+            agent_provisioning=service,
+        )
+        payload = {
+            "client_operation_id": "provision-builder-1",
+            "definition": {
+                "handle": "builder",
+                "display_name": "Builder",
+                "description": "Builds things.",
+                "presentation": {"avatar": "B"},
+            },
+            "revision": {
+                "purpose": "Build bounded changes.",
+                "instructions": "Work carefully.",
+                "capabilities": ["text_generation"],
+                "collaboration_operations": [],
+            },
+            "runtime": {
+                "runtime_profile_id": str(profile_id(101)),
+                "backend_option_id": "claude:anthropic",
+                "model": "claude-sonnet-4-5",
+                "workspace": "/srv/daniel",
+                "timeout_seconds": 300,
+            },
+            "collaboration_policy": {"allowed_operations": []},
+        }
+        try:
+            unauthenticated = await client.post("/v1/client/agents/provision", json=payload)
+            assert unauthenticated.status == 401
+            invalid = await client.post(
+                "/v1/client/agents/provision",
+                headers={"Authorization": "Bearer alice"},
+                json={**payload, "principal_id": str(alice_id)},
+            )
+            assert invalid.status == 400
+
+            response = await client.post(
+                "/v1/client/agents/provision",
+                headers={"Authorization": "Bearer alice"},
+                json=payload,
+            )
+            assert response.status == 201
+            body = await response.json()
+            assert body["provisioning"] == {
+                "operation_id": "apv_" + "1" * 32,
+                "client_operation_id": "provision-builder-1",
+                "status": "ready",
+                "replayed": False,
+                "definition_id": "adf_" + "2" * 32,
+                "revision_id": "adr_" + "3" * 32,
+                "agent_id": "agt_" + "4" * 32,
+                "enablement_id": "aen_" + "5" * 32,
+                "direct_channel_id": "chn_" + "6" * 32,
+                "runtime_profile_id": str(profile_id(101)),
+                "completed_stages": list(_AGENT_PROVISIONING_STAGES_FOR_TEST),
+                "next_stage": None,
+                "blockers": [],
+            }
+            assert service.calls == [(alice_id, payload)]
         finally:
             await client.close()
             await store.close()

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -451,7 +451,7 @@ async def test_version_sixty_seven_migrates_only_legacy_delegation_requests(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 75
+        assert await upgraded.schema_version() == 76
         async with upgraded.connection.execute(
             "SELECT id, capabilities_json, collaboration_operations_json "
             "FROM agent_definition_revisions ORDER BY revision_number"

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -412,7 +412,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
             after = workshop_runtime_session_status(path)
             assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
@@ -440,7 +440,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
             assert session is not None
             assert session.runtime_profile_id == _RUNTIME_PROFILE_ID

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -273,7 +273,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 75
+        assert await workshop_store.schema_version() == 76
         async with workshop_store.connection.execute("PRAGMA table_info(principals)") as cursor:
             principal_columns = {str(row[1]) for row in await cursor.fetchall()}
         assert {"display_name_state_version", "display_name_event_position"} <= principal_columns
@@ -327,7 +327,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 75
+        assert await second.schema_version() == 76
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -411,7 +411,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             async with upgraded.connection.execute(
                 "SELECT reaction, created_event_position FROM message_reactions "
                 "WHERE message_id = ? AND principal_id = ?",
@@ -452,7 +452,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -480,7 +480,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -573,6 +573,7 @@ class TestWorkshopSchema:
                     73,
                     74,
                     75,
+                    76,
                 ]
         finally:
             await upgraded.close()
@@ -595,7 +596,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -636,7 +637,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -689,7 +690,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -733,7 +734,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -777,7 +778,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -821,7 +822,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -925,7 +926,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -1052,7 +1053,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -319,7 +319,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 75
+            assert await upgraded.schema_version() == 76
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),

--- a/workshop-client/src/api.test.ts
+++ b/workshop-client/src/api.test.ts
@@ -16,6 +16,7 @@ import {
   advanceThreadReadPosition,
   createChannel,
   createAgentDefinition,
+  provisionAgent,
   createMemoryFact,
   deleteMemories,
   deleteMemory,
@@ -325,6 +326,38 @@ function agentCreationOptionsPayload(): Record<string, unknown> {
         ],
       },
     ],
+  };
+}
+
+function agentProvisioningPayload(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    agent_id: agentId,
+    blockers: [],
+    client_operation_id: "provision-builder-1",
+    completed_stages: [
+      "definition_created",
+      "revision_activated",
+      "enablement_created",
+      "runtime_registered",
+      "backend_selected",
+      "model_selected",
+      "workspace_selected",
+      "timeout_selected",
+      "collaboration_policy_set",
+      "ready",
+    ],
+    definition_id: agentDefinitionId,
+    direct_channel_id: channelId,
+    enablement_id: agentEnablementId,
+    next_stage: null,
+    operation_id: "apv_00000000000000000000000000000001",
+    replayed: false,
+    revision_id: agentRevisionId,
+    runtime_profile_id: runtimeProfileId,
+    status: "ready",
+    ...overrides,
   };
 }
 
@@ -2813,6 +2846,90 @@ describe("Workshop client API", () => {
     await expect(loadAgentCreationOptions("session-secret")).rejects.toThrow(
       "Kai returned unsupported agent creation options.",
     );
+  });
+
+  it("provisions an agent through the strict replay-safe contract", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      provisioning: agentProvisioningPayload(),
+      version: 1,
+    }), { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await provisionAgent("session-secret", {
+      allowedCollaborationOperations: ["context_read"],
+      avatar: "B",
+      backendOptionId: "claude:anthropic",
+      capabilities: ["text_generation"],
+      clientOperationId: "provision-builder-1",
+      collaborationOperations: ["context_read"],
+      description: "Builds things.",
+      displayName: "Builder",
+      handle: "builder",
+      instructions: "Work carefully.",
+      model: "claude-sonnet-4-5",
+      purpose: "Build bounded changes.",
+      runtimeProfileId,
+      timeoutSeconds: 300,
+      workspace: "/srv/workspaces/home",
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      definitionId: agentDefinitionId,
+      operationId: "apv_00000000000000000000000000000001",
+      status: "ready",
+    }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/v1/client/agents/provision",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[0][1]?.body))).toEqual({
+      client_operation_id: "provision-builder-1",
+      collaboration_policy: { allowed_operations: ["context_read"] },
+      definition: {
+        description: "Builds things.",
+        display_name: "Builder",
+        handle: "builder",
+        presentation: { avatar: "B" },
+      },
+      revision: {
+        capabilities: ["text_generation"],
+        collaboration_operations: ["context_read"],
+        instructions: "Work carefully.",
+        purpose: "Build bounded changes.",
+      },
+      runtime: {
+        backend_option_id: "claude:anthropic",
+        model: "claude-sonnet-4-5",
+        runtime_profile_id: runtimeProfileId,
+        timeout_seconds: 300,
+        workspace: "/srv/workspaces/home",
+      },
+    });
+  });
+
+  it("rejects unsupported agent provisioning state", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      provisioning: agentProvisioningPayload({ completed_stages: ["unknown"] }),
+      version: 1,
+    }), { status: 200 })));
+
+    await expect(provisionAgent("session-secret", {
+      allowedCollaborationOperations: [],
+      avatar: "",
+      backendOptionId: "claude:anthropic",
+      capabilities: ["text_generation"],
+      clientOperationId: "provision-builder-1",
+      collaborationOperations: [],
+      description: "Builds things.",
+      displayName: "Builder",
+      handle: "builder",
+      instructions: "Work carefully.",
+      model: "claude-sonnet-4-5",
+      purpose: "Build bounded changes.",
+      runtimeProfileId,
+      timeoutSeconds: 300,
+      workspace: "/srv/workspaces/home",
+    })).rejects.toThrow("Kai returned unsupported agent provisioning state.");
   });
 
   it("uses versioned agent lifecycle and enablement mutation contracts", async () => {

--- a/workshop-client/src/api.ts
+++ b/workshop-client/src/api.ts
@@ -63,6 +63,7 @@ import type {
   WorkshopAgentDefinition,
   WorkshopAgentEnablement,
   WorkshopAgentCreationOptions,
+  WorkshopAgentProvisioning,
   WorkshopCollaborationOperation,
   WorkshopCollaborationPolicy,
   WorkshopStandingParticipation,
@@ -97,6 +98,7 @@ import { isWorkshopThemeId } from "./theme";
 import {
   AGENT_PATTERN,
   AGENT_DEFINITION_PATTERN,
+  AGENT_PROVISIONING_PATTERN,
   AGENT_ENABLEMENT_PATTERN,
   AGENT_REVISION_PATTERN,
   ARTIFACT_PATTERN,
@@ -1164,6 +1166,75 @@ function parseAgentCreationOptions(value: unknown): WorkshopAgentCreationOptions
   };
 }
 
+function parseAgentProvisioning(value: unknown): WorkshopAgentProvisioning | null {
+  const statuses = ["draft", "needs_attention", "ready"];
+  const stages = [
+    "definition_created",
+    "revision_activated",
+    "enablement_created",
+    "runtime_registered",
+    "backend_selected",
+    "model_selected",
+    "workspace_selected",
+    "timeout_selected",
+    "collaboration_policy_set",
+    "ready",
+  ];
+  if (
+    !isRecord(value) ||
+    typeof value.operation_id !== "string" ||
+    !AGENT_PROVISIONING_PATTERN.test(value.operation_id) ||
+    typeof value.client_operation_id !== "string" ||
+    value.client_operation_id.length === 0 ||
+    typeof value.status !== "string" ||
+    !statuses.includes(value.status) ||
+    typeof value.replayed !== "boolean" ||
+    (value.definition_id !== null &&
+      (typeof value.definition_id !== "string" ||
+        !AGENT_DEFINITION_PATTERN.test(value.definition_id))) ||
+    (value.revision_id !== null &&
+      (typeof value.revision_id !== "string" ||
+        !AGENT_REVISION_PATTERN.test(value.revision_id))) ||
+    (value.agent_id !== null &&
+      (typeof value.agent_id !== "string" || !AGENT_PATTERN.test(value.agent_id))) ||
+    (value.enablement_id !== null &&
+      (typeof value.enablement_id !== "string" ||
+        !AGENT_ENABLEMENT_PATTERN.test(value.enablement_id))) ||
+    (value.direct_channel_id !== null &&
+      (typeof value.direct_channel_id !== "string" ||
+        !CHANNEL_PATTERN.test(value.direct_channel_id))) ||
+    typeof value.runtime_profile_id !== "string" ||
+    !RUNTIME_PROFILE_PATTERN.test(value.runtime_profile_id) ||
+    !Array.isArray(value.completed_stages) ||
+    value.completed_stages.some(
+      (stage) => typeof stage !== "string" || !stages.includes(stage),
+    ) ||
+    (value.next_stage !== null &&
+      (typeof value.next_stage !== "string" || !stages.includes(value.next_stage)))
+  ) {
+    return null;
+  }
+  const blockers = parseAgentCreationBlockers(value.blockers);
+  if (!blockers) {
+    return null;
+  }
+  return {
+    agentId: value.agent_id,
+    blockers,
+    clientOperationId: value.client_operation_id,
+    completedStages: value.completed_stages as string[],
+    definitionId: value.definition_id,
+    directChannelId: value.direct_channel_id,
+    enablementId: value.enablement_id,
+    nextStage: value.next_stage,
+    operationId: value.operation_id,
+    replayed: value.replayed,
+    revisionId: value.revision_id,
+    runtimeProfileId: value.runtime_profile_id,
+    status: value.status as WorkshopAgentProvisioning["status"],
+  };
+}
+
 async function agentMutation(
   token: string,
   path: string,
@@ -1250,6 +1321,74 @@ export async function loadAgentCreationOptions(
     throw new Error("Kai returned unsupported agent creation options.");
   }
   return options;
+}
+
+export interface AgentProvisioningInput {
+  allowedCollaborationOperations: WorkshopCollaborationOperation[];
+  avatar: string;
+  backendOptionId: string;
+  capabilities: WorkshopAgentCapability[];
+  clientOperationId: string;
+  collaborationOperations: WorkshopCollaborationOperation[];
+  description: string;
+  displayName: string;
+  handle: string;
+  instructions: string;
+  model: string;
+  purpose: string;
+  runtimeProfileId: string;
+  timeoutSeconds: number;
+  workspace: string;
+}
+
+export async function provisionAgent(
+  token: string,
+  input: AgentProvisioningInput,
+): Promise<WorkshopAgentProvisioning> {
+  const response = await authorizedFetch(
+    { channelId: "", token },
+    "/v1/client/agents/provision",
+    {
+      body: JSON.stringify({
+        client_operation_id: input.clientOperationId,
+        collaboration_policy: {
+          allowed_operations: input.allowedCollaborationOperations,
+        },
+        definition: {
+          description: input.description,
+          display_name: input.displayName,
+          handle: input.handle,
+          presentation: input.avatar.trim() ? { avatar: input.avatar.trim() } : {},
+        },
+        revision: {
+          capabilities: input.capabilities,
+          collaboration_operations: input.collaborationOperations,
+          instructions: input.instructions,
+          purpose: input.purpose,
+        },
+        runtime: {
+          backend_option_id: input.backendOptionId,
+          model: input.model,
+          runtime_profile_id: input.runtimeProfileId,
+          timeout_seconds: input.timeoutSeconds,
+          workspace: input.workspace,
+        },
+      }),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    },
+  );
+  const payload = await responsePayload(response);
+  if (!response.ok) {
+    throw new Error(safeErrorMessage(payload, "Could not provision this agent."));
+  }
+  const provisioning = isRecord(payload) && payload.version === 1
+    ? parseAgentProvisioning(payload.provisioning)
+    : null;
+  if (!provisioning) {
+    throw new Error("Kai returned unsupported agent provisioning state.");
+  }
+  return provisioning;
 }
 
 export async function loadAgentEnablements(

--- a/workshop-client/src/types.ts
+++ b/workshop-client/src/types.ts
@@ -1,6 +1,7 @@
 export const CHANNEL_PATTERN = /^chn_[0-9a-f]{32}$/;
 export const AGENT_PATTERN = /^agt_[0-9a-f]{32}$/;
 export const AGENT_DEFINITION_PATTERN = /^adf_[0-9a-f]{32}$/;
+export const AGENT_PROVISIONING_PATTERN = /^apv_[0-9a-f]{32}$/;
 export const AGENT_REVISION_PATTERN = /^adr_[0-9a-f]{32}$/;
 export const AGENT_ENABLEMENT_PATTERN = /^aen_[0-9a-f]{32}$/;
 export const PRINCIPAL_PATTERN = /^prn_[0-9a-f]{32}$/;
@@ -484,6 +485,22 @@ export interface WorkshopAgentCreationOptions {
   principalId: string;
   ready: boolean;
   runtimes: WorkshopAgentCreationRuntimeOption[];
+}
+
+export interface WorkshopAgentProvisioning {
+  agentId: string | null;
+  blockers: WorkshopAgentCreationBlocker[];
+  clientOperationId: string;
+  completedStages: string[];
+  definitionId: string | null;
+  directChannelId: string | null;
+  enablementId: string | null;
+  nextStage: string | null;
+  operationId: string;
+  replayed: boolean;
+  revisionId: string | null;
+  runtimeProfileId: string;
+  status: "draft" | "needs_attention" | "ready";
 }
 
 export interface WorkshopAgentChangeSignal {


### PR DESCRIPTION
Closes #1488

## Summary
- add one strict authenticated agent-provisioning operation spanning definition, revision, enablement, runtime registration, settings, workspace, timeout, and owner collaboration policy
- persist canonical requests and ordered stage receipts so interrupted operations resume safely and exact retries converge
- expose bounded readiness results, diagnostics, and typed Workshop client support without automatically starting a direct conversation

## Validation
- make check
- make typecheck
- make client-check
- focused provisioning, API, schema migration, host, and webhook tests
- make test: 6609 passed