### PR TITLE
Make canonical runtime reminder transport neutral

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -1594,7 +1594,7 @@ def build_foreign_workspace_reminder(workspace: Path, home_workspace: Path) -> s
     if workspace == home_workspace:
         return None
     return (
-        "[IMPORTANT: This message is from a user via Telegram. "
+        "[IMPORTANT: This is the user's current message. "
         "Respond ONLY to what they wrote below. Do NOT continue, "
         "resume, or start any previous work, plans, or tasks.]"
     )

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1168,6 +1168,8 @@ class TestContextInjection:
         assert prompt_text.count(USER_MESSAGE_MARKER) == 1
         assert memory_block in prompt_text
         assert "ACTUAL_USER_TEXT" in prompt_text
+        assert "This is the user's current message" in prompt_text
+        assert "Telegram" not in prompt_text
         # Marker sits between any injected layer and the user text. Per
         # assemble_turn_context's documented stacking, the final reading
         # order from top to bottom is: workspace_reminder, semantic

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -872,14 +872,17 @@ class TestBuildForeignWorkspaceReminder:
         assert build_foreign_workspace_reminder(ws, ws) is None
 
     def test_foreign_workspace_returns_reminder(self):
-        """Reminder string returned when in a foreign workspace."""
+        """Foreign-workspace reminder is exact and transport-neutral."""
         result = build_foreign_workspace_reminder(
             Path("/home/user/project"),
             Path("/var/lib/kai/home/12345"),
         )
-        assert result is not None
-        assert "IMPORTANT" in result
-        assert "Respond ONLY" in result
+        assert result == (
+            "[IMPORTANT: This is the user's current message. "
+            "Respond ONLY to what they wrote below. Do NOT continue, "
+            "resume, or start any previous work, plans, or tasks.]"
+        )
+        assert "Telegram" not in result
 
 
 # ── Test ensure_user_home / resolve_home_workspace (#353) ───────────

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1960,8 +1960,9 @@ class TestContextInjection:
         # it natively from cwd; bot-side reads risk PermissionError on Linux)
         assert "Foreign workspace memory" not in prompt
         # Per-message reminder should be present
-        assert "IMPORTANT" in prompt
+        assert "This is the user's current message" in prompt
         assert "Respond ONLY" in prompt
+        assert "Telegram" not in prompt
 
     @pytest.mark.asyncio
     async def test_home_workspace_no_identity_injection(self, home_workspace):

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1177,7 +1177,9 @@ class TestContextInjection:
         assert prompt_text.count(USER_MESSAGE_MARKER) == 1
         # All three other context blocks fired.
         assert memory_block in prompt_text
+        assert "This is the user's current message" in prompt_text
         assert "Respond ONLY" in prompt_text  # foreign-workspace reminder
+        assert "Telegram" not in prompt_text
         assert "[CONTEXT]" in prompt_text  # session_ctx
 
         marker_idx = prompt_text.index(USER_MESSAGE_MARKER)

--- a/tests/test_goose.py
+++ b/tests/test_goose.py
@@ -730,7 +730,8 @@ class TestContextInjection:
         # block prepended
         prompt_texts = [b["text"] for b in prompt_msg["params"]["prompt"]]
         combined = " ".join(prompt_texts)
-        assert "IMPORTANT" in combined
+        assert "This is the user's current message" in combined
+        assert "Telegram" not in combined
         assert "hello" in combined
 
     @pytest.mark.asyncio

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -259,6 +259,41 @@ class TestPiTurns:
         assert transport.sent[0]["type"] == "prompt"
 
     @pytest.mark.asyncio
+    async def test_foreign_workspace_uses_transport_neutral_reminder(self, tmp_path, monkeypatch):
+        from kai.backend import build_foreign_workspace_reminder
+
+        captured: dict[str, str] = {}
+
+        async def capture_context(prompt, **kwargs):
+            captured["workspace_reminder"] = kwargs["workspace_reminder"]
+            return prompt
+
+        monkeypatch.setattr("kai.pi.build_foreign_workspace_reminder", build_foreign_workspace_reminder)
+        monkeypatch.setattr("kai.pi.assemble_turn_context", capture_context)
+
+        backend = make_backend(
+            tmp_path,
+            workspace=tmp_path / "project",
+            home_workspace=tmp_path / "home",
+        )
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._supports_image_input = True
+        backend._fresh_session = False
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "agent_settled"},
+            ]
+        )
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        await collect(backend)
+
+        assert "This is the user's current message" in captured["workspace_reminder"]
+        assert "Telegram" not in captured["workspace_reminder"]
+
+    @pytest.mark.asyncio
     async def test_image_is_forwarded_in_documented_shape(self, tmp_path, monkeypatch):
         backend = make_backend(tmp_path)
         backend._proc = FakeProcess()


### PR DESCRIPTION
Closes #1462.

## Summary

- replace Telegram-specific canonical prompt wording with a transport-neutral current-message reminder
- retain the existing instruction not to resume previous work in foreign workspaces
- pin the shared helper's exact output and exercise the neutral reminder through Claude, Codex, Pi, ACP, and Goose paths

## Validation

- make check
- 639 focused backend tests
