### PR TITLE
Split Workshop tests into balanced parallel CI shards

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -20,7 +20,7 @@ Unknown or empty change input fails closed to complete validation.
 
 - `core`: general application, adapter, configuration, installation, and integration tests;
 - `memory`: `test_memory*` and `test_eval_*` modules;
-- `workshop`: `test_workshop_*` modules.
+- `workshop-1`, `workshop-2`, and `workshop-3`: `test_workshop_*` modules distributed by a frozen consistent hash. Existing paths remain in the same sub-shard, and new modules are assigned automatically.
 
 The shards run concurrently with fail-fast disabled, so failures remain independently visible. Unit coverage proves that their sets are exhaustive and disjoint. The required `check` job succeeds only after the quality job and every selected shard succeed.
 
@@ -31,5 +31,7 @@ Run a shard locally with:
 ```bash
 python scripts/ci_test_shard.py core
 python scripts/ci_test_shard.py memory
-python scripts/ci_test_shard.py workshop
+python scripts/ci_test_shard.py workshop-1
+python scripts/ci_test_shard.py workshop-2
+python scripts/ci_test_shard.py workshop-3
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [core, memory, workshop]
+        shard: [core, memory, workshop-1, workshop-2, workshop-3]
     steps:
       - uses: actions/checkout@v7
 

--- a/scripts/ci_test_shard.py
+++ b/scripts/ci_test_shard.py
@@ -3,17 +3,27 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 from pathlib import Path
 
-CI_TEST_SHARDS = ("core", "memory", "workshop")
+WORKSHOP_TEST_SHARDS = ("workshop-1", "workshop-2", "workshop-3")
+CI_TEST_SHARDS = ("core", "memory", *WORKSHOP_TEST_SHARDS)
 _REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+_WORKSHOP_SHARD_SALT = b"kai-workshop-shards-v6540:"
+
+
+def _workshop_test_shard(path: Path) -> str:
+    """Assign Workshop modules without reshuffling existing paths."""
+    digest = hashlib.sha256(_WORKSHOP_SHARD_SALT + path.as_posix().encode()).digest()
+    index = int.from_bytes(digest[:8], "big") % len(WORKSHOP_TEST_SHARDS)
+    return WORKSHOP_TEST_SHARDS[index]
 
 
 def classify_test_file(path: Path) -> str:
     """Assign one test module to exactly one stable CI shard."""
     name = path.name
     if name.startswith("test_workshop_"):
-        return "workshop"
+        return _workshop_test_shard(path)
     if name.startswith(("test_memory", "test_eval_")):
         return "memory"
     return "core"

--- a/tests/test_ci_test_shard.py
+++ b/tests/test_ci_test_shard.py
@@ -4,6 +4,7 @@ import pytest
 
 from scripts.ci_test_shard import (
     CI_TEST_SHARDS,
+    WORKSHOP_TEST_SHARDS,
     classify_test_file,
     discover_test_files,
     select_test_files,
@@ -17,7 +18,9 @@ from scripts.ci_test_shard import (
         ("test_memory.py", "memory"),
         ("test_memory_extraction.py", "memory"),
         ("test_eval_behavioral.py", "memory"),
-        ("test_workshop_foundation.py", "workshop"),
+        ("test_workshop_client_api.py", "workshop-1"),
+        ("test_workshop_foundation.py", "workshop-2"),
+        ("test_workshop_agent_provisioning.py", "workshop-3"),
     ],
 )
 def test_test_module_classification_is_stable(name: str, expected: str) -> None:
@@ -38,3 +41,7 @@ def test_shards_are_disjoint_and_cover_every_test_module() -> None:
 def test_unknown_shard_fails_closed() -> None:
     with pytest.raises(ValueError, match="Unknown CI test shard"):
         select_test_files("unknown")
+
+
+def test_every_workshop_sub_shard_is_populated() -> None:
+    assert all(select_test_files(shard) for shard in WORKSHOP_TEST_SHARDS)


### PR DESCRIPTION
Closes #1493

## Summary
- split the former Workshop test lane into three parallel sub-shards
- use a frozen consistent hash so new modules are assigned automatically without reshuffling existing paths
- preserve exhaustive, disjoint complete-suite coverage and the aggregate required check
- document each local shard command

## Measured distribution
- workshop-1: 24 modules, approximately 89.1 seconds of #1492 test execution
- workshop-2: 29 modules, approximately 89.7 seconds
- workshop-3: 41 modules, approximately 90.1 seconds

## Validation
- tests/test_ci_test_shard.py: 10 passed
- make check
- git diff --check

This is CI-only; no make install is required.