### PR TITLE
Separate principal policy from Kai identity

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -5,7 +5,7 @@ Provides:
 1. AgentBackend ABC - the interface that pool.py programs against
 2. AgentResponse / StreamEvent - backend-agnostic protocol types
 3. ApiContext - groups webhook/service info for context injection
-4. Context injection functions - build the identity/memory/history/API
+4. Context injection functions - build the principal-policy/memory/history/API
    prefix that gets prepended to the first message of each session
 
 The ABC defines the minimal surface that SubprocessPool needs. Concrete
@@ -38,6 +38,7 @@ from kai.config import (
     validate_model_for_backend,
 )
 from kai.history import get_recent_history, history_search_directories
+from kai.principal_policy import plan_principal_policy_migration, record_principal_policy_migration
 from kai.prompt_utils import render_untrusted_json_block
 
 log = logging.getLogger(__name__)
@@ -680,7 +681,7 @@ def build_session_context(
 
     Args:
         workspace: The backend's current working directory.
-        home_workspace: Kai's home workspace (identity + memory source).
+        home_workspace: The principal's home workspace (policy + memory source).
         api: Webhook port, secret, and services info.
         workspace_config: Per-workspace config (for system_prompt).
         chat_id: Private compatibility runtime key used by transitional
@@ -688,7 +689,7 @@ def build_session_context(
             routing derive from the credential-bound canonical context.
         data_dir: Root data directory (memory, history, files live here).
         backend_name: Canonical backend identifier used to validate explicit
-            identity routing. Required whenever the active workspace differs
+            principal-policy routing. Required whenever the active workspace differs
             from the home workspace.
         memory_enabled: Operator-intent flag (Config.memory_enabled).
             Drives the memory subsystem marker emission and gates
@@ -705,31 +706,31 @@ def build_session_context(
     """
     parts: list[str] = []
 
-    # When in a foreign workspace, inject Kai's identity from home.
+    # When in a foreign workspace, inject the principal's neutral policy from home.
     # try/except guards against race (file deleted between exists()
     # and read_text()) and permission errors, matching the pattern
     # in get_workspace_system_prompt().
     if workspace != home_workspace:
         if backend_name is None:
-            raise ValueError("backend_name is required for foreign-workspace identity routing")
+            raise ValueError("backend_name is required for foreign-workspace principal-policy routing")
         if backend_name not in VALID_BACKENDS:
-            raise ValueError(f"Unknown backend for identity routing: {backend_name!r}")
+            raise ValueError(f"Unknown backend for principal-policy routing: {backend_name!r}")
         # AGENTS.md is the canonical content source for every backend. Claude's
         # native home-workspace surface is a thin import adapter, but injecting
         # that literal adapter text into a foreign-workspace prompt would not
         # cause Claude's file loader to expand it. Read (or ask the isolated
         # subprocess to read) the canonical source directly here.
-        identity_path = home_workspace / "AGENTS.md"
+        policy_path = home_workspace / "AGENTS.md"
         if defer_user_file_reads:
             parts.append(
-                "[Your core identity and instructions are stored at "
-                f"{identity_path}. Read this file before applying identity-specific instructions.]"
+                "[Your principal policy and instructions are stored at "
+                f"{policy_path}. Read this file before applying principal-specific instructions.]"
             )
         else:
             try:
-                identity = identity_path.read_text().strip()
-                if identity:
-                    parts.append(f"[Your core identity and instructions:]\n{identity}")
+                policy = policy_path.read_text().strip()
+                if policy:
+                    parts.append(f"[Your principal policy and instructions:]\n{policy}")
             except OSError:
                 pass
 
@@ -1297,7 +1298,7 @@ def _write_private_text_atomic(path: Path, content: str) -> None:
 
 
 def _ensure_development_identity_files(home: Path, backend_name: str) -> None:
-    """Seed the canonical identity and the selected backend's adapter.
+    """Seed the canonical principal policy and the selected backend's adapter.
 
     Protected installations use the stricter installer migration instead.
     This helper preserves the historical lazy bootstrap for development and
@@ -1312,39 +1313,48 @@ def _ensure_development_identity_files(home: Path, backend_name: str) -> None:
     template = PROJECT_ROOT / "templates" / "AGENTS.md"
 
     if claude_dir.is_symlink():
-        raise RuntimeError(f"Refusing symlinked Kai identity directory: {claude_dir}")
+        raise RuntimeError(f"Refusing symlinked Kai principal-policy directory: {claude_dir}")
     if claude_dir.exists() and not claude_dir.is_dir():
-        raise RuntimeError(f"Kai Claude identity path is not a directory: {claude_dir}")
+        raise RuntimeError(f"Kai Claude policy path is not a directory: {claude_dir}")
     if agents_dst.is_symlink() or claude_dst.is_symlink():
-        raise RuntimeError(f"Refusing symlinked Kai identity surface under {home}")
+        raise RuntimeError(f"Refusing symlinked Kai principal-policy surface under {home}")
     if agents_dst.exists() and not agents_dst.is_file():
-        raise RuntimeError(f"Kai identity path is not a regular file: {agents_dst}")
+        raise RuntimeError(f"Kai principal-policy path is not a regular file: {agents_dst}")
     if claude_dst.exists() and not claude_dst.is_file():
-        raise RuntimeError(f"Kai Claude adapter path is not a regular file: {claude_dst}")
+        raise RuntimeError(f"Kai Claude policy adapter path is not a regular file: {claude_dst}")
 
     claude_content = claude_dst.read_text() if claude_dst.is_file() else None
     if not agents_dst.exists():
         if claude_content is not None:
             if claude_content == _CLAUDE_IDENTITY_ADAPTER:
-                raise RuntimeError(f"Claude identity adapter exists but canonical identity is missing: {agents_dst}")
+                raise RuntimeError(
+                    f"Claude policy adapter exists but canonical principal policy is missing: {agents_dst}"
+                )
             _write_private_text_atomic(agents_dst, claude_content)
         elif template.is_file():
             shutil.copy2(template, agents_dst)
             _chmod_private_user_file(agents_dst)
         else:
-            _write_private_text_atomic(agents_dst, "# Identity\n")
+            _write_private_text_atomic(agents_dst, "# Principal Policy\n")
 
     agents_content = agents_dst.read_text()
-    if claude_content not in (None, _CLAUDE_IDENTITY_ADAPTER, agents_content):
+    original_agents_content = agents_content
+    if claude_content not in (None, _CLAUDE_IDENTITY_ADAPTER, original_agents_content):
         raise RuntimeError(
-            f"Conflicting customized identity files: {agents_dst} and {claude_dst}. Reconcile them before continuing."
+            f"Conflicting customized principal-policy files: {agents_dst} and {claude_dst}. "
+            "Reconcile them before continuing."
         )
+    policy_plan = plan_principal_policy_migration(original_agents_content)
+    if policy_plan.changed:
+        record_principal_policy_migration(home, original_agents_content, policy_plan.content)
+        _write_private_text_atomic(agents_dst, policy_plan.content)
+        agents_content = policy_plan.content
     if backend_name == "claude":
         claude_dir.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
         _chmod_private_user_dir(claude_dir)
         if claude_content != _CLAUDE_IDENTITY_ADAPTER:
             _write_private_text_atomic(claude_dst, _CLAUDE_IDENTITY_ADAPTER)
-    elif claude_content in (_CLAUDE_IDENTITY_ADAPTER, agents_content):
+    elif claude_content in (_CLAUDE_IDENTITY_ADAPTER, original_agents_content):
         claude_dst.unlink(missing_ok=True)
 
     _chmod_private_user_file(agents_dst)
@@ -1393,7 +1403,7 @@ def ensure_user_home(chat_id: int | None, data_dir: Path, *, backend_name: str) 
     os_user entries added after install still require a reinstall so
     install.py can apply the correct ownership.
 
-    The lazy path also seeds the canonical `AGENTS.md`. Claude receives a
+    The lazy path also seeds the canonical principal-policy `AGENTS.md`. Claude receives a
     `.claude/CLAUDE.md` adapter importing that file; other backends use
     `AGENTS.md` directly. Existing customized CLAUDE.md content is migrated
     into AGENTS.md before the adapter is written.

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -75,6 +75,12 @@ from kai.config import (
     validate_model_for_backend_policy,
 )
 from kai.named_access import replace_named_inherited_read_access, replace_named_read_access
+from kai.principal_policy import (
+    PrincipalPolicyMigrationPlan,
+    plan_principal_policy_migration,
+    record_principal_policy_migration,
+    validate_principal_policy_migration_record,
+)
 from kai.protected_config import ProtectedConfigError, validate_protected_file_metadata
 from kai.user_isolation import validate_protected_user_isolation
 from kai.workshop.agent_enablement import initial_kai_enablement_ids
@@ -157,7 +163,7 @@ _BACKEND_SELECTION_POLICY_VERSION = 1
 _CONF_VERSION = 1
 
 # Claude discovers instructions through CLAUDE.md, while Kai's canonical
-# managed identity is backend-neutral AGENTS.md. Keep the compatibility file
+# managed principal policy is backend-neutral AGENTS.md. Keep the compatibility file
 # deliberately content-free so there is only one editable source of truth.
 _CLAUDE_IDENTITY_ADAPTER = "@../AGENTS.md\n"
 
@@ -6003,7 +6009,7 @@ def _managed_identity_state(user_home: Path) -> tuple[Path, Path, str | None, st
         raise RuntimeError(f"Refusing non-directory Claude identity path: {claude_dir}")
     agents_path = user_home / "AGENTS.md"
     claude_path = claude_dir / "CLAUDE.md"
-    for label, path in (("canonical identity", agents_path), ("Claude adapter", claude_path)):
+    for label, path in (("canonical principal policy", agents_path), ("Claude policy adapter", claude_path)):
         if path.is_symlink():
             raise RuntimeError(f"Refusing symlinked {label} path: {path}")
         if path.exists() and not path.is_file():
@@ -6012,21 +6018,21 @@ def _managed_identity_state(user_home: Path) -> tuple[Path, Path, str | None, st
     agents_content = agents_path.read_text() if agents_path.is_file() else None
     claude_content = claude_path.read_text() if claude_path.is_file() else None
     if agents_content is None and claude_content == _CLAUDE_IDENTITY_ADAPTER:
-        raise RuntimeError(f"Claude identity adapter exists but canonical identity is missing: {agents_path}")
+        raise RuntimeError(f"Claude policy adapter exists but canonical principal policy is missing: {agents_path}")
     if (
         agents_content is not None
         and claude_content is not None
         and claude_content not in (_CLAUDE_IDENTITY_ADAPTER, agents_content)
     ):
         raise RuntimeError(
-            f"Conflicting customized identity files: {agents_path} and {claude_path}. "
+            f"Conflicting customized principal-policy files: {agents_path} and {claude_path}. "
             "Reconcile their content before re-running `make install`; neither file was changed."
         )
     return agents_path, claude_path, agents_content, claude_content
 
 
 def _write_managed_identity_atomic(path: Path, content: str) -> None:
-    """Atomically write a private managed identity file in its directory."""
+    """Atomically write a private managed principal-policy file in its directory."""
     path.parent.mkdir(parents=True, exist_ok=True, mode=_PRIVATE_USER_DIR_MODE)
     fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     temporary = Path(temporary_name)
@@ -6608,8 +6614,8 @@ def _apply_migrate(
         if not user_dir_exists:
             print(f"  Created {user_dir}")
 
-    # -- Canonical per-user identity and backend-native adapters --
-    # AGENTS.md is the sole editable Kai-managed identity source. Claude's
+    # -- Canonical per-user principal policy and backend-native adapters --
+    # AGENTS.md is the sole editable Kai-managed principal-policy source. Claude's
     # native CLAUDE.md surface imports it; every other backend consumes
     # AGENTS.md directly. Existing customized CLAUDE.md content is migrated
     # losslessly before compatibility files are changed.
@@ -6624,7 +6630,17 @@ def _apply_migrate(
     # Validate every managed identity surface before changing any of them.
     # This prevents a conflict for a later user from leaving earlier users
     # partially migrated.
-    managed_identities: list[tuple[int, str | None, Path, Path, str | None, str | None]] = []
+    managed_identities: list[
+        tuple[
+            int,
+            str | None,
+            Path,
+            Path,
+            str | None,
+            str | None,
+            PrincipalPolicyMigrationPlan | None,
+        ]
+    ] = []
     for chat_id, _os_user in memory_owners:
         if chat_id is None:
             continue
@@ -6641,8 +6657,16 @@ def _apply_migrate(
         if dry_run and migration is not None and not user_home.exists() and migration[0].is_dir():
             inspection_home = migration[0]
         _source_agents, _source_claude, agents_content, claude_content = _managed_identity_state(inspection_home)
+        source_content = agents_content if agents_content is not None else claude_content
+        policy_plan = plan_principal_policy_migration(source_content) if source_content is not None else None
         agents_path = user_home / "AGENTS.md"
         claude_path = user_home / ".claude" / "CLAUDE.md"
+        if policy_plan is not None and policy_plan.changed and source_content is not None:
+            validate_principal_policy_migration_record(
+                agents_path.parent,
+                source_content,
+                policy_plan.content,
+            )
         managed_identities.append(
             (
                 chat_id,
@@ -6651,6 +6675,7 @@ def _apply_migrate(
                 claude_path,
                 agents_content,
                 claude_content,
+                policy_plan,
             )
         )
 
@@ -6661,7 +6686,15 @@ def _apply_migrate(
             dry_run=False,
         )
 
-    for chat_id, backend_name, agents_path, claude_path, agents_content, claude_content in managed_identities:
+    for (
+        chat_id,
+        backend_name,
+        agents_path,
+        claude_path,
+        agents_content,
+        claude_content,
+        policy_plan,
+    ) in managed_identities:
         if dry_run:
             if agents_content is None:
                 if claude_content is not None:
@@ -6670,6 +6703,11 @@ def _apply_migrate(
                     print(f"[DRY RUN] Would seed {agents_path} from {home_template}")
                 else:
                     print(f"[DRY RUN] Would seed {agents_path} with placeholder (template missing)")
+            if policy_plan is not None and policy_plan.changed:
+                print(
+                    f"[DRY RUN] Would migrate {agents_path} from Kai identity to neutral "
+                    "principal policy and retain a private backup/receipt"
+                )
 
             migration_source: Path | None = None
             if agents_content is not None:
@@ -6708,16 +6746,32 @@ def _apply_migrate(
             continue
 
         try:
+            migration_dir: Path | None = None
             if agents_content is None:
                 if claude_content is not None:
-                    _write_managed_identity_atomic(agents_path, claude_content)
-                    print(f"  Migrated identity {claude_path} -> {agents_path}")
+                    migrated_content = policy_plan.content if policy_plan is not None else claude_content
+                    if policy_plan is not None and policy_plan.changed:
+                        migration_dir = record_principal_policy_migration(
+                            agents_path.parent,
+                            claude_content,
+                            migrated_content,
+                        )
+                    _write_managed_identity_atomic(agents_path, migrated_content)
+                    print(f"  Migrated principal policy {claude_path} -> {agents_path}")
                 elif home_template_exists:
                     _write_managed_identity_atomic(agents_path, home_template.read_text())
                     print(f"  Seeded {agents_path} from AGENTS.md template")
                 else:
-                    _write_managed_identity_atomic(agents_path, "# Identity\n")
+                    _write_managed_identity_atomic(agents_path, "# Principal Policy\n")
                     print(f"  WARNING: {home_template} not found; wrote placeholder to {agents_path}")
+            elif policy_plan is not None and policy_plan.changed:
+                migration_dir = record_principal_policy_migration(
+                    agents_path.parent,
+                    agents_content,
+                    policy_plan.content,
+                )
+                _write_managed_identity_atomic(agents_path, policy_plan.content)
+                print(f"  Migrated {agents_path} from Kai identity to neutral principal policy")
 
             if (
                 home_template_exists
@@ -6756,6 +6810,9 @@ def _apply_migrate(
             os.chmod(agents_path, _PRIVATE_USER_FILE_MODE)
             uid, gid = per_user_ids.get(str(chat_id), (svc_uid, svc_gid))
             _set_ownership(agents_path, uid, gid, recursive=False)
+            if migration_dir is not None:
+                _set_ownership(migration_dir.parent, uid, gid, recursive=True)
+                _set_private_user_tree_modes(migration_dir.parent)
             if claude_path.parent.is_dir():
                 _set_ownership(claude_path.parent, uid, gid, recursive=True)
                 _set_private_user_tree_modes(claude_path.parent)

--- a/src/kai/principal_policy.py
+++ b/src/kai/principal_policy.py
@@ -1,0 +1,151 @@
+"""Migration helpers for the backend-neutral per-principal policy file."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+PRINCIPAL_POLICY_MIGRATION = "principal-policy-v1"
+
+_LEGACY_TITLE = "# Kai"
+_NEUTRAL_TITLE = "# Principal Policy"
+_LEGACY_ABOUT = (
+    "This file is the bootstrap template for Kai's backend-neutral identity. The installer "
+    "copies it to `<DATA_DIR>/home/<principal_id>/AGENTS.md` for each canonical Workshop "
+    "human with an assigned runtime; `backend.ensure_user_home` lazily seeds it for profiles "
+    "added later in development mode. Claude receives a thin `.claude/CLAUDE.md` import "
+    "adapter; all managed identity content remains here. Edit the per-principal `AGENTS.md` "
+    "to add operator-personal content; the tracked template ships universal content only. "
+    'Once customized, you can delete this "About This File" section from the per-principal copy.'
+)
+_NEUTRAL_ABOUT = (
+    "This file is the bootstrap template for Kai's backend-neutral principal policy. The "
+    "installer copies it to `<DATA_DIR>/home/<principal_id>/AGENTS.md` for each canonical "
+    "Workshop human with an assigned runtime; `backend.ensure_user_home` lazily seeds it for "
+    "profiles added later in development mode. Claude receives a thin `.claude/CLAUDE.md` "
+    "import adapter; all managed policy content remains here. Edit the per-principal "
+    "`AGENTS.md` to add operator-personal content; the tracked template ships universal "
+    'content only. Once customized, you can delete this "About This File" section from the '
+    "per-principal copy. Agent identity belongs exclusively to the active canonical agent "
+    "definition."
+)
+_LEGACY_IDENTITY_SECTION = (
+    "## Who You Are\n\n"
+    "You're Kai, a personal AI assistant available through configured clients such as "
+    "Workshop and Telegram. You run locally on the operator's machine and have access to a "
+    "shell, the filesystem, the web, a scheduler, and a per-principal memory store.\n\n"
+)
+_IDENTITY_MARKERS = ("you're kai", "you are kai")
+
+
+class PrincipalPolicyMigrationConflict(RuntimeError):
+    """A managed policy contains identity text that cannot be isolated safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class PrincipalPolicyMigrationPlan:
+    content: str
+    changed: bool
+
+
+def plan_principal_policy_migration(content: str) -> PrincipalPolicyMigrationPlan:
+    """Remove only the known legacy Kai identity material from one policy file.
+
+    Everything outside the managed title, About paragraph, and exact legacy
+    identity section is preserved byte-for-byte. An unfamiliar ``Who You Are``
+    section or stray Kai identity assertion is ambiguous and therefore fails
+    closed instead of silently rewriting operator-authored content.
+    """
+    migrated = content
+    if _LEGACY_IDENTITY_SECTION in migrated:
+        migrated = migrated.replace(_LEGACY_IDENTITY_SECTION, "", 1)
+
+    identity_scan = migrated.casefold().replace("\u2019", "'")
+    if "## who you are" in identity_scan or any(marker in identity_scan for marker in _IDENTITY_MARKERS):
+        raise PrincipalPolicyMigrationConflict(
+            "Managed AGENTS.md contains a customized or ambiguous Kai identity section. "
+            "The original was not changed; move that identity wording into the canonical "
+            "Kai agent definition before re-running `make install`."
+        )
+
+    if migrated.startswith(_LEGACY_TITLE + "\n"):
+        migrated = _NEUTRAL_TITLE + migrated[len(_LEGACY_TITLE) :]
+    if _LEGACY_ABOUT in migrated:
+        migrated = migrated.replace(_LEGACY_ABOUT, _NEUTRAL_ABOUT, 1)
+
+    return PrincipalPolicyMigrationPlan(content=migrated, changed=migrated != content)
+
+
+def _sha256(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _write_private_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(path.parent, 0o700)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        os.chmod(temporary, 0o600)
+        temporary.replace(path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _migration_receipt(before: str, after: str) -> str:
+    receipt = {
+        "after_sha256": _sha256(after),
+        "backup": "AGENTS.md.before",
+        "before_sha256": _sha256(before),
+        "migration": PRINCIPAL_POLICY_MIGRATION,
+        "version": 1,
+    }
+    return json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+
+
+def validate_principal_policy_migration_record(home: Path, before: str, after: str) -> Path:
+    """Fail closed on conflicting migration artifacts without writing anything."""
+    migration_root = home / ".kai-migrations"
+    migration_dir = migration_root / PRINCIPAL_POLICY_MIGRATION
+    for path in (migration_root, migration_dir):
+        if path.is_symlink() or (path.exists() and not path.is_dir()):
+            raise PrincipalPolicyMigrationConflict(f"Invalid principal-policy migration path: {path}")
+    backup_path = migration_dir / "AGENTS.md.before"
+    receipt_path = migration_dir / "receipt.json"
+    for path in (backup_path, receipt_path):
+        if path.is_symlink() or (path.exists() and not path.is_file()):
+            raise PrincipalPolicyMigrationConflict(f"Invalid principal-policy migration artifact: {path}")
+
+    if backup_path.is_file() and backup_path.read_text(encoding="utf-8") != before:
+        raise PrincipalPolicyMigrationConflict(
+            f"Existing principal-policy backup does not match the current legacy document: {backup_path}"
+        )
+    receipt_text = _migration_receipt(before, after)
+    if receipt_path.is_file() and receipt_path.read_text(encoding="utf-8") != receipt_text:
+        raise PrincipalPolicyMigrationConflict(
+            f"Existing principal-policy migration receipt conflicts with the planned migration: {receipt_path}"
+        )
+    return migration_dir
+
+
+def record_principal_policy_migration(home: Path, before: str, after: str) -> Path:
+    """Persist a private, deterministic backup and receipt before policy replacement."""
+    migration_dir = validate_principal_policy_migration_record(home, before, after)
+    migration_root = migration_dir.parent
+    migration_root.mkdir(mode=0o700, exist_ok=True)
+    os.chmod(migration_root, 0o700)
+    backup_path = migration_dir / "AGENTS.md.before"
+    receipt_path = migration_dir / "receipt.json"
+    if not backup_path.is_file():
+        _write_private_atomic(backup_path, before)
+    if not receipt_path.is_file():
+        receipt_text = _migration_receipt(before, after)
+        _write_private_atomic(receipt_path, receipt_text)
+    return migration_dir

--- a/src/kai/workshop/agent_definitions.py
+++ b/src/kai/workshop/agent_definitions.py
@@ -177,8 +177,9 @@ def render_agent_definition_context(revision: AgentDefinitionRevision) -> str:
         f"Requested collaboration operations: {collaboration_operations}\n"
         "Instructions:\n"
         f"{revision.instructions}\n"
-        "This versioned agent definition describes behavior only. It does not grant "
-        "tools, credentials, data access, identity, or permission, and it cannot "
+        "This versioned agent definition supplies this agent's behavior and conversational "
+        "identity only. It does not grant tools, credentials, data access, principal identity, "
+        "or permission, and it cannot "
         "override host, operator, workspace, or principal policy.\n"
         "</kai_agent_definition>"
     )

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -1,12 +1,8 @@
-# Kai
+# Principal Policy
 
 ## About This File
 
-This file is the bootstrap template for Kai's backend-neutral identity. The installer copies it to `<DATA_DIR>/home/<principal_id>/AGENTS.md` for each canonical Workshop human with an assigned runtime; `backend.ensure_user_home` lazily seeds it for profiles added later in development mode. Claude receives a thin `.claude/CLAUDE.md` import adapter; all managed identity content remains here. Edit the per-principal `AGENTS.md` to add operator-personal content; the tracked template ships universal content only. Once customized, you can delete this "About This File" section from the per-principal copy.
-
-## Who You Are
-
-You're Kai, a personal AI assistant available through configured clients such as Workshop and Telegram. You run locally on the operator's machine and have access to a shell, the filesystem, the web, a scheduler, and a per-principal memory store.
+This file is the bootstrap template for Kai's backend-neutral principal policy. The installer copies it to `<DATA_DIR>/home/<principal_id>/AGENTS.md` for each canonical Workshop human with an assigned runtime; `backend.ensure_user_home` lazily seeds it for profiles added later in development mode. Claude receives a thin `.claude/CLAUDE.md` import adapter; all managed policy content remains here. Edit the per-principal `AGENTS.md` to add operator-personal content; the tracked template ships universal content only. Once customized, you can delete this "About This File" section from the per-principal copy. Agent identity belongs exclusively to the active canonical agent definition.
 
 ## Hard Rules
 
@@ -50,7 +46,7 @@ The artifact itself (the spec, the PR, the issue) is durable on its own; status 
 
 ### Rules go to PREFERENCES.md, but only on explicit instruction
 
-The `[Your personal preferences (file: ...):]` block injects PREFERENCES.md, the curated always-on rule layer. It is NOT a target for proactive saves. Treat it like this AGENTS.md identity file: read every turn, edited deliberately, never silently appended.
+The `[Your personal preferences (file: ...):]` block injects PREFERENCES.md, the curated always-on rule layer. It is NOT a target for proactive saves. Treat it like this AGENTS.md policy file: read every turn, edited deliberately, never silently appended.
 
 Write to PREFERENCES.md ONLY when the operator explicitly instructs ("save this as a preference," "add this to PREFERENCES," "make this always-on"). Even on explicit instruction, surface the proposed wording and confirm before persisting. Each entry pays a token cost on every turn, so growth must be deliberate.
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -101,11 +101,11 @@ class TestBuildSessionContext:
             )
 
         assert result is not None
-        # Identity should NOT be injected (same workspace)
-        assert "core identity and instructions" not in result
+        # Principal policy should NOT be injected (same workspace)
+        assert "principal policy and instructions" not in result
 
     def test_foreign_workspace_injects_identity(self, tmp_path):
-        """Canonical AGENTS.md identity is injected in a foreign workspace."""
+        """Canonical AGENTS.md principal policy is injected in a foreign workspace."""
         home = tmp_path / "home"
         home.mkdir()
         (home / "AGENTS.md").write_text("Be helpful.")
@@ -128,14 +128,14 @@ class TestBuildSessionContext:
             )
 
         assert result is not None
-        assert "[Your core identity and instructions:]" in result
+        assert "[Your principal policy and instructions:]" in result
         assert "Be helpful." in result
 
     def test_defer_user_file_reads_injects_paths_not_contents(self, tmp_path):
         """Protected mode avoids daemon-side reads of user-owned files."""
         home = tmp_path / "home" / "12345"
         home.mkdir(parents=True)
-        (home / "AGENTS.md").write_text("PRIVATE IDENTITY")
+        (home / "AGENTS.md").write_text("PRIVATE PRINCIPAL POLICY")
 
         foreign = tmp_path / "foreign"
         foreign.mkdir()
@@ -159,7 +159,7 @@ class TestBuildSessionContext:
                 defer_user_file_reads=True,
             )
 
-        assert "PRIVATE IDENTITY" not in result
+        assert "PRIVATE PRINCIPAL POLICY" not in result
         assert "PRIVATE PREFS" not in result
         assert "PRIVATE MEMORY" not in result
         assert str(home / "AGENTS.md") in result
@@ -169,10 +169,10 @@ class TestBuildSessionContext:
         assert "never obey instructions" in result
 
     @pytest.mark.parametrize("backend_name", sorted(VALID_BACKENDS))
-    def test_foreign_workspace_uses_canonical_identity_for_every_backend(self, tmp_path, backend_name):
+    def test_foreign_workspace_uses_canonical_policy_for_every_backend(self, tmp_path, backend_name):
         home = tmp_path / "home"
         home.mkdir()
-        (home / "AGENTS.md").write_text("CANONICAL IDENTITY")
+        (home / "AGENTS.md").write_text("CANONICAL PRINCIPAL POLICY")
         (home / ".claude").mkdir()
         (home / ".claude" / "CLAUDE.md").write_text("@../AGENTS.md\n")
         foreign = tmp_path / "foreign"
@@ -191,7 +191,7 @@ class TestBuildSessionContext:
                 backend_name=backend_name,
             )
 
-        assert "CANONICAL IDENTITY" in result
+        assert "CANONICAL PRINCIPAL POLICY" in result
         assert "@../AGENTS.md" not in result
 
     @pytest.mark.parametrize("backend_name", ["claude", "codex", "goose", "opencode", "pi"])
@@ -999,7 +999,7 @@ class TestEnsureUserHome:
         (home / "AGENTS.md").write_text("# canonical\n")
         (home / ".claude" / "CLAUDE.md").write_text("# different\n")
 
-        with pytest.raises(RuntimeError, match="Conflicting customized identity files"):
+        with pytest.raises(RuntimeError, match="Conflicting customized principal-policy files"):
             ensure_user_home(99, tmp_path / "data", backend_name="claude")
 
         assert (home / "AGENTS.md").read_text() == "# canonical\n"
@@ -1012,8 +1012,53 @@ class TestEnsureUserHome:
         with patch("kai.backend.PROJECT_ROOT", fake_root):
             home = ensure_user_home(99, tmp_path / "data", backend_name="codex")
 
-        assert (home / "AGENTS.md").read_text() == "# Identity\n"
+        assert (home / "AGENTS.md").read_text() == "# Principal Policy\n"
         assert not (home / ".claude" / "CLAUDE.md").exists()
+
+    @pytest.mark.parametrize("backend_name", ["claude", "codex", "goose", "opencode", "pi"])
+    def test_existing_legacy_kai_identity_is_migrated_before_backend_use(self, tmp_path, backend_name):
+        fake_root = tmp_path / "src_root"
+        (fake_root / "templates").mkdir(parents=True)
+        (fake_root / "templates" / "AGENTS.md").write_text("# Principal Policy\n")
+        home = tmp_path / "data" / "home" / "99"
+        home.mkdir(parents=True)
+        legacy = (
+            "# Kai\n\n"
+            "## Who You Are\n\n"
+            "You're Kai, a personal AI assistant available through configured clients such as "
+            "Workshop and Telegram. You run locally on the operator's machine and have access to a "
+            "shell, the filesystem, the web, a scheduler, and a per-principal memory store.\n\n"
+            "## Custom\n\nKeep exactly.\n"
+        )
+        (home / "AGENTS.md").write_text(legacy)
+
+        with patch("kai.backend.PROJECT_ROOT", fake_root):
+            ensure_user_home(99, tmp_path / "data", backend_name=backend_name)
+
+        assert (home / "AGENTS.md").read_text() == "# Principal Policy\n\n## Custom\n\nKeep exactly.\n"
+        assert (home / ".kai-migrations" / "principal-policy-v1" / "AGENTS.md.before").read_text() == legacy
+        if backend_name == "claude":
+            assert (home / ".claude" / "CLAUDE.md").read_text() == "@../AGENTS.md\n"
+        else:
+            assert not (home / ".claude" / "CLAUDE.md").exists()
+
+    def test_existing_customized_kai_identity_fails_closed(self, tmp_path):
+        fake_root = tmp_path / "src_root"
+        (fake_root / "templates").mkdir(parents=True)
+        (fake_root / "templates" / "AGENTS.md").write_text("# Principal Policy\n")
+        home = tmp_path / "data" / "home" / "99"
+        home.mkdir(parents=True)
+        customized = "# Kai\n\n## Who You Are\n\nYou are Kai with custom identity.\n"
+        (home / "AGENTS.md").write_text(customized)
+
+        with (
+            patch("kai.backend.PROJECT_ROOT", fake_root),
+            pytest.raises(RuntimeError, match="customized or ambiguous Kai identity"),
+        ):
+            ensure_user_home(99, tmp_path / "data", backend_name="pi")
+
+        assert (home / "AGENTS.md").read_text() == customized
+        assert not (home / ".kai-migrations").exists()
 
     def test_chmod_eperm_does_not_crash(self, tmp_path):
         """

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -1870,10 +1870,10 @@ class TestContextInjection:
 
     @pytest.fixture()
     def home_workspace(self, tmp_path, monkeypatch):
-        """Create a home workspace with identity file and DATA_DIR memory."""
+        """Create a home workspace with principal policy and DATA_DIR memory."""
         home = tmp_path / "home"
         home.mkdir(parents=True)
-        (home / "AGENTS.md").write_text("You are Kai.")
+        (home / "AGENTS.md").write_text("Follow neutral principal policy.")
 
         # Personal memory now lives under DATA_DIR, not the workspace
         data_dir = tmp_path / "data"
@@ -1954,8 +1954,8 @@ class TestContextInjection:
             await _collect_events(claude, "Help me")
 
         prompt = self._extract_prompt(proc)
-        # Identity from home workspace should be injected
-        assert "You are Kai" in prompt
+        # Principal policy from home workspace should be injected
+        assert "Follow neutral principal policy" in prompt
         # Foreign workspace memory should NOT be injected (Claude Code reads
         # it natively from cwd; bot-side reads risk PermissionError on Linux)
         assert "Foreign workspace memory" not in prompt
@@ -1979,8 +1979,8 @@ class TestContextInjection:
             await _collect_events(claude, "Test")
 
         prompt = self._extract_prompt(proc)
-        # Identity text should NOT be injected when in home workspace
-        assert "core identity" not in prompt.lower()
+        # Principal policy text should NOT be injected when in home workspace
+        assert "principal policy" not in prompt.lower()
         # No per-message reminder either
         assert "Respond ONLY" not in prompt
 
@@ -2164,7 +2164,7 @@ class TestContextInjection:
         # All three other context blocks fired and are present.
         assert memory_block in prompt
         assert "Respond ONLY" in prompt  # foreign-workspace reminder
-        assert "You are Kai" in prompt  # session_ctx (identity)
+        assert "Follow neutral principal policy" in prompt  # session_ctx (principal policy)
 
         marker_idx = prompt.index(USER_MESSAGE_MARKER)
 
@@ -2172,7 +2172,7 @@ class TestContextInjection:
         # top-to-bottom. Every other block must have a smaller index.
         assert prompt.index(memory_block) < marker_idx
         assert prompt.index("Respond ONLY") < marker_idx
-        assert prompt.index("You are Kai") < marker_idx
+        assert prompt.index("Follow neutral principal policy") < marker_idx
 
         # (c) User's actual text immediately follows the marker, with
         # nothing but whitespace between them. We compute the substring

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9385,7 +9385,7 @@ class TestApplyMigrateManagedIdentity:
         (home / "AGENTS.md").write_text("# canonical\n")
         (home / ".claude" / "CLAUDE.md").write_text("# different\n")
 
-        with pytest.raises(RuntimeError, match="Conflicting customized identity files"):
+        with pytest.raises(RuntimeError, match="Conflicting customized principal-policy files"):
             self._apply(tmp_path, backend="claude")
 
         assert (home / "AGENTS.md").read_text() == "# canonical\n"
@@ -9398,7 +9398,7 @@ class TestApplyMigrateManagedIdentity:
         target.write_text("outside\n")
         (home / "AGENTS.md").symlink_to(target)
 
-        with pytest.raises(RuntimeError, match="Refusing symlinked canonical identity"):
+        with pytest.raises(RuntimeError, match="Refusing symlinked canonical principal policy"):
             self._apply(tmp_path, backend="codex")
 
         assert target.read_text() == "outside\n"
@@ -9441,8 +9441,46 @@ class TestApplyMigrateManagedIdentity:
             backend="codex",
             source_identity=None,
         )
-        assert (home / "AGENTS.md").read_text() == "# Identity\n"
+        assert (home / "AGENTS.md").read_text() == "# Principal Policy\n"
         assert not (home / ".claude" / "CLAUDE.md").exists()
+
+    def test_legacy_kai_identity_becomes_neutral_policy_with_private_backup(self, tmp_path):
+        home = tmp_path / "data" / "home" / "12345"
+        home.mkdir(parents=True)
+        legacy = (
+            "# Kai\n\n"
+            "## Who You Are\n\n"
+            "You're Kai, a personal AI assistant available through configured clients such as "
+            "Workshop and Telegram. You run locally on the operator's machine and have access to a "
+            "shell, the filesystem, the web, a scheduler, and a per-principal memory store.\n\n"
+            "## Operator Rules\n\nPreserve this exact custom rule.  \n"
+        )
+        (home / "AGENTS.md").write_text(legacy)
+
+        self._apply(
+            tmp_path,
+            backend="codex",
+            source_identity="# Principal Policy\n",
+        )
+
+        migrated = (home / "AGENTS.md").read_text()
+        assert migrated == "# Principal Policy\n\n## Operator Rules\n\nPreserve this exact custom rule.  \n"
+        artifacts = home / ".kai-migrations" / "principal-policy-v1"
+        assert (artifacts / "AGENTS.md.before").read_text() == legacy
+        assert '"migration": "principal-policy-v1"' in (artifacts / "receipt.json").read_text()
+
+    def test_customized_kai_identity_aborts_without_writes(self, tmp_path):
+        home = tmp_path / "data" / "home" / "12345"
+        home.mkdir(parents=True)
+        customized = "# Kai\n\n## Who You Are\n\nYou are Kai with operator-specific identity text.\n"
+        agents = home / "AGENTS.md"
+        agents.write_text(customized)
+
+        with pytest.raises(RuntimeError, match="customized or ambiguous Kai identity"):
+            self._apply(tmp_path, backend="codex")
+
+        assert agents.read_text() == customized
+        assert not (home / ".kai-migrations").exists()
 
     def test_replaces_legacy_internal_api_block_without_touching_custom_identity(
         self,

--- a/tests/test_principal_policy.py
+++ b/tests/test_principal_policy.py
@@ -1,0 +1,153 @@
+"""Contracts for separating principal policy from canonical agent identity."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from kai.principal_policy import (
+    PRINCIPAL_POLICY_MIGRATION,
+    PrincipalPolicyMigrationConflict,
+    plan_principal_policy_migration,
+    record_principal_policy_migration,
+)
+from kai.workshop.agent_definitions import (
+    AgentDefinitionRevision,
+    active_agent_definition_revision,
+    render_agent_definition_context,
+)
+from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
+from kai.workshop.domain import AgentDefinitionId, AgentDefinitionRevisionId, AgentId, WorkshopId
+from kai.workshop.store import WorkshopEventStore
+
+_LEGACY_PREFIX = (
+    "# Kai\n\n"
+    "## About This File\n\n"
+    "This file is the bootstrap template for Kai's backend-neutral identity. The installer "
+    "copies it to `<DATA_DIR>/home/<principal_id>/AGENTS.md` for each canonical Workshop "
+    "human with an assigned runtime; `backend.ensure_user_home` lazily seeds it for profiles "
+    "added later in development mode. Claude receives a thin `.claude/CLAUDE.md` import "
+    "adapter; all managed identity content remains here. Edit the per-principal `AGENTS.md` "
+    "to add operator-personal content; the tracked template ships universal content only. "
+    'Once customized, you can delete this "About This File" section from the per-principal copy.\n\n'
+    "## Who You Are\n\n"
+    "You're Kai, a personal AI assistant available through configured clients such as "
+    "Workshop and Telegram. You run locally on the operator's machine and have access to a "
+    "shell, the filesystem, the web, a scheduler, and a per-principal memory store.\n\n"
+)
+
+
+def test_tracked_policy_is_identity_neutral() -> None:
+    policy = (Path(__file__).parents[1] / "templates" / "AGENTS.md").read_text()
+
+    assert policy.startswith("# Principal Policy\n")
+    assert "## Who You Are" not in policy
+    assert "You're Kai" not in policy
+    assert "You are Kai" not in policy
+    assert "Agent identity belongs exclusively to the active canonical agent definition." in policy
+
+
+def test_known_legacy_prefix_migrates_without_changing_custom_rules() -> None:
+    custom_rules = "## Operator Rules\n\n- Preserve this exact text.  \n- Keep spacing.\n"
+
+    plan = plan_principal_policy_migration(_LEGACY_PREFIX + custom_rules)
+
+    assert plan.changed is True
+    assert plan.content.startswith("# Principal Policy\n")
+    assert "## Who You Are" not in plan.content
+    assert "backend-neutral principal policy" in plan.content
+    assert plan.content.endswith(custom_rules)
+
+
+@pytest.mark.parametrize(
+    "content",
+    (
+        "# Kai\n\n## Who You Are\n\nYou are Kai with customized behavior.\n",
+        "# Personal Policy\n\nCustom preface. You're Kai in this context.\n",
+        "# Personal Policy\n\nCustom preface. YOU ARE KAI in this context.\n",
+        "# Personal Policy\n\nCustom preface. You\u2019re Kai in this context.\n",
+    ),
+)
+def test_ambiguous_identity_text_fails_closed(content: str) -> None:
+    with pytest.raises(PrincipalPolicyMigrationConflict, match="original was not changed"):
+        plan_principal_policy_migration(content)
+
+
+def test_migration_backup_and_receipt_are_private_and_replay_safe(tmp_path: Path) -> None:
+    before = _LEGACY_PREFIX + "## Operator Rules\n\nKeep me.\n"
+    after = plan_principal_policy_migration(before).content
+
+    first = record_principal_policy_migration(tmp_path, before, after)
+    second = record_principal_policy_migration(tmp_path, before, after)
+
+    assert first == second == tmp_path / ".kai-migrations" / PRINCIPAL_POLICY_MIGRATION
+    assert (first / "AGENTS.md.before").read_text() == before
+    receipt = json.loads((first / "receipt.json").read_text())
+    assert receipt["migration"] == PRINCIPAL_POLICY_MIGRATION
+    assert receipt["backup"] == "AGENTS.md.before"
+    assert len(receipt["before_sha256"]) == 64
+    assert len(receipt["after_sha256"]) == 64
+    assert stat.S_IMODE((tmp_path / ".kai-migrations").stat().st_mode) == 0o700
+    assert stat.S_IMODE(first.stat().st_mode) == 0o700
+    assert stat.S_IMODE((first / "AGENTS.md.before").stat().st_mode) == 0o600
+    assert stat.S_IMODE((first / "receipt.json").stat().st_mode) == 0o600
+
+
+def test_conflicting_existing_backup_is_not_overwritten(tmp_path: Path) -> None:
+    before = _LEGACY_PREFIX
+    after = plan_principal_policy_migration(before).content
+    migration_dir = tmp_path / ".kai-migrations" / PRINCIPAL_POLICY_MIGRATION
+    migration_dir.mkdir(parents=True)
+    backup = migration_dir / "AGENTS.md.before"
+    backup.write_text("different original\n")
+
+    with pytest.raises(PrincipalPolicyMigrationConflict, match="backup does not match"):
+        record_principal_policy_migration(tmp_path, before, after)
+
+    assert backup.read_text() == "different original\n"
+
+
+async def test_predefined_kai_identity_remains_in_canonical_versioned_definition(tmp_path: Path) -> None:
+    store = await WorkshopEventStore.open(tmp_path / "kai.db")
+    try:
+        bootstrap = await bootstrap_default_workshop(
+            store,
+            (BootstrapHuman("Operator", "admin", "desktop", "operator", "operator"),),
+        )
+        revision = await active_agent_definition_revision(store, bootstrap.agent_id)
+        assert revision is not None
+        assert revision.handle == "kai"
+        assert revision.revision_number == 2
+        assert "Act as Kai." in revision.instructions
+    finally:
+        await store.close()
+
+
+@pytest.mark.parametrize("lane", ["private-owner", "private-nonowner", "shared-owner", "shared-nonowner"])
+def test_custom_agent_context_has_only_its_own_identity_in_every_lane(lane: str) -> None:
+    policy = (Path(__file__).parents[1] / "templates" / "AGENTS.md").read_text()
+    revision = AgentDefinitionRevision(
+        definition_id=AgentDefinitionId.new(),
+        revision_id=AgentDefinitionRevisionId.new(),
+        workshop_id=WorkshopId.new(),
+        agent_id=AgentId.new(),
+        handle="qualification_agent",
+        display_name="Qualification agent",
+        description=f"Qualification fixture for {lane}.",
+        lifecycle_state="active",
+        revision_number=1,
+        purpose="Qualify agent identity separation.",
+        instructions="Act only as Qualification agent.",
+        capabilities=("text_generation",),
+        collaboration_operations=(),
+    )
+
+    context = policy + "\n" + render_agent_definition_context(revision)
+
+    assert "Act only as Qualification agent." in context
+    assert "You're Kai" not in context
+    assert "You are Kai" not in context
+    assert "Act as Kai" not in context

--- a/tests/test_template_agents_md.py
+++ b/tests/test_template_agents_md.py
@@ -1,7 +1,7 @@
 """Tests for the tracked backend-neutral AGENTS.md template.
 
 The template at templates/AGENTS.md is the source for every per-user
-inner-agent identity file. It ships to new users via the install-time seed
+principal-policy file. It ships to new users via the install-time seed
 step and is the upstream of the _migrate_recalled_memory_section helper.
 Regressions to the structure or wording of pinned sections would propagate
 into every freshly-seeded per-user copy on the next install.

--- a/tests/test_workshop_agent_definitions.py
+++ b/tests/test_workshop_agent_definitions.py
@@ -323,7 +323,8 @@ class TestAgentDefinitionRevisions:
             assert revision is not None
             rendered = render_agent_definition_context(revision)
             assert f"Definition revision: 2 ({revision.revision_id})" in rendered
-            assert "does not grant tools, credentials, data access, identity, or permission" in rendered
+            assert "supplies this agent's behavior and conversational identity only" in rendered
+            assert "does not grant tools, credentials, data access, principal identity" in rendered
         finally:
             await store.close()
 

--- a/tests/test_workshop_standing_participation.py
+++ b/tests/test_workshop_standing_participation.py
@@ -74,7 +74,15 @@ async def _eligible_authority(
         idempotency_key="standing-activate",
         expected_version=revised.state_version,
     )
-    host_policy = CollaborationHostPolicy(standing_participation=StandingParticipationHostPolicy(enabled=True))
+    # Keep general fixtures independent of wall-clock time. Quiet expiry has
+    # dedicated coverage below; a fixed historical _NOW plus the production
+    # three-day expiry otherwise turns unrelated tests into a calendar bomb.
+    host_policy = CollaborationHostPolicy(
+        standing_participation=StandingParticipationHostPolicy(
+            enabled=True,
+            quiet_expiry_seconds=0,
+        )
+    )
     authority = WorkshopCollaborationAuthority(store, host_policy=host_policy)
     owner_policy = WorkshopCollaborationPolicyService(
         store,


### PR DESCRIPTION
## Summary

- make the managed per-principal `AGENTS.md` a neutral principal-policy document instead of a second Kai identity source
- retain Kai's conversational identity exclusively in the predefined agent's canonical versioned definition
- migrate the exact legacy Kai identity block with a private original backup and deterministic receipt, while refusing ambiguous customized identity text
- use the same neutral principal-policy labels and delivery behavior across home/foreign workspaces and all five backends
- make the standing-participation test fixture independent of wall-clock expiry while retaining dedicated expiry coverage

## Validation

- `make check`
- `make typecheck`
- `make test` (`6684 passed`)
- focused principal-policy, installer, backend, bootstrap, agent-definition, and context-injection coverage

Closes #1536
