### PR TITLE
Preserve agent provisioning across projection rebuilds

### DIFF
--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -2016,6 +2016,40 @@ class CanonicalConversationProjection:
     # Agent ownership and runtime sponsorship project from explicit authority events.
     version = 33
 
+    async def prepare_rebuild(self, connection: aiosqlite.Connection) -> None:
+        """Preserve durable coordination rows that reference this projection."""
+        async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
+            existing_tables = {str(row[0]) for row in await cursor.fetchall()}
+        if "agent_provisioning_operations" not in existing_tables:
+            return
+        await connection.execute("DROP TABLE IF EXISTS temp.canonical_rebuild_agent_provisioning_receipts")
+        await connection.execute("DROP TABLE IF EXISTS temp.canonical_rebuild_agent_provisioning_operations")
+        await connection.execute(
+            "CREATE TEMP TABLE canonical_rebuild_agent_provisioning_operations AS "
+            "SELECT * FROM agent_provisioning_operations"
+        )
+        await connection.execute(
+            "CREATE TEMP TABLE canonical_rebuild_agent_provisioning_receipts AS "
+            "SELECT * FROM agent_provisioning_stage_receipts"
+        )
+        await connection.execute("DELETE FROM agent_provisioning_stage_receipts")
+        await connection.execute("DELETE FROM agent_provisioning_operations")
+
+    async def finish_rebuild(self, connection: aiosqlite.Connection) -> None:
+        """Restore durable coordination rows after their references are replayed."""
+        async with connection.execute("SELECT name FROM sqlite_temp_master WHERE type = 'table'") as cursor:
+            temporary_tables = {str(row[0]) for row in await cursor.fetchall()}
+        if "canonical_rebuild_agent_provisioning_operations" not in temporary_tables:
+            return
+        await connection.execute(
+            "INSERT INTO agent_provisioning_operations SELECT * FROM canonical_rebuild_agent_provisioning_operations"
+        )
+        await connection.execute(
+            "INSERT INTO agent_provisioning_stage_receipts SELECT * FROM canonical_rebuild_agent_provisioning_receipts"
+        )
+        await connection.execute("DROP TABLE canonical_rebuild_agent_provisioning_receipts")
+        await connection.execute("DROP TABLE canonical_rebuild_agent_provisioning_operations")
+
     async def reset(self, connection: aiosqlite.Connection) -> None:
         async with connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'") as cursor:
             existing_tables = {str(row[0]) for row in await cursor.fetchall()}

--- a/src/kai/workshop/store.py
+++ b/src/kai/workshop/store.py
@@ -8,7 +8,7 @@ import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 import aiosqlite
 
@@ -55,6 +55,15 @@ class Projection(Protocol):
     async def reset(self, connection: aiosqlite.Connection) -> None: ...
 
     async def apply(self, connection: aiosqlite.Connection, event: StoredEvent) -> None: ...
+
+
+@runtime_checkable
+class ProjectionRebuildHooks(Protocol):
+    """Optional hooks for non-projected state that spans an atomic rebuild."""
+
+    async def prepare_rebuild(self, connection: aiosqlite.Connection) -> None: ...
+
+    async def finish_rebuild(self, connection: aiosqlite.Connection) -> None: ...
 
 
 def _parse_timestamp(value: str) -> datetime:
@@ -268,10 +277,14 @@ class WorkshopEventStore:
 
         try:
             await self._connection.execute("BEGIN IMMEDIATE")
+            if isinstance(projection, ProjectionRebuildHooks):
+                await projection.prepare_rebuild(self._connection)
             await projection.reset(self._connection)
             events = await self.read_events()
             for event in events:
                 await projection.apply(self._connection, event)
+            if isinstance(projection, ProjectionRebuildHooks):
+                await projection.finish_rebuild(self._connection)
             last_position = events[-1].position if events else 0
             updated_at = _format_timestamp(datetime.now(UTC))
             await self._connection.execute(

--- a/tests/test_workshop_agent_provisioning.py
+++ b/tests/test_workshop_agent_provisioning.py
@@ -30,6 +30,7 @@ from kai.workshop.internal_api_contexts import (
     WorkshopInternalAPIContextRegistry,
     WorkshopInternalAPIExecutionContext,
 )
+from kai.workshop.projection import CanonicalConversationProjection
 from kai.workshop.store import WorkshopEventStore
 from tests.workshop_profiles import profile_id, profile_registry
 
@@ -372,6 +373,46 @@ async def test_committed_enablement_recovers_registration_after_store_reopen(
         assert runtime_pool.registered[0].channel_id == result.direct_channel_id
     finally:
         await reopened.close()
+
+
+async def test_completed_provisioning_survives_canonical_projection_rebuild(
+    tmp_path: Path,
+) -> None:
+    store, principal_id, dependencies, _runtime_pool, _settings = await _services(tmp_path)
+    request = _request()
+    request["runtime"] = {**request["runtime"], "workspace": str(tmp_path.resolve())}  # type: ignore[dict-item]
+    service = WorkshopAgentProvisioningService(*dependencies)  # type: ignore[arg-type]
+    try:
+        completed = await service.provision(principal_id, **request)
+        assert completed.status == "ready"
+
+        await store.rebuild_projection(CanonicalConversationProjection())
+
+        replayed = await service.provision(principal_id, **request)
+        assert replayed.status == "ready"
+        assert replayed.replayed is True
+        assert replayed.definition_id == completed.definition_id
+        assert replayed.revision_id == completed.revision_id
+        assert replayed.enablement_id == completed.enablement_id
+        assert replayed.direct_channel_id == completed.direct_channel_id
+        async with store.connection.execute(
+            "SELECT status, definition_id, revision_id, enablement_id, direct_channel_id, "
+            "(SELECT COUNT(*) FROM agent_provisioning_stage_receipts WHERE operation_id = ?) "
+            "FROM agent_provisioning_operations WHERE id = ?",
+            (completed.operation_id, completed.operation_id),
+        ) as cursor:
+            row = await cursor.fetchone()
+        assert row is not None
+        assert tuple(row) == (
+            "ready",
+            str(completed.definition_id),
+            str(completed.revision_id),
+            str(completed.enablement_id),
+            str(completed.direct_channel_id),
+            10,
+        )
+    finally:
+        await store.close()
 
 
 async def test_late_failure_is_bounded_and_resumable(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #1504.

## Summary
- add optional atomic projection-rebuild hooks
- preserve durable agent provisioning operations and stage receipts while canonical rows are reset and replayed
- restore the coordination records only after their canonical foreign-key targets exist again
- cover successful provisioning followed by a full canonical rebuild and idempotent replay

## Validation
- `make check`
- `.venv/bin/python -m pytest tests/test_workshop_foundation.py tests/test_workshop_agent_provisioning.py tests/test_workshop_agent_definitions.py tests/test_workshop_agent_enablement.py -q` (93 passed)
- `make test` (6,616 passed)