### PR TITLE
Fix Pi principal policy delivery

### DIFF
--- a/src/kai/backend.py
+++ b/src/kai/backend.py
@@ -87,6 +87,7 @@ class ContextAssemblyObservation:
     workspace_reminder_delivered: bool
     workspace_reminder_revision: str | None = None
     principal_documents: PrincipalDocumentReport | None = None
+    ambient_context_discovery_enabled: bool | None = None
 
 
 type ContextAssemblyObserver = Callable[[ContextAssemblyObservation], Awaitable[None]]
@@ -1777,6 +1778,7 @@ async def assemble_turn_context(
     session_id: str | None = None,
     context_observer: ContextAssemblyObserver | None = None,
     principal_documents: PrincipalDocumentReport | None = None,
+    ambient_context_discovery_enabled: bool | None = None,
 ) -> str | list:
     """
     Assemble the per-turn prompt context for an interactive backend.
@@ -1827,6 +1829,10 @@ async def assemble_turn_context(
     inputs (fresh-session detection, workspace state, API context)
     and stay backend-owned. The backend builds those strings and
     passes them in. The helper owns only the ordering invariant.
+
+    ``ambient_context_discovery_enabled`` records whether the backend admits
+    ambient context files or equivalent native resources. ``None`` means the
+    adapter does not make that behavior observable to Kai.
 
     Returns the assembled prompt in the same type family as the
     input (`str | list`). Backends do their own protocol-specific
@@ -1938,6 +1944,7 @@ async def assemble_turn_context(
                     hashlib.sha256(workspace_reminder.encode("utf-8")).hexdigest() if workspace_reminder else None
                 ),
                 principal_documents=principal_documents,
+                ambient_context_discovery_enabled=ambient_context_discovery_enabled,
             )
         )
 

--- a/src/kai/pi.py
+++ b/src/kai/pi.py
@@ -476,6 +476,7 @@ class PiBackend(AgentBackend):
             session_id=self._session_id,
             context_observer=context_observer,
             principal_documents=principal_documents,
+            ambient_context_discovery_enabled=False,
         )
         if isinstance(prompt, str):
             message_text = prompt

--- a/src/kai/workshop/context_manifests.py
+++ b/src/kai/workshop/context_manifests.py
@@ -639,8 +639,20 @@ def build_context_manifest_draft(
                 if observation.provider_dispatch_reached is False
                 else ContextSourceState.PROVIDER_CONTROLLED
             ),
-            "dispatch_not_reached" if observation.provider_dispatch_reached is False else "not_observable",
-            delivery_shape="provider_managed_unknown",
+            (
+                "dispatch_not_reached"
+                if observation.provider_dispatch_reached is False
+                else "ambient_discovery_disabled"
+                if observation.ambient_context_discovery_enabled is False
+                else "ambient_discovery_enabled"
+                if observation.ambient_context_discovery_enabled is True
+                else "not_observable"
+            ),
+            delivery_shape=(
+                "provider_managed_ambient_disabled"
+                if observation.ambient_context_discovery_enabled is False
+                else "provider_managed_unknown"
+            ),
         ),
     )
     return ContextManifestDraft(

--- a/tests/test_pi.py
+++ b/tests/test_pi.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -211,6 +212,92 @@ class TestPiStartup:
 
         with pytest.raises(Exception, match="different model"):
             await backend._ensure_started()
+
+
+class TestPiCanonicalContext:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("foreign_workspace", [False, True], ids=["home", "foreign"])
+    async def test_fresh_private_lane_delivers_principal_policy_once(
+        self,
+        tmp_path,
+        monkeypatch,
+        foreign_workspace,
+    ):
+        data_dir = tmp_path / "data"
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "AGENTS.md").write_text("DURABLE OPERATOR RULE\nKeep this principal policy active.\n")
+        workspace = tmp_path / "project" if foreign_workspace else home
+        workspace.mkdir(exist_ok=True)
+        backend = make_backend(
+            tmp_path,
+            workspace=workspace,
+            home_workspace=home,
+            memory_enabled=True,
+        )
+        backend._proc = FakeProcess()
+        backend._session_id = "session-1"
+        backend._supports_image_input = True
+        backend._transport = FakeTransport(
+            [
+                {"id": "kai-prompt-1", "type": "response", "command": "prompt", "success": True},
+                {"type": "agent_settled"},
+                {"id": "kai-prompt-2", "type": "response", "command": "prompt", "success": True},
+                {"type": "agent_settled"},
+            ]
+        )
+        identity = SimpleNamespace(
+            principal_id="prn_" + "1" * 32,
+            channel_id="chn_" + "2" * 32,
+            agent_id="agt_" + "3" * 32,
+            runtime_profile_id="rtp_" + "4" * 32,
+            private_context=True,
+        )
+        assemblies: list[dict] = []
+
+        async def capture_assembly(prompt, **kwargs):
+            assemblies.append(kwargs)
+            return "\n\n".join(
+                part
+                for part in (
+                    kwargs["session_context"],
+                    kwargs["agent_definition_context"],
+                    str(prompt),
+                )
+                if part
+            )
+
+        monkeypatch.setattr("kai.pi.DATA_DIR", data_dir)
+        monkeypatch.setattr("kai.pi.ensure_user_context_files", lambda *a, **kw: None)
+        monkeypatch.setattr("kai.pi.assemble_turn_context", capture_assembly)
+        monkeypatch.setattr(backend, "_ensure_started", AsyncMock())
+
+        for marker in ("FIRST", "SECOND"):
+            backend.stage_canonical_agent_context(f"CUSTOM AGENT IDENTITY {marker}")
+            events = [
+                event
+                async for event in backend.send(
+                    f"request {marker}",
+                    runtime_identity=identity,
+                )
+            ]
+            assert events[-1].done is True
+
+        first, second = assemblies
+        assert first["session_context"].count("DURABLE OPERATOR RULE") == 1
+        assert second["session_context"] == ""
+        assert first["agent_definition_context"] == "CUSTOM AGENT IDENTITY FIRST"
+        assert second["agent_definition_context"] == "CUSTOM AGENT IDENTITY SECOND"
+        assert first["ambient_context_discovery_enabled"] is False
+        assert second["ambient_context_discovery_enabled"] is False
+        assert first["principal_documents"].policy.content == (
+            "DURABLE OPERATOR RULE\nKeep this principal policy active.\n"
+        )
+        assert bool(first["workspace_reminder"]) is foreign_workspace
+        sent_text = "\n".join(str(command["message"]) for command in backend._transport.sent)
+        assert sent_text.count("DURABLE OPERATOR RULE") == 1
+        assert "CUSTOM AGENT IDENTITY FIRST" in sent_text
+        assert "CUSTOM AGENT IDENTITY SECOND" in sent_text
 
 
 class TestPiTurns:

--- a/tests/test_workshop_execution_coordinator.py
+++ b/tests/test_workshop_execution_coordinator.py
@@ -59,10 +59,12 @@ class _Prepared:
         response: AgentResponse | None = None,
         wait: asyncio.Event | None = None,
         on_stream: Callable[[], Awaitable[None]] | None = None,
+        selection: RunExecutionSelection | None = None,
+        ambient_context_discovery_enabled: bool | None = None,
     ) -> None:
         self.run = run
         self.runtime_profile_id = _RUNTIME_PROFILE_ID
-        self.selection = RunExecutionSelection("codex", "gpt-5.6-sol")
+        self.selection = selection or RunExecutionSelection("codex", "gpt-5.6-sol")
         self.workspace = Path("/private/tmp/kai-workshop-test-workspace")
         self.home_workspace = self.workspace
         self.response = response or AgentResponse(success=True, text="Canonical answer")
@@ -77,6 +79,7 @@ class _Prepared:
         self.collaboration_invocations = []
         self.discarded_collaboration_invocations = []
         self.context_observer = None
+        self.ambient_context_discovery_enabled = ambient_context_discovery_enabled
 
     def stage_canonical_history(self, history: str) -> None:
         self.canonical_histories.append(history)
@@ -134,6 +137,7 @@ class _Prepared:
                             "missing",
                         ),
                     ),
+                    ambient_context_discovery_enabled=self.ambient_context_discovery_enabled,
                 )
             )
         if self.on_stream is not None:
@@ -278,11 +282,17 @@ async def _accepted_group_pair(path: Path):
     return store, first.command.runs[0], second.command.runs[0]
 
 
-def _coordinator(store, preparation, *, lease_seconds: int = 60):
+def _coordinator(
+    store,
+    preparation,
+    *,
+    lease_seconds: int = 60,
+    registered_backend_ids: frozenset[str] = frozenset({"codex"}),
+):
     return WorkshopCanonicalExecutionCoordinator(
         store,
         preparation,
-        registered_backend_ids=frozenset({"codex"}),
+        registered_backend_ids=registered_backend_ids,
         clock=lambda: _NOW + timedelta(seconds=10),
         lease_duration=timedelta(seconds=lease_seconds),
         delivery_policy=TELEGRAM_DELIVERY_POLICY,
@@ -319,6 +329,8 @@ class TestCanonicalExecutionCoordinator:
             assert manifest.draft.sources[5].reason == "semantic_memory_enabled_or_shared"
             assert manifest.draft.sources[7].history_boundary == 0
             assert manifest.draft.sources[10].reason == "accepted_input"
+            assert manifest.draft.sources[11].reason == "not_observable"
+            assert manifest.draft.sources[11].delivery_shape == "provider_managed_unknown"
             assert prepared.collaboration_invocations[0].token not in repr(manifest)
             assert workshop_context_manifest_status(tmp_path / "kai.db").startswith(
                 "Workshop context manifests: active; post-cutover attempts=1, manifests=1, missing=0, malformed=0"
@@ -329,6 +341,37 @@ class TestCanonicalExecutionCoordinator:
             replayed = await WorkshopContextManifestService(store).load_run(run.run_id)
             assert len(replayed) == 1
             assert replayed[0].manifest_sha256 == digest
+        finally:
+            await store.close()
+
+    async def test_pi_manifest_records_disabled_ambient_context_discovery(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store, run = await _accepted(tmp_path / "kai.db")
+        prepared = _Prepared(
+            run,
+            selection=RunExecutionSelection(
+                "pi",
+                "anthropic/claude-sonnet-4-6",
+                provider="anthropic",
+            ),
+            ambient_context_discovery_enabled=False,
+        )
+        coordinator = _coordinator(
+            store,
+            _Preparation(prepared),
+            registered_backend_ids=frozenset({"codex", "pi"}),
+        )
+        try:
+            result = await coordinator.execute(run.run_id)
+            assert result.disposition == CanonicalExecutionDisposition.COMPLETED
+
+            manifests = await WorkshopContextManifestService(store).load_run(run.run_id)
+            assert len(manifests) == 1
+            provider_native = manifests[0].draft.sources[11]
+            assert provider_native.reason == "ambient_discovery_disabled"
+            assert provider_native.delivery_shape == "provider_managed_ambient_disabled"
         finally:
             await store.close()
 


### PR DESCRIPTION
Closes #1534.

## Summary

- record Pi's deliberate ambient-context shutdown in every observed turn and in the redacted run context manifest
- preserve Pi's existing `--no-context-files`, `--no-skills`, `--no-prompt-templates`, and `--no-extensions` boundary
- pin fresh home and foreign Pi sessions to one canonical neutral principal-policy delivery while custom agent identity remains independently turn-bound
- preserve the existing unknown/provider-managed manifest semantics for Claude, Codex, Goose, and OpenCode

## Validation

- `make check`
- `make client-check` (211 tests)
- `.venv/bin/python -m pytest tests/test_pi.py tests/test_workshop_execution_coordinator.py -q` (54 passed)
- `make test` (6,722 passed)

## Installed qualification

After merge, `make install` is required. Qualify one Pi-backed private agent in its home workspace and again after selecting a foreign workspace. In both runs, verify the neutral principal policy applies, the custom agent retains its own identity, and the context manifest reports `ambient_discovery_disabled` with `provider_managed_ambient_disabled`.
