### PR TITLE
Fix cross-adapter workspace runtime alias divergence

### DIFF
--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -455,7 +455,15 @@ class SubprocessPool:
                 raise RuntimeError("Runtime profile selector requires protected runtime policy")
             profile = self._runtime_profiles.resolve(runtime)
             legacy_key = self._runtime_profiles.legacy_runtime_key(profile.profile_id)
-            return profile.profile_id, legacy_key, profile
+            primary = self._contexts_by_runtime.get(profile.profile_id)
+            if not isinstance(primary, WorkshopInternalAPIExecutionContext):
+                raise RuntimeError("Protected runtime has no canonical execution context")
+            # Profile selectors and adapter compatibility keys address the
+            # primary canonical lane.  Giving them a second profile-keyed
+            # cache entry lets Workshop and an adapter retain different live
+            # workspaces (and backend state) for the same runtime.
+            self._register_lane_state(primary)
+            return _CanonicalRuntimeLaneKey.from_context(primary), legacy_key, profile
         if not isinstance(runtime, int):
             raise TypeError("Runtime selector must be a runtime profile ID or integer")
         if self._runtime_profiles is None:
@@ -466,7 +474,14 @@ class SubprocessPool:
             if runtime >= 0:
                 raise
             return runtime, runtime, None
-        return profile.profile_id, runtime, profile
+        primary = self._contexts_by_runtime.get(profile.profile_id)
+        if not isinstance(primary, WorkshopInternalAPIExecutionContext):
+            raise RuntimeError("Protected runtime has no canonical execution context")
+        # Telegram still identifies the caller with this compatibility
+        # key; lifecycle state belongs to the same canonical lane used by
+        # every other adapter.
+        self._register_lane_state(primary)
+        return _CanonicalRuntimeLaneKey.from_context(primary), runtime, profile
 
     def _register_lane_state(self, context: WorkshopInternalAPIExecutionContext) -> None:
         """Register one channel-agent lane while inheriting protected policy."""
@@ -604,7 +619,7 @@ class SubprocessPool:
             runtime_profile_id=context.runtime_profile_id,
             legacy_runtime_key=(
                 self._runtime_profiles.legacy_runtime_key(profile.profile_id)
-                if runtime_key == profile.profile_id
+                if isinstance(runtime, (int, RuntimeProfileId))
                 else None
             ),
             sponsor_principal_id=context.runtime_owner_principal_id,

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -108,6 +108,88 @@ class TestInstanceCreation:
         assert a is not b
         assert a._api_context.webhook_secret != b._api_context.webhook_secret
 
+    def test_primary_canonical_lane_reuses_protected_adapter_runtime(self, tmp_path):
+        """Telegram's compatibility key and Workshop's primary lane are one runtime."""
+        runtime_id = profile_id(111)
+        primary = WorkshopInternalAPIExecutionContext.for_unprotected_runtime(111, runtime_id)
+        profiles = WorkshopRuntimeProfileRegistry(
+            (
+                ProtectedRuntimeProfile(
+                    profile_id=runtime_id,
+                    display_name="shared policy",
+                    os_user=None,
+                    backend="codex",
+                    provider="openai",
+                    model="gpt-5.6-sol",
+                    timeout_seconds=120,
+                    allowed_services=(),
+                    home_workspace=tmp_path,
+                    workspace_base=None,
+                    allowed_workspaces=(),
+                ),
+            ),
+            legacy_runtime_keys={runtime_id: 111},
+        )
+        pool = SubprocessPool(
+            config=_make_config(allowed_user_ids={111}),
+            services_info=[],
+            runtime_profiles=profiles,
+            internal_api_contexts=WorkshopInternalAPIContextRegistry((primary,)),
+        )
+
+        telegram = pool.get(111)
+        workshop = pool.get(primary)
+        profile = pool.get(runtime_id)
+
+        assert telegram is workshop is profile
+        assert len(pool._pool) == 1
+
+    @pytest.mark.asyncio
+    async def test_primary_workspace_change_is_live_across_adapters(self, tmp_path):
+        """Neither adapter may retain a stale primary workspace process."""
+        home = tmp_path / "home"
+        repository = tmp_path / "repository"
+        home.mkdir()
+        repository.mkdir()
+        runtime_id = profile_id(111)
+        primary = WorkshopInternalAPIExecutionContext.for_unprotected_runtime(111, runtime_id)
+        profiles = WorkshopRuntimeProfileRegistry(
+            (
+                ProtectedRuntimeProfile(
+                    profile_id=runtime_id,
+                    display_name="shared policy",
+                    os_user=None,
+                    backend="codex",
+                    provider="openai",
+                    model="gpt-5.6-sol",
+                    timeout_seconds=120,
+                    allowed_services=(),
+                    home_workspace=home,
+                    workspace_base=tmp_path,
+                    allowed_workspaces=(),
+                ),
+            ),
+            legacy_runtime_keys={runtime_id: 111},
+        )
+        pool = SubprocessPool(
+            config=_make_config(allowed_user_ids={111}),
+            services_info=[],
+            runtime_profiles=profiles,
+            internal_api_contexts=WorkshopInternalAPIContextRegistry((primary,)),
+        )
+
+        telegram = pool.get(111)
+        await pool.change_workspace(primary, repository)
+
+        assert telegram.workspace == repository
+        assert await pool.get_effective_workspace(111) == repository
+
+        await pool.change_workspace(111, home)
+
+        assert pool.get(primary).workspace == home
+        assert await pool.get_effective_workspace(primary) == home
+        assert len(pool._pool) == 1
+
     def test_same_profile_uses_distinct_channel_agent_runtime_lanes(self, tmp_path):
         runtime_id = profile_id(111)
         primary = WorkshopInternalAPIExecutionContext.for_unprotected_runtime(111, runtime_id)
