### PR TITLE
Fix agent collaboration provisioning validation

### DIFF
--- a/src/kai/workshop/agent_provisioning.py
+++ b/src/kai/workshop/agent_provisioning.py
@@ -442,8 +442,8 @@ class WorkshopAgentProvisioningService:
         self._validate_model(backend, request.model)
         try:
             self._collaboration_policy.validate_initial_allowed_operations(
-                request.collaboration_operations,
-                request.allowed_collaboration_operations,
+                list(request.collaboration_operations),
+                list(request.allowed_collaboration_operations),
             )
         except WorkshopCollaborationPolicyValidationError as exc:
             raise WorkshopAgentProvisioningValidationError(str(exc)) from exc

--- a/tests/test_workshop_agent_provisioning.py
+++ b/tests/test_workshop_agent_provisioning.py
@@ -119,6 +119,8 @@ class _CollaborationPolicy:
     values: tuple[str, ...] = ()
 
     def validate_initial_allowed_operations(self, requested, allowed):
+        assert isinstance(requested, list)
+        assert isinstance(allowed, list)
         assert set(allowed).issubset(requested)
         return tuple(allowed)
 


### PR DESCRIPTION
## Summary
- pass normalized collaboration operation sets back to the creation-time policy validator as JSON-compatible lists
- tighten the provisioning test double to enforce the real collaboration-policy input contract

## Validation
- `pytest tests/test_workshop_agent_provisioning.py tests/test_workshop_collaboration_policy.py -q` (18 passed)
- `pytest tests/test_workshop_client_api.py -k "creation_options or provisioning" -q` (2 passed)
- `make check`

Closes #1496