### PR TITLE
Define canonical context-source revisions and per-run manifests

### DIFF
--- a/src/kai/acp.py
+++ b/src/kai/acp.py
@@ -1486,6 +1486,7 @@ class AcpBackend(AgentBackend):
             workspace=self.workspace,
             backend_name=self.backend_name,
             job_type="interactive",
+            context_observer=self.consume_context_assembly_observer(),
         )
 
         # Coerce to the ACP content-block shape. `prompt` is either a

--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -14,6 +14,7 @@ process management; the context functions here handle the Kai-specific
 prompt assembly that is identical across all backends.
 """
 
+import hashlib
 import hmac
 import logging
 import os
@@ -21,7 +22,7 @@ import shutil
 import tempfile
 import time
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Protocol, runtime_checkable
@@ -62,6 +63,24 @@ class AgentRuntimeIdentity(Protocol):
     agent_id: str
     runtime_profile_id: str
     private_context: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ContextAssemblyObservation:
+    """Content-free facts observed immediately before provider dispatch."""
+
+    provider_dispatch_reached: bool | None
+    session_context_delivered: bool
+    session_context_revision: str | None
+    semantic_recall_attempted: bool
+    semantic_recall_delivered: bool
+    semantic_recall_reason: str
+    semantic_recall_revision: str | None
+    workspace_reminder_delivered: bool
+    workspace_reminder_revision: str | None = None
+
+
+type ContextAssemblyObserver = Callable[[ContextAssemblyObservation], Awaitable[None]]
 
 
 def _principal_directories(
@@ -557,6 +576,22 @@ class AgentBackend(ABC):
         """Clear unconsumed definition context after protected dispatch."""
         if hasattr(self, "_canonical_agent_context"):
             del self._canonical_agent_context
+
+    def stage_context_assembly_observer(self, observer: ContextAssemblyObserver) -> None:
+        """Stage a one-shot redacted context observer for protected execution."""
+        if not callable(observer):
+            raise TypeError("context assembly observer must be callable")
+        self._context_assembly_observer = observer
+
+    def consume_context_assembly_observer(self) -> ContextAssemblyObserver | None:
+        """Consume the protected execution's one-shot context observer."""
+        observer = getattr(self, "_context_assembly_observer", None)
+        self.discard_context_assembly_observer()
+        return observer
+
+    def discard_context_assembly_observer(self) -> None:
+        if hasattr(self, "_context_assembly_observer"):
+            del self._context_assembly_observer
 
     def stage_collaboration_invocation(self, context: str, proof: str) -> None:
         """Stage exact-attempt collaboration authority for one protected turn.
@@ -1694,6 +1729,7 @@ async def assemble_turn_context(
     backend_name: str | None = None,
     job_type: str | None = None,
     session_id: str | None = None,
+    context_observer: ContextAssemblyObserver | None = None,
 ) -> str | list:
     """
     Assemble the per-turn prompt context for an interactive backend.
@@ -1794,7 +1830,11 @@ async def assemble_turn_context(
         else None
     )
     private_context = runtime_identity is None or getattr(runtime_identity, "private_context", True)
