### PR TITLE
Fix installed principal-policy legacy migration

### DIFF
--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -8,7 +8,7 @@ Provides functionality to:
 
 The two-step workflow separates privilege levels:
     python -m kai install config   -- interactive Q&A, writes install.conf (no sudo)
-    sudo python -m kai install apply  -- reads install.conf, creates /opt layout (root)
+    make install                    -- reads install.conf, creates /opt layout (root)
     python -m kai install status   -- shows current state (no sudo)
 
 A protected installation puts read-only source in /opt/kai/ (root-owned) and
@@ -76,6 +76,7 @@ from kai.config import (
 )
 from kai.named_access import replace_named_inherited_read_access, replace_named_read_access
 from kai.principal_policy import (
+    PrincipalPolicyMigrationConflict,
     PrincipalPolicyMigrationPlan,
     plan_principal_policy_migration,
     record_principal_policy_migration,
@@ -3439,7 +3440,7 @@ def _cmd_config() -> None:
     os.chmod(INSTALL_CONF, 0o600)
     print(f"Configuration written to {INSTALL_CONF}")
     if deployment_mode == "protected":
-        print("Review the file, then run: sudo python -m kai install apply")
+        print("Review the file, then run: make install")
     else:
         # In single-user mode, also write the local .env so the
         # daemon can find runtime env config via `load_dotenv`
@@ -6657,10 +6658,14 @@ def _apply_migrate(
         if dry_run and migration is not None and not user_home.exists() and migration[0].is_dir():
             inspection_home = migration[0]
         _source_agents, _source_claude, agents_content, claude_content = _managed_identity_state(inspection_home)
-        source_content = agents_content if agents_content is not None else claude_content
-        policy_plan = plan_principal_policy_migration(source_content) if source_content is not None else None
         agents_path = user_home / "AGENTS.md"
         claude_path = user_home / ".claude" / "CLAUDE.md"
+        source_content = agents_content if agents_content is not None else claude_content
+        source_path = agents_path if agents_content is not None else claude_path
+        try:
+            policy_plan = plan_principal_policy_migration(source_content) if source_content is not None else None
+        except PrincipalPolicyMigrationConflict as exc:
+            raise PrincipalPolicyMigrationConflict(f"{source_path}: {exc}") from exc
         if policy_plan is not None and policy_plan.changed and source_content is not None:
             validate_principal_policy_migration_record(
                 agents_path.parent,
@@ -6936,7 +6941,7 @@ def _cmd_apply() -> None:
     """
     # -- Validate preconditions --
     if os.geteuid() != 0:
-        raise SystemExit("'install apply' must be run as root (try: sudo python -m kai install apply)")
+        raise SystemExit("'install apply' must be run as root (run it through: make install)")
 
     if not INSTALL_CONF.exists():
         raise SystemExit(f"{INSTALL_CONF} not found. Run 'python -m kai install config' first.")
@@ -7413,10 +7418,10 @@ def _cmd_apply() -> None:
             else:
                 Path(runtime_profiles_staging_path).unlink(missing_ok=True)
                 _strip_install_conf_keys("runtime_profiles_staging_path")
-    except Exception:
-        print("\nInstallation failed. See error above.")
+    except Exception as exc:
+        print(f"\nInstallation failed: {type(exc).__name__}: {exc}")
         print("The installation may be in a partial state.")
-        print("Fix the issue and re-run: sudo python -m kai install apply")
+        print("Fix the issue and re-run: make install")
         raise
     finally:
         # Always restart the service, even after failure. A partially updated

--- a/src/kai/principal_policy.py
+++ b/src/kai/principal_policy.py
@@ -22,6 +22,15 @@ _LEGACY_ABOUT = (
     "to add operator-personal content; the tracked template ships universal content only. "
     'Once customized, you can delete this "About This File" section from the per-principal copy.'
 )
+_LEGACY_CHAT_ID_ABOUT = (
+    "This file is the bootstrap template for Kai's backend-neutral identity. The installer "
+    "copies it to `<DATA_DIR>/home/<chat_id>/AGENTS.md` for every user in `users.yaml` at "
+    "install time; `backend.ensure_user_home` lazily seeds it for users added later in "
+    "development mode. Claude receives a thin `.claude/CLAUDE.md` import adapter; all managed "
+    "identity content remains here. Edit the per-user `AGENTS.md` to add operator-personal "
+    "content; the tracked template ships universal content only. Once customized, you can "
+    'delete this "About This File" section from the per-user copy.'
+)
 _NEUTRAL_ABOUT = (
     "This file is the bootstrap template for Kai's backend-neutral principal policy. The "
     "installer copies it to `<DATA_DIR>/home/<principal_id>/AGENTS.md` for each canonical "
@@ -39,6 +48,24 @@ _LEGACY_IDENTITY_SECTION = (
     "Workshop and Telegram. You run locally on the operator's machine and have access to a "
     "shell, the filesystem, the web, a scheduler, and a per-principal memory store.\n\n"
 )
+_LEGACY_TELEGRAM_IDENTITY_SECTION = (
+    "## Who You Are\n\n"
+    "You're Kai, a personal AI assistant accessed via Telegram. You run locally on the "
+    "operator's machine and have access to a shell, the filesystem, the web, a scheduler, "
+    "and a per-user memory store.\n\n"
+)
+_LEGACY_OPERATOR_IDENTITY_SECTION = (
+    "## Who You Are\n\n"
+    "You're Kai, an agentic AI coding assistant who lives in Telegram and runs locally on "
+    "your user's machine. You're not a butler or a service. You're a peer who happens to "
+    "have access to a shell, the filesystem, the web, and a scheduling API. Act like one.\n\n"
+)
+_LEGACY_IDENTITY_SECTIONS = (
+    _LEGACY_IDENTITY_SECTION,
+    _LEGACY_TELEGRAM_IDENTITY_SECTION,
+    _LEGACY_OPERATOR_IDENTITY_SECTION,
+)
+_LEGACY_ABOUT_SECTIONS = (_LEGACY_ABOUT, _LEGACY_CHAT_ID_ABOUT)
 _IDENTITY_MARKERS = ("you're kai", "you are kai")
 
 
@@ -61,8 +88,9 @@ def plan_principal_policy_migration(content: str) -> PrincipalPolicyMigrationPla
     closed instead of silently rewriting operator-authored content.
     """
     migrated = content
-    if _LEGACY_IDENTITY_SECTION in migrated:
-        migrated = migrated.replace(_LEGACY_IDENTITY_SECTION, "", 1)
+    for legacy_identity in _LEGACY_IDENTITY_SECTIONS:
+        if legacy_identity in migrated:
+            migrated = migrated.replace(legacy_identity, "", 1)
 
     identity_scan = migrated.casefold().replace("\u2019", "'")
     if "## who you are" in identity_scan or any(marker in identity_scan for marker in _IDENTITY_MARKERS):
@@ -74,8 +102,9 @@ def plan_principal_policy_migration(content: str) -> PrincipalPolicyMigrationPla
 
     if migrated.startswith(_LEGACY_TITLE + "\n"):
         migrated = _NEUTRAL_TITLE + migrated[len(_LEGACY_TITLE) :]
-    if _LEGACY_ABOUT in migrated:
-        migrated = migrated.replace(_LEGACY_ABOUT, _NEUTRAL_ABOUT, 1)
+    for legacy_about in _LEGACY_ABOUT_SECTIONS:
+        if legacy_about in migrated:
+            migrated = migrated.replace(legacy_about, _NEUTRAL_ABOUT, 1)
 
     return PrincipalPolicyMigrationPlan(content=migrated, changed=migrated != content)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3850,6 +3850,9 @@ class TestCmdApply:
         # visibility into both failure modes.
         out = capsys.readouterr().out
         assert "Manual recovery" in out
+        assert "Installation failed: ApplyBlewUp: simulated apply step failure" in out
+        assert "Fix the issue and re-run: make install" in out
+        assert "sudo python -m kai install apply" not in out
 
 
 class TestProtectedUserIsolationPreflight:
@@ -9469,6 +9472,35 @@ class TestApplyMigrateManagedIdentity:
         assert (artifacts / "AGENTS.md.before").read_text() == legacy
         assert '"migration": "principal-policy-v1"' in (artifacts / "receipt.json").read_text()
 
+    @pytest.mark.parametrize(
+        "identity",
+        (
+            "You're Kai, a personal AI assistant accessed via Telegram. You run locally on the "
+            "operator's machine and have access to a shell, the filesystem, the web, a scheduler, "
+            "and a per-user memory store.",
+            "You're Kai, an agentic AI coding assistant who lives in Telegram and runs locally on "
+            "your user's machine. You're not a butler or a service. You're a peer who happens to "
+            "have access to a shell, the filesystem, the web, and a scheduling API. Act like one.",
+        ),
+        ids=("tracked-telegram-era", "installed-operator-personality"),
+    )
+    def test_installed_legacy_identity_variants_migrate_with_backup(self, tmp_path, identity):
+        home = tmp_path / "data" / "home" / "12345"
+        home.mkdir(parents=True)
+        custom_rules = "## Operator Rules\n\nPreserve this exact custom rule.  \n"
+        legacy = f"# Kai\n\n## Who You Are\n\n{identity}\n\n{custom_rules}"
+        (home / "AGENTS.md").write_text(legacy)
+
+        self._apply(
+            tmp_path,
+            backend="codex",
+            source_identity="# Principal Policy\n",
+        )
+
+        assert (home / "AGENTS.md").read_text() == f"# Principal Policy\n\n{custom_rules}"
+        artifacts = home / ".kai-migrations" / "principal-policy-v1"
+        assert (artifacts / "AGENTS.md.before").read_text() == legacy
+
     def test_customized_kai_identity_aborts_without_writes(self, tmp_path):
         home = tmp_path / "data" / "home" / "12345"
         home.mkdir(parents=True)
@@ -9476,7 +9508,10 @@ class TestApplyMigrateManagedIdentity:
         agents = home / "AGENTS.md"
         agents.write_text(customized)
 
-        with pytest.raises(RuntimeError, match="customized or ambiguous Kai identity"):
+        with pytest.raises(
+            RuntimeError,
+            match=r"home/12345/AGENTS\.md: Managed AGENTS\.md contains a customized or ambiguous Kai identity",
+        ):
             self._apply(tmp_path, backend="codex")
 
         assert agents.read_text() == customized

--- a/tests/test_principal_policy.py
+++ b/tests/test_principal_policy.py
@@ -38,6 +38,28 @@ _LEGACY_PREFIX = (
     "Workshop and Telegram. You run locally on the operator's machine and have access to a "
     "shell, the filesystem, the web, a scheduler, and a per-principal memory store.\n\n"
 )
+_LEGACY_TELEGRAM_PREFIX = (
+    "# Kai\n\n"
+    "## About This File\n\n"
+    "This file is the bootstrap template for Kai's backend-neutral identity. The installer "
+    "copies it to `<DATA_DIR>/home/<chat_id>/AGENTS.md` for every user in `users.yaml` at "
+    "install time; `backend.ensure_user_home` lazily seeds it for users added later in "
+    "development mode. Claude receives a thin `.claude/CLAUDE.md` import adapter; all managed "
+    "identity content remains here. Edit the per-user `AGENTS.md` to add operator-personal "
+    "content; the tracked template ships universal content only. Once customized, you can "
+    'delete this "About This File" section from the per-user copy.\n\n'
+    "## Who You Are\n\n"
+    "You're Kai, a personal AI assistant accessed via Telegram. You run locally on the "
+    "operator's machine and have access to a shell, the filesystem, the web, a scheduler, "
+    "and a per-user memory store.\n\n"
+)
+_LEGACY_OPERATOR_PREFIX = (
+    "# Kai\n\n"
+    "## Who You Are\n\n"
+    "You're Kai, an agentic AI coding assistant who lives in Telegram and runs locally on "
+    "your user's machine. You're not a butler or a service. You're a peer who happens to "
+    "have access to a shell, the filesystem, the web, and a scheduling API. Act like one.\n\n"
+)
 
 
 def test_tracked_policy_is_identity_neutral() -> None:
@@ -60,6 +82,33 @@ def test_known_legacy_prefix_migrates_without_changing_custom_rules() -> None:
     assert "## Who You Are" not in plan.content
     assert "backend-neutral principal policy" in plan.content
     assert plan.content.endswith(custom_rules)
+
+
+@pytest.mark.parametrize(
+    "legacy_prefix",
+    (_LEGACY_TELEGRAM_PREFIX, _LEGACY_OPERATOR_PREFIX),
+    ids=("tracked-telegram-era", "installed-operator-personality"),
+)
+def test_installed_legacy_identity_variants_migrate_losslessly(legacy_prefix: str) -> None:
+    custom_rules = "## Operator Rules\n\n- Preserve this exact text.  \n- Keep spacing.\n"
+
+    plan = plan_principal_policy_migration(legacy_prefix + custom_rules)
+
+    assert plan.changed is True
+    assert plan.content.startswith("# Principal Policy\n")
+    assert "## Who You Are" not in plan.content
+    assert "You're Kai" not in plan.content
+    assert "you are Kai" not in plan.content
+    assert plan.content.endswith(custom_rules)
+
+
+def test_tracked_telegram_about_text_becomes_current_principal_policy_text() -> None:
+    plan = plan_principal_policy_migration(_LEGACY_TELEGRAM_PREFIX)
+
+    assert "<chat_id>" not in plan.content
+    assert "every user in `users.yaml`" not in plan.content
+    assert "backend-neutral principal policy" in plan.content
+    assert "<principal_id>" in plan.content
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- recognize the exact Telegram-era and longstanding operator Kai identity forms already present in protected installations
- preserve the complete original document in the private replay-safe migration backup while leaving all non-identity policy bytes unchanged
- normalize the prior chat-ID About text to current principal-policy terminology
- keep unknown identity customization fail-closed and name the affected file
- report apply failures before service recovery and direct operators to make install

## Validation

- make check
- make typecheck
- focused migration and installer tests: 37 passed
- full suite: 6689 passed

Closes #1545