### PR TITLE
Fix workspace creation to honor configured base

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -144,6 +144,7 @@ _DEPLOYED_ENV_FILE = Path("/etc/kai/env")
 # hardcodes the same path; keep them in sync.
 PRINCIPAL_MEMORY_READER = Path("/etc/kai/read-principal-memory")
 PRINCIPAL_PREFERENCE_MANAGER = Path("/etc/kai/manage-principal-preferences")
+PRINCIPAL_WORKSPACE_PROVISIONER = Path("/etc/kai/provision-principal-workspace")
 
 # Default installation paths
 _DEFAULT_INSTALL_DIR = "/opt/kai"
@@ -4399,6 +4400,39 @@ def _generate_principal_preference_manager(
     """)
 
 
+def _generate_principal_workspace_provisioner(install_dir: str = "/opt/kai") -> str:
+    """Generate the fixed root wrapper for bounded workspace provisioning."""
+    python = repr(str(Path(install_dir) / "venv" / "bin" / "python"))
+    return textwrap.dedent(f"""\
+        #!/usr/bin/python3
+        # Kai - provision one runtime-owned workspace below protected policy.
+        # Managed by 'python -m kai install apply'. Do not edit manually.
+        import os
+        import sys
+
+        PYTHON = {python}
+
+
+        def main() -> int:
+            argv = [
+                PYTHON,
+                "-I",
+                "-m",
+                "kai.workshop.workspace_provisioning",
+                *sys.argv[1:],
+            ]
+            os.execve(
+                PYTHON,
+                argv,
+                {{"LANG": "C.UTF-8", "PATH": "/usr/bin:/bin"}},
+            )
+            return 1
+
+
+        sys.exit(main())
+    """)
+
+
 def _generate_sudoers(
     service_user: str,
     os_users: Iterable[str] = (),
@@ -4485,6 +4519,7 @@ def _generate_sudoers(
     if target_users:
         rules += f"{service_user} ALL=(root) NOPASSWD: {PRINCIPAL_MEMORY_READER} *\n"
         rules += f"{service_user} ALL=(root) NOPASSWD: {PRINCIPAL_PREFERENCE_MANAGER} *\n"
+        rules += f"{service_user} ALL=(root) NOPASSWD: {PRINCIPAL_WORKSPACE_PROVISIONER} *\n"
 
     if target_users:
         # In protected installs, these arguments come from
@@ -9021,8 +9056,8 @@ def _apply_sudoers(
     checks. `agent_backend` and users.yaml retain compatibility coverage for
     the global/default runtime path.
 
-    `data_dir` additionally installs the principal-memory reader and preference
-    manager helpers
+    `data_dir` additionally installs the principal-memory reader, preference
+    manager, and bounded workspace-provisioning helpers
     when the deployment has foreign os_users (the only case where its
     sudoers rule is emitted); None (direct/dev callers) always skips
     the helper.
@@ -9129,6 +9164,7 @@ def _apply_sudoers(
         if install_reader:
             print(f"[DRY RUN] Would write: {PRINCIPAL_MEMORY_READER} (mode 0755)")
             print(f"[DRY RUN] Would write: {PRINCIPAL_PREFERENCE_MANAGER} (mode 0755)")
+            print(f"[DRY RUN] Would write: {PRINCIPAL_WORKSPACE_PROVISIONER} (mode 0755)")
         print(f"[DRY RUN] Would write: {sudoers_path} (mode 0440)")
         print("[DRY RUN] Would validate with visudo -cf")
         return
@@ -9168,6 +9204,21 @@ def _apply_sudoers(
         os.chmod(PRINCIPAL_PREFERENCE_MANAGER, 0o755)
         os.chown(PRINCIPAL_PREFERENCE_MANAGER, 0, 0)
         print(f"  Wrote {PRINCIPAL_PREFERENCE_MANAGER}")
+
+        fd, tmp_name = tempfile.mkstemp(prefix="kai-workspace-provisioner-", suffix=".tmp")
+        try:
+            os.write(
+                fd,
+                _generate_principal_workspace_provisioner(install_dir).encode(),
+            )
+            os.close(fd)
+            shutil.move(tmp_name, str(PRINCIPAL_WORKSPACE_PROVISIONER))
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        os.chmod(PRINCIPAL_WORKSPACE_PROVISIONER, 0o755)
+        os.chown(PRINCIPAL_WORKSPACE_PROVISIONER, 0, 0)
+        print(f"  Wrote {PRINCIPAL_WORKSPACE_PROVISIONER}")
 
     # Write to a secure temp file first, validate, then move into place.
     # Uses mkstemp (random name, restrictive permissions) instead of a

--- a/src/kai/workshop/settings_workspaces.py
+++ b/src/kai/workshop/settings_workspaces.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-import stat
 import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
@@ -32,6 +31,11 @@ from kai.workshop.model_catalogue import (
 )
 from kai.workshop.runtime_pool import WorkshopRuntimePool
 from kai.workshop.runtime_profiles import WorkshopRuntimeProfileError
+from kai.workshop.workspace_provisioning import (
+    WorkspaceProvisioningError,
+    provision_via_helper,
+    provision_workspace,
+)
 from kai.workspace_utils import is_workspace_allowed
 
 
@@ -742,58 +746,37 @@ class WorkshopSettingsWorkspaceService:
                 raise WorkshopSettingsWorkspaceBusy(
                     "A workspace cannot be created while this conversation has an active run"
                 )
-            home = self._runtime_pool.get_home_workspace(runtime_authority)
-            if not home.is_absolute() or home.is_symlink() or not home.is_dir():
-                raise WorkshopSettingsWorkspaceValidationError("The private workspace home is unavailable")
-            home_resolved = home.resolve()
-            workspace_root = home_resolved / "workspaces"
-            if workspace_root.is_symlink():
-                raise WorkshopSettingsWorkspaceValidationError("The private workspace directory is invalid")
-            if workspace_root.exists() and not workspace_root.is_dir():
-                raise WorkshopSettingsWorkspaceValidationError("The private workspace directory is unavailable")
-            workspace_root.mkdir(mode=0o700, exist_ok=True)
-            if workspace_root.is_symlink() or workspace_root.resolve().parent != home_resolved:
-                raise WorkshopSettingsWorkspaceValidationError("The private workspace directory is invalid")
-            if stat.S_IMODE(workspace_root.stat().st_mode) & 0o077:
-                raise WorkshopSettingsWorkspaceValidationError(
-                    "The private workspace directory permissions are not private"
-                )
-            target = workspace_root / workspace_name
-            created_directory = False
-            if target.is_symlink():
-                raise WorkshopSettingsWorkspaceValidationError("The workspace name resolves through a symbolic link")
+            workspace_base, _allowed = await self._runtime_pool.resolve_workspace_access(runtime_authority)
+            if workspace_base is None:
+                raise WorkshopSettingsWorkspaceValidationError("No workspace base is configured for this runtime")
+            profile = self._runtime_pool.runtime_profile(runtime_authority)
+            os_user = profile.os_user
             try:
-                target.mkdir(mode=0o700)
-                created_directory = True
-            except FileExistsError:
-                if target.is_symlink() or not target.is_dir():
-                    raise WorkshopSettingsWorkspaceValidationError(
-                        "A non-directory entry already uses this workspace name"
-                    ) from None
-            target_resolved = target.resolve()
-            if target_resolved.parent != workspace_root.resolve():
-                raise WorkshopSettingsWorkspaceValidationError(
-                    "The workspace would escape the private workspace directory"
+                if self._config.protected_install and os_user is not None:
+                    provisioned = await asyncio.to_thread(
+                        provision_via_helper,
+                        authority.runtime_profile_id,
+                        workspace_name,
+                    )
+                else:
+                    provisioned = await asyncio.to_thread(
+                        provision_workspace,
+                        workspace_base,
+                        workspace_name,
+                    )
+            except WorkspaceProvisioningError as exc:
+                raise WorkshopSettingsWorkspaceValidationError(str(exc)) from exc
+            target_resolved = Path(provisioned.path)
+            expected_target = workspace_base.resolve() / workspace_name
+            if target_resolved != expected_target:
+                raise WorkshopSettingsWorkspaceConsistencyError(
+                    "Workspace provisioner returned a path outside the configured workspace base"
                 )
-            if stat.S_IMODE(target_resolved.stat().st_mode) & 0o077:
-                raise WorkshopSettingsWorkspaceValidationError("The workspace directory permissions are not private")
             grant_created = await sessions.add_canonical_workspace_grant(
                 self._namespace(authority),
                 str(target_resolved),
             )
-            git_ready = (target_resolved / ".git").is_dir()
-            if not git_ready:
-                try:
-                    process = await asyncio.create_subprocess_exec(
-                        "git",
-                        "init",
-                        cwd=str(target_resolved),
-                        stdout=asyncio.subprocess.DEVNULL,
-                        stderr=asyncio.subprocess.DEVNULL,
-                    )
-                    git_ready = await process.wait() == 0
-                except OSError:
-                    git_ready = False
+            git_ready = provisioned.git_ready
             creator_runtime_key = self._runtime_pool.legacy_runtime_key(authority.runtime_profile_id)
             if creator_runtime_key is None:
                 memory_project_registered = False
@@ -821,7 +804,12 @@ class WorkshopSettingsWorkspaceService:
                 authority,
                 mutation=SettingsMutationOutcome(
                     operation="create_workspace",
-                    changed=(created_directory or grant_created or memory_project_created or switch_mutation.changed),
+                    changed=(
+                        provisioned.directory_created
+                        or grant_created
+                        or memory_project_created
+                        or switch_mutation.changed
+                    ),
                     runtime_action=switch_mutation.runtime_action,
                     provider_session_invalidated=switch_mutation.provider_session_invalidated,
                 ),
@@ -829,7 +817,7 @@ class WorkshopSettingsWorkspaceService:
             return WorkspaceCreationResult(
                 snapshot=snapshot,
                 path=str(target_resolved),
-                directory_created=created_directory,
+                directory_created=provisioned.directory_created,
                 git_ready=git_ready,
                 memory_project_registered=memory_project_registered,
                 memory_project_note=memory_project_note,

--- a/src/kai/workshop/workspace_provisioning.py
+++ b/src/kai/workshop/workspace_provisioning.py
@@ -1,0 +1,192 @@
+"""Bounded filesystem provisioning for self-service workspaces."""
+
+from __future__ import annotations
+
+import json
+import os
+import pwd
+import stat
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.runtime_profiles import WorkshopRuntimeProfileRegistry
+
+WORKSPACE_PROVISIONER = Path("/etc/kai/provision-principal-workspace")
+RUNTIME_PROFILES_POLICY = Path("/etc/kai/runtime-profiles.yaml")
+GIT_COMMAND = Path("/usr/bin/git")
+
+
+class WorkspaceProvisioningError(RuntimeError):
+    """A bounded workspace filesystem operation could not be completed."""
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceProvisioningResult:
+    """Filesystem facts returned by the local or privileged provisioner."""
+
+    path: str
+    directory_created: bool
+    git_ready: bool
+
+
+def _validate_flat_name(name: str) -> str:
+    if (
+        not name
+        or name != name.strip()
+        or name in {".", ".."}
+        or "/" in name
+        or "\\" in name
+        or any(ord(character) < 32 or ord(character) == 127 for character in name)
+    ):
+        raise WorkspaceProvisioningError("Invalid workspace name")
+    return name
+
+
+def _target_identity(os_user: str | None) -> tuple[int, int, tuple[int, ...], str] | None:
+    if os_user is None:
+        return None
+    try:
+        account = pwd.getpwnam(os_user)
+    except KeyError as exc:
+        raise WorkspaceProvisioningError("The runtime OS identity is unavailable") from exc
+    groups = tuple(os.getgrouplist(account.pw_name, account.pw_gid))
+    return account.pw_uid, account.pw_gid, groups, account.pw_dir
+
+
+def provision_workspace(
+    workspace_base: Path,
+    name: str,
+    *,
+    os_user: str | None = None,
+    git_command: Path = GIT_COMMAND,
+) -> WorkspaceProvisioningResult:
+    """Create one direct child of an operator-authorized workspace base."""
+    checked_name = _validate_flat_name(name)
+    if not workspace_base.is_absolute() or workspace_base.is_symlink() or not workspace_base.is_dir():
+        raise WorkspaceProvisioningError("The configured workspace base is unavailable or invalid")
+    try:
+        base = workspace_base.resolve(strict=True)
+        base_fd = os.open(base, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    except OSError as exc:
+        raise WorkspaceProvisioningError("The configured workspace base is unavailable or invalid") from exc
+
+    identity = _target_identity(os_user)
+    created = False
+    target_fd = -1
+    try:
+        try:
+            os.mkdir(checked_name, mode=0o755, dir_fd=base_fd)
+            created = True
+        except FileExistsError:
+            pass
+        try:
+            target_fd = os.open(
+                checked_name,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+                dir_fd=base_fd,
+            )
+        except OSError as exc:
+            raise WorkspaceProvisioningError(
+                "A non-directory or symbolic link already uses this workspace name"
+            ) from exc
+        info = os.fstat(target_fd)
+        if not stat.S_ISDIR(info.st_mode):
+            raise WorkspaceProvisioningError("A non-directory entry already uses this workspace name")
+        if identity is not None:
+            uid, gid, _groups, _home = identity
+            if created:
+                if os.geteuid() != 0 and info.st_uid != uid:
+                    raise WorkspaceProvisioningError("Protected workspace provisioning requires root authority")
+                if os.geteuid() == 0:
+                    os.fchown(target_fd, uid, gid)
+            elif info.st_uid != uid:
+                raise WorkspaceProvisioningError("An existing workspace with this name has a different owner")
+        if created:
+            os.fchmod(target_fd, 0o755)
+    finally:
+        if target_fd >= 0:
+            os.close(target_fd)
+        os.close(base_fd)
+
+    target = base / checked_name
+    git_ready = (target / ".git").is_dir()
+    if not git_ready:
+        command: dict[str, object] = {
+            "cwd": str(target),
+            "stdout": subprocess.DEVNULL,
+            "stderr": subprocess.DEVNULL,
+            "check": False,
+            "env": {"LANG": "C.UTF-8", "PATH": "/usr/bin:/bin"},
+        }
+        if identity is not None:
+            uid, gid, groups, home = identity
+            command.update(user=uid, group=gid, extra_groups=groups)
+            environment = command["env"]
+            assert isinstance(environment, dict)
+            environment["HOME"] = home
+        try:
+            completed = subprocess.run([str(git_command), "init"], **command)  # type: ignore[arg-type]
+        except OSError:
+            git_ready = False
+        else:
+            git_ready = completed.returncode == 0 and (target / ".git").is_dir()
+    return WorkspaceProvisioningResult(str(target), created, git_ready)
+
+
+def provision_via_helper(profile_id: RuntimeProfileId, name: str) -> WorkspaceProvisioningResult:
+    """Invoke the fixed root helper without giving the daemon a path argument."""
+    completed = subprocess.run(
+        ["sudo", "-n", str(WORKSPACE_PROVISIONER), str(profile_id), name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    try:
+        payload = json.loads(completed.stdout)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise WorkspaceProvisioningError("Protected workspace provisioning failed") from exc
+    if completed.returncode != 0 or not isinstance(payload, dict) or payload.get("ok") is not True:
+        message = payload.get("error") if isinstance(payload, dict) else None
+        raise WorkspaceProvisioningError(
+            str(message) if isinstance(message, str) and message else "Protected workspace provisioning failed"
+        )
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        raise WorkspaceProvisioningError("Protected workspace provisioning returned an invalid result")
+    path = result.get("path")
+    directory_created = result.get("directory_created")
+    git_ready = result.get("git_ready")
+    if not isinstance(path, str) or not isinstance(directory_created, bool) or not isinstance(git_ready, bool):
+        raise WorkspaceProvisioningError("Protected workspace provisioning returned an invalid result")
+    return WorkspaceProvisioningResult(path, directory_created, git_ready)
+
+
+def _helper_main(argv: list[str]) -> int:
+    if len(argv) != 2 or os.geteuid() != 0:
+        print(json.dumps({"ok": False, "error": "Invalid workspace provisioning request"}))
+        return 64
+    try:
+        profile_id = RuntimeProfileId(argv[0])
+        content = RUNTIME_PROFILES_POLICY.read_text(encoding="utf-8")
+        profile = WorkshopRuntimeProfileRegistry.from_yaml(content).resolve(profile_id)
+        if profile.workspace_base is None:
+            raise WorkspaceProvisioningError("No workspace base is configured for this runtime")
+        if profile.os_user is None:
+            raise WorkspaceProvisioningError("The protected runtime has no OS identity")
+        result = provision_workspace(
+            profile.workspace_base,
+            argv[1],
+            os_user=profile.os_user,
+        )
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+    print(json.dumps({"ok": True, "result": asdict(result)}, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_helper_main(sys.argv[1:]))

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -66,6 +66,7 @@ from kai.install import (
     _generate_launcher_script,
     _generate_principal_memory_reader,
     _generate_principal_preference_manager,
+    _generate_principal_workspace_provisioner,
     _generate_sudoers,
     _generate_systemd_unit,
     _generate_users_yaml,
@@ -452,6 +453,12 @@ class TestGenerateSudoers:
         assert rule not in _generate_sudoers("kai")
         assert rule not in _generate_sudoers("kai", ["kai"])
 
+    def test_principal_workspace_provisioner_rule_requires_foreign_users(self):
+        rule = "kai ALL=(root) NOPASSWD: /etc/kai/provision-principal-workspace *"
+        assert rule in _generate_sudoers("kai", ["daniel"])
+        assert rule not in _generate_sudoers("kai")
+        assert rule not in _generate_sudoers("kai", ["kai"])
+
 
 class TestGeneratePrincipalPreferenceManager:
     def test_wrapper_pins_interpreter_module_and_data_root(self):
@@ -467,6 +474,17 @@ class TestGeneratePrincipalPreferenceManager:
         assert "os.execve(" in script
         assert "environ" not in script
         compile(script, "<preference-manager>", "exec")
+
+
+class TestGeneratePrincipalWorkspaceProvisioner:
+    def test_wrapper_pins_interpreter_and_module(self):
+        script = _generate_principal_workspace_provisioner("/opt/kai")
+        assert script.startswith("#!/usr/bin/python3\n")
+        assert "PYTHON = '/opt/kai/venv/bin/python'" in script
+        assert '"kai.workshop.workspace_provisioning"' in script
+        assert "os.execve(" in script
+        assert "environ" not in script
+        compile(script, "<workspace-provisioner>", "exec")
 
     def test_paths_are_baked_in_as_literals(self):
         script = _generate_principal_preference_manager(

--- a/tests/test_workshop_settings_workspaces.py
+++ b/tests/test_workshop_settings_workspaces.py
@@ -2,12 +2,12 @@
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from kai import sessions
-from kai.config import Config, WorkspaceConfig
+from kai.config import Config, DeploymentMode, WorkspaceConfig
 from kai.workshop.domain import AgentId, ChannelId, PrincipalId
 from kai.workshop.execution_state import (
     WorkshopExecutionStateNamespace,
@@ -21,6 +21,7 @@ from kai.workshop.settings_workspaces import (
     WorkshopSettingsWorkspaceService,
     WorkshopSettingsWorkspaceValidationError,
 )
+from kai.workshop.workspace_provisioning import WorkspaceProvisioningResult
 from tests.workshop_profiles import profile_id
 
 
@@ -43,6 +44,8 @@ class _RuntimePool:
             timeout_seconds=120,
             maximum_timeout_seconds=600,
             allowed_models=None,
+            os_user=None,
+            workspace_base=allowed.parent,
         )
         self.profile.backend_options = (
             SimpleNamespace(option_id="codex:openai", backend="codex", provider="openai"),
@@ -406,7 +409,7 @@ async def test_workspace_switch_rejects_paths_outside_runtime_grants(
     assert pool.events == []
 
 
-async def test_workspace_creation_is_private_registered_and_idempotent(
+async def test_workspace_creation_uses_configured_base_and_is_idempotent(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -457,10 +460,10 @@ async def test_workspace_creation_is_private_registered_and_idempotent(
         expected_revision=created.snapshot.revision,
     )
 
-    path = pool.home / "workspaces" / "research-notes"
+    path = pool.allowed.parent / "research-notes"
     assert path.is_dir()
     assert (path / ".git").is_dir()
-    assert path.stat().st_mode & 0o777 == 0o700
+    assert path.stat().st_mode & 0o777 == 0o755
     assert created.directory_created is True
     assert created.git_ready is True
     assert created.memory_project_registered is True
@@ -494,7 +497,7 @@ async def test_workspace_creation_rejects_unsafe_names(
     with pytest.raises(WorkshopSettingsWorkspaceValidationError):
         await service.create_workspace(authority, name)
 
-    assert not (pool.home / "workspaces").exists()
+    assert [path.name for path in pool.allowed.parent.iterdir()] == ["kai"]
     add_grant.assert_not_awaited()
 
 
@@ -504,12 +507,10 @@ async def test_workspace_creation_rejects_symlink_and_file_collisions(
 ) -> None:
     service, pool, authority, _, _ = _service(tmp_path)
     _canonical_state(monkeypatch)
-    workspace_root = pool.home / "workspaces"
-    workspace_root.mkdir(mode=0o700)
     outside = tmp_path / "outside"
     outside.mkdir()
-    (workspace_root / "linked").symlink_to(outside, target_is_directory=True)
-    (workspace_root / "occupied").write_text("not a directory")
+    (pool.allowed.parent / "linked").symlink_to(outside, target_is_directory=True)
+    (pool.allowed.parent / "occupied").write_text("not a directory")
     add_grant = AsyncMock()
     monkeypatch.setattr(sessions, "add_canonical_workspace_grant", add_grant)
 
@@ -521,7 +522,7 @@ async def test_workspace_creation_rejects_symlink_and_file_collisions(
     add_grant.assert_not_awaited()
 
 
-async def test_workspace_creation_rejects_symlinked_private_workspace_root(
+async def test_workspace_creation_rejects_symlinked_workspace_base(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -529,15 +530,77 @@ async def test_workspace_creation_rejects_symlinked_private_workspace_root(
     _canonical_state(monkeypatch)
     outside = tmp_path / "outside"
     outside.mkdir()
-    (pool.home / "workspaces").symlink_to(outside, target_is_directory=True)
+    symlinked_base = tmp_path / "linked-projects"
+    symlinked_base.symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(pool, "resolve_workspace_access", AsyncMock(return_value=(symlinked_base, [])))
     add_grant = AsyncMock()
     monkeypatch.setattr(sessions, "add_canonical_workspace_grant", add_grant)
 
-    with pytest.raises(WorkshopSettingsWorkspaceValidationError, match="private workspace directory"):
+    with pytest.raises(WorkshopSettingsWorkspaceValidationError, match="workspace base"):
         await service.create_workspace(authority, "Research")
 
     assert not (outside / "Research").exists()
     add_grant.assert_not_awaited()
+
+
+async def test_workspace_creation_requires_configured_base(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    service, pool, authority, _, _ = _service(tmp_path)
+    _canonical_state(monkeypatch)
+    monkeypatch.setattr(pool, "resolve_workspace_access", AsyncMock(return_value=(None, [])))
+    add_grant = AsyncMock()
+    monkeypatch.setattr(sessions, "add_canonical_workspace_grant", add_grant)
+
+    with pytest.raises(WorkshopSettingsWorkspaceValidationError, match="No workspace base"):
+        await service.create_workspace(authority, "Research")
+
+    add_grant.assert_not_awaited()
+
+
+async def test_protected_workspace_creation_uses_privileged_runtime_provisioner(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config = Config(
+        telegram_bot_token="unused",
+        allowed_user_ids=set(),
+        default_backend="codex",
+        default_model="gpt-5.6-sol",
+        deployment_mode=DeploymentMode.PROTECTED,
+    )
+    service, pool, authority, _, _ = _service(tmp_path, config=config)
+    _canonical_state(monkeypatch)
+    base = pool.allowed.parent
+    target = base / "protected-project"
+    pool.profile.os_user = "daniel"
+
+    def provision(_profile_id, name: str) -> WorkspaceProvisioningResult:
+        assert name == "protected-project"
+        target.mkdir(mode=0o755)
+        (target / ".git").mkdir()
+        return WorkspaceProvisioningResult(str(target), True, True)
+
+    provisioner = MagicMock(side_effect=provision)
+    monkeypatch.setattr(
+        "kai.workshop.settings_workspaces.provision_via_helper",
+        provisioner,
+    )
+    monkeypatch.setattr(sessions, "add_canonical_workspace_grant", AsyncMock(return_value=True))
+    monkeypatch.setattr(sessions, "upsert_canonical_workspace_history", AsyncMock())
+    monkeypatch.setattr(
+        "kai.workshop.settings_workspaces._register_workspace_memory_project",
+        AsyncMock(return_value=(True, True, "Registered memory project.")),
+    )
+
+    result = await service.create_workspace(authority, "protected-project")
+
+    provisioner.assert_called_once_with(authority.runtime_profile_id, "protected-project")
+    assert result.path == str(target)
+    assert result.directory_created is True
+    assert result.git_ready is True
+    assert pool.workspace == target
 
 
 async def test_timeout_validation_precedes_persistence(tmp_path: Path) -> None:

--- a/tests/test_workshop_workspace_provisioning.py
+++ b/tests/test_workshop_workspace_provisioning.py
@@ -1,0 +1,132 @@
+"""Bounded self-service workspace filesystem provisioning tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kai.workshop.domain import RuntimeProfileId
+from kai.workshop.workspace_provisioning import (
+    WorkspaceProvisioningError,
+    WorkspaceProvisioningResult,
+    _helper_main,
+    provision_via_helper,
+    provision_workspace,
+)
+
+
+def test_local_provisioning_creates_direct_child_and_git_repository(tmp_path: Path) -> None:
+    base = tmp_path / "configured-projects"
+    base.mkdir()
+
+    created = provision_workspace(base, "research")
+    retried = provision_workspace(base, "research")
+
+    target = base / "research"
+    assert created == WorkspaceProvisioningResult(str(target), True, True)
+    assert retried == WorkspaceProvisioningResult(str(target), False, True)
+    assert target.stat().st_mode & 0o777 == 0o755
+    assert (target / ".git").is_dir()
+
+
+@pytest.mark.parametrize("name", ["", ".", "..", "../escape", "nested/name", "nested\\name", "bad\x00name"])
+def test_local_provisioning_rejects_unsafe_names(tmp_path: Path, name: str) -> None:
+    with pytest.raises(WorkspaceProvisioningError, match="Invalid workspace name"):
+        provision_workspace(tmp_path, name)
+
+
+def test_local_provisioning_rejects_symlinked_base_and_target(tmp_path: Path) -> None:
+    real_base = tmp_path / "real"
+    real_base.mkdir()
+    linked_base = tmp_path / "linked"
+    linked_base.symlink_to(real_base, target_is_directory=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (real_base / "linked-target").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(WorkspaceProvisioningError, match="workspace base"):
+        provision_workspace(linked_base, "project")
+    with pytest.raises(WorkspaceProvisioningError, match="symbolic link"):
+        provision_workspace(real_base, "linked-target")
+
+
+def test_helper_invocation_accepts_only_bounded_json_result(monkeypatch) -> None:
+    profile_id = RuntimeProfileId("rtp_" + "1" * 32)
+    monkeypatch.setattr(
+        "kai.workshop.workspace_provisioning.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "ok": True,
+                    "result": {
+                        "path": "/configured/projects/research",
+                        "directory_created": True,
+                        "git_ready": True,
+                    },
+                }
+            ),
+        ),
+    )
+
+    assert provision_via_helper(profile_id, "research") == WorkspaceProvisioningResult(
+        "/configured/projects/research",
+        True,
+        True,
+    )
+
+
+def test_helper_invocation_surfaces_bounded_error(monkeypatch) -> None:
+    profile_id = RuntimeProfileId("rtp_" + "1" * 32)
+    monkeypatch.setattr(
+        "kai.workshop.workspace_provisioning.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=1,
+            stdout=json.dumps({"ok": False, "error": "No workspace base is configured for this runtime"}),
+        ),
+    )
+
+    with pytest.raises(WorkspaceProvisioningError, match="No workspace base"):
+        provision_via_helper(profile_id, "research")
+
+
+def test_root_helper_derives_base_and_owner_from_runtime_profile(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    profile_id = RuntimeProfileId("rtp_" + "1" * 32)
+    configured_base = tmp_path / "configured-projects"
+    configured_base.mkdir()
+    policy = tmp_path / "runtime-profiles.yaml"
+    policy.write_text("version: 2\nruntime_profiles: {}\n")
+    profile = SimpleNamespace(workspace_base=configured_base, os_user="daniel")
+    registry = SimpleNamespace(resolve=lambda selected: profile if selected == profile_id else None)
+
+    def provisioner(base: Path, name: str, *, os_user: str) -> WorkspaceProvisioningResult:
+        assert base == configured_base
+        assert name == "research"
+        assert os_user == "daniel"
+        return WorkspaceProvisioningResult(str(base / name), True, True)
+
+    monkeypatch.setattr("kai.workshop.workspace_provisioning.RUNTIME_PROFILES_POLICY", policy)
+    monkeypatch.setattr("kai.workshop.workspace_provisioning.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "kai.workshop.workspace_provisioning.WorkshopRuntimeProfileRegistry.from_yaml",
+        lambda _content: registry,
+    )
+    monkeypatch.setattr("kai.workshop.workspace_provisioning.provision_workspace", provisioner)
+
+    assert _helper_main([str(profile_id), "research"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "ok": True,
+        "result": {
+            "path": str(configured_base / "research"),
+            "directory_created": True,
+            "git_ready": True,
+        },
+    }


### PR DESCRIPTION
Closes #1522.

## Summary

- create self-service workspaces under the requester's configured runtime `workspace_base`
- provision protected workspaces through a bounded root-owned helper that derives both the base and OS owner from `/etc/kai/runtime-profiles.yaml`
- preserve the shared canonical operation used by Workshop and protected Telegram, including Git initialization, workspace grants, memory-project registration, selection, and session invalidation
- return structured validation failures for missing, invalid, inaccessible, or conflicting workspace targets

## Validation

- `make check`
- `make typecheck`
- `make client-check`
- `pytest tests/test_install.py -q` — 684 passed
- focused workspace/API tests — 119 passed
- `make test` — 6648 passed
- deployed policy inspection confirms Daniel `/Users/daniel/work` and Scott `/Users/sellison/work`