@@ -807,15 +889,17 @@ class TestPerUserActions:
         first.shutdown = AsyncMock()
         second = MagicMock()
         second.shutdown = AsyncMock()
-        pool._pool[first_id] = first
-        pool._pool[second_id] = second
+        first_key = pool._resolve_runtime(first_id)[0]
+        second_key = pool._resolve_runtime(second_id)[0]
+        pool._pool[first_key] = first
+        pool._pool[second_key] = second
 
         assert await pool.select_backend(first_id, "claude")
 
         first.shutdown.assert_awaited_once()
         second.shutdown.assert_not_awaited()
-        assert first_id not in pool._pool
-        assert pool._pool[second_id] is second
+        assert first_key not in pool._pool
+        assert pool._pool[second_key] is second
         assert pool.get_backend_provider(first_id) == ("claude", "anthropic")
         assert pool.get_backend_provider(second_id) == ("codex", "openai")
 
@@ -1087,7 +1171,7 @@ class TestPropertyAccessors:
         )
         instance = pool.get(111)
         assert instance.model == "gpt-5.6-sol"
-        assert profile_id(111) in pool._pending_settings_restore
+        assert pool._resolve_runtime(111)[0] in pool._pending_settings_restore
 
         with patch(
             "kai.pool.sessions.get_canonical_execution_settings",

--- a/tests/test_workshop_runtime_pool.py
+++ b/tests/test_workshop_runtime_pool.py
@@ -134,7 +134,7 @@ def test_protected_profile_selects_backend_and_os_user_over_compatibility_config
     assert instance.timeout_seconds == 345
 
 
-def test_protected_runtime_lifecycle_is_keyed_by_canonical_profile():
+def test_protected_runtime_lifecycle_is_keyed_by_primary_canonical_lane():
     from kai.pool import SubprocessPool
 
     profiles = profile_registry(111)
@@ -149,12 +149,13 @@ def test_protected_runtime_lifecycle_is_keyed_by_canonical_profile():
 
     from_profile = pool.get(profile_id(111))
     from_compatibility_adapter = pool.get(111)
+    primary_key = pool._resolve_runtime(111)[0]
 
     assert from_profile is from_compatibility_adapter
-    assert set(pool._pool) == {profile_id(111)}
-    assert set(pool._last_activity) == {profile_id(111)}
-    assert set(pool._pending_workspace_restore) == {profile_id(111)}
-    assert set(pool._pending_settings_restore) == {profile_id(111)}
+    assert set(pool._pool) == {primary_key}
+    assert set(pool._last_activity) == {primary_key}
+    assert set(pool._pending_workspace_restore) == {primary_key}
+    assert set(pool._pending_settings_restore) == {primary_key}
 
 
 def test_protected_profile_service_scopes_override_compatibility_config(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary\n\n- normalize the protected runtime-profile selector and Telegram compatibility selector onto the primary canonical channel-agent lane\n- prevent Workshop and Telegram from retaining separate live backend objects for the same Kai runtime\n- retain isolated keys for genuinely distinct agent and sponsored execution lanes\n- add regressions proving one live runtime and bidirectional live workspace visibility\n\n## Validation\n\n- .venv/bin/ruff check .
All checks passed!
.venv/bin/ruff format --check .
366 files already formatted\n- 491 focused runtime, settings, protected-execution, private-execution, and Telegram tests\n- full suite: 6,652 passed\n\nCloses #1526