-    if private_context and memory_user_id is not None and search_query.strip():
+    recall_attempted = private_context and memory_user_id is not None and bool(search_query.strip())
+    recall_delivered = False
+    recall_reason = "ineligible"
+    recall_revision: str | None = None
+    if recall_attempted:
         from kai.memory import (
             _emit_recall_log,
             format_scoped_context_with_recall_payload,
@@ -1820,6 +1860,12 @@ async def assemble_turn_context(
         _emit_recall_log(scoped_recall.recall_payload)
         if scoped_recall.rendered_context:
             prompt = prepend_to_prompt(prompt, scoped_recall.rendered_context)
+            recall_delivered = True
+            recall_reason = "matches_delivered"
+            recall_revision = hashlib.sha256(scoped_recall.rendered_context.encode("utf-8")).hexdigest()
+        else:
+            reason = scoped_recall.recall_payload.get("reason")
+            recall_reason = str(reason) if isinstance(reason, str) and reason else "no_matches"
 
     # Foreign-workspace reminder is built fresh by the caller on
     # every turn (it depends on the workspace state at call time).
@@ -1827,6 +1873,25 @@ async def assemble_turn_context(
     # matching the pre-extraction Claude behavior.
     if workspace_reminder:
         prompt = prepend_to_prompt(prompt, workspace_reminder)
+
+    if context_observer is not None:
+        await context_observer(
+            ContextAssemblyObservation(
+                provider_dispatch_reached=True,
+                session_context_delivered=bool(session_context),
+                session_context_revision=(
+                    hashlib.sha256(session_context.encode("utf-8")).hexdigest() if session_context else None
+                ),
+                semantic_recall_attempted=recall_attempted,
+                semantic_recall_delivered=recall_delivered,
+                semantic_recall_reason=recall_reason,
+                semantic_recall_revision=recall_revision,
+                workspace_reminder_delivered=bool(workspace_reminder),
+                workspace_reminder_revision=(
+                    hashlib.sha256(workspace_reminder.encode("utf-8")).hexdigest() if workspace_reminder else None
+                ),
+            )
+        )
 
     return prompt
 

--- a/src/kai/claude.py
+++ b/src/kai/claude.py
@@ -865,6 +865,7 @@ class ClaudeCodeBackend(AgentBackend):
             workspace=self.workspace,
             backend_name=self.backend_name,
             job_type="interactive",
+            context_observer=self.consume_context_assembly_observer(),
         )
 
         content = prompt if isinstance(prompt, list) else [{"type": "text", "text": prompt}]

--- a/src/kai/codex.py
+++ b/src/kai/codex.py
@@ -972,6 +972,7 @@ class CodexBackend(AgentBackend):
             workspace=self.workspace,
             backend_name=self.backend_name,
             job_type="interactive",
+            context_observer=self.consume_context_assembly_observer(),
         )
 
         # Coerce to the JSON-RPC content-block shape. `prompt` is

--- a/src/kai/install.py
+++ b/src/kai/install.py
@@ -95,6 +95,7 @@ from kai.workshop.diagnostics import (
     workshop_channel_notification_policy_status,
     workshop_client_preference_status,
     workshop_collaboration_authority_status,
+    workshop_context_manifest_status,
     workshop_delivery_authority_status,
     workshop_execution_state_status,
     workshop_human_avatar_status,
@@ -9669,6 +9670,7 @@ def _cmd_status() -> None:
     print(_channel_lifecycle_status(Path(data_dir) / "kai.db"))
     print(_direct_message_archive_status(Path(data_dir) / "kai.db"))
     print(workshop_delivery_authority_status(Path(data_dir) / "kai.db"))
+    print(workshop_context_manifest_status(Path(data_dir) / "kai.db"))
     print(workshop_runtime_session_status(Path(data_dir) / "kai.db"))
     print(_runtime_key_cutover_status(Path(data_dir) / "kai.db", RUNTIME_PROFILES_YAML))
     print(workshop_execution_state_status(Path(data_dir) / "kai.db"))

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -457,6 +457,7 @@ class PiBackend(AgentBackend):
             backend_name=self.backend_name,
             job_type="interactive",
             session_id=self._session_id,
+            context_observer=self.consume_context_assembly_observer(),
         )
         if isinstance(prompt, str):
             message_text = prompt

--- a/src/kai/pool.py
+++ b/src/kai/pool.py
@@ -24,7 +24,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from kai import sessions
-from kai.backend import AgentBackend, StreamEvent, require_backend_name, resolve_home_workspace
+from kai.backend import (
+    AgentBackend,
+    ContextAssemblyObserver,
+    StreamEvent,
+    require_backend_name,
+    resolve_home_workspace,
+)
 from kai.claude import ClaudeCodeBackend
 from kai.config import (
     OPEN_ENDED_PROVIDERS,
@@ -153,6 +159,10 @@ class PreparedBackendExecution:
     def workspace(self) -> Path:
         return self._fingerprint.workspace
 
+    @property
+    def home_workspace(self) -> Path:
+        return self._instance.home_workspace
+
     def stage_canonical_history(self, history: str) -> None:
         """Stage restart context on this exact protected runtime."""
         self._pool._validate_prepared(self)
@@ -162,6 +172,11 @@ class PreparedBackendExecution:
         """Stage the run-bound agent revision on this exact runtime."""
         self._pool._validate_prepared(self)
         self._instance.stage_canonical_agent_context(context)
+
+    def stage_context_assembly_observer(self, observer: ContextAssemblyObserver) -> None:
+        """Stage one redacted pre-dispatch observer on the exact runtime."""
+        self._pool._validate_prepared(self)
+        self._instance.stage_context_assembly_observer(observer)
 
     def stage_collaboration_invocation(self, context: str, proof: str) -> None:
         """Stage exact-attempt collaboration authority on this runtime."""
@@ -1274,6 +1289,7 @@ class SubprocessPool:
         finally:
             instance.discard_canonical_history()
             instance.discard_canonical_agent_context()
+            instance.discard_context_assembly_observer()
             self._in_flight.discard(runtime_key)
             self._last_activity[runtime_key] = time.monotonic()
 
@@ -1304,6 +1320,7 @@ class SubprocessPool:
         finally:
             instance.discard_canonical_history()
             instance.discard_canonical_agent_context()
+            instance.discard_context_assembly_observer()
             self._in_flight.discard(instance_key)
             self._last_activity[instance_key] = time.monotonic()
 

--- a/src/kai/workshop/client_api.py
+++ b/src/kai/workshop/client_api.py
@@ -136,6 +136,7 @@ from kai.workshop.collaboration_policy import (
     WorkshopCollaborationPolicyStorageError,
     WorkshopCollaborationPolicyValidationError,
 )
+from kai.workshop.context_manifests import RunContextManifest, WorkshopContextManifestService
 from kai.workshop.conversation_commands import ConversationCommandAcceptanceError
 from kai.workshop.direct_message_archives import (
     WorkshopDirectMessageArchiveAccessDenied,
@@ -378,6 +379,7 @@ _ARTIFACT_CONTENT_PATH = "/v1/channels/{channel_id}/artifacts/{artifact_id}/cont
 _ARTIFACT_DOWNLOAD_PATH = "/v1/channels/{channel_id}/artifacts/{artifact_id}/download"
 _RUN_STATE_PATH = "/v1/channels/{channel_id}/runs/{run_id}"
 _RUN_TRACE_PATH = "/v1/channels/{channel_id}/runs/{run_id}/trace"
+_RUN_CONTEXT_MANIFESTS_PATH = "/v1/channels/{channel_id}/runs/{run_id}/context-manifests"
 _RUN_CANCELLATION_PATH = "/v1/channels/{channel_id}/runs/{run_id}/cancel"
 _RUNTIME_SETTINGS_PATH = "/v1/channels/{channel_id}/settings"
 _EFFECTIVE_AGENT_RUNTIME_PATH = "/v1/channels/{channel_id}/effective-agent-runtime"
@@ -8030,6 +8032,60 @@ async def _handle_run_state(
     )
 
 
+def _serialize_context_manifest(manifest: RunContextManifest) -> dict[str, object]:
+    return {
+        "attempt_id": str(manifest.attempt_id),
+        "run_id": str(manifest.run_id),
+        "channel_id": str(manifest.channel_id),
+        "agent_id": str(manifest.agent_id),
+        "runtime_profile_id": str(manifest.draft.runtime_profile_id),
+        "backend": manifest.draft.selection.backend,
+        "provider": manifest.draft.selection.provider,
+        "model": manifest.draft.selection.model,
+        "workspace_kind": manifest.draft.workspace_kind,
+        "workspace_digest": manifest.draft.workspace_digest,
+        "provider_session_revision": manifest.draft.provider_session_revision,
+        "manifest_sha256": manifest.manifest_sha256,
+        "created_at": manifest.created_at.isoformat().replace("+00:00", "Z"),
+        "created_event_position": manifest.created_event_position,
+        "sources": [source.payload() for source in manifest.draft.sources],
+    }
+
+
+async def _handle_run_context_manifests(
+    request: web.Request,
+    *,
+    store: WorkshopEventStore,
+    authenticator: WorkshopClientAuthenticator,
+    submitter: WorkshopClientCommandSubmitter,
+    request_lock: asyncio.Lock,
+) -> web.Response:
+    if request.query:
+        return _error_response(status=400, code="invalid_request", message="Invalid context-manifest request")
+    authorized = await _authorized_run(
+        request,
+        authenticator=authenticator,
+        submitter=submitter,
+        request_lock=request_lock,
+    )
+    if isinstance(authorized, web.Response):
+        return authorized
+    principal_id, channel_id, run = authorized
+    async with request_lock:
+        manifests = await WorkshopContextManifestService(store).load_run(run.run_id)
+    if any(item.requested_by_principal_id != principal_id or item.channel_id != channel_id for item in manifests):
+        return _error_response(status=403, code="access_denied", message="Access denied")
+    return _json_response(
+        {
+            "version": 1,
+            "channel_id": str(channel_id),
+            "run_id": str(run.run_id),
+            "manifests": [_serialize_context_manifest(item) for item in manifests],
+        },
+        status=200,
+    )
+
+
 async def _handle_run_trace(
     request: web.Request,
     *,
@@ -9349,6 +9405,15 @@ def register_workshop_command_routes(
             collaboration_policy=collaboration_policy,
         )
 
+    async def handle_run_context_manifests(request: web.Request) -> web.Response:
+        return await _handle_run_context_manifests(
+            request,
+            store=store,
+            authenticator=authenticator,
+            submitter=submitter,
+            request_lock=request_lock,
+        )
+
     async def handle_run_cancellation(request: web.Request) -> web.Response:
         return await _handle_run_cancellation(
             request,
@@ -9368,5 +9433,6 @@ def register_workshop_command_routes(
     app.router.add_post(_COMMAND_SUBMISSION_PATH, handle_command_submission)
     app.router.add_get(_RUN_STATE_PATH, handle_run_state)
     app.router.add_get(_RUN_TRACE_PATH, handle_run_trace)
+    app.router.add_get(_RUN_CONTEXT_MANIFESTS_PATH, handle_run_context_manifests)
     app.router.add_post(_RUN_CANCELLATION_PATH, handle_run_cancellation)
     app.router.add_post(_AGENT_DISMISSAL_PATH, handle_agent_dismissal)

--- a/src/kai/workshop/context_manifests.py
+++ b/src/kai/workshop/context_manifests.py
@@ -1,0 +1,764 @@
+"""Redacted, replay-stable context manifests for canonical run attempts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from kai.workshop.domain import (
+    AgentId,
+    ChannelId,
+    EventEnvelope,
+    EventId,
+    PrincipalId,
+    RunAttemptId,
+    RunId,
+    RuntimeProfileId,
+    WorkshopEventType,
+    WorkshopId,
+)
+from kai.workshop.projection import CanonicalConversationProjection
+from kai.workshop.run_execution_authority import RunExecutionClaim, RunExecutionSelection
+from kai.workshop.store import WorkshopEventStore
+
+if TYPE_CHECKING:
+    from kai.backend import ContextAssemblyObservation
+
+_CODE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_REVISION = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,255}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ContextSourceKind(StrEnum):
+    HOST_POLICY = "host_policy"
+    PRINCIPAL_POLICY = "principal_policy"
+    AGENT_DEFINITION = "agent_definition"
+    WORKSPACE_POLICY = "workspace_policy"
+    PERSONAL_PREFERENCES = "personal_preferences"
+    FILE_MEMORY = "file_memory"
+    SEMANTIC_RECALL = "semantic_recall"
+    CANONICAL_CONVERSATION = "canonical_conversation"
+    CAPABILITY_GUIDANCE = "capability_guidance"
+    ATTEMPT_AUTHORITY = "attempt_authority"
+    CURRENT_INPUT = "current_input"
+    PROVIDER_NATIVE = "provider_native"
+
+
+CONTEXT_SOURCE_ORDER = tuple(ContextSourceKind)
+
+
+class ContextOwnerKind(StrEnum):
+    HOST = "host"
+    PRINCIPAL = "principal"
+    AGENT = "agent"
+    WORKSPACE = "workspace"
+    CHANNEL = "channel"
+    ATTEMPT = "attempt"
+    PROVIDER = "provider"
+
+
+class ContextTrustClass(StrEnum):
+    HOST_POLICY = "host_policy"
+    PRINCIPAL_POLICY = "principal_policy"
+    AGENT_DEFINITION = "agent_definition"
+    WORKSPACE_POLICY = "workspace_policy"
+    UNTRUSTED_DATA = "untrusted_data"
+    CAPABILITY_METADATA = "capability_metadata"
+    ATTEMPT_AUTHORITY = "attempt_authority"
+    CURRENT_INPUT = "current_input"
+    PROVIDER_CONTROLLED = "provider_controlled"
+
+
+class ContextAuthorityClass(StrEnum):
+    HOST = "host"
+    PRINCIPAL = "principal"
+    AGENT_OWNER = "agent_owner"
+    WORKSPACE_OWNER = "workspace_owner"
+    CANONICAL_DATA = "canonical_data"
+    CAPABILITY_CONTRACT = "capability_contract"
+    ATTEMPT = "attempt"
+    REQUESTER = "requester"
+    PROVIDER = "provider"
+
+
+class ContextRefreshClass(StrEnum):
+    DEPLOYMENT = "deployment"
+    SOURCE_REVISION = "source_revision"
+    PROVIDER_SESSION = "provider_session"
+    PER_ATTEMPT = "per_attempt"
+    PER_TURN = "per_turn"
+    PROVIDER_CONTROLLED = "provider_controlled"
+
+
+class ContextDeliveryRole(StrEnum):
+    NATIVE_INSTRUCTION = "native_instruction"
+    SESSION_CONTEXT = "session_context"
+    TURN_CONTEXT = "turn_context"
+    UNTRUSTED_CONTEXT = "untrusted_context"
+    ATTEMPT_CONTEXT = "attempt_context"
+    CURRENT_INPUT = "current_input"
+    PROVIDER_NATIVE = "provider_native"
+
+
+class ContextSourceState(StrEnum):
+    NEWLY_DELIVERED = "newly_delivered"
+    RETAINED = "retained"
+    OMITTED = "omitted"
+    UNAVAILABLE = "unavailable"
+    PROVIDER_CONTROLLED = "provider_controlled"
+
+
+@dataclass(frozen=True, slots=True)
+class ContextSourceDescriptor:
+    """One content-free description of a logical context source."""
+
+    kind: ContextSourceKind
+    owner_kind: ContextOwnerKind
+    owner_id: str | None
+    scope: str
+    trust_class: ContextTrustClass
+    authority_class: ContextAuthorityClass
+    refresh_class: ContextRefreshClass
+    delivery_role: ContextDeliveryRole
+    state: ContextSourceState
+    reason: str
+    revision: str | None = None
+    history_boundary: int | None = None
+    delivery_shape: str = "metadata"
+
+    def __post_init__(self) -> None:
+        for value, field_name in (
+            (self.scope, "scope"),
+            (self.reason, "reason"),
+            (self.delivery_shape, "delivery_shape"),
+        ):
+            if not isinstance(value, str) or _CODE.fullmatch(value) is None:
+                raise ValueError(f"{field_name} must be a bounded lowercase identifier")
+        if self.owner_id is not None and (
+            not isinstance(self.owner_id, str) or not self.owner_id or len(self.owner_id) > 128
+        ):
+            raise ValueError("owner_id must be a bounded identifier")
+        if self.revision is not None and _REVISION.fullmatch(self.revision) is None:
+            raise ValueError("revision must be a bounded revision identifier")
+        if self.history_boundary is not None and (
+            not isinstance(self.history_boundary, int)
+            or isinstance(self.history_boundary, bool)
+            or self.history_boundary < 0
+        ):
+            raise ValueError("history_boundary must be a non-negative integer")
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "owner_kind": self.owner_kind.value,
+            "owner_id": self.owner_id,
+            "scope": self.scope,
+            "trust_class": self.trust_class.value,
+            "authority_class": self.authority_class.value,
+            "refresh_class": self.refresh_class.value,
+            "delivery_role": self.delivery_role.value,
+            "state": self.state.value,
+            "reason": self.reason,
+            "revision": self.revision,
+            "history_boundary": self.history_boundary,
+            "delivery_shape": self.delivery_shape,
+        }
+
+    @classmethod
+    def from_payload(cls, value: object) -> ContextSourceDescriptor:
+        if not isinstance(value, dict) or set(value) != {
+            "kind",
+            "owner_kind",
+            "owner_id",
+            "scope",
+            "trust_class",
+            "authority_class",
+            "refresh_class",
+            "delivery_role",
+            "state",
+            "reason",
+            "revision",
+            "history_boundary",
+            "delivery_shape",
+        }:
+            raise ValueError("Context source descriptor has an invalid shape")
+        owner_id = value["owner_id"]
+        revision = value["revision"]
+        boundary = value["history_boundary"]
+        return cls(
+            kind=ContextSourceKind(str(value["kind"])),
+            owner_kind=ContextOwnerKind(str(value["owner_kind"])),
+            owner_id=None if owner_id is None else str(owner_id),
+            scope=str(value["scope"]),
+            trust_class=ContextTrustClass(str(value["trust_class"])),
+            authority_class=ContextAuthorityClass(str(value["authority_class"])),
+            refresh_class=ContextRefreshClass(str(value["refresh_class"])),
+            delivery_role=ContextDeliveryRole(str(value["delivery_role"])),
+            state=ContextSourceState(str(value["state"])),
+            reason=str(value["reason"]),
+            revision=None if revision is None else str(revision),
+            history_boundary=None if boundary is None else int(boundary),
+            delivery_shape=str(value["delivery_shape"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ContextManifestDraft:
+    runtime_profile_id: RuntimeProfileId
+    selection: RunExecutionSelection
+    workspace_kind: str
+    workspace_digest: str | None
+    provider_session_revision: str | None
+    sources: tuple[ContextSourceDescriptor, ...]
+
+    def __post_init__(self) -> None:
+        if self.workspace_kind not in {"home", "foreign", "unknown"}:
+            raise ValueError("workspace_kind is invalid")
+        for value, field_name in (
+            (self.workspace_digest, "workspace_digest"),
+            (self.provider_session_revision, "provider_session_revision"),
+        ):
+            if value is not None and _SHA256.fullmatch(value) is None:
+                raise ValueError(f"{field_name} must be a SHA-256 digest")
+        if tuple(source.kind for source in self.sources) != CONTEXT_SOURCE_ORDER:
+            raise ValueError("sources must contain every context kind exactly once in canonical order")
+
+
+@dataclass(frozen=True, slots=True)
+class RunContextManifest:
+    attempt_id: RunAttemptId
+    run_id: RunId
+    workshop_id: WorkshopId
+    channel_id: ChannelId
+    requested_by_principal_id: PrincipalId
+    agent_id: AgentId
+    draft: ContextManifestDraft
+    manifest_sha256: str
+    created_at: datetime
+    created_event_position: int
+
+
+def content_digest(value: object) -> str:
+    """Return a deterministic digest without retaining the source material."""
+    encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def manifest_digest(payload: dict[str, object]) -> str:
+    """Digest the redacted manifest body in its canonical JSON form."""
+    return content_digest(payload)
+
+
+def _timestamp(value: datetime) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("occurred_at must be timezone-aware")
+    return value.astimezone(UTC)
+
+
+def _draft_payload(draft: ContextManifestDraft) -> dict[str, object]:
+    return {
+        "runtime_profile_id": str(draft.runtime_profile_id),
+        "backend": draft.selection.backend,
+        "provider": draft.selection.provider,
+        "model": draft.selection.model,
+        "workspace_kind": draft.workspace_kind,
+        "workspace_digest": draft.workspace_digest,
+        "provider_session_revision": draft.provider_session_revision,
+        "sources": [source.payload() for source in draft.sources],
+    }
+
+
+def _manifest_body(
+    *,
+    run_id: RunId,
+    channel_id: ChannelId,
+    requested_by_principal_id: PrincipalId,
+    agent_id: AgentId,
+    draft: ContextManifestDraft,
+) -> dict[str, object]:
+    return {
+        "run_id": str(run_id),
+        "channel_id": str(channel_id),
+        "requested_by_principal_id": str(requested_by_principal_id),
+        "agent_id": str(agent_id),
+        **_draft_payload(draft),
+    }
+
+
+def validate_manifest_sources(value: object) -> tuple[ContextSourceDescriptor, ...]:
+    if not isinstance(value, list):
+        raise ValueError("Context manifest sources must be a list")
+    sources = tuple(ContextSourceDescriptor.from_payload(item) for item in value)
+    if tuple(source.kind for source in sources) != CONTEXT_SOURCE_ORDER:
+        raise ValueError("Context manifest sources are incomplete or out of canonical order")
+    return sources
+
+
+def validate_manifest_event_payload(payload: dict[str, Any]) -> tuple[ContextManifestDraft, str]:
+    expected = {
+        "run_id",
+        "channel_id",
+        "requested_by_principal_id",
+        "agent_id",
+        "runtime_profile_id",
+        "backend",
+        "provider",
+        "model",
+        "workspace_kind",
+        "workspace_digest",
+        "provider_session_revision",
+        "sources",
+        "manifest_sha256",
+    }
+    if set(payload) != expected:
+        raise ValueError("Context manifest event payload has an invalid shape")
+    provider = payload["provider"]
+    selection = RunExecutionSelection(
+        backend=str(payload["backend"]),
+        provider=None if provider is None else str(provider),
+        model=str(payload["model"]),
+    )
+    draft = ContextManifestDraft(
+        runtime_profile_id=RuntimeProfileId(str(payload["runtime_profile_id"])),
+        selection=selection,
+        workspace_kind=str(payload["workspace_kind"]),
+        workspace_digest=None if payload["workspace_digest"] is None else str(payload["workspace_digest"]),
+        provider_session_revision=(
+            None if payload["provider_session_revision"] is None else str(payload["provider_session_revision"])
+        ),
+        sources=validate_manifest_sources(payload["sources"]),
+    )
+    digest = str(payload["manifest_sha256"])
+    if _SHA256.fullmatch(digest) is None:
+        raise ValueError("Context manifest digest is invalid")
+    body = {key: value for key, value in payload.items() if key != "manifest_sha256"}
+    if manifest_digest(body) != digest:
+        raise ValueError("Context manifest digest does not match its redacted body")
+    return draft, digest
+
+
+def build_context_manifest_draft(
+    *,
+    runtime_profile_id: RuntimeProfileId,
+    selection: RunExecutionSelection,
+    workspace_kind: str,
+    workspace_digest: str | None,
+    provider_session_revision: str | None,
+    principal_id: PrincipalId,
+    agent_id: AgentId,
+    agent_revision: str,
+    agent_context_digest: str,
+    channel_id: ChannelId,
+    history_boundary: int,
+    history_digest: str,
+    current_input_digest: str,
+    attempt_id: RunAttemptId,
+    attempt_authority_revision: str | None,
+    observation: ContextAssemblyObservation,
+) -> ContextManifestDraft:
+    """Build the fixed source vocabulary from facts observed at dispatch."""
+    dispatch_reached = observation.provider_dispatch_reached is True
+    dispatch_reason = (
+        "provider_dispatch_reached"
+        if dispatch_reached
+        else "dispatch_not_reached"
+        if observation.provider_dispatch_reached is False
+        else "dispatch_state_unknown"
+    )
+    session_state = (
+        ContextSourceState.UNAVAILABLE
+        if not dispatch_reached
+        else ContextSourceState.NEWLY_DELIVERED
+        if observation.session_context_delivered
+        else ContextSourceState.RETAINED
+    )
+    session_reason = (
+        dispatch_reason
+        if not dispatch_reached
+        else "fresh_provider_session"
+        if observation.session_context_delivered
+        else "live_provider_session"
+    )
+    granular_session_state = ContextSourceState.UNAVAILABLE if observation.session_context_delivered else session_state
+    granular_session_reason = (
+        "bootstrap_source_not_individually_observable" if observation.session_context_delivered else session_reason
+    )
+    workspace_policy_state = (
+        ContextSourceState.NEWLY_DELIVERED
+        if dispatch_reached and observation.workspace_reminder_delivered
+        else ContextSourceState.UNAVAILABLE
+        if not dispatch_reached or observation.session_context_delivered
+        else ContextSourceState.RETAINED
+    )
+    workspace_policy_reason = (
+        dispatch_reason
+        if not dispatch_reached
+        else "foreign_workspace_reminder"
+        if observation.workspace_reminder_delivered
+        else granular_session_reason
+    )
+    semantic_state = (
+        ContextSourceState.NEWLY_DELIVERED if observation.semantic_recall_delivered else ContextSourceState.OMITTED
+    )
+    semantic_reason = _safe_code(observation.semantic_recall_reason, fallback="no_matches")
+    authority_state = (
+        ContextSourceState.NEWLY_DELIVERED
+        if dispatch_reached and attempt_authority_revision is not None
+        else ContextSourceState.UNAVAILABLE
+        if not dispatch_reached and attempt_authority_revision is not None
+        else ContextSourceState.OMITTED
+    )
+    authority_reason = (
+        "grant_delivered"
+        if dispatch_reached and attempt_authority_revision is not None
+        else dispatch_reason
+        if attempt_authority_revision is not None
+        else "no_grant"
+    )
+    effective_provider_session_revision = (
+        None
+        if not dispatch_reached
+        else content_digest(
+            {
+                "attempt_id": str(attempt_id),
+                "bootstrap_revision": observation.session_context_revision,
+            }
+        )
+        if observation.session_context_delivered
+        else provider_session_revision
+    )
+    session_revision = observation.session_context_revision or effective_provider_session_revision
+    sources = (
+        ContextSourceDescriptor(
+            ContextSourceKind.HOST_POLICY,
+            ContextOwnerKind.HOST,
+            None,
+            "service",
+            ContextTrustClass.HOST_POLICY,
+            ContextAuthorityClass.HOST,
+            ContextRefreshClass.PER_TURN,
+            ContextDeliveryRole.TURN_CONTEXT,
+            ContextSourceState.NEWLY_DELIVERED if dispatch_reached else ContextSourceState.UNAVAILABLE,
+            "host_turn_contract" if dispatch_reached else dispatch_reason,
+            revision="context_contract_v1",
+            delivery_shape="inline_host_marker",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.PRINCIPAL_POLICY,
+            ContextOwnerKind.PRINCIPAL,
+            str(principal_id),
+            "principal",
+            ContextTrustClass.PRINCIPAL_POLICY,
+            ContextAuthorityClass.PRINCIPAL,
+            ContextRefreshClass.PROVIDER_SESSION,
+            ContextDeliveryRole.SESSION_CONTEXT,
+            granular_session_state,
+            granular_session_reason,
+            revision=session_revision,
+            delivery_shape="protected_document_pointer",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.AGENT_DEFINITION,
+            ContextOwnerKind.AGENT,
+            str(agent_id),
+            "agent",
+            ContextTrustClass.AGENT_DEFINITION,
+            ContextAuthorityClass.AGENT_OWNER,
+            ContextRefreshClass.SOURCE_REVISION,
+            ContextDeliveryRole.TURN_CONTEXT,
+            ContextSourceState.NEWLY_DELIVERED if dispatch_reached else ContextSourceState.OMITTED,
+            "run_bound_revision" if dispatch_reached else dispatch_reason,
+            revision=f"{agent_revision}:{agent_context_digest}",
+            delivery_shape="inline_redacted_block",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.WORKSPACE_POLICY,
+            ContextOwnerKind.WORKSPACE,
+            workspace_digest,
+            "workspace",
+            ContextTrustClass.WORKSPACE_POLICY,
+            ContextAuthorityClass.WORKSPACE_OWNER,
+            ContextRefreshClass.PER_TURN,
+            ContextDeliveryRole.SESSION_CONTEXT,
+            workspace_policy_state,
+            workspace_policy_reason,
+            revision=observation.workspace_reminder_revision or session_revision,
+            delivery_shape="bootstrap_or_reminder",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.PERSONAL_PREFERENCES,
+            ContextOwnerKind.PRINCIPAL,
+            str(principal_id),
+            "principal",
+            ContextTrustClass.UNTRUSTED_DATA,
+            ContextAuthorityClass.PRINCIPAL,
+            ContextRefreshClass.PROVIDER_SESSION,
+            ContextDeliveryRole.UNTRUSTED_CONTEXT,
+            granular_session_state,
+            granular_session_reason,
+            revision=session_revision,
+            delivery_shape="protected_document_pointer",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.FILE_MEMORY,
+            ContextOwnerKind.PRINCIPAL,
+            str(principal_id),
+            "principal",
+            ContextTrustClass.UNTRUSTED_DATA,
+            ContextAuthorityClass.PRINCIPAL,
+            ContextRefreshClass.PROVIDER_SESSION,
+            ContextDeliveryRole.UNTRUSTED_CONTEXT,
+            granular_session_state,
+            granular_session_reason,
+            revision=session_revision,
+            delivery_shape="protected_document_pointer",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.SEMANTIC_RECALL,
+            ContextOwnerKind.PRINCIPAL,
+            str(principal_id),
+            "principal",
+            ContextTrustClass.UNTRUSTED_DATA,
+            ContextAuthorityClass.CANONICAL_DATA,
+            ContextRefreshClass.PER_TURN,
+            ContextDeliveryRole.UNTRUSTED_CONTEXT,
+            semantic_state,
+            semantic_reason,
+            revision=observation.semantic_recall_revision,
+            delivery_shape="scoped_recall_block",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.CANONICAL_CONVERSATION,
+            ContextOwnerKind.CHANNEL,
+            str(channel_id),
+            "channel",
+            ContextTrustClass.UNTRUSTED_DATA,
+            ContextAuthorityClass.CANONICAL_DATA,
+            ContextRefreshClass.PROVIDER_SESSION,
+            ContextDeliveryRole.UNTRUSTED_CONTEXT,
+            session_state,
+            session_reason,
+            revision=history_digest,
+            history_boundary=history_boundary,
+            delivery_shape="bounded_canonical_timeline",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.CAPABILITY_GUIDANCE,
+            ContextOwnerKind.HOST,
+            None,
+            "service",
+            ContextTrustClass.CAPABILITY_METADATA,
+            ContextAuthorityClass.CAPABILITY_CONTRACT,
+            ContextRefreshClass.PROVIDER_SESSION,
+            ContextDeliveryRole.SESSION_CONTEXT,
+            granular_session_state,
+            granular_session_reason,
+            revision=session_revision or "capability_guidance_v1",
+            delivery_shape="generated_guidance",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.ATTEMPT_AUTHORITY,
+            ContextOwnerKind.ATTEMPT,
+            str(attempt_id),
+            "attempt",
+            ContextTrustClass.ATTEMPT_AUTHORITY,
+            ContextAuthorityClass.ATTEMPT,
+            ContextRefreshClass.PER_ATTEMPT,
+            ContextDeliveryRole.ATTEMPT_CONTEXT,
+            authority_state,
+            authority_reason,
+            revision=attempt_authority_revision,
+            delivery_shape="proof_excluded",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.CURRENT_INPUT,
+            ContextOwnerKind.PRINCIPAL,
+            str(principal_id),
+            "attempt",
+            ContextTrustClass.CURRENT_INPUT,
+            ContextAuthorityClass.REQUESTER,
+            ContextRefreshClass.PER_TURN,
+            ContextDeliveryRole.CURRENT_INPUT,
+            ContextSourceState.NEWLY_DELIVERED if dispatch_reached else ContextSourceState.OMITTED,
+            "accepted_input" if dispatch_reached else dispatch_reason,
+            revision=current_input_digest,
+            delivery_shape="native_user_input",
+        ),
+        ContextSourceDescriptor(
+            ContextSourceKind.PROVIDER_NATIVE,
+            ContextOwnerKind.PROVIDER,
+            selection.provider,
+            "provider",
+            ContextTrustClass.PROVIDER_CONTROLLED,
+            ContextAuthorityClass.PROVIDER,
+            ContextRefreshClass.PROVIDER_CONTROLLED,
+            ContextDeliveryRole.PROVIDER_NATIVE,
+            (
+                ContextSourceState.UNAVAILABLE
+                if observation.provider_dispatch_reached is False
+                else ContextSourceState.PROVIDER_CONTROLLED
+            ),
+            "dispatch_not_reached" if observation.provider_dispatch_reached is False else "not_observable",
+            delivery_shape="provider_managed_unknown",
+        ),
+    )
+    return ContextManifestDraft(
+        runtime_profile_id=runtime_profile_id,
+        selection=selection,
+        workspace_kind=workspace_kind,
+        workspace_digest=workspace_digest,
+        provider_session_revision=effective_provider_session_revision,
+        sources=sources,
+    )
+
+
+def _safe_code(value: str, *, fallback: str) -> str:
+    normalized = re.sub(r"[^a-z0-9_]+", "_", value.strip().lower()).strip("_")[:64]
+    return normalized if normalized and _CODE.fullmatch(normalized) else fallback
+
+
+class WorkshopContextManifestService:
+    """Persist and read immutable manifests at the run-attempt boundary."""
+
+    def __init__(self, store: WorkshopEventStore) -> None:
+        self._store = store
+
+    async def available(self) -> bool:
+        async with self._store.connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'run_context_manifests'"
+        ) as cursor:
+            return await cursor.fetchone() is not None
+
+    async def record(
+        self,
+        claim: RunExecutionClaim,
+        draft: ContextManifestDraft,
+        *,
+        occurred_at: datetime,
+    ) -> RunContextManifest:
+        if not isinstance(claim, RunExecutionClaim) or not isinstance(draft, ContextManifestDraft):
+            raise TypeError("claim and draft must be canonical context-manifest values")
+        occurred_at = _timestamp(occurred_at)
+        connection = self._store.connection
+        try:
+            await connection.execute("BEGIN IMMEDIATE")
+            projection = CanonicalConversationProjection()
+            await self._store.project_pending_in_transaction(projection)
+            async with connection.execute(
+                "SELECT ra.run_id, ra.owner_id, ra.fence_token, ra.backend, ra.provider, ra.model, "
+                "r.workshop_id, r.channel_id, r.requested_by_principal_id, r.agent_id, "
+                "r.runtime_profile_id, a.principal_id FROM run_attempts ra "
+                "JOIN runs r ON r.id = ra.run_id JOIN agents a ON a.id = r.agent_id "
+                "WHERE ra.id = ?",
+                (claim.attempt_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+            if row is None or (
+                str(row[0]) != str(claim.run_id)
+                or str(row[1]) != str(claim.owner_id)
+                or int(row[2]) != claim.fence_token
+                or str(row[3]) != draft.selection.backend
+                or (None if row[4] is None else str(row[4])) != draft.selection.provider
+                or str(row[5]) != draft.selection.model
+                or str(row[10]) != str(draft.runtime_profile_id)
+            ):
+                raise ValueError("Context manifest does not match its fenced run attempt")
+            workshop_id = WorkshopId(str(row[6]))
+            channel_id = ChannelId(str(row[7]))
+            requester = PrincipalId(str(row[8]))
+            agent_id = AgentId(str(row[9]))
+            body = _manifest_body(
+                run_id=claim.run_id,
+                channel_id=channel_id,
+                requested_by_principal_id=requester,
+                agent_id=agent_id,
+                draft=draft,
+            )
+            digest = manifest_digest(body)
+            existing = await self.load_attempt(claim.attempt_id)
+            if existing is not None:
+                if existing.manifest_sha256 != digest:
+                    raise ValueError("Context manifest attempt already has different immutable facts")
+                await connection.commit()
+                return existing
+            event = EventEnvelope.create(
+                event_id=EventId.derived(claim.attempt_id, "context-manifest"),
+                event_type=WorkshopEventType.RUN_ATTEMPT_CONTEXT_MANIFEST_RECORDED,
+                event_version=1,
+                workshop_id=workshop_id,
+                aggregate_type="run_attempt",
+                aggregate_id=claim.attempt_id,
+                actor_principal_id=PrincipalId(str(row[11])),
+                occurred_at=occurred_at,
+                idempotency_key=f"workshop-context-manifest:v1:{claim.attempt_id}",
+                payload={**body, "manifest_sha256": digest},
+                metadata={"source": "workshop_context_manifest"},
+            )
+            await self._store.append_in_transaction(event)
+            await self._store.project_pending_in_transaction(projection)
+            manifest = await self.load_attempt(claim.attempt_id)
+            if manifest is None:
+                raise RuntimeError("Context manifest projection did not persist the recorded event")
+            await connection.commit()
+            return manifest
+        except Exception:
+            await connection.rollback()
+            raise
+
+    async def load_attempt(self, attempt_id: RunAttemptId) -> RunContextManifest | None:
+        async with self._store.connection.execute(
+            "SELECT attempt_id, run_id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
+            "runtime_profile_id, backend, provider, model, workspace_kind, workspace_digest, "
+            "provider_session_revision, sources_json, manifest_sha256, created_at, created_event_position "
+            "FROM run_context_manifests WHERE attempt_id = ?",
+            (attempt_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+        return None if row is None else _manifest_from_row(row)
+
+    async def load_run(self, run_id: RunId) -> tuple[RunContextManifest, ...]:
+        async with self._store.connection.execute(
+            "SELECT attempt_id, run_id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
+            "runtime_profile_id, backend, provider, model, workspace_kind, workspace_digest, "
+            "provider_session_revision, sources_json, manifest_sha256, created_at, created_event_position "
+            "FROM run_context_manifests WHERE run_id = ? ORDER BY created_event_position, attempt_id",
+            (run_id,),
+        ) as cursor:
+            rows = list(await cursor.fetchall())
+        return tuple(_manifest_from_row(row) for row in rows)
+
+
+def _manifest_from_row(row: Sequence[Any]) -> RunContextManifest:
+    values = tuple(row)
+    provider = values[8]
+    sources = validate_manifest_sources(json.loads(str(values[13])))
+    draft = ContextManifestDraft(
+        runtime_profile_id=RuntimeProfileId(str(values[6])),
+        selection=RunExecutionSelection(
+            backend=str(values[7]),
+            provider=None if provider is None else str(provider),
+            model=str(values[9]),
+        ),
+        workspace_kind=str(values[10]),
+        workspace_digest=None if values[11] is None else str(values[11]),
+        provider_session_revision=None if values[12] is None else str(values[12]),
+        sources=sources,
+    )
+    return RunContextManifest(
+        attempt_id=RunAttemptId(str(values[0])),
+        run_id=RunId(str(values[1])),
+        workshop_id=WorkshopId(str(values[2])),
+        channel_id=ChannelId(str(values[3])),
+        requested_by_principal_id=PrincipalId(str(values[4])),
+        agent_id=AgentId(str(values[5])),
+        draft=draft,
+        manifest_sha256=str(values[14]),
+        created_at=datetime.fromisoformat(str(values[15]).replace("Z", "+00:00")).astimezone(UTC),
+        created_event_position=int(values[16]),
+    )

--- a/src/kai/workshop/diagnostics.py
+++ b/src/kai/workshop/diagnostics.py
@@ -1519,6 +1519,60 @@ def workshop_runtime_session_status(db_path: Path) -> str:
     )
 
 
+def workshop_context_manifest_status(db_path: Path) -> str:
+    """Describe post-cutover run-attempt manifest coverage and integrity."""
+    prefix = "Workshop context manifests:"
+    if not db_path.is_file():
+        return f"{prefix} pending; canonical manifest schema unavailable"
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        try:
+            connection.execute("PRAGMA query_only=ON")
+            tables = {
+                str(row[0])
+                for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+            }
+            required = {"workshop_context_manifest_cutover", "run_context_manifests", "run_attempts"}
+            if not tables >= required:
+                return f"{prefix} pending; canonical manifest schema unavailable"
+            cutover_row = connection.execute(
+                "SELECT event_position FROM workshop_context_manifest_cutover WHERE singleton = 1"
+            ).fetchone()
+            if cutover_row is None:
+                return f"{prefix} pending; canonical manifest cutover unavailable"
+            cutover = int(cutover_row[0])
+            attempts = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM run_attempts WHERE last_event_position > ?",
+                (cutover,),
+            )
+            manifests = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM run_context_manifests WHERE created_event_position > ?",
+                (cutover,),
+            )
+            missing = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM run_attempts ra WHERE ra.last_event_position > ? "
+                "AND NOT EXISTS (SELECT 1 FROM run_context_manifests m WHERE m.attempt_id = ra.id)",
+                (cutover,),
+            )
+            malformed = _scalar(
+                connection,
+                "SELECT COUNT(*) FROM run_context_manifests WHERE json_valid(sources_json) = 0 "
+                "OR json_array_length(sources_json) != 12",
+            )
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error, TypeError, ValueError) as exc:
+        return f"{prefix} NOT VERIFIED ({type(exc).__name__})"
+    state = "active" if missing == 0 and malformed == 0 else "INCOMPLETE"
+    return (
+        f"{prefix} {state}; post-cutover attempts={attempts}, manifests={manifests}, "
+        f"missing={missing}, malformed={malformed}; authority=immutable/redacted"
+    )
+
+
 def workshop_execution_state_status(db_path: Path) -> str:
     """Describe canonical mutable execution-state authority and backfill."""
     prefix = "Workshop execution state:"

--- a/src/kai/workshop/domain.py
+++ b/src/kai/workshop/domain.py
@@ -84,6 +84,7 @@ class WorkshopEventType(StrEnum):
     RUN_ATTEMPT_COMPLETED = "run_attempt.completed"
     RUN_ATTEMPT_FAILED = "run_attempt.failed"
     RUN_ATTEMPT_CANCELLED = "run_attempt.cancelled"
+    RUN_ATTEMPT_CONTEXT_MANIFEST_RECORDED = "run_attempt.context_manifest_recorded"
     COLLABORATION_GRANT_ISSUED = "collaboration_grant.issued"
     COLLABORATION_GRANT_REVOKED = "collaboration_grant.revoked"
     COLLABORATION_OPERATION_DECIDED = "collaboration_operation.decided"

--- a/src/kai/workshop/execution_coordinator.py
+++ b/src/kai/workshop/execution_coordinator.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Protocol
 
 from kai.agent_failure import AgentFailureKind
-from kai.backend import AgentResponse, StreamEvent
+from kai.backend import AgentResponse, ContextAssemblyObservation, StreamEvent
 from kai.workshop.agent_definitions import (
     load_agent_definition_revision,
     render_agent_definition_context,
@@ -26,9 +26,21 @@ from kai.workshop.collaboration_authority import (
     CollaborationOperation,
     WorkshopCollaborationAuthority,
 )
+from kai.workshop.context_manifests import (
+    WorkshopContextManifestService,
+    build_context_manifest_draft,
+    content_digest,
+)
 from kai.workshop.conversation_context import assemble_canonical_conversation_context
 from kai.workshop.delivery_policy import WorkshopDeliveryBindingPolicy
-from kai.workshop.domain import AgentDefinitionId, AgentId, ChannelId, RunExecutionOwnerId, RunId
+from kai.workshop.domain import (
+    AgentDefinitionId,
+    AgentId,
+    ChannelId,
+    RunExecutionOwnerId,
+    RunId,
+    RuntimeProfileId,
+)
 from kai.workshop.protected_execution import (
     PreparedWorkshopExecution,
     ProtectedExecutionRoutingRejected,
@@ -42,7 +54,7 @@ from kai.workshop.run_execution_authority import (
 )
 from kai.workshop.run_lifecycle import DurableRun, RunKind, RunStatus, WorkshopRunLifecycle
 from kai.workshop.run_traces import WorkshopRunTraceStore
-from kai.workshop.runtime_sessions import RuntimeSessionSettlement
+from kai.workshop.runtime_sessions import RuntimeSessionSettlement, load_runtime_session
 from kai.workshop.standing_observation import (
     StandingObserveSettlement,
     WorkshopStandingObservationService,
@@ -351,11 +363,19 @@ class WorkshopCanonicalExecutionCoordinator:
             for attempt in attempts:
                 authority = self._authority(attempt.selection)
                 claim = RunExecutionClaim.from_attempt(attempt)
+                run = await WorkshopRunLifecycle(self._store).state(attempt.run_id)
+                if run.runtime_profile_id is not None:
+                    await self._record_unprepared_manifest_locked(
+                        run,
+                        claim,
+                        runtime_profile_id=run.runtime_profile_id,
+                        selection=attempt.selection,
+                        dispatch_reached=(False if attempt.status == RunAttemptStatus.GRANTED else None),
+                    )
                 if attempt.status == RunAttemptStatus.GRANTED:
                     await authority.expire_grant(claim, occurred_at=now)
                     expired += 1
                 else:
-                    run = await WorkshopRunLifecycle(self._store).state(attempt.run_id)
                     if run.kind == RunKind.OBSERVE:
                         await authority.interrupt_observe_expired(
                             claim,
@@ -403,6 +423,7 @@ class WorkshopCanonicalExecutionCoordinator:
             active.ready.set()
 
             if active.cancellation_requested:
+                await self._record_undispatched_manifest(active, prepared)
                 return await self._settle_requested_cancellation(active)
 
             prepared.validate_current()
@@ -569,6 +590,16 @@ class WorkshopCanonicalExecutionCoordinator:
                 active.claim = started.claim
                 active.started = True
                 active.ready.set()
+                runtime_profile_id = run.runtime_profile_id
+                if runtime_profile_id is None:
+                    raise RuntimeError("accepted run is missing its canonical runtime profile") from rejection
+                await self._record_unprepared_manifest_locked(
+                    run,
+                    started.claim,
+                    runtime_profile_id=runtime_profile_id,
+                    selection=rejection.decision.selection,
+                    dispatch_reached=False,
+                )
                 if run.kind == RunKind.OBSERVE:
                     if await self._collaboration_authority.available():
                         grant, active.collaboration_invocation = await self._collaboration_authority.issue(
@@ -605,6 +636,8 @@ class WorkshopCanonicalExecutionCoordinator:
             )
         except Exception:
             if active.cancellation_requested and active.claim is not None:
+                if active.prepared is not None:
+                    await self._record_undispatched_manifest(active, active.prepared)
                 return await self._settle_requested_cancellation(active)
             if active.settling:
                 raise
@@ -644,6 +677,8 @@ class WorkshopCanonicalExecutionCoordinator:
                     selection=active.prepared.selection if active.prepared is not None else None,
                 )
             log.exception("Workshop run %s preparation deferred", run.run_id)
+            if active.claim is not None and active.prepared is not None:
+                await self._record_undispatched_manifest(active, active.prepared)
             return CanonicalExecutionResult(
                 CanonicalExecutionDisposition.PREPARATION_DEFERRED, await self._run(run.run_id)
             )
@@ -663,6 +698,125 @@ class WorkshopCanonicalExecutionCoordinator:
                     # attempted, so failure remains fail-closed. Recovery and
                     # diagnostics can reconcile the immutable grant later.
                     log.exception("Workshop collaboration-grant revocation could not be recorded")
+
+    async def _record_undispatched_manifest(
+        self,
+        active: _ActiveExecution,
+        prepared: PreparedWorkshopExecution,
+    ) -> None:
+        """Record an honest omitted-source manifest when dispatch never begins."""
+        if active.claim is None:
+            return
+        claim = active.claim
+        async with self._database_lock:
+            service = WorkshopContextManifestService(self._store)
+            if not await service.available() or await service.load_attempt(claim.attempt_id) is not None:
+                return
+            context = await assemble_canonical_conversation_context(self._store, prepared.run)
+            revision_id = prepared.run.agent_definition_revision_id
+            if revision_id is None:
+                return
+            definition_revision = await load_agent_definition_revision(self._store, revision_id)
+            if definition_revision is None:
+                return
+            async with self._store.connection.execute(
+                "SELECT body FROM messages WHERE id = ? AND channel_id = ?",
+                (prepared.run.inbound_message_id, prepared.run.channel_id),
+            ) as cursor:
+                input_row = await cursor.fetchone()
+            if input_row is None:
+                return
+            agent_context = render_agent_definition_context(definition_revision)
+            workspace_digest = content_digest(str(prepared.workspace.resolve()))
+            draft = build_context_manifest_draft(
+                runtime_profile_id=prepared.runtime_profile_id,
+                selection=prepared.selection,
+                workspace_kind=(
+                    "home" if prepared.workspace.resolve() == prepared.home_workspace.resolve() else "foreign"
+                ),
+                workspace_digest=workspace_digest,
+                provider_session_revision=None,
+                principal_id=prepared.run.requested_by_principal_id,
+                agent_id=prepared.run.agent_id,
+                agent_revision=str(definition_revision.revision_id),
+                agent_context_digest=content_digest(agent_context),
+                channel_id=prepared.run.channel_id,
+                history_boundary=context.through_event_position,
+                history_digest=content_digest(context.text),
+                current_input_digest=content_digest(str(input_row[0])),
+                attempt_id=claim.attempt_id,
+                attempt_authority_revision=None,
+                observation=ContextAssemblyObservation(
+                    provider_dispatch_reached=False,
+                    session_context_delivered=False,
+                    session_context_revision=None,
+                    semantic_recall_attempted=False,
+                    semantic_recall_delivered=False,
+                    semantic_recall_reason="dispatch_not_reached",
+                    semantic_recall_revision=None,
+                    workspace_reminder_delivered=False,
+                ),
+            )
+            await service.record(claim, draft, occurred_at=self._now())
+
+    async def _record_unprepared_manifest_locked(
+        self,
+        run: DurableRun,
+        claim: RunExecutionClaim,
+        *,
+        runtime_profile_id: RuntimeProfileId,
+        selection: RunExecutionSelection,
+        dispatch_reached: bool | None,
+    ) -> None:
+        """Record a content-free manifest when no prepared runtime survives."""
+        service = WorkshopContextManifestService(self._store)
+        if not await service.available() or await service.load_attempt(claim.attempt_id) is not None:
+            return
+        context = await assemble_canonical_conversation_context(self._store, run)
+        revision_id = run.agent_definition_revision_id
+        if revision_id is None:
+            return
+        definition_revision = await load_agent_definition_revision(self._store, revision_id)
+        if definition_revision is None or definition_revision.agent_id != run.agent_id:
+            return
+        async with self._store.connection.execute(
+            "SELECT body FROM messages WHERE id = ? AND channel_id = ?",
+            (run.inbound_message_id, run.channel_id),
+        ) as cursor:
+            input_row = await cursor.fetchone()
+        if input_row is None:
+            return
+        agent_context = render_agent_definition_context(definition_revision)
+        draft = build_context_manifest_draft(
+            runtime_profile_id=runtime_profile_id,
+            selection=selection,
+            workspace_kind="unknown",
+            workspace_digest=None,
+            provider_session_revision=None,
+            principal_id=run.requested_by_principal_id,
+            agent_id=run.agent_id,
+            agent_revision=str(definition_revision.revision_id),
+            agent_context_digest=content_digest(agent_context),
+            channel_id=run.channel_id,
+            history_boundary=context.through_event_position,
+            history_digest=content_digest(context.text),
+            current_input_digest=content_digest(str(input_row[0])),
+            attempt_id=claim.attempt_id,
+            attempt_authority_revision=None,
+            observation=ContextAssemblyObservation(
+                provider_dispatch_reached=dispatch_reached,
+                session_context_delivered=False,
+                session_context_revision=None,
+                semantic_recall_attempted=False,
+                semantic_recall_delivered=False,
+                semantic_recall_reason=(
+                    "dispatch_not_reached" if dispatch_reached is False else "dispatch_state_unknown"
+                ),
+                semantic_recall_revision=None,
+                workspace_reminder_delivered=False,
+            ),
+        )
+        await service.record(claim, draft, occurred_at=self._now())
 
     async def _settle_requested_cancellation(self, active: _ActiveExecution) -> CanonicalExecutionResult:
         await active.cancellation_done.wait()
@@ -756,6 +910,13 @@ class WorkshopCanonicalExecutionCoordinator:
             definition_revision = await load_agent_definition_revision(self._store, revision_id)
             if definition_revision is None or definition_revision.agent_id != prepared.run.agent_id:
                 raise RuntimeError("Canonical run agent definition revision is unavailable")
+            prior_session = await load_runtime_session(
+                self._store,
+                prepared.run.channel_id,
+                prepared.run.agent_id,
+            )
+            manifest_service = WorkshopContextManifestService(self._store)
+            manifest_available = await manifest_service.available()
         history = context.text
         if self._transcript_projection is not None:
             try:
@@ -771,30 +932,108 @@ class WorkshopCanonicalExecutionCoordinator:
                 log.warning("Canonical transcript projection refresh failed", exc_info=True)
             else:
                 history = _history_with_transcript_pointer(history, transcript_path)
+        agent_context = render_agent_definition_context(definition_revision)
         prepared.stage_canonical_history(history)
-        prepared.stage_agent_definition_context(render_agent_definition_context(definition_revision))
+        prepared.stage_agent_definition_context(agent_context)
+        assert active.claim is not None
+        claim = active.claim
+        workspace_digest = content_digest(str(prepared.workspace.resolve()))
+        provider_session_revision = None
+        if (
+            prior_session is not None
+            and prior_session.runtime_profile_id == prepared.runtime_profile_id
+            and prior_session.selection == prepared.selection
+            and Path(prior_session.workspace).resolve() == prepared.workspace.resolve()
+        ):
+            provider_session_revision = content_digest(
+                {
+                    "channel_id": str(prior_session.channel_id),
+                    "agent_id": str(prior_session.agent_id),
+                    "last_run_id": str(prior_session.last_run_id),
+                    "context_through_event_position": prior_session.context_through_event_position,
+                }
+            )
+        attempt_authority_revision = (
+            content_digest(
+                {
+                    "attempt_id": str(claim.attempt_id),
+                    "operations": sorted(operation.value for operation in active.collaboration_operations),
+                }
+            )
+            if active.collaboration_invocation is not None
+            else None
+        )
+        manifest_recorded = False
+
+        async def record_manifest(observation: ContextAssemblyObservation) -> None:
+            nonlocal manifest_recorded
+            draft = build_context_manifest_draft(
+                runtime_profile_id=prepared.runtime_profile_id,
+                selection=prepared.selection,
+                workspace_kind=(
+                    "home" if prepared.workspace.resolve() == prepared.home_workspace.resolve() else "foreign"
+                ),
+                workspace_digest=workspace_digest,
+                provider_session_revision=provider_session_revision,
+                principal_id=prepared.run.requested_by_principal_id,
+                agent_id=prepared.run.agent_id,
+                agent_revision=str(definition_revision.revision_id),
+                agent_context_digest=content_digest(agent_context),
+                channel_id=prepared.run.channel_id,
+                history_boundary=context.through_event_position,
+                history_digest=content_digest(history),
+                current_input_digest=content_digest(prompt),
+                attempt_id=claim.attempt_id,
+                attempt_authority_revision=attempt_authority_revision,
+                observation=observation,
+            )
+            async with self._database_lock:
+                await manifest_service.record(
+                    claim,
+                    draft,
+                    occurred_at=self._now(),
+                )
+            manifest_recorded = True
+
+        if manifest_available:
+            prepared.stage_context_assembly_observer(record_manifest)
         response: AgentResponse | None = None
         traces_truncated = False
-        async for event in prepared.stream(prompt):
-            if active.collaboration_invocation is not None:
-                event = _redact_collaboration_event(event, active.collaboration_invocation)
-            if event.done:
-                response = event.response
-                break
-            if event.trace is not None and not traces_truncated:
-                # Persisted under the current fenced claim so a
-                # superseded attempt cannot write; staleness raises
-                # and aborts the doomed attempt, the same posture the
-                # lease-renewal task takes. Once the run's cap is
-                # reached, later trace events skip the write
-                # transaction entirely.
-                assert active.claim is not None
-                async with self._database_lock:
-                    appended = await self._trace_store.append(active.claim, event.trace, occurred_at=self._now())
-                if not appended:
-                    traces_truncated = True
-            if stream_observer is not None:
-                await stream_observer(event)
+        try:
+            async for event in prepared.stream(prompt):
+                if active.collaboration_invocation is not None:
+                    event = _redact_collaboration_event(event, active.collaboration_invocation)
+                if event.done:
+                    response = event.response
+                    break
+                if event.trace is not None and not traces_truncated:
+                    # Persisted under the current fenced claim so a
+                    # superseded attempt cannot write; staleness raises
+                    # and aborts the doomed attempt, the same posture the
+                    # lease-renewal task takes. Once the run's cap is
+                    # reached, later trace events skip the write
+                    # transaction entirely.
+                    assert active.claim is not None
+                    async with self._database_lock:
+                        appended = await self._trace_store.append(active.claim, event.trace, occurred_at=self._now())
+                    if not appended:
+                        traces_truncated = True
+                if stream_observer is not None:
+                    await stream_observer(event)
+        finally:
+            if manifest_available and not manifest_recorded:
+                await record_manifest(
+                    ContextAssemblyObservation(
+                        provider_dispatch_reached=False,
+                        session_context_delivered=False,
+                        session_context_revision=None,
+                        semantic_recall_attempted=False,
+                        semantic_recall_delivered=False,
+                        semantic_recall_reason="dispatch_not_reached",
+                        semantic_recall_revision=None,
+                        workspace_reminder_delivered=False,
+                    )
+                )
         return response
 
     async def _consume_with_renewal(

--- a/src/kai/workshop/projection.py
+++ b/src/kai/workshop/projection.py
@@ -1177,6 +1177,90 @@ async def _apply_run_attempt_event(connection: aiosqlite.Connection, event: Stor
     )
 
 
+async def _apply_run_context_manifest_event(
+    connection: aiosqlite.Connection,
+    event: StoredEvent,
+) -> None:
+    """Project one immutable, content-free manifest for a fenced attempt."""
+    from kai.workshop.context_manifests import validate_manifest_event_payload
+
+    envelope = event.envelope
+    if not isinstance(envelope.aggregate_id, RunAttemptId) or envelope.aggregate_type != "run_attempt":
+        raise ValueError("Workshop context manifests require a typed run-attempt aggregate")
+    if envelope.event_version != 1:
+        raise ValueError("Unsupported Workshop context-manifest event version")
+    draft, digest = validate_manifest_event_payload(envelope.payload)
+    run_id = RunId(_required_text(envelope.payload, "run_id"))
+    channel_id = ChannelId(_required_text(envelope.payload, "channel_id"))
+    requester = PrincipalId(_required_text(envelope.payload, "requested_by_principal_id"))
+    agent_id = AgentId(_required_text(envelope.payload, "agent_id"))
+    async with connection.execute(
+        "SELECT ra.run_id, ra.status, ra.backend, ra.provider, ra.model, "
+        "r.workshop_id, r.channel_id, r.requested_by_principal_id, r.agent_id, "
+        "r.runtime_profile_id, a.principal_id FROM run_attempts ra "
+        "JOIN runs r ON r.id = ra.run_id JOIN agents a ON a.id = r.agent_id "
+        "WHERE ra.id = ?",
+        (envelope.aggregate_id,),
+    ) as cursor:
+        row = await cursor.fetchone()
+    if (
+        row is None
+        or RunId(str(row[0])) != run_id
+        or str(row[1]) not in {"granted", "started"}
+        or str(row[2]) != draft.selection.backend
+        or (None if row[3] is None else str(row[3])) != draft.selection.provider
+        or str(row[4]) != draft.selection.model
+        or WorkshopId(str(row[5])) != envelope.workshop_id
+        or ChannelId(str(row[6])) != channel_id
+        or PrincipalId(str(row[7])) != requester
+        or AgentId(str(row[8])) != agent_id
+        or RuntimeProfileId(str(row[9])) != draft.runtime_profile_id
+        or envelope.actor_principal_id != PrincipalId(str(row[10]))
+    ):
+        raise ValueError("Workshop context manifest does not match its started execution attempt")
+    sources_json = json.dumps(
+        [source.payload() for source in draft.sources],
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    async with connection.execute(
+        "SELECT manifest_sha256 FROM run_context_manifests WHERE attempt_id = ?",
+        (envelope.aggregate_id,),
+    ) as cursor:
+        existing = await cursor.fetchone()
+    if existing is not None:
+        if str(existing[0]) != digest:
+            raise ValueError("Workshop context manifest immutable replay conflicts with existing facts")
+        return
+    await connection.execute(
+        "INSERT INTO run_context_manifests "
+        "(attempt_id, run_id, workshop_id, channel_id, requested_by_principal_id, agent_id, "
+        "runtime_profile_id, backend, provider, model, workspace_kind, workspace_digest, "
+        "provider_session_revision, sources_json, manifest_sha256, created_at, created_event_position) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            envelope.aggregate_id,
+            run_id,
+            envelope.workshop_id,
+            channel_id,
+            requester,
+            agent_id,
+            draft.runtime_profile_id,
+            draft.selection.backend,
+            draft.selection.provider,
+            draft.selection.model,
+            draft.workspace_kind,
+            draft.workspace_digest,
+            draft.provider_session_revision,
+            sources_json,
+            digest,
+            envelope.occurred_at.isoformat(),
+            event.position,
+        ),
+    )
+
+
 async def _apply_collaboration_grant_event(
     connection: aiosqlite.Connection,
     event: StoredEvent,
@@ -2089,6 +2173,7 @@ class CanonicalConversationProjection:
             "collaboration_reaction_receipts",
             "collaboration_operation_decisions",
             "collaboration_grants",
+            "run_context_manifests",
             "run_attempts",
             "runs",
             "human_notification_adapter_delivery_decisions",
@@ -2238,6 +2323,10 @@ class CanonicalConversationProjection:
             WorkshopEventType.RUN_ATTEMPT_CANCELLED,
         }:
             await _apply_run_attempt_event(connection, event)
+            return
+
+        if envelope.event_type == WorkshopEventType.RUN_ATTEMPT_CONTEXT_MANIFEST_RECORDED:
+            await _apply_run_context_manifest_event(connection, event)
             return
 
         if envelope.event_type == WorkshopEventType.WORKSHOP_CREATED:

--- a/src/kai/workshop/protected_execution.py
+++ b/src/kai/workshop/protected_execution.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from kai.backend import StreamEvent
+from kai.backend import ContextAssemblyObserver, StreamEvent
 from kai.config import VALID_BACKENDS, validate_model_for_backend
 from kai.workshop.collaboration_authority import CollaborationInvocation
 from kai.workshop.domain import ChannelId, RunId, RuntimeProfileId
@@ -46,6 +46,7 @@ class PreparedWorkshopExecution:
     runtime_profile_id: RuntimeProfileId
     selection: RunExecutionSelection
     workspace: Path
+    home_workspace: Path
     history_reader_user: str | None
     routing_decision: RunRoutingDecision
     _runtime: PreparedBackendExecution = field(repr=False, compare=False)
@@ -60,6 +61,9 @@ class PreparedWorkshopExecution:
 
     def stage_agent_definition_context(self, context: str) -> None:
         self._runtime.stage_canonical_agent_context(context)
+
+    def stage_context_assembly_observer(self, observer: ContextAssemblyObserver) -> None:
+        self._runtime.stage_context_assembly_observer(observer)
 
     def stage_collaboration_invocation(self, invocation: CollaborationInvocation) -> None:
         self._runtime.stage_collaboration_invocation(invocation.render_context(), invocation.token)
@@ -175,6 +179,7 @@ class WorkshopProtectedExecutionPreparationService:
             runtime_profile_id=run.runtime_profile_id,
             selection=selection,
             workspace=runtime.workspace,
+            home_workspace=runtime.home_workspace,
             history_reader_user=profile.os_user,
             routing_decision=decision,
             _runtime=runtime,

--- a/src/kai/workshop/schema.py
+++ b/src/kai/workshop/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import aiosqlite
 
-WORKSHOP_SCHEMA_VERSION = 76
+WORKSHOP_SCHEMA_VERSION = 77
 
 
 @dataclass(frozen=True, slots=True)
@@ -3409,6 +3409,66 @@ _REPLAY_SAFE_AGENT_PROVISIONING_SCHEMA = SchemaMigration(
     ),
 )
 
+
+_CANONICAL_CONTEXT_MANIFEST_SCHEMA = SchemaMigration(
+    version=77,
+    name="canonical_run_context_manifests",
+    statements=(
+        """
+        CREATE TABLE workshop_context_manifest_cutover (
+            singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+            event_position INTEGER NOT NULL CHECK (event_position >= 0)
+        )
+        """,
+        "INSERT INTO workshop_context_manifest_cutover (singleton, event_position) "
+        "SELECT 1, COALESCE(MAX(position), 0) FROM event_log",
+        """
+        CREATE TABLE run_context_manifests (
+            attempt_id TEXT PRIMARY KEY
+                REFERENCES run_attempts(id) ON DELETE CASCADE,
+            run_id TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+            workshop_id TEXT NOT NULL REFERENCES workshops(id) ON DELETE CASCADE,
+            channel_id TEXT NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+            requested_by_principal_id TEXT NOT NULL
+                REFERENCES principals(id) ON DELETE RESTRICT,
+            agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE RESTRICT,
+            runtime_profile_id TEXT NOT NULL,
+            backend TEXT NOT NULL,
+            provider TEXT,
+            model TEXT NOT NULL,
+            workspace_kind TEXT NOT NULL CHECK (
+                workspace_kind IN ('home', 'foreign', 'unknown')
+            ),
+            workspace_digest TEXT CHECK (
+                workspace_digest IS NULL OR (
+                    length(workspace_digest) = 64
+                    AND workspace_digest NOT GLOB '*[^0-9a-f]*'
+                )
+            ),
+            provider_session_revision TEXT CHECK (
+                provider_session_revision IS NULL OR (
+                    length(provider_session_revision) = 64
+                    AND provider_session_revision NOT GLOB '*[^0-9a-f]*'
+                )
+            ),
+            sources_json TEXT NOT NULL CHECK (
+                json_valid(sources_json) AND json_type(sources_json) = 'array'
+            ),
+            manifest_sha256 TEXT NOT NULL CHECK (
+                length(manifest_sha256) = 64
+                AND manifest_sha256 NOT GLOB '*[^0-9a-f]*'
+            ),
+            created_at TEXT NOT NULL,
+            created_event_position INTEGER NOT NULL UNIQUE
+                REFERENCES event_log(position) ON DELETE RESTRICT
+        )
+        """,
+        "CREATE INDEX run_context_manifests_run_idx ON run_context_manifests (run_id, attempt_id)",
+        "CREATE INDEX run_context_manifests_principal_idx ON run_context_manifests "
+        "(requested_by_principal_id, created_event_position)",
+    ),
+)
+
 _MIGRATIONS = (
     _INITIAL_SCHEMA,
     _DELIVERY_SCHEMA,
@@ -3486,6 +3546,7 @@ _MIGRATIONS = (
     _STANDING_OBSERVE_EXECUTION_SCHEMA,
     _RUN_KIND_SCOPED_IDENTITY_SCHEMA,
     _REPLAY_SAFE_AGENT_PROVISIONING_SCHEMA,
+    _CANONICAL_CONTEXT_MANIFEST_SCHEMA,
 )
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2422,3 +2422,31 @@ class TestAssembleTurnContext:
         assert "scoped_error" not in result  # nothing scoped-specific prepended
         assert emit_mock.call_count == 1
         assert emit_mock.call_args.args[0]["reason"] == "scoped_error"
+
+    async def test_context_observer_reports_actual_delivery_without_content(self, monkeypatch):
+        from kai.backend import ContextAssemblyObservation, assemble_turn_context
+
+        _patch_scoped_recall(monkeypatch, rendered_context="PRIVATE RECALL")
+        observations: list[ContextAssemblyObservation] = []
+
+        async def observe(value: ContextAssemblyObservation) -> None:
+            observations.append(value)
+
+        await assemble_turn_context(
+            "private input",
+            chat_id=42,
+            session_context="PRIVATE BOOTSTRAP",
+            workspace_reminder="PRIVATE REMINDER",
+            context_observer=observe,
+        )
+
+        assert len(observations) == 1
+        observation = observations[0]
+        assert observation.provider_dispatch_reached is True
+        assert observation.session_context_delivered is True
+        assert observation.semantic_recall_attempted is True
+        assert observation.semantic_recall_delivered is True
+        assert observation.semantic_recall_reason == "matches_delivered"
+        assert observation.semantic_recall_revision is not None
+        assert "PRIVATE" not in repr(observation)
+        assert observation.workspace_reminder_delivered is True

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -897,6 +897,7 @@ class TestNotificationChatIdMutations:
                 "/v1/channels/{channel_id}/runs/{run_id}",
                 "/v1/channels/{channel_id}/runs/{run_id}/cancel",
                 "/v1/channels/{channel_id}/runs/{run_id}/trace",
+                "/v1/channels/{channel_id}/runs/{run_id}/context-manifests",
                 "/v1/channels/{channel_id}/settings",
                 "/v1/channels/{channel_id}/effective-agent-runtime",
                 "/v1/channels/{channel_id}/models",

--- a/tests/test_workshop_agent_enablement.py
+++ b/tests/test_workshop_agent_enablement.py
@@ -579,7 +579,7 @@ async def test_version_fifty_seven_archived_enablement_is_retired_on_upgrade(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 76
+        assert await upgraded.schema_version() == 77
         async with upgraded.connection.execute(
             "SELECT lifecycle_state, conversation_started_at "
             "FROM principal_agent_enablements WHERE agent_definition_id = ?",

--- a/tests/test_workshop_client_api.py
+++ b/tests/test_workshop_client_api.py
@@ -6129,6 +6129,38 @@ async def _insert_trace_rows(store: WorkshopEventStore, run_id: str, count: int,
 
 
 class TestWorkshopRunTraceHTTPContract:
+    async def test_context_manifest_access_is_requester_scoped(self, tmp_path: Path):
+        store, alice_id, alice_channel, bob_id, _ = await _open_store(tmp_path / "kai.db")
+        submitter = _CommandSubmitter()
+        client = await _open_command_client(
+            store,
+            _Authenticator({"alice-token": alice_id, "bob-token": bob_id}),
+            submitter,
+        )
+        try:
+            accepted = await client.post(
+                f"/v1/channels/{alice_channel}/commands",
+                headers={"Authorization": "Bearer alice-token"},
+                json={"client_message_id": "context-manifest-command-1", "body": "Private work"},
+            )
+            run_id = (await accepted.json())["run_id"]
+            path = f"/v1/channels/{alice_channel}/runs/{run_id}/context-manifests"
+
+            denied = await client.get(path, headers={"Authorization": "Bearer bob-token"})
+            allowed = await client.get(path, headers={"Authorization": "Bearer alice-token"})
+
+            assert denied.status == 403
+            assert allowed.status == 200
+            assert await allowed.json() == {
+                "version": 1,
+                "channel_id": alice_channel,
+                "run_id": run_id,
+                "manifests": [],
+            }
+        finally:
+            await client.close()
+            await store.close()
+
     async def test_trace_access_is_denied_across_principals(self, tmp_path: Path):
         store, alice_id, alice_channel, bob_id, _ = await _open_store(tmp_path / "kai.db")
         submitter = _CommandSubmitter()

--- a/tests/test_workshop_collaboration_authority.py
+++ b/tests/test_workshop_collaboration_authority.py
@@ -451,7 +451,7 @@ async def test_version_sixty_seven_migrates_only_legacy_delegation_requests(
 
     upgraded = await WorkshopEventStore.open(path)
     try:
-        assert await upgraded.schema_version() == 76
+        assert await upgraded.schema_version() == 77
         async with upgraded.connection.execute(
             "SELECT id, capabilities_json, collaboration_operations_json "
             "FROM agent_definition_revisions ORDER BY revision_number"

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -10,12 +10,13 @@ from pathlib import Path
 import pytest
 
 from kai.agent_failure import AgentFailureKind
-from kai.backend import AgentResponse, StreamEvent, TraceEntry
+from kai.backend import AgentResponse, ContextAssemblyObservation, StreamEvent, TraceEntry
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.channel_lifecycle import WorkshopChannelLifecycleService
+from kai.workshop.context_manifests import CONTEXT_SOURCE_ORDER, WorkshopContextManifestService
 from kai.workshop.conversation_commands import WorkshopConversationCommandService
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
-from kai.workshop.diagnostics import workshop_runtime_session_status
+from kai.workshop.diagnostics import workshop_context_manifest_status, workshop_runtime_session_status
 from kai.workshop.domain import ChannelId, PrincipalId, RunExecutionOwnerId, RuntimeProfileId
 from kai.workshop.execution_coordinator import (
     CanonicalCancellationDisposition,
@@ -57,6 +58,7 @@ class _Prepared:
         self.runtime_profile_id = _RUNTIME_PROFILE_ID
         self.selection = RunExecutionSelection("codex", "gpt-5.6-sol")
         self.workspace = Path("/private/tmp/kai-workshop-test-workspace")
+        self.home_workspace = self.workspace
         self.response = response or AgentResponse(success=True, text="Canonical answer")
         self.wait = wait
         self.on_stream = on_stream
@@ -68,12 +70,16 @@ class _Prepared:
         self.agent_definition_contexts: list[str] = []
         self.collaboration_invocations = []
         self.discarded_collaboration_invocations = []
+        self.context_observer = None
 
     def stage_canonical_history(self, history: str) -> None:
         self.canonical_histories.append(history)
 
     def stage_agent_definition_context(self, context: str) -> None:
         self.agent_definition_contexts.append(context)
+
+    def stage_context_assembly_observer(self, observer) -> None:
+        self.context_observer = observer
 
     def stage_collaboration_invocation(self, invocation) -> None:
         self.collaboration_invocations.append(invocation)
@@ -94,6 +100,20 @@ class _Prepared:
 
     async def stream(self, prompt: str) -> AsyncIterator[StreamEvent]:
         self.prompts.append(prompt)
+        if self.context_observer is not None:
+            observer, self.context_observer = self.context_observer, None
+            await observer(
+                ContextAssemblyObservation(
+                    provider_dispatch_reached=True,
+                    session_context_delivered=True,
+                    session_context_revision="0" * 64,
+                    semantic_recall_attempted=True,
+                    semantic_recall_delivered=False,
+                    semantic_recall_reason="no_matches",
+                    semantic_recall_revision=None,
+                    workspace_reminder_delivered=False,
+                )
+            )
         if self.on_stream is not None:
             await self.on_stream()
         if self.wait is not None:
@@ -119,7 +139,10 @@ class _PreparationByRun:
         self.prepared = {item.run.run_id: item for item in prepared}
 
     async def prepare(self, run_id):
-        return self.prepared[run_id]
+        prepared = self.prepared[run_id]
+        assert prepared.run.runtime_profile_id is not None
+        prepared.runtime_profile_id = prepared.run.runtime_profile_id
+        return prepared
 
 
 class _RejectedPreparation:
@@ -250,6 +273,39 @@ async def _terminal_bodies(store: WorkshopEventStore) -> list[str]:
 
 
 class TestCanonicalExecutionCoordinator:
+    async def test_records_redacted_context_manifest_before_dispatch_and_replays_it(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, run = await _accepted(tmp_path / "kai.db")
+        prepared = _Prepared(run)
+        coordinator = _coordinator(store, _Preparation(prepared))
+        try:
+            result = await coordinator.execute(run.run_id)
+            assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+
+            manifests = await WorkshopContextManifestService(store).load_run(run.run_id)
+            assert len(manifests) == 1
+            manifest = manifests[0]
+            assert tuple(source.kind for source in manifest.draft.sources) == CONTEXT_SOURCE_ORDER
+            assert manifest.draft.workspace_kind == "home"
+            assert manifest.draft.selection == prepared.selection
+            assert manifest.draft.sources[2].reason == "run_bound_revision"
+            assert manifest.draft.sources[7].history_boundary == 0
+            assert manifest.draft.sources[10].reason == "accepted_input"
+            assert prepared.collaboration_invocations[0].token not in repr(manifest)
+            assert workshop_context_manifest_status(tmp_path / "kai.db").startswith(
+                "Workshop context manifests: active; post-cutover attempts=1, manifests=1, missing=0, malformed=0"
+            )
+
+            digest = manifest.manifest_sha256
+            await store.rebuild_projection(CanonicalConversationProjection())
+            replayed = await WorkshopContextManifestService(store).load_run(run.run_id)
+            assert len(replayed) == 1
+            assert replayed[0].manifest_sha256 == digest
+        finally:
+            await store.close()
+
     async def test_two_humans_alternate_in_one_group_agent_lane_in_order(
         self,
         tmp_path: Path,
@@ -285,6 +341,34 @@ class TestCanonicalExecutionCoordinator:
                 first_run.requested_by_principal_id,
                 second_run.requested_by_principal_id,
             ]
+            first_manifests = await WorkshopContextManifestService(store).load_run(first_run.run_id)
+            second_manifests = await WorkshopContextManifestService(store).load_run(second_run.run_id)
+            assert len(first_manifests) == len(second_manifests) == 1
+            assert first_manifests[0].requested_by_principal_id == first_run.requested_by_principal_id
+            assert second_manifests[0].requested_by_principal_id == second_run.requested_by_principal_id
+            assert first_manifests[0].requested_by_principal_id != second_manifests[0].requested_by_principal_id
+        finally:
+            await store.close()
+
+    async def test_foreign_workspace_manifest_records_only_redacted_workspace_identity(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, run = await _accepted(tmp_path / "kai.db")
+        prepared = _Prepared(run)
+        prepared.home_workspace = Path("/private/home/principal")
+        prepared.workspace = Path("/private/workspaces/secret-project-name")
+        try:
+            result = await _coordinator(store, _Preparation(prepared)).execute(run.run_id)
+
+            assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+            manifests = await WorkshopContextManifestService(store).load_run(run.run_id)
+            assert len(manifests) == 1
+            manifest = manifests[0]
+            assert manifest.draft.workspace_kind == "foreign"
+            assert manifest.draft.workspace_digest is not None
+            assert "secret-project-name" not in repr(manifest)
+            assert all("/private/" not in repr(source) for source in manifest.draft.sources)
         finally:
             await store.close()
 
@@ -304,6 +388,12 @@ class TestCanonicalExecutionCoordinator:
                 (run.run_id,),
             ) as cursor:
                 assert [str(row[0]) for row in await cursor.fetchall()] == ["failed"]
+            manifests = await WorkshopContextManifestService(store).load_run(run.run_id)
+            assert len(manifests) == 1
+            assert manifests[0].draft.workspace_kind == "unknown"
+            assert manifests[0].draft.workspace_digest is None
+            assert {source.reason for source in manifests[0].draft.sources} >= {"dispatch_not_reached"}
+            assert "not_observable" not in {source.reason for source in manifests[0].draft.sources}
         finally:
             await store.close()
 
@@ -412,7 +502,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             assert await load_runtime_session(upgraded, run.channel_id, run.agent_id) is None
             after = workshop_runtime_session_status(path)
             assert after.startswith("Workshop conversation continuity: active; successful lanes=0, sessions=0")
@@ -440,7 +530,7 @@ class TestCanonicalExecutionCoordinator:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             session = await load_runtime_session(upgraded, run.channel_id, run.agent_id)
             assert session is not None
             assert session.runtime_profile_id == _RUNTIME_PROFILE_ID
@@ -785,6 +875,13 @@ class TestCanonicalExecutionCoordinator:
             assert (await _terminal_bodies(store))[-1] == (
                 "Kai was interrupted while the configured agent was working. This request was not retried."
             )
+            manifests = await WorkshopContextManifestService(store).load_run(run.run_id)
+            assert len(manifests) == 1
+            assert manifests[0].draft.workspace_kind == "unknown"
+            assert {source.reason for source in manifests[0].draft.sources} >= {
+                "dispatch_state_unknown",
+                "not_observable",
+            }
             replay = await coordinator.execute(run.run_id)
             assert replay.disposition == CanonicalExecutionDisposition.TERMINAL_REPLAY
             assert preparation.calls == 0

--- a/tests/test_workshop_foundation.py
+++ b/tests/test_workshop_foundation.py
@@ -154,6 +154,7 @@ class TestEventEnvelope:
             "run_attempt.completed",
             "run_attempt.failed",
             "run_attempt.cancelled",
+            "run_attempt.context_manifest_recorded",
             "collaboration_grant.issued",
             "collaboration_grant.revoked",
             "collaboration_operation.decided",
@@ -251,6 +252,8 @@ class TestWorkshopSchema:
             "telegram_streaming_previews",
             "runs",
             "run_attempts",
+            "run_context_manifests",
+            "workshop_context_manifest_cutover",
             "agent_delegations",
             "collaboration_grants",
             "agent_collaboration_owner_policies",
@@ -273,7 +276,7 @@ class TestWorkshopSchema:
         }
 
         assert expected <= await workshop_store.schema_tables()
-        assert await workshop_store.schema_version() == 76
+        assert await workshop_store.schema_version() == 77
         async with workshop_store.connection.execute("PRAGMA table_info(principals)") as cursor:
             principal_columns = {str(row[1]) for row in await cursor.fetchall()}
         assert {"display_name_state_version", "display_name_event_position"} <= principal_columns
@@ -327,7 +330,7 @@ class TestWorkshopSchema:
         await first.close()
 
         second = await WorkshopEventStore.open(path)
-        assert await second.schema_version() == 76
+        assert await second.schema_version() == 77
         async with second.connection.execute(
             "SELECT COUNT(*) FROM workshop_schema_migrations WHERE version = 1"
         ) as cursor:
@@ -411,7 +414,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             async with upgraded.connection.execute(
                 "SELECT reaction, created_event_position FROM message_reactions "
                 "WHERE message_id = ? AND principal_id = ?",
@@ -452,7 +455,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             async with upgraded.connection.execute("SELECT id, lane, status FROM delivery_authority_epochs") as cursor:
                 assert tuple(await cursor.fetchone()) == (
                     epoch_id,
@@ -480,7 +483,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             assert {
                 "deliveries",
                 "channel_memberships",
@@ -574,6 +577,7 @@ class TestWorkshopSchema:
                     74,
                     75,
                     76,
+                    77,
                 ]
         finally:
             await upgraded.close()
@@ -596,7 +600,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             assert {
                 "channel_memberships",
                 "workshop_client_devices",
@@ -637,7 +641,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             assert {
                 "workshop_client_devices",
                 "workshop_client_enrollment_grants",
@@ -690,7 +694,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             assert "workshop_client_enrollment_grants" in await upgraded.schema_tables()
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
@@ -734,7 +738,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             assert "artifacts" in await upgraded.schema_tables()
             assert "delivery_outbox" in await upgraded.schema_tables()
             async with upgraded.connection.execute(
@@ -778,7 +782,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             assert {"delivery_outbox", "delivery_attempts"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -822,7 +826,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             assert {"delivery_outbox", "delivery_attempts", "delivery_fragments"} <= await upgraded.schema_tables()
             async with upgraded.connection.execute(
                 "SELECT display_name FROM principals WHERE id = ?",
@@ -926,7 +930,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             async with upgraded.connection.execute(
                 "SELECT message_id, channel_binding_id, transport, mode, status FROM deliveries WHERE id = ?",
                 (delivery_id,),
@@ -1053,7 +1057,7 @@ class TestWorkshopSchema:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             async with upgraded.connection.execute(
                 "SELECT purpose, status, attempt_count FROM delivery_outbox WHERE id = ?",
                 (delivery_id,),

--- a/tests/test_workshop_human_notifications.py
+++ b/tests/test_workshop_human_notifications.py
@@ -320,7 +320,7 @@ class TestHumanNotificationAuthority:
 
         upgraded = await WorkshopEventStore.open(path)
         try:
-            assert await upgraded.schema_version() == 76
+            assert await upgraded.schema_version() == 77
             async with upgraded.connection.execute(
                 "SELECT kind FROM human_notifications WHERE recipient_principal_id = ?",
                 (scott_id,),

--- a/tests/test_workshop_private_text_execution.py
+++ b/tests/test_workshop_private_text_execution.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import kai.workshop.private_text_execution as private_text_execution_module
-from kai.backend import AgentResponse, StreamEvent
+from kai.backend import AgentResponse, ContextAssemblyObservation, StreamEvent
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop, bootstrap_human_principal_id
 from kai.workshop.delivery_authority import WorkshopConversationDeliveryAuthority
 from kai.workshop.domain import ChannelId, PrincipalId
@@ -47,18 +47,23 @@ class _Runtime:
     def __init__(self, workspace: Path, *, wait: asyncio.Event | None = None) -> None:
         self.selection = SimpleNamespace(backend="codex", provider="openai", model="gpt-5.6-sol")
         self.workspace = workspace
+        self.home_workspace = workspace
         self.wait = wait
         self.validated = False
         self.cancelled = False
         self.canonical_histories: list[str] = []
         self.agent_definition_contexts: list[str] = []
         self.collaboration_proof: str | None = None
+        self.context_observer = None
 
     def stage_canonical_history(self, history: str) -> None:
         self.canonical_histories.append(history)
 
     def stage_canonical_agent_context(self, context: str) -> None:
         self.agent_definition_contexts.append(context)
+
+    def stage_context_assembly_observer(self, observer) -> None:
+        self.context_observer = observer
 
     def stage_collaboration_invocation(self, _context: str, proof: str) -> None:
         self.collaboration_proof = proof
@@ -76,6 +81,20 @@ class _Runtime:
             self.wait.set()
 
     async def stream(self, prompt: str):
+        if self.context_observer is not None:
+            observer, self.context_observer = self.context_observer, None
+            await observer(
+                ContextAssemblyObservation(
+                    provider_dispatch_reached=True,
+                    session_context_delivered=True,
+                    session_context_revision="0" * 64,
+                    semantic_recall_attempted=True,
+                    semantic_recall_delivered=False,
+                    semantic_recall_reason="no_matches",
+                    semantic_recall_revision=None,
+                    workspace_reminder_delivered=False,
+                )
+            )
         yield StreamEvent(text_so_far="Stable preview.", done=False)
         if self.wait is not None:
             await self.wait.wait()

--- a/tests/test_workshop_protected_execution.py
+++ b/tests/test_workshop_protected_execution.py
@@ -58,6 +58,7 @@ class _PreparedRuntime:
             provider="openai",
         )
         self.workspace = workspace
+        self.home_workspace = workspace
 
     async def cancel(self) -> None:
         return None

--- a/tests/test_workshop_scheduler.py
+++ b/tests/test_workshop_scheduler.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from kai import sessions
-from kai.backend import AgentResponse, StreamEvent
+from kai.backend import AgentResponse, ContextAssemblyObservation, StreamEvent
 from kai.workshop.bootstrap import BootstrapHuman, bootstrap_default_workshop
 from kai.workshop.client_events import ClientTimelineMessageEvent, read_client_channel_events
 from kai.workshop.conversation_commands import ConversationCommandDisposition
@@ -111,13 +111,18 @@ class _CanonicalRuntime:
             model="gpt-5.6-sol",
         )
         self.workspace = workspace
+        self.home_workspace = workspace
         self.collaboration_proof: str | None = None
+        self.context_observer = None
 
     def stage_canonical_history(self, _history: str) -> None:
         pass
 
     def stage_canonical_agent_context(self, _context: str) -> None:
         pass
+
+    def stage_context_assembly_observer(self, observer) -> None:
+        self.context_observer = observer
 
     def stage_collaboration_invocation(self, _context: str, proof: str) -> None:
         self.collaboration_proof = proof
@@ -133,6 +138,20 @@ class _CanonicalRuntime:
         pass
 
     async def stream(self, _prompt: str):
+        if self.context_observer is not None:
+            observer, self.context_observer = self.context_observer, None
+            await observer(
+                ContextAssemblyObservation(
+                    provider_dispatch_reached=True,
+                    session_context_delivered=True,
+                    session_context_revision="0" * 64,
+                    semantic_recall_attempted=True,
+                    semantic_recall_delivered=False,
+                    semantic_recall_reason="no_matches",
+                    semantic_recall_revision=None,
+                    workspace_reminder_delivered=False,
+                )
+            )
         yield StreamEvent(
             text_so_far="Scheduled agent answer",
             done=True,


### PR DESCRIPTION
Closes #1537

## Summary
- define a fixed typed vocabulary for all twelve Kai-controlled and provider-controlled context sources
- persist one immutable, redacted, replay-stable manifest for every post-cutover execution attempt
- observe actual fresh/live context assembly across Claude, Codex, Goose, OpenCode, and Pi without storing context contents, secrets, proof values, or raw paths
- expose manifests through a principal- and channel-authorized read API and add install diagnostics
- cover normal dispatch, routing rejection, crash recovery, cancellation, shared channels, projection rebuild, backend parity, and redaction

## Validation
- `make check`
- `make typecheck`
- `make client-check` (210 tests)
- focused context-manifest and integration tests
- `make test` (6693 passed)