### PR TITLE
Fix workspace provisioning for users with many groups

### DIFF
--- a/src/kai/workshop/workspace_provisioning.py
+++ b/src/kai/workshop/workspace_provisioning.py
@@ -45,15 +45,14 @@ def _validate_flat_name(name: str) -> str:
     return name
 
 
-def _target_identity(os_user: str | None) -> tuple[int, int, tuple[int, ...], str] | None:
+def _target_identity(os_user: str | None) -> tuple[int, int, str] | None:
     if os_user is None:
         return None
     try:
         account = pwd.getpwnam(os_user)
     except KeyError as exc:
         raise WorkspaceProvisioningError("The runtime OS identity is unavailable") from exc
-    groups = tuple(os.getgrouplist(account.pw_name, account.pw_gid))
-    return account.pw_uid, account.pw_gid, groups, account.pw_dir
+    return account.pw_uid, account.pw_gid, account.pw_dir
 
 
 def provision_workspace(
@@ -96,7 +95,7 @@ def provision_workspace(
         if not stat.S_ISDIR(info.st_mode):
             raise WorkspaceProvisioningError("A non-directory entry already uses this workspace name")
         if identity is not None:
-            uid, gid, _groups, _home = identity
+            uid, gid, _home = identity
             if created:
                 if os.geteuid() != 0 and info.st_uid != uid:
                     raise WorkspaceProvisioningError("Protected workspace provisioning requires root authority")
@@ -122,8 +121,12 @@ def provision_workspace(
             "env": {"LANG": "C.UTF-8", "PATH": "/usr/bin:/bin"},
         }
         if identity is not None:
-            uid, gid, groups, home = identity
-            command.update(user=uid, group=gid, extra_groups=groups)
+            uid, gid, home = identity
+            # The workspace is owned by this UID/GID, so Git needs no
+            # supplementary groups. Clearing them also prevents inheriting
+            # root's groups and avoids macOS's small setgroups(2) limit for
+            # users with many directory-service memberships.
+            command.update(user=uid, group=gid, extra_groups=())
             environment = command["env"]
             assert isinstance(environment, dict)
             environment["HOME"] = home

--- a/tests/test_workshop_workspace_provisioning.py
+++ b/tests/test_workshop_workspace_provisioning.py
@@ -53,6 +53,37 @@ def test_local_provisioning_rejects_symlinked_base_and_target(tmp_path: Path) ->
         provision_workspace(real_base, "linked-target")
 
 
+def test_git_identity_drop_clears_supplementary_groups(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base = tmp_path / "configured-projects"
+    base.mkdir()
+    target = base / "research"
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "kai.workshop.workspace_provisioning._target_identity",
+        lambda _user: (501, 20, "/Users/daniel"),
+    )
+    monkeypatch.setattr("kai.workshop.workspace_provisioning.os.geteuid", lambda: 0)
+    monkeypatch.setattr("kai.workshop.workspace_provisioning.os.fchown", lambda *_args: None)
+
+    def run(_argv, **kwargs):
+        recorded.update(kwargs)
+        (target / ".git").mkdir()
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("kai.workshop.workspace_provisioning.subprocess.run", run)
+
+    result = provision_workspace(base, "research", os_user="daniel")
+
+    assert result.git_ready is True
+    assert recorded["user"] == 501
+    assert recorded["group"] == 20
+    assert recorded["extra_groups"] == ()
+
+
 def test_helper_invocation_accepts_only_bounded_json_result(monkeypatch) -> None:
     profile_id = RuntimeProfileId("rtp_" + "1" * 32)
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #1524.

## Summary

- run protected workspace Git initialization with the runtime owner's UID and primary GID
- explicitly clear supplementary groups, avoiding macOS's `too many extra_groups` failure and inherited root groups
- add a regression that verifies the exact subprocess identity arguments

## Validation

- focused provisioning tests: 13 passed
- `make check`
- `make typecheck`